### PR TITLE
Memory: use NOT_PROVIDED singleton in _LazyLakebaseStore.aput

### DIFF
--- a/src/dao_ai/memory/databricks.py
+++ b/src/dao_ai/memory/databricks.py
@@ -39,7 +39,15 @@ from langgraph.checkpoint.base import (
     CheckpointMetadata,
     CheckpointTuple,
 )
-from langgraph.store.base import BaseStore, Item, NotProvided, Op, Result, SearchItem
+from langgraph.store.base import (
+    NOT_PROVIDED,
+    BaseStore,
+    Item,
+    NotProvided,
+    Op,
+    Result,
+    SearchItem,
+)
 from loguru import logger
 from psycopg_pool import AsyncConnectionPool
 
@@ -245,8 +253,14 @@ class _LazyLakebaseStore(BaseStore):
         value: dict[str, Any],
         index: Literal[False] | list[str] | None = None,
         *,
-        ttl: float | None | NotProvided = NotProvided(),
+        ttl: float | None | NotProvided = NOT_PROVIDED,
     ) -> None:
+        # Use the langgraph NOT_PROVIDED singleton (not a new NotProvided()
+        # instance) so that the inner store's _ensure_ttl identity check
+        # `if ttl is NOT_PROVIDED` succeeds. Constructing a fresh instance
+        # here meant callers like langmem's manage_memory_tool would let
+        # NotProvided() escape into PutOp.ttl, which langgraph's postgres
+        # store then tried to `float()` and raised TypeError on.
         return await (await self._ensure()).aput(namespace, key, value, index, ttl=ttl)
 
     async def adelete(self, namespace: tuple[str, ...], key: str) -> None:

--- a/tests/dao_ai/test_memory_tools.py
+++ b/tests/dao_ai/test_memory_tools.py
@@ -213,3 +213,65 @@ class TestMemorySchemas:
     def test_resolve_schemas_unknown_raises(self) -> None:
         with pytest.raises(ValueError, match="Unknown memory schema 'nonexistent'"):
             resolve_schemas(["nonexistent"])
