### PR TITLE
Apps deploy: serialize Python-built AppConfig to YAML before upload

### DIFF
--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Final, Sequence
 import mlflow
 import pandas as pd
 import sqlparse
+import yaml
 from databricks import agents
 from databricks.agents import PermissionLevel, set_permissions
 from databricks.sdk import WorkspaceClient
@@ -1024,55 +1025,65 @@ class DatabricksProvider(ServiceProvider):
                 scorer_count=len(registered_scorers),
             )
 
-        # Upload the configuration file to the workspace
+        # Upload the configuration file to the workspace.
+        #
+        # Three input shapes feed this step:
+        #   1. AppConfig.from_file(path, params={...}) — substituted text
+        #      is on config.rendered_yaml. Prefer that.
+        #   2. Legacy AppConfig.from_file callers without params= — fall
+        #      back to reading the raw source file from disk.
+        #   3. AppConfig built in pure Python — neither rendered_yaml nor
+        #      a source file exists, so serialize the in-memory model
+        #      back to YAML and ship that.
         source_config_path: str | None = config.source_config_path
-        if source_config_path:
-            # Read the config file and upload to workspace
-            config_file_name: str = "dao_ai.yaml"
-            workspace_config_path: str = f"{source_path}/{config_file_name}"
+        config_file_name: str = "dao_ai.yaml"
+        workspace_config_path: str = f"{source_path}/{config_file_name}"
 
-            logger.info(
-                "Uploading config file to workspace",
-                source=source_config_path,
-                destination=workspace_config_path,
-            )
-
-            # Prefer the rendered (parameter-substituted) YAML so the
-            # deployed app sees fully-resolved values. Fall back to the
-            # raw source file if rendering wasn't tracked (e.g. legacy
-            # callers that constructed AppConfig without from_file()).
-            rendered: str | None = config.rendered_yaml
-            if rendered is not None:
-                config_content: bytes = rendered.encode("utf-8")
-            else:
-                with open(source_config_path, "rb") as f:
-                    config_content = f.read()
-
-            # Clean the workspace directory to remove stale artifacts
-            # from previous deployments (old wheels, leftover src/, etc.)
-            try:
-                self.w.workspace.delete(source_path, recursive=True)
-            except Exception:
-                pass  # Directory may not exist yet
-            try:
-                self.w.workspace.mkdirs(source_path)
-            except Exception as e:
-                logger.debug(f"Directory may already exist: {e}")
-
-            # Upload the config file
-            self.w.workspace.upload(
-                path=workspace_config_path,
-                content=io.BytesIO(config_content),
-                format=ImportFormat.AUTO,
-                overwrite=True,
-            )
-            logger.info("Config file uploaded", path=workspace_config_path)
+        rendered: str | None = config.rendered_yaml
+        config_content: bytes
+        config_origin: str
+        if rendered is not None:
+            config_content = rendered.encode("utf-8")
+            config_origin = "rendered_yaml (parameter-substituted)"
+        elif source_config_path:
+            with open(source_config_path, "rb") as f:
+                config_content = f.read()
+            config_origin = f"source file {source_config_path}"
         else:
