### PR TITLE
Feature/support tool discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dao-ai"
-version = "0.0.1"
+version = "0.0.2"
 description = "DAO AI: A modular, multi-agent orchestration framework for complex AI workflows. Supports agent handoff, tool integration, and dynamic configuration via YAML."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -668,7 +668,7 @@ class PythonFunctionModel(BaseFunctionModel, HasFullName):
     def full_name(self) -> str:
         return self.name
 
-    def as_tool(self, **kwargs: Any) -> Callable[..., Any]:
+    def as_tools(self, **kwargs: Any) -> Sequence[Callable[..., Any]]:
         from dao_ai.tools import create_python_tool
 
         return create_python_tool(self, **kwargs)
@@ -683,7 +683,7 @@ class FactoryFunctionModel(BaseFunctionModel, HasFullName):
     def full_name(self) -> str:
         return self.name
 
-    def as_tool(self, **kwargs: Any) -> Callable[..., Any]:
+    def as_tools(self, **kwargs: Any) -> Sequence[Callable[..., Any]]:
         from dao_ai.tools import create_factory_tool
 
         return create_factory_tool(self, **kwargs)
@@ -717,10 +717,10 @@ class McpFunctionModel(BaseFunctionModel, HasFullName):
             raise ValueError("args must not be provided for STDIO transport")
         return self
 
-    def as_tool(self, **kwargs: Any) -> BaseTool:
-        from dao_ai.tools import create_mcp_tool
+    def as_tools(self, **kwargs: Any) -> Sequence[BaseTool]:
+        from dao_ai.tools import create_mcp_tools
 
-        return create_mcp_tool(self)
+        return create_mcp_tools(self)
 
 
 class UnityCatalogFunctionModel(BaseFunctionModel, HasFullName):
@@ -734,10 +734,10 @@ class UnityCatalogFunctionModel(BaseFunctionModel, HasFullName):
             return f"{self.schema_model.catalog_name}.{self.schema_model.schema_name}.{self.name}"
         return self.name
 
-    def as_tool(self, **kwargs: Any) -> BaseTool:
-        from dao_ai.tools import create_uc_tool
+    def as_tools(self, **kwargs: Any) -> Sequence[BaseTool]:
+        from dao_ai.tools import create_uc_tools
 
