### PR TITLE
Swarm: reject deterministic handoff edges inside cycles at config load (Option A)

### DIFF
--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -4216,6 +4216,103 @@ class SwarmModel(BaseModel):
         ),
     )
 
+    @model_validator(mode="after")
+    def validate_no_deterministic_handoff_in_cycle(self) -> Self:
+        """Reject swarm configs where a deterministic edge participates in a cycle.
+
+        A deterministic handoff transfers control unconditionally on every
+        traversal. If any cycle in the handoff graph contains at least one
+        deterministic edge, the workflow can run forever -- the deterministic
+        edge guarantees re-entry, and the agentic edges that close the cycle
+        only need an LLM whose prompt occasionally fires the handoff tool to
+        keep the loop going.
+
+        This validator runs at config load time and rejects the pattern with
+        a clear cycle path so the user can break or reconfigure the cycle
+        before any compute is spent.
+
+        Allowed:
+          * No cycle (``A -det-> B`` with no path back to A).
+          * A cycle of all-agentic edges (LLMs can choose to terminate).
+
+        Rejected:
+          * Any cycle containing at least one deterministic edge.
+        """
+        if not self.handoffs:
+            return self
+
+        # Build edge list: list[(source_name, target_name, is_deterministic)]
+        edges: list[tuple[str, str, bool]] = []
+        for source, targets in self.handoffs.items():
+            if not targets:
+                continue
+            for entry in targets:
+                if isinstance(entry, HandoffRouteModel):
+                    target_obj = entry.agent
+                    is_det = entry.is_deterministic
+                else:
+                    target_obj = entry
+                    is_det = False
+                # Resolve AgentModel -> name; pass strings through.
+                target_name: str = (
+                    target_obj.name if hasattr(target_obj, "name") else str(target_obj)
+                )
+                # Skip self-references; they're handled (and rejected for
+                # deterministic) at swarm-build time, not here.
+                if target_name == source:
+                    continue
+                edges.append((source, target_name, is_det))
+
+        # Adjacency list keyed by source -> list[(target, is_deterministic)]
+        adj: dict[str, list[tuple[str, bool]]] = {}
+        for u, v, det in edges:
+            adj.setdefault(u, []).append((v, det))
+
+        # For each deterministic edge (u, v), is there a path v -> ... -> u?
+        # If yes, that path + the (u, v) edge forms a cycle containing a
+        # deterministic edge.
+        def find_path(start: str, goal: str) -> list[str] | None:
+            """BFS for any path from start to goal. Returns the node sequence
+            including endpoints, or None if no path exists."""
+            if start == goal:
+                return [start]
+            from collections import deque
+
+            queue: deque[tuple[str, list[str]]] = deque([(start, [start])])
+            visited: set[str] = {start}
+            while queue:
+                node, path = queue.popleft()
+                for nxt, _det in adj.get(node, []):
+                    if nxt == goal:
+                        return path + [nxt]
+                    if nxt not in visited:
+                        visited.add(nxt)
+                        queue.append((nxt, path + [nxt]))
+            return None
+
+        for u, v, det in edges:
+            if not det:
+                continue
+            return_path: list[str] | None = find_path(v, u)
+            if return_path is None:
+                continue
+            # Cycle = u -det-> v -> ... -> u. Format with edge annotations.
+            full_path: list[str] = [u] + return_path  # u -> v -> ... -> u
+            # Annotate the deterministic edge so the message is unambiguous.
+            edge_str = (
+                f"{u} =[deterministic]=> "
+                + " -> ".join(full_path[1:])
+            )
+            raise ValueError(
+                "Swarm has a deterministic handoff inside a cycle: "
+                f"{edge_str}. Deterministic edges fire unconditionally on every "
+                "traversal, so any path back to the source forms a runaway loop. "
+                "Either remove the return path or make the deterministic edge "
+                "agentic."
+            )
+
+        return self
+
 
 class OrchestrationModel(BaseModel):
     """Multi-agent orchestration configuration. Exactly one of supervisor or swarm must be specified."""