-            logger.warning(
-                "No source config path available. "
-                "Ensure DAO_AI_CONFIG_PATH is set in the app environment or "
-                "dao_ai.yaml exists in the app source directory."
+            # Python-built AppConfig: serialize the in-memory object.
+            config_dict: dict[str, Any] = config.model_dump(
+                mode="json", by_alias=True, exclude_none=True
             )
+            config_content = yaml.safe_dump(
+                config_dict, sort_keys=False, default_flow_style=False
+            ).encode("utf-8")
+            config_origin = "in-memory AppConfig (programmatic)"
+
+        logger.info(
+            "Uploading config file to workspace",
+            source=config_origin,
+            destination=workspace_config_path,
+        )
+
+        # Clean the workspace directory to remove stale artifacts from
+        # previous deployments (old wheels, leftover src/, etc.).
+        try:
+            self.w.workspace.delete(source_path, recursive=True)
+        except Exception:
+            pass  # Directory may not exist yet
+        try:
+            self.w.workspace.mkdirs(source_path)
+        except Exception as e:
+            logger.debug(f"Directory may already exist: {e}")
+
+        # Upload the config file
+        self.w.workspace.upload(
+            path=workspace_config_path,
+            content=io.BytesIO(config_content),
+            format=ImportFormat.AUTO,
+            overwrite=True,
+        )
+        logger.info("Config file uploaded", path=workspace_config_path)
 
         # Determine install command based on dev vs published mode.
         # Respect config.app.enable_chat_proxy (default True) so the deployed

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -724,6 +724,8 @@ def test_deploy_apps_agent_creates_new_app():
     mock_app.enable_chat_proxy = True
     mock_config.app = mock_app
     mock_config.source_config_path = None  # No config file to upload
+    mock_config.rendered_yaml = None
+    mock_config.model_dump.return_value = {"app": {"name": "test_app"}}
     mock_config.resources = None  # No resources (required for generate_app_resources)
     mock_config.agents = None
     mock_config.retrievers = None
@@ -807,6 +809,8 @@ def test_deploy_apps_agent_updates_existing_app():
     mock_app.enable_chat_proxy = True
     mock_config.app = mock_app
     mock_config.source_config_path = None  # No config file to upload
+    mock_config.rendered_yaml = None
+    mock_config.model_dump.return_value = {"app": {"name": "test_app"}}
     mock_config.resources = None  # No resources (required for generate_app_resources)
     mock_config.agents = None
     mock_config.retrievers = None
@@ -985,6 +989,84 @@ def test_deploy_apps_agent_falls_back_to_source_when_no_rendered_yaml(tmp_path):
     assert upload_calls
     uploaded_text = upload_calls[0].kwargs["content"].getvalue().decode("utf-8")
     assert uploaded_text == raw_yaml
+
+
+@pytest.mark.unit
+def test_deploy_apps_agent_serializes_python_built_config(tmp_path):
+    """When AppConfig has neither rendered_yaml nor a source file (i.e. it was
+    constructed entirely in Python), deploy_apps_agent should serialize the
+    in-memory model_dump back to YAML and upload that, instead of failing."""
+    import yaml as _yaml
+    from unittest.mock import MagicMock, patch
+
+    from databricks.sdk.service.apps import (
+        App,
+        AppDeployment,
+        AppDeploymentState,
+        ApplicationState,
+    )
+    from databricks.sdk.service.iam import User
+
+    from dao_ai.config import AppConfig, AppModel
+    from dao_ai.providers.databricks import DatabricksProvider
+
+    real_config = AppConfig()
+    assert real_config.source_config_path is None
+    assert real_config.rendered_yaml is None
+    expected_yaml = _yaml.safe_dump(
+        real_config.model_dump(mode="json", by_alias=True, exclude_none=True),
+        sort_keys=False,
+        default_flow_style=False,
+    )
+
+    mock_config = MagicMock(spec=AppConfig)
+    mock_app = MagicMock(spec=AppModel)
+    mock_app.name = "py-built"
+    mock_app.description = ""
+    mock_app.environment_vars = {}
+    mock_app.trace_location = None
+    mock_app.monitoring = None
+    mock_app.enable_chat_proxy = True
+    mock_config.app = mock_app
+    mock_config.source_config_path = None
+    mock_config.rendered_yaml = None
+    mock_config.model_dump.return_value = real_config.model_dump(
+        mode="json", by_alias=True, exclude_none=True
+    )
+    mock_config.resources = None
+    mock_config.agents = None
+    mock_config.retrievers = None
+
+    mock_existing_app = MagicMock(spec=App)
+    mock_existing_app.app_status = MagicMock(state=ApplicationState.RUNNING)
+    mock_deployment = MagicMock(spec=AppDeployment)
+    mock_deployment.status = MagicMock(state=AppDeploymentState.SUCCEEDED)
+    mock_user = MagicMock(spec=User, user_name="test.user@example.com")
+
+    with patch.object(DatabricksProvider, "__init__", return_value=None):
+        provider = DatabricksProvider()
+        provider.w = MagicMock()
+        provider.w.current_user.me.return_value = mock_user
+        with patch.object(
+            provider, "get_or_create_experiment", return_value=MagicMock(experiment_id="exp-1")
+        ):
+            provider.w.apps.get.return_value = mock_existing_app
+            provider.w.apps.deploy_and_wait.return_value = mock_deployment
+
+            provider.deploy_apps_agent(mock_config)
+
+    # The provider should have created the workspace dir and uploaded a YAML
+    # serialized from the in-memory model.
+    provider.w.workspace.mkdirs.assert_called()
+    upload_calls = [
+        c for c in provider.w.workspace.upload.call_args_list
+        if c.kwargs.get("path", "").endswith("dao_ai.yaml")
+    ]
+    assert upload_calls, "expected an upload of dao_ai.yaml even without a source file"
+    uploaded_text = upload_calls[0].kwargs["content"].getvalue().decode("utf-8")
+    # Round-trip equivalence: the uploaded YAML parses to the same dict
+    # the AppConfig.model_dump() would have produced.
+    assert _yaml.safe_load(uploaded_text) == _yaml.safe_load(expected_yaml)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

`deploy_apps_agent` previously gated the workspace upload on `config.source_config_path` -- when an `AppConfig` is constructed entirely in Python (no `from_file` call) `source_config_path` is `None`, so the upload step was skipped and the deploy then failed with `ResourceDoesNotExist` on the workspace folder:

```
ResourceDoesNotExist: The parent folder
(/Workspace/Users/<user>/apps/<app-name>) does not exist.
```

This blocked any workshop / library use of programmatic construction (`AppConfig(resources=..., agents=..., app=...)` then `config.deploy_agent(target=APPS)`) -- the same pattern the new L300 Lab 12 in the workshop demonstrates.

## Change

Restructure the upload step around three input shapes:

1. `config.rendered_yaml` is set (`from_file(..., params=...)`) — ship the substituted text. (PR #64, 0.1.59)
2. `source_config_path` is set but `rendered_yaml` is None — fall back to reading the source file. (legacy)
3. Neither is set (**new**) — serialize the in-memory model via `config.model_dump(mode="json", by_alias=True, exclude_none=True)` and `yaml.safe_dump` it.

In all three cases the workspace dir is created and a single `dao_ai.yaml` gets uploaded, so the rest of `deploy_apps_agent` is input-shape-agnostic.

## Test plan

- [x] New unit `test_deploy_apps_agent_serializes_python_built_config`: builds a real `AppConfig()` (no source, no rendered), runs `deploy_apps_agent` against a mocked `WorkspaceClient`, and asserts the uploaded YAML round-trips to the same dict that `model_dump` produced.
- [x] Updated `test_deploy_apps_agent_creates_new_app` + `test_deploy_apps_agent_updates_existing_app` to explicitly set `mock_config.rendered_yaml = None` and provide a `model_dump` return value, since their `MagicMock(spec=AppConfig)` previously short-circuited the upload via a truthy-by-default mock attribute.
- [x] `test_deploy_apps_agent_uploads_rendered_yaml` and `test_deploy_apps_agent_falls_back_to_source_when_no_rendered_yaml` from #64 still pass unchanged.
- [ ] End-to-end: deploy the workshop's `L300-advanced/lab-12-programmatic` notebook (pure-Python `AppConfig`) and confirm the resulting Databricks App boots cleanly.

This pull request and its description were written by Isaac.