-        return create_uc_tool(self)
+        return create_uc_tools(self)
 
 
 AnyTool: TypeAlias = (

--- a/src/dao_ai/hooks/core.py
+++ b/src/dao_ai/hooks/core.py
@@ -17,7 +17,7 @@ def create_hooks(
     for function_hook in function_hooks:
         if isinstance(function_hook, str):
             function_hook = PythonFunctionModel(name=function_hook)
-        hook: Callable[..., Any] = function_hook.as_tool()
+        hook: Callable[..., Any] = function_hook.as_tools()
         hooks.append(hook)
     logger.debug(f"Created hooks: {hooks}")
     return hooks

--- a/src/dao_ai/hooks/core.py
+++ b/src/dao_ai/hooks/core.py
@@ -17,8 +17,7 @@ def create_hooks(
     for function_hook in function_hooks:
         if isinstance(function_hook, str):
             function_hook = PythonFunctionModel(name=function_hook)
-        hook: Callable[..., Any] = function_hook.as_tools()
-        hooks.append(hook)
+        hooks.extend(function_hook.as_tools())
     logger.debug(f"Created hooks: {hooks}")
     return hooks
 

--- a/src/dao_ai/tools/__init__.py
+++ b/src/dao_ai/tools/__init__.py
@@ -2,10 +2,10 @@ from dao_ai.hooks.core import create_hooks
 from dao_ai.tools.agent import create_agent_endpoint_tool
 from dao_ai.tools.core import (
     create_factory_tool,
-    create_mcp_tool,
+    create_mcp_tools,
     create_python_tool,
     create_tools,
-    create_uc_tool,
+    create_uc_tools,
     search_tool,
 )
 from dao_ai.tools.genie import create_genie_tool
@@ -26,10 +26,10 @@ __all__ = [
     "create_factory_tool",
     "create_genie_tool",
     "create_hooks",
-    "create_mcp_tool",
+    "create_mcp_tools",
     "create_python_tool",
     "create_tools",
-    "create_uc_tool",
+    "create_uc_tools",
     "create_vector_search_tool",
     "current_time_tool",
     "format_time_tool",

--- a/src/dao_ai/tools/core.py
+++ b/src/dao_ai/tools/core.py
@@ -151,9 +151,9 @@ def create_tools(tool_models: Sequence[ToolModel]) -> Sequence[BaseTool]:
     return list(tools.values())
 
 
-def create_mcp_tool(
+def create_mcp_tools(
     function: McpFunctionModel,
-) -> Callable[..., Any]:
+) -> Sequence[BaseTool]:
     """
     Create a tool for invoking a Databricks MCP function.
 
@@ -166,7 +166,7 @@ def create_mcp_tool(
     Returns:
         A callable tool function that wraps the specified MCP function
     """
-    logger.debug(f"create_mcp_tool: {function}")
+    logger.debug(f"create_mcp_tools: {function}")
 
     connection: dict[str, Any]
     match function.transport:
@@ -244,7 +244,7 @@ def create_python_tool(
     return tool
 
 
-def create_uc_tool(function: UnityCatalogFunctionModel | str) -> BaseTool:
+def create_uc_tools(function: UnityCatalogFunctionModel | str) -> Sequence[BaseTool]:
     """
     Create LangChain tools from Unity Catalog functions.
 
@@ -259,7 +259,7 @@ def create_uc_tool(function: UnityCatalogFunctionModel | str) -> BaseTool:
         A sequence of BaseTool objects that wrap the specified UC functions
     """
 
-    logger.debug(f"create_uc_tool: {function}")
+    logger.debug(f"create_uc_tools: {function}")
 
     if isinstance(function, UnityCatalogFunctionModel):
         function = function.full_name
@@ -270,14 +270,11 @@ def create_uc_tool(function: UnityCatalogFunctionModel | str) -> BaseTool:
         function_names=[function], client=client
     )
 
-    tool = next(iter(toolkit.tools or []), None)
+    tools = toolkit.tools or []
 
-    tool = as_human_in_the_loop(
-        tool=tool,
-        function=function,
-    )
+    tools = [as_human_in_the_loop(tool=tool, function=function) for tool in tools]
 
-    return tool
+    return tools
 
 
 def search_tool() -> BaseTool:

--- a/src/quick_serve_restaurant/tools.py
+++ b/src/quick_serve_restaurant/tools.py
@@ -45,7 +45,9 @@ def insert_coffee_order_tool(
         if isinstance(unity_catalog_function, dict):
             unity_catalog_function = UnityCatalogFunctionModel(**unity_catalog_function)
 
-        unity_catalog_tool: BaseTool = unity_catalog_function.as_tools()
+        unity_catalog_tool: BaseTool = next(
+            iter(unity_catalog_function.as_tools() or []), None
+        )
         logger.debug(f"Invoking Unity Catalog tool: {unity_catalog_tool.name}")
         result: str = unity_catalog_tool.invoke(
             {

--- a/src/quick_serve_restaurant/tools.py
+++ b/src/quick_serve_restaurant/tools.py
@@ -45,7 +45,7 @@ def insert_coffee_order_tool(
         if isinstance(unity_catalog_function, dict):
             unity_catalog_function = UnityCatalogFunctionModel(**unity_catalog_function)
 
-        unity_catalog_tool: BaseTool = unity_catalog_function.as_tool()
+        unity_catalog_tool: BaseTool = unity_catalog_function.as_tools()
         logger.debug(f"Invoking Unity Catalog tool: {unity_catalog_tool.name}")
         result: str = unity_catalog_tool.invoke(
             {

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "dao-ai"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "databricks-agents" },


### PR DESCRIPTION
This PR allows multiple tools to be configured from a single "function" declaration. This is needed for things like MCP servers and UC Toolkits which allow "discoverability" for MCP servers and for the wildcard syntax with UC Tools to bring in multiple tools.

This is implemented my changing the interface method:

class BaseFunctionModel(ABC, BaseModel):
   ...
    **@abstractmethod
    def as_tool(self, **kwargs: Any) -> BaseTool | Callable[..., Any]: ...**

TO:

class BaseFunctionModel(ABC, BaseModel):
   ...
    **@abstractmethod
    def as_tools(self, **kwargs: Any) -> Sequence[RunnableLike]: ...**

And updating the implementations and references to support these composites.

We may revisit the implementation in the future.