--- a/tests/dao_ai/test_deterministic_handoffs.py
+++ b/tests/dao_ai/test_deterministic_handoffs.py
@@ -894,3 +894,218 @@ class TestDeterministicHandoffValidation:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+# =============================================================================
+# Static Cycle Detection Unit Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSwarmDeterministicCycleDetection:
+    """Tests for the SwarmModel validator that rejects deterministic edges in cycles.
+
+    A deterministic edge fires unconditionally on every traversal. If any
+    cycle in the handoff graph contains at least one deterministic edge, the
+    workflow can run forever -- the loop is closed by the deterministic edge,
+    only the agentic edge needs an LLM whose prompt occasionally fires.
+    """
+
+    def test_two_node_det_then_agentic_cycle_rejected(self) -> None:
+        """A -[det]-> B -[agentic]-> A: minimal failing case."""
+        with pytest.raises(ValueError, match="deterministic handoff inside a cycle"):
+            SwarmModel(
+                handoffs={
+                    "a": [HandoffRouteModel(agent="b", is_deterministic=True)],
+                    "b": ["a"],
+                }
+            )
+
+    def test_two_node_all_deterministic_cycle_rejected(self) -> None:
+        """A -[det]-> B -[det]-> A: at-most-one-det-per-agent passes here
+        (each source has one), but the static cycle check catches it."""
+        with pytest.raises(ValueError, match="deterministic handoff inside a cycle"):
+            SwarmModel(
+                handoffs={
+                    "a": [HandoffRouteModel(agent="b", is_deterministic=True)],
+                    "b": [HandoffRouteModel(agent="a", is_deterministic=True)],
+                }
+            )
+
+    def test_three_hop_cycle_with_one_det_rejected(self) -> None:
+        """A -[det]-> B -[agentic]-> C -[agentic]-> A: longer cycle still loops."""
+        with pytest.raises(ValueError, match="deterministic handoff inside a cycle"):
+            SwarmModel(
+                handoffs={
+                    "a": [HandoffRouteModel(agent="b", is_deterministic=True)],
+                    "b": ["c"],
+                    "c": ["a"],
+                }
+            )
+
+    def test_all_agentic_cycle_allowed(self) -> None:
+        """A -[agentic]-> B -[agentic]-> A: LLMs can choose to terminate, so allowed."""
+        # Should not raise.
+        swarm = SwarmModel(handoffs={"a": ["b"], "b": ["a"]})
+        assert swarm.handoffs is not None
+
+    def test_three_node_all_agentic_cycle_allowed(self) -> None:
+        """All-agentic cycles of any size are allowed."""
+        swarm = SwarmModel(handoffs={"a": ["b"], "b": ["c"], "c": ["a"]})
+        assert swarm.handoffs is not None
+
+    def test_deterministic_edge_no_return_path_allowed(self) -> None:
+        """A -[det]-> B with no path B -> A is fine. No cycle, no loop."""
+        swarm = SwarmModel(
+            handoffs={
+                "a": [HandoffRouteModel(agent="b", is_deterministic=True)],
+                "b": [],
+            }
+        )
+        assert swarm.handoffs is not None
+
+    def test_chain_of_deterministic_edges_allowed(self) -> None:
+        """A -[det]-> B -[det]-> C with no return path: pipeline-style flow."""
+        swarm = SwarmModel(
+            handoffs={
+                "a": [HandoffRouteModel(agent="b", is_deterministic=True)],
+                "b": [HandoffRouteModel(agent="c", is_deterministic=True)],
+                "c": [],
+            }
+        )
+        assert swarm.handoffs is not None
+
+    def test_self_referencing_deterministic_handoff_ignored_by_cycle_check(
+        self,
+    ) -> None:
+        """A self-reference (A -[det]-> A) is a separate concern handled at
+        swarm-build time. The cycle validator skips self-references so the
+        existing 'no deterministic self-handoff' error path stays intact."""
+        # Should not raise here; the swarm-build path raises a different error.
+        swarm = SwarmModel(
+            handoffs={
+                "a": [HandoffRouteModel(agent="a", is_deterministic=True)],
+            }
+        )
+        assert swarm.handoffs is not None
+
+    def test_unrelated_cycle_does_not_taint_acyclic_det_edge(self) -> None:
+        """A separate all-agentic cycle in another component is fine when a
+        deterministic edge exists in an acyclic part of the graph."""
+        swarm = SwarmModel(
+            handoffs={
+                # acyclic deterministic edge
+                "a": [HandoffRouteModel(agent="b", is_deterministic=True)],
+                "b": [],
+                # separate all-agentic cycle
+                "x": ["y"],
+                "y": ["x"],
+            }
+        )
+        assert swarm.handoffs is not None
+
+    def test_error_message_includes_cycle_path(self) -> None:
+        """The error string should include the cycle so the user can see it."""
+        with pytest.raises(ValueError) as excinfo:
+            SwarmModel(
+                handoffs={
+                    "tier2": [
+                        HandoffRouteModel(agent="escalation", is_deterministic=True)
+                    ],
+                    "escalation": ["tier2"],
+                }
+            )
+        msg = str(excinfo.value)
+        assert "tier2" in msg
+        assert "escalation" in msg
+        assert "deterministic" in msg
+
+    def test_handoff_with_agent_model_target_in_cycle_rejected(self) -> None:
+        """Cycle detection works when handoff targets are AgentModel objects
+        (not just bare name strings)."""
+        agent_b = AgentModel(name="b", model=LLMModel(name="m"))
+        with pytest.raises(ValueError, match="deterministic handoff inside a cycle"):
+            SwarmModel(
+                handoffs={
+                    "a": [HandoffRouteModel(agent=agent_b, is_deterministic=True)],
+                    "b": ["a"],
+                }
+            )
+
+    def test_empty_handoffs_allowed(self) -> None:
+        """An empty or None handoffs map is trivially fine."""
+        SwarmModel(handoffs=None)
+        SwarmModel(handoffs={})
+        SwarmModel()
+
+
+# =============================================================================
+# End-to-end Cycle Detection Integration Test
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestSwarmCycleDetectionIntegration:
+    """End-to-end tests: load a full AppConfig with a buggy swarm config and
+    verify the validator fires before any compute is spent."""
+
+    def test_full_appconfig_with_det_in_cycle_rejects_at_load(self) -> None:
+        """Constructing an AppConfig that nests SwarmModel inside should
+        propagate the cycle-detection error -- no need to call as_graph()."""
+        agents = {
+            "tier1": AgentModel(name="tier1", model=LLMModel(name="m")),
+            "tier2": AgentModel(name="tier2", model=LLMModel(name="m")),
+            "escalation": AgentModel(name="escalation", model=LLMModel(name="m")),
+        }
+        config_dict = {
+            "agents": agents,
+            "app": {
+                "name": "tier-routing",
+                "deployment_target": "apps",
+                "agents": list(agents.values()),
+                "orchestration": {
+                    "swarm": {
+                        "default_agent": "tier1",
+                        "handoffs": {
+                            "tier1": ["tier2", "escalation"],
+                            "tier2": [
+                                {"agent": "escalation", "is_deterministic": True}
+                            ],
+                            "escalation": ["tier2"],
+                        },
+                    }
+                },
+            },
+        }
+        with pytest.raises(ValueError, match="deterministic handoff inside a cycle"):
+            AppConfig(**config_dict)
+
+    def test_full_appconfig_with_all_agentic_cycle_allowed(self) -> None:
+        """Same shape, but with all edges agentic -- must construct cleanly."""
+        agents = {
+            "tier1": AgentModel(name="tier1", model=LLMModel(name="m")),
+            "tier2": AgentModel(name="tier2", model=LLMModel(name="m")),
+            "escalation": AgentModel(name="escalation", model=LLMModel(name="m")),
+        }
+        config_dict = {
+            "agents": agents,
+            "app": {
+                "name": "tier-routing",
+                "deployment_target": "apps",
+                "agents": list(agents.values()),
+                "orchestration": {
+                    "swarm": {
+                        "default_agent": "tier1",
+                        "handoffs": {
+                            "tier1": ["tier2", "escalation"],
+                            "tier2": ["escalation"],
+                            "escalation": ["tier2"],
+                        },
+                    }
+                },
+            },
+        }
+        config = AppConfig(**config_dict)
+        assert config.app is not None
+        assert config.app.orchestration is not None
+        assert config.app.orchestration.swarm is not None


