### PR TITLE
Fix filter precedence and verification retry loop in instructed retrieval

### DIFF
--- a/src/dao_ai/tools/vector_search.py
+++ b/src/dao_ai/tools/vector_search.py
@@ -476,7 +476,8 @@ def create_vector_search_tool(
                 )
                 k: int = search_parameters.num_results or 5
                 query_type: str = search_parameters.query_type or "ANN"
-                combined_filters: dict[str, Any] = {**sq_filters, **base_filters}
+                # Decomposed filters take precedence over base filters
+                combined_filters: dict[str, Any] = {**base_filters, **sq_filters}
                 logger.trace(
                     "Executing search",
                     query=sq.text,

--- a/src/dao_ai/tools/vector_search.py
+++ b/src/dao_ai/tools/vector_search.py
@@ -464,6 +464,11 @@ def create_vector_search_tool(
                         normalized[key] = value
                 return normalized
 
+            # Normalize base_filters once for consistent case matching
+            normalized_base_filters = normalize_filter_values(
+                base_filters, decomposition_config.normalize_filter_case
+            )
+
             def execute_search(sq: SearchQuery) -> list[Document]:
                 logger.trace("Executing search", query=sq.text, filters=sq.filters)
                 # Convert FilterItem list to dict
@@ -477,7 +482,7 @@ def create_vector_search_tool(
                 k: int = search_parameters.num_results or 5
                 query_type: str = search_parameters.query_type or "ANN"
                 # Decomposed filters take precedence over base filters
-                combined_filters: dict[str, Any] = {**base_filters, **sq_filters}
+                combined_filters: dict[str, Any] = {**normalized_base_filters, **sq_filters}
                 logger.trace(
                     "Executing search",
                     query=sq.text,
@@ -568,7 +573,7 @@ def create_vector_search_tool(
         auto_bypass: bool,
         context: Context | None = None,
     ) -> list[Document]:
-        """Apply instruction-aware reranking and verification based on mode and bypass settings."""
+        """Apply instruction-aware reranking based on mode and bypass settings."""
         # Skip post-processing for standard mode when auto_bypass is enabled
         if mode == "standard" and auto_bypass:
             span = mlflow.get_current_active_span()
@@ -600,71 +605,6 @@ def create_vector_search_tool(
                     if instruction_rerank_config.model
                     else None,
                 )
-
-        # Apply verification if configured (verifier is always under instructed)
-        if verifier_config and instructed_config:
-            verifier_llm = (
-                _get_cached_llm(verifier_config.model, context)
-                if verifier_config.model
-                else None
-            )
-
-            if verifier_llm:
-                constraints = instructed_config.constraints
-                retry_count = 0
-                verification_result: VerificationResult | None = None
-                previous_feedback: str | None = None
-
-                while retry_count <= verifier_config.max_retries:
-                    verification_result = verify_results(
-                        llm=verifier_llm,
-                        query=query,
-                        documents=documents,
-                        columns=instructed_columns,
-                        constraints=constraints,
-                        previous_feedback=previous_feedback,
-                        resource_info=ResourceInfo(
-                            "model_serving",
-                            verifier_config.model.on_behalf_of_user,
-                            verifier_config.model.name,
-                        )
-                        if verifier_config.model
-                        else None,
-                    )
-
-                    _span = mlflow.get_current_active_span()
-                    if verification_result.passed:
-                        if _span:
-                            _span.set_attribute(ATTR_VERIFIER_OUTCOME, "passed")
-                            _span.set_attribute(ATTR_VERIFIER_RETRIES, retry_count)
-                        break
-
-                    # Handle failure based on configuration
-                    if verifier_config.on_failure == "warn":
-                        if _span:
-                            _span.set_attribute(ATTR_VERIFIER_OUTCOME, "warned")
-                        documents = add_verification_metadata(
-                            documents, verification_result
-                        )
-                        break
-
-                    if retry_count >= verifier_config.max_retries:
-                        if _span:
-                            _span.set_attribute(ATTR_VERIFIER_OUTCOME, "exhausted")
-                            _span.set_attribute(ATTR_VERIFIER_RETRIES, retry_count)
-                        documents = add_verification_metadata(
-                            documents, verification_result, exhausted=True
-                        )
-                        break
-
-                    # Retry with feedback
-                    if _span:
-                        _span.set_attribute(ATTR_VERIFIER_OUTCOME, "retried")
-                    previous_feedback = verification_result.feedback
-                    retry_count += 1
-                    logger.debug(
-                        "Retrying search with verification feedback", retry=retry_count
-                    )
 
         return documents
 
@@ -752,23 +692,102 @@ def create_vector_search_tool(
         if span:
             span.set_attribute(ATTR_ROUTER_MODE, mode)
 
-        # Execute search based on mode
-        if mode == "instructed" and instructed_config and decomposition_config:
-            documents = _execute_instructed_retrieval(
-                vs, query, base_filters, context=context
+        # Search + verify loop: re-executes search with feedback on verification failure
+        retry_count = 0
+        max_retries = verifier_config.max_retries if verifier_config else 0
+        previous_feedback: str | None = None
+
+        while True:
+            # Execute search based on mode
+            if mode == "instructed" and instructed_config and decomposition_config:
+                documents = _execute_instructed_retrieval(
+                    vs, query, base_filters, previous_feedback, context=context
+                )
+            else:
+                documents = _execute_standard_search(vs, query, base_filters)
+
+            # Apply FlashRank reranking if configured
+            if ranker and rerank_config and documents:
+                logger.debug("Applying FlashRank reranking")
+                documents = _rerank_documents(query, documents, ranker, rerank_config)
+
+            # Apply instruction-aware reranking
+            documents = _apply_post_processing(
+                documents, query, mode, auto_bypass, context=context
             )
-        else:
-            documents = _execute_standard_search(vs, query, base_filters)
 
-        # Apply FlashRank reranking if configured
-        if ranker and rerank_config:
-            logger.debug("Applying FlashRank reranking")
-            documents = _rerank_documents(query, documents, ranker, rerank_config)
+            # Verification (if configured)
+            if not verifier_config:
+                break
 
-        # Apply post-processing (instruction reranking + verification)
-        documents = _apply_post_processing(
-            documents, query, mode, auto_bypass, context=context
-        )
+            # Skip verification for standard mode when auto_bypass is enabled
+            if mode == "standard" and auto_bypass:
+                break
+
+            verifier_llm = (
+                _get_cached_llm(verifier_config.model, context)
+                if verifier_config.model
+                else None
+            )
+            if not verifier_llm:
+                break
+
+            constraints = instructed_config.constraints if instructed_config else None
+
+            verification_result = verify_results(
+                llm=verifier_llm,
+                query=query,
+                documents=documents,
+                columns=instructed_columns,
+                constraints=constraints,
+                previous_feedback=previous_feedback,
+                resource_info=ResourceInfo(
+                    "model_serving",
+                    verifier_config.model.on_behalf_of_user,
+                    verifier_config.model.name,
+                )
+                if verifier_config.model
+                else None,
+            )
+
+            _span = mlflow.get_current_active_span()
+            if verification_result.passed:
+                if _span:
+                    _span.set_attribute(ATTR_VERIFIER_OUTCOME, "passed")
+                    _span.set_attribute(ATTR_VERIFIER_RETRIES, retry_count)
+                break
+
+            # Warn-only: annotate and stop
+            if verifier_config.on_failure == "warn":
+                if _span:
+                    _span.set_attribute(ATTR_VERIFIER_OUTCOME, "warned")
+                documents = add_verification_metadata(documents, verification_result)
+                break
+
+            # Retries exhausted
+            if retry_count >= max_retries:
+                if _span:
+                    _span.set_attribute(ATTR_VERIFIER_OUTCOME, "exhausted")
+                    _span.set_attribute(ATTR_VERIFIER_RETRIES, retry_count)
+                documents = add_verification_metadata(
+                    documents, verification_result, exhausted=True
+                )
+                break
+
+            # Standard mode can't meaningfully retry (no decomposition to adjust)
+            if mode != "instructed":
+                if _span:
+                    _span.set_attribute(ATTR_VERIFIER_OUTCOME, "warned")
+                documents = add_verification_metadata(documents, verification_result)
+                break
+
+            # Retry: re-execute search with verifier feedback
+            retry_count += 1
+            previous_feedback = verification_result.feedback
+            logger.debug(
+                "Retrying search with verification feedback",
+                retry=retry_count,
+            )
 
         # Serialize documents to JSON format for LLM consumption
         serialized_docs: list[dict[str, Any]] = []

--- a/tests/dao_ai/test_instructed_retriever.py
+++ b/tests/dao_ai/test_instructed_retriever.py
@@ -754,6 +754,84 @@ class TestLLMCaching:
         assert result1 is mock_chat_model
 
 
+@pytest.mark.unit
+class TestRRFMergeEmptyFallback:
+    """Tests for RRF merge edge cases not covered by TestRRFMerge."""
+
+    def test_single_empty_list(self) -> None:
+        """Test that rrf_merge handles a single empty list (vs empty input)."""
+        result = rrf_merge([[]])
+        assert result == []
+
+
+@pytest.mark.unit
+class TestDecomposeQueryFeedback:
+    """Tests for feedback propagation in query decomposition (retry support)."""
+
+    def _create_mock_llm(self, result: DecomposedQueries) -> MagicMock:
+        mock_llm = MagicMock()
+        mock_structured_llm = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured_llm
+        mock_structured_llm.invoke.return_value = result
+        return mock_llm
+
+    @patch("dao_ai.tools.instructed_retriever._load_prompt_template")
+    @patch("dao_ai.tools.instructed_retriever.mlflow")
+    def test_previous_feedback_appended_to_prompt(
+        self, mock_mlflow: MagicMock, mock_load_prompt: MagicMock
+    ) -> None:
+        """Test that previous_feedback is appended to the decomposition prompt."""
+        mock_load_prompt.return_value = {
+            "template": "{current_time} {constraints} {examples} {max_subqueries} {query}"
+        }
+
+        decomposed = DecomposedQueries(
+            queries=[SearchQuery(text="adjusted query")]
+        )
+        mock_llm = self._create_mock_llm(decomposed)
+
+        decompose_query(
+            llm=mock_llm,
+            query="test query",
+            columns=[ColumnInfo(name="brand", type="string")],
+            previous_feedback="Brand filter was too restrictive",
+        )
+
+        # Verify the LLM was called with a prompt containing the feedback
+        structured_llm = mock_llm.with_structured_output.return_value
+        call_args = structured_llm.invoke.call_args
+        prompt_sent = call_args[0][0]
+        assert "Previous Attempt Feedback" in prompt_sent
+        assert "Brand filter was too restrictive" in prompt_sent
+
+    @patch("dao_ai.tools.instructed_retriever._load_prompt_template")
+    @patch("dao_ai.tools.instructed_retriever.mlflow")
+    def test_no_feedback_section_when_none(
+        self, mock_mlflow: MagicMock, mock_load_prompt: MagicMock
+    ) -> None:
+        """Test that no feedback section is added when previous_feedback is None."""
+        mock_load_prompt.return_value = {
+            "template": "{current_time} {constraints} {examples} {max_subqueries} {query}"
+        }
+
+        decomposed = DecomposedQueries(
+            queries=[SearchQuery(text="test")]
+        )
+        mock_llm = self._create_mock_llm(decomposed)
+
+        decompose_query(
+            llm=mock_llm,
+            query="test query",
+            columns=[ColumnInfo(name="brand", type="string")],
+            previous_feedback=None,
+        )
+
+        structured_llm = mock_llm.with_structured_output.return_value
+        call_args = structured_llm.invoke.call_args
+        prompt_sent = call_args[0][0]
+        assert "Previous Attempt Feedback" not in prompt_sent
+
+
 @pytest.mark.integration
 @pytest.mark.skipif(True, reason="Requires Databricks workspace and LLM endpoint")
 class TestInstructedRetrieverIntegration:

--- a/tests/dao_ai/test_vector_search_instructed.py
+++ b/tests/dao_ai/test_vector_search_instructed.py
@@ -1,0 +1,428 @@
+"""Integration tests for instructed retrieval control flow in vector_search.py.
+
+Tests the retry loop, empty-result fallback, and verification flow at the
+create_vector_search_tool / _vector_search_tool level with mocked dependencies.
+"""
+
+import json
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from conftest import add_databricks_resource_attrs
+from langchain_core.documents import Document
+
+from dao_ai.config import (
+    ColumnInfo,
+    DecompositionModel,
+    FilterItem,
+    InstructedRetrieverModel,
+    LLMModel,
+    RetrieverModel,
+    RouterModel,
+    SearchQuery,
+    VerificationResult,
+    VerifierModel,
+    VectorStoreModel,
+)
+
+# Shared test column definitions
+_TEST_COLUMNS = [
+    ColumnInfo(name="brand", type="string"),
+    ColumnInfo(name="text", type="string"),
+]
+
+
+def _create_mock_vector_store() -> Mock:
+    """Create a mock VectorStoreModel for tool creation."""
+    vector_store = Mock(spec=VectorStoreModel)
+    vector_store.columns = ["text"]
+    vector_store.embedding_model = None
+    vector_store.primary_key = "id"
+    vector_store.index = Mock()
+    vector_store.index.full_name = "catalog.schema.test_index"
+    vector_store.index.name = "test_index"
+    vector_store.index.columns = ["text"]
+    vector_store.endpoint = Mock()
+    vector_store.source_table = None
+    vector_store.embedding_source_column = None
+    vector_store.doc_uri = None
+    add_databricks_resource_attrs(vector_store)
+
+    # workspace_client_from returns a mock WorkspaceClient
+    mock_ws = MagicMock()
+    vector_store.workspace_client_from.return_value = mock_ws
+
+    return vector_store
+
+
+def _make_instructed(
+    llm_model: LLMModel,
+    verifier: VerifierModel | None = None,
+    router: RouterModel | None = None,
+    max_subqueries: int = 3,
+) -> InstructedRetrieverModel:
+    """Build an InstructedRetrieverModel with the new nested config structure."""
+    return InstructedRetrieverModel(
+        columns=_TEST_COLUMNS,
+        decomposition=DecompositionModel(
+            model=llm_model,
+            max_subqueries=max_subqueries,
+        ),
+        verifier=verifier,
+        router=router,
+    )
+
+
+@pytest.mark.unit
+class TestEmptyResultFallback:
+    """Tests that empty instructed retrieval results trigger standard search fallback."""
+
+    @patch("dao_ai.tools.vector_search.rrf_merge")
+    @patch("dao_ai.tools.vector_search.decompose_query")
+    @patch("dao_ai.tools.vector_search._get_cached_llm")
+    @patch("dao_ai.tools.vector_search.DatabricksVectorSearch")
+    def test_empty_merge_falls_back_to_standard_search(
+        self,
+        MockDVS,
+        mock_get_llm,
+        mock_decompose,
+        mock_rrf,
+    ):
+        """When rrf_merge returns empty, _execute_instructed_retrieval should
+        fall back to vs.similarity_search with base_filters only."""
+        vector_store = _create_mock_vector_store()
+        llm_model = LLMModel(name="test-decomp-model")
+        instructed = _make_instructed(llm_model, max_subqueries=2)
+        retriever = RetrieverModel(
+            vector_store=vector_store,
+            instructed=instructed,
+        )
+
+        # Setup mocks
+        mock_vs = MagicMock()
+        MockDVS.return_value = mock_vs
+        mock_get_llm.return_value = MagicMock()
+
+        # decompose returns subqueries, but rrf_merge returns empty
+        mock_decompose.return_value = [
+            SearchQuery(text="subquery1", filters=[FilterItem(key="brand", value="ACME")]),
+        ]
+        mock_rrf.return_value = []  # Empty merge result
+
+        # The fallback similarity_search should return something
+        fallback_docs = [Document(page_content="fallback result", metadata={"id": "1"})]
+        mock_vs.similarity_search.return_value = fallback_docs
+
+        from dao_ai.tools.vector_search import create_vector_search_tool
+
+        tool = create_vector_search_tool(retriever=retriever)
+        result_json = tool.invoke({"query": "test query"})
+        result = json.loads(result_json)
+
+        assert len(result) == 1
+        assert result[0]["page_content"] == "fallback result"
+
+        # similarity_search should have been called at least twice:
+        # once for the subquery execution, once for the fallback
+        # The fallback call should NOT include decomposed filters
+        calls = mock_vs.similarity_search.call_args_list
+        assert len(calls) >= 2
+        # Last call is the fallback — should use base_filters (empty), not decomposed filters
+        fallback_call = calls[-1]
+        # filter should be None or empty dict (no decomposed filters)
+        fallback_filter = fallback_call.kwargs.get("filter") or fallback_call[1].get("filter")
+        assert fallback_filter is None or fallback_filter == {}
+
+    @patch("dao_ai.tools.vector_search.rrf_merge")
+    @patch("dao_ai.tools.vector_search.decompose_query")
+    @patch("dao_ai.tools.vector_search._get_cached_llm")
+    @patch("dao_ai.tools.vector_search.DatabricksVectorSearch")
+    def test_nonempty_merge_does_not_fallback(
+        self,
+        MockDVS,
+        mock_get_llm,
+        mock_decompose,
+        mock_rrf,
+    ):
+        """When rrf_merge returns results, no fallback should occur."""
+        vector_store = _create_mock_vector_store()
+        llm_model = LLMModel(name="test-decomp-model")
+        instructed = _make_instructed(llm_model)
+        retriever = RetrieverModel(
+            vector_store=vector_store,
+            instructed=instructed,
+        )
+
+        mock_vs = MagicMock()
+        MockDVS.return_value = mock_vs
+        mock_get_llm.return_value = MagicMock()
+
+        mock_decompose.return_value = [SearchQuery(text="subquery1")]
+        merged_docs = [Document(page_content="merged result", metadata={"id": "1", "rrf_score": 0.5})]
+        mock_rrf.return_value = merged_docs
+
+        # This should NOT be called as fallback
+        mock_vs.similarity_search.return_value = [Document(page_content="standard", metadata={})]
+
+        from dao_ai.tools.vector_search import create_vector_search_tool
+
+        tool = create_vector_search_tool(retriever=retriever)
+        result_json = tool.invoke({"query": "test query"})
+        result = json.loads(result_json)
+
+        assert len(result) == 1
+        assert result[0]["page_content"] == "merged result"
+
+
+@pytest.mark.unit
+class TestVerificationRetryLoop:
+    """Tests that verification failure re-executes instructed search with feedback."""
+
+    @patch("dao_ai.tools.vector_search.verify_results")
+    @patch("dao_ai.tools.vector_search.rrf_merge")
+    @patch("dao_ai.tools.vector_search.decompose_query")
+    @patch("dao_ai.tools.vector_search._get_cached_llm")
+    @patch("dao_ai.tools.vector_search.DatabricksVectorSearch")
+    def test_retry_re_executes_search_with_feedback(
+        self,
+        MockDVS,
+        mock_get_llm,
+        mock_decompose,
+        mock_rrf,
+        mock_verify,
+    ):
+        """When verification fails and on_failure=retry, the tool should
+        re-execute instructed retrieval with previous_feedback from the verifier."""
+        vector_store = _create_mock_vector_store()
+        llm_model = LLMModel(name="test-model")
+        verifier = VerifierModel(
+            model=llm_model,
+            on_failure="retry",
+            max_retries=1,
+        )
+        instructed = _make_instructed(llm_model, verifier=verifier)
+        retriever = RetrieverModel(
+            vector_store=vector_store,
+            instructed=instructed,
+        )
+
+        mock_vs = MagicMock()
+        MockDVS.return_value = mock_vs
+        mock_get_llm.return_value = MagicMock()
+
+        # First decomposition returns initial results
+        first_docs = [Document(page_content="first attempt", metadata={"id": "1"})]
+        second_docs = [Document(page_content="second attempt", metadata={"id": "2"})]
+
+        mock_decompose.side_effect = [
+            [SearchQuery(text="initial query")],
+            [SearchQuery(text="adjusted query")],
+        ]
+        mock_rrf.side_effect = [first_docs, second_docs]
+        mock_vs.similarity_search.return_value = []
+
+        # First verification fails with feedback, second passes
+        mock_verify.side_effect = [
+            VerificationResult(
+                passed=False,
+                confidence=0.3,
+                feedback="Brand filter was too restrictive",
+            ),
+            VerificationResult(
+                passed=True,
+                confidence=0.9,
+            ),
+        ]
+
+        from dao_ai.tools.vector_search import create_vector_search_tool
+
+        tool = create_vector_search_tool(retriever=retriever)
+        result_json = tool.invoke({"query": "test query"})
+        result = json.loads(result_json)
+
+        # Should get second attempt results (after retry)
+        assert len(result) == 1
+        assert result[0]["page_content"] == "second attempt"
+
+        # decompose_query should have been called twice
+        assert mock_decompose.call_count == 2
+
+        # Second decompose call should include previous_feedback
+        second_call_kwargs = mock_decompose.call_args_list[1]
+        assert second_call_kwargs.kwargs.get("previous_feedback") == "Brand filter was too restrictive"
+
+        # verify_results should have been called twice
+        assert mock_verify.call_count == 2
+
+    @patch("dao_ai.tools.vector_search.verify_results")
+    @patch("dao_ai.tools.vector_search.rrf_merge")
+    @patch("dao_ai.tools.vector_search.decompose_query")
+    @patch("dao_ai.tools.vector_search._get_cached_llm")
+    @patch("dao_ai.tools.vector_search.DatabricksVectorSearch")
+    def test_warn_mode_does_not_retry(
+        self,
+        MockDVS,
+        mock_get_llm,
+        mock_decompose,
+        mock_rrf,
+        mock_verify,
+    ):
+        """When on_failure=warn, verification failure should annotate docs but not retry."""
+        vector_store = _create_mock_vector_store()
+        llm_model = LLMModel(name="test-model")
+        verifier = VerifierModel(
+            model=llm_model,
+            on_failure="warn",
+            max_retries=3,
+        )
+        instructed = _make_instructed(llm_model, verifier=verifier)
+        retriever = RetrieverModel(
+            vector_store=vector_store,
+            instructed=instructed,
+        )
+
+        mock_vs = MagicMock()
+        MockDVS.return_value = mock_vs
+        mock_get_llm.return_value = MagicMock()
+
+        docs = [Document(page_content="result", metadata={"id": "1"})]
+        mock_decompose.return_value = [SearchQuery(text="query")]
+        mock_rrf.return_value = docs
+
+        mock_verify.return_value = VerificationResult(
+            passed=False,
+            confidence=0.2,
+            feedback="Results don't match constraints",
+        )
+
+        from dao_ai.tools.vector_search import create_vector_search_tool
+
+        tool = create_vector_search_tool(retriever=retriever)
+        result_json = tool.invoke({"query": "test query"})
+        result = json.loads(result_json)
+
+        # decompose should only be called once (no retry)
+        assert mock_decompose.call_count == 1
+
+        # verify should only be called once
+        assert mock_verify.call_count == 1
+
+        # Result should contain verification metadata
+        assert result[0]["metadata"]["_verification_status"] == "failed"
+
+    @patch("dao_ai.tools.vector_search.verify_results")
+    @patch("dao_ai.tools.vector_search.rrf_merge")
+    @patch("dao_ai.tools.vector_search.decompose_query")
+    @patch("dao_ai.tools.vector_search._get_cached_llm")
+    @patch("dao_ai.tools.vector_search.DatabricksVectorSearch")
+    def test_retries_exhausted_annotates_docs(
+        self,
+        MockDVS,
+        mock_get_llm,
+        mock_decompose,
+        mock_rrf,
+        mock_verify,
+    ):
+        """When max_retries is exhausted, docs should be annotated with exhausted status."""
+        vector_store = _create_mock_vector_store()
+        llm_model = LLMModel(name="test-model")
+        verifier = VerifierModel(
+            model=llm_model,
+            on_failure="retry",
+            max_retries=1,
+        )
+        instructed = _make_instructed(llm_model, verifier=verifier)
+        retriever = RetrieverModel(
+            vector_store=vector_store,
+            instructed=instructed,
+        )
+
+        mock_vs = MagicMock()
+        MockDVS.return_value = mock_vs
+        mock_get_llm.return_value = MagicMock()
+
+        docs = [Document(page_content="result", metadata={"id": "1"})]
+        mock_decompose.return_value = [SearchQuery(text="query")]
+        mock_rrf.return_value = docs
+
+        # Verification always fails
+        mock_verify.return_value = VerificationResult(
+            passed=False,
+            confidence=0.1,
+            feedback="Still not matching",
+        )
+
+        from dao_ai.tools.vector_search import create_vector_search_tool
+
+        tool = create_vector_search_tool(retriever=retriever)
+        result_json = tool.invoke({"query": "test query"})
+        result = json.loads(result_json)
+
+        # decompose called twice: initial + 1 retry
+        assert mock_decompose.call_count == 2
+
+        # verify called twice: initial + after retry
+        assert mock_verify.call_count == 2
+
+        # Result should have exhausted verification status
+        assert result[0]["metadata"]["_verification_status"] == "exhausted"
+
+
+@pytest.mark.unit
+class TestStandardModeNoRetry:
+    """Tests that standard mode never retries verification, even when retry is configured."""
+
+    @patch("dao_ai.tools.vector_search.verify_results")
+    @patch("dao_ai.tools.vector_search._get_cached_llm")
+    @patch("dao_ai.tools.vector_search.DatabricksVectorSearch")
+    def test_standard_mode_does_not_retry_on_verification_failure(
+        self,
+        MockDVS,
+        mock_get_llm,
+        mock_verify,
+    ):
+        """When mode is standard, verification failure should annotate docs
+        but never retry — there is no decomposition to adjust."""
+        vector_store = _create_mock_vector_store()
+        llm_model = LLMModel(name="test-model")
+        verifier = VerifierModel(
+            model=llm_model,
+            on_failure="retry",
+            max_retries=3,
+        )
+        # Router with auto_bypass=False so verification actually runs in standard mode
+        router = RouterModel(auto_bypass=False)
+        instructed = _make_instructed(llm_model, verifier=verifier, router=router)
+        retriever = RetrieverModel(
+            vector_store=vector_store,
+            instructed=instructed,
+        )
+
+        mock_vs = MagicMock()
+        MockDVS.return_value = mock_vs
+        mock_get_llm.return_value = MagicMock()
+
+        docs = [Document(page_content="standard result", metadata={"id": "1"})]
+        mock_vs.similarity_search.return_value = docs
+
+        # Verification fails
+        mock_verify.return_value = VerificationResult(
+            passed=False,
+            confidence=0.2,
+            feedback="Results don't match constraints",
+        )
+
+        from dao_ai.tools.vector_search import create_vector_search_tool
+
+        tool = create_vector_search_tool(retriever=retriever)
+        result_json = tool.invoke({"query": "test query"})
+        result = json.loads(result_json)
+
+        # similarity_search should be called exactly once — no retry for standard mode
+        assert mock_vs.similarity_search.call_count == 1
+
+        # verify should be called exactly once
+        assert mock_verify.call_count == 1
+
+        # Result should be annotated as failed (not exhausted)
+        assert result[0]["metadata"]["_verification_status"] == "failed"


### PR DESCRIPTION
## Summary

- **Filter precedence**: `base_filters` were silently overwriting LLM-decomposed `sq_filters` due to wrong dict merge order (`{**sq_filters, **base_filters}`). Flipped to `{**base_filters, **sq_filters}` so decomposed filters take precedence.
- **Verification retry loop**: verification was re-checking the same documents without re-executing search. Moved verification out of `_apply_post_processing` and into the main tool function as a search+verify loop. On failure with `on_failure=retry`, the loop calls `_execute_instructed_retrieval` again with `previous_feedback` so decomposition produces adjusted subqueries/filters. Standard mode skips retry since there is no decomposition to adjust.

## Test plan

- [x] `pytest tests/dao_ai/test_vector_search_instructed.py -v` — 6 integration tests against `create_vector_search_tool()` covering retry re-execution with feedback, warn mode, retry exhaustion, empty-merge fallback, and standard-mode no-retry
- [x] `pytest tests/dao_ai/test_instructed_retriever.py -v` — helper-level tests for RRF merge edge cases and `decompose_query` feedback propagation
- [x] Full suite passes (74 passed, 2 skipped integration)