+
+
+class TestLazyLakebaseStoreTTLSentinel:
+    """Regression tests for the NotProvided/float() ttl bug.
+
+    See dao_ai.memory.databricks._LazyLakebaseStore.aput. langgraph's
+    _ensure_ttl uses an identity check (`if ttl is NOT_PROVIDED`) against
+    the langgraph singleton. If our wrapper defaults ttl to a fresh
+    NotProvided() instance, it isn't the singleton -- the identity check
+    fails, the new instance lands in PutOp.ttl, and the postgres store
+    tries to `float()` it.
+    """
+
+    @pytest.mark.unit
+    def test_aput_default_ttl_is_singleton(self) -> None:
+        """The default ttl on _LazyLakebaseStore.aput must be the langgraph
+        NOT_PROVIDED singleton, not a new NotProvided() instance."""
+        from inspect import signature
+
+        from langgraph.store.base import NOT_PROVIDED
+
+        from dao_ai.memory.databricks import _LazyLakebaseStore
+
+        sig = signature(_LazyLakebaseStore.aput)
+        ttl_param = sig.parameters["ttl"]
+        assert ttl_param.default is NOT_PROVIDED, (
+            "ttl default must be the langgraph NOT_PROVIDED singleton; otherwise "
+            "_ensure_ttl's identity check fails and NotProvided() leaks into PutOp"
+        )
+
+    @pytest.mark.unit
+    def test_aput_forwards_singleton_when_caller_omits_ttl(self) -> None:
+        """When a caller (e.g. langmem) calls aput() without specifying ttl,
+        the underlying store should receive the NOT_PROVIDED singleton -- not
+        a freshly-constructed NotProvided() instance."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from langgraph.store.base import NOT_PROVIDED
+
+        from dao_ai.memory.databricks import _LazyLakebaseStore
+
+        # Stub the inner store so we can capture the kwargs it receives.
+        inner = MagicMock()
+        inner.aput = AsyncMock(return_value=None)
+
+        # Bypass __init__ and inject the stub directly.
+        store = _LazyLakebaseStore.__new__(_LazyLakebaseStore)
+
+        async def _stub_ensure() -> object:
+            return inner
+
+        store._ensure = _stub_ensure  # type: ignore[attr-defined]
+
+        # Call aput WITHOUT specifying ttl, mirroring how langmem invokes it.
+        asyncio.run(store.aput(("ns",), "k", {"v": 1}))
+
+        inner.aput.assert_awaited_once()
+        forwarded_ttl = inner.aput.await_args.kwargs.get("ttl")
+        assert forwarded_ttl is NOT_PROVIDED, (
+            f"expected the NOT_PROVIDED singleton, got {forwarded_ttl!r} "
+            f"({type(forwarded_ttl).__name__})"
+        )


### PR DESCRIPTION
## Summary

When Lab 7's `support_assistant` calls the `manage_memory` tool to write a long-term memory entry without an explicit TTL, the deployed app raises:

```
TypeError: float() argument must be a string or a real number, not 'NotProvided'
  at langgraph/store/postgres/base.py: ttl_minutes = float(op.ttl)
```

The cause is **not** in langmem or langgraph -- it's a subtle sentinel-identity bug in this repo's `_LazyLakebaseStore.aput`.

## The flow

```
langmem 0.0.30 (knowledge/tools.py:298)
  store.aput(namespace, key, value)                         # no ttl arg
    -> _LazyLakebaseStore.aput
         ttl: float | None | NotProvided = NotProvided()   # FRESH instance
         -> inner.aput(..., ttl=<that fresh NotProvided>)
              -> AsyncBatchedBaseStore.aput
                   -> _ensure_ttl(self.ttl_config, ttl):
                          if ttl is NOT_PROVIDED:           # IDENTITY check
                              return None
                          return ttl                        # ← returns the fresh instance
                   -> PutOp(..., ttl=<NotProvided instance>)
                        -> AsyncPostgresStore._batch_put_ops
                              if op.ttl is not None:        # truthy + not None
                                  float(op.ttl)             # TypeError
```

langgraph's `_ensure_ttl` uses `if ttl is NOT_PROVIDED` -- an **identity** check against its own module-level singleton. By constructing a brand-new `NotProvided()` instance in our wrapper's default, we defeat that identity check, the sentinel never normalizes to `None`, and it leaks into `PutOp.ttl`.

## Change

Import the langgraph `NOT_PROVIDED` singleton and use it as the default:

```python
from langgraph.store.base import NOT_PROVIDED, NotProvided

async def aput(self, ..., *, ttl: float | None | NotProvided = NOT_PROVIDED) -> None:
    return await (await self._ensure()).aput(namespace, key, value, index, ttl=ttl)
```

The signature still types `ttl` as `float | None | NotProvided` so explicit callers can pass either form, but our default now matches what langgraph's identity check expects.

## Test plan

- [x] New unit `TestLazyLakebaseStoreTTLSentinel::test_aput_default_ttl_is_singleton`: the parameter default is the `NOT_PROVIDED` singleton.
- [x] New unit `TestLazyLakebaseStoreTTLSentinel::test_aput_forwards_singleton_when_caller_omits_ttl`: when a caller invokes `aput(...)` without specifying ttl, the inner store receives the singleton (not a fresh instance).
- [x] All 24 tests in `test_memory_tools.py` still pass.
- [ ] End-to-end: re-run the workshop's Lab 7 notebook (`L200-real-agents/lab-7-memory/`) and confirm the agent can write a memory + survive on a deployed app.

Repro from the workshop:

```python
config = AppConfig.from_file("support_assistant.yaml", params=params)
agent = config.as_graph()
await agent.ainvoke(
    {"messages": [{"role": "user", "content": "I'm Jordan. I'm getting 401 errors..."}]},
    config={"configurable": {"thread_id": "...", "user_id": "..."}},
)
# -> manage_memory tool fires -> TypeError before the fix
```

Sister PR pattern: same kind of "subtle thing that breaks a real workshop lab" as #64 (rendered_yaml) and #65 (Python-built deploy).

This pull request and its description were written by Isaac.