### PR DESCRIPTION
## Summary

Implements **Option A** of the cycle-detection investigation tracked in the workshop's vault note (`SSA-brain/40-reference/dao-ai-deterministic-handoff-loop.md`): a `SwarmModel.@model_validator` that fails fast at config load when any deterministic handoff edge participates in a cycle.

### The bug it prevents

A deterministic handoff transfers control unconditionally on every traversal. If any cycle in the handoff graph contains at least one deterministic edge, the workflow can run forever -- the deterministic edge guarantees re-entry, and the agentic edges that close the cycle only need an LLM whose prompt occasionally fires the handoff tool to keep the loop going.

Real-world repro from `dao-ai-workshop` Lab 9: `tier2 -[deterministic]-> escalation` + agentic `escalation -> tier2`. The escalation prompt said *"If the customer needs a technical diagnostic, hand off to tier-2"* -- for any technical-flavored conversation, the LLM kept invoking that handoff. The deterministic edge then immediately routed back to escalation. The workflow ran 26+ minutes without progress before being cancelled.

### Why static is the right fix

Three categories of cycles:

| Cycle type | Outcome |
|---|---|
| All-deterministic | Infinite tight loop, no LLM intervention. Existing per-source "at most one deterministic" check **doesn't** catch a 2-cycle (each source has one). |
| **At least one deterministic edge** | The buggy case. Hides behind LLM "judgment" until you realize the prompt actually does keep firing the handoff. Burns tokens slowly. |
| All-agentic | Generally terminates -- each LLM has full agency to stop handing off. Permitted. |

A deterministic edge participating in a cycle is almost always a config bug -- it's hard to construct a legitimate use case for it. Failing fast at validation time saves debugging the runaway workflow, gives a clear error message with the cycle path, and is microseconds to compute.

## Change

`SwarmModel.validate_no_deterministic_handoff_in_cycle`:

1. Builds an edge list from `self.handoffs` (resolves `AgentModel` / `HandoffRouteModel` / bare string entries uniformly).
2. For each deterministic edge `(u, v)`, BFS the rest of the graph for any path `v -> ... -> u`.
3. If a return path exists, raises `ValueError` with the cycle path.

Self-references skip the cycle check because they're handled separately at swarm-build time (existing different error path, separate concern).

## Test plan

51 / 51 tests pass under `tests/dao_ai/test_deterministic_handoffs.py`.

New `TestSwarmDeterministicCycleDetection` unit suite:
- [x] Two-node `A -det-> B -agentic-> A` rejected
- [x] Two-node `A -det-> B -det-> A` rejected (the per-source check misses this)
- [x] Three-hop `A -det-> B -agentic-> C -agentic-> A` rejected
- [x] All-agentic 2-cycle allowed
- [x] All-agentic 3-cycle allowed
- [x] `A -det-> B` with no return path allowed
- [x] Deterministic chain `A -det-> B -det-> C` (no return) allowed
- [x] Self-referencing det handoff skipped here (handled at build time)
- [x] Unrelated cycle in another component doesn't taint an acyclic det edge
- [x] Error message includes the cycle path
- [x] `HandoffRouteModel.agent` as `AgentModel` object (not just string)
- [x] Empty / `None` / missing `handoffs` allowed

New `TestSwarmCycleDetectionIntegration`:
- [x] Full `AppConfig(...)` construction with a buggy nested swarm raises at load
- [x] Same shape with all-agentic edges constructs cleanly

This pull request and its description were written by Isaac.