### PR TITLE
Lakebase: emit DatabricksLakebase / AppResourceDatabase resources for both deploy targets

### DIFF
--- a/src/dao_ai/apps/resources.py
+++ b/src/dao_ai/apps/resources.py
@@ -121,7 +121,9 @@ VALID_USER_API_SCOPES: set[str] = {
 # deliberately omitted and fall through to the no-op branch in
 # generate_user_api_scopes:
 #   - "apps.apps"                      (DatabricksAppModel — no cross-app OBO)
-#   - "postgres" / "database.database-instances"  (Lakebase — no OBO scope)
+#   - "postgres" / "database.database-instances"  (Lakebase — no OBO scope;
+#     non-OBO SP access is granted via the AppResourceDatabase resource
+#     binding emitted by _extract_database_resources)
 #   - "mcp.genie" / "mcp.functions" / "mcp.vectorsearch" / "mcp.external"
 #     (MCP resource scopes; OBO falls back to the underlying Databricks
 #      scopes on the same resource, e.g. catalog.connections +
@@ -336,10 +338,36 @@ def _extract_database_resources(
 ) -> list[dict[str, Any]]:
     """Extract Lakebase database resources from DatabaseModels.
 
-    Autoscaling Lakebase uses the ``postgres`` API scope and does not
-    register as a database instance resource, so this always returns empty.
+    When a Lakebase database is registered as an App resource, the
+    Databricks Apps platform grants the app's auto-generated service
+    principal ``CAN_CONNECT_AND_CREATE`` on that database instance --
+    no pre-created SP or secret-scope wiring needed.
+
+    Standalone PostgreSQL connections (``host:`` set, no ``project:``)
+    have no Databricks-managed resource binding and are skipped here.
+    OBO databases are skipped too -- the user identity handles
+    permissions via ``user_api_scopes``.
     """
-    return []
+    resources: list[dict[str, Any]] = []
+    for key, db in databases.items():
+        if not db.is_lakebase:
+            continue
+        if db.on_behalf_of_user:
+            continue
+        sanitized_name: str = _sanitize_resource_name(key)
+        resource: dict[str, Any] = {
+            "name": sanitized_name,
+            "type": "database",
+            "instance_name": db.project,
+            "database_name": db.name or db.project,
+            "permissions": [{"level": p} for p in DEFAULT_PERMISSIONS["database"]],
+        }
+        resources.append(resource)
+        logger.debug(
+            f"Extracted Lakebase database resource: {sanitized_name} -> "
+            f"instance={db.project} database={db.name or db.project}"
+        )
+    return resources
 
 
 def _extract_app_resources(
@@ -773,10 +801,35 @@ def _extract_sdk_database_resources(
 ) -> list[AppResource]:
     """Extract SDK AppResource objects for Lakebase databases.
 
-    Autoscaling Lakebase uses the ``postgres`` API scope and does not
-    register as a database instance resource, so this always returns empty.
+    Mirror of ``_extract_database_resources`` for SDK-format deploys.
+    Standalone PostgreSQL and OBO databases are skipped.
     """
-    return []
+    from databricks.sdk.service.apps import (
+        AppResourceDatabase,
+        AppResourceDatabaseDatabasePermission,
+    )
+
+    resources: list[AppResource] = []
+    for key, db in databases.items():
+        if not db.is_lakebase:
+            continue
+        if db.on_behalf_of_user:
+            continue
+        sanitized_name: str = _sanitize_resource_name(key)
+        resource = AppResource(
+            name=sanitized_name,
+            database=AppResourceDatabase(
+                instance_name=db.project,
+                database_name=db.name or db.project,
+                permission=AppResourceDatabaseDatabasePermission.CAN_CONNECT_AND_CREATE,
+            ),
+        )
+        resources.append(resource)
+        logger.debug(
+            f"Extracted SDK Lakebase database resource: {sanitized_name} -> "
+            f"instance={db.project} database={db.name or db.project}"
+        )
+    return resources
 
 
 def _extract_sdk_volume_resources(

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -70,6 +70,7 @@ from mlflow.models.resources import (
     DatabricksApp,
     DatabricksFunction,
     DatabricksGenieSpace,
+    DatabricksLakebase,
     DatabricksResource,
     DatabricksServingEndpoint,
     DatabricksSQLWarehouse,
@@ -1896,8 +1897,17 @@ class DatabaseModel(IsDatabricksResource):
         return self.is_lakebase
 
     def as_resources(self) -> Sequence[DatabricksResource]:
-        # Autoscaling Lakebase uses the "postgres" API scope and does not
-        # register as a database instance resource.
+        # Lakebase databases register as DatabricksLakebase resources so the
+        # deploying agent (Model Serving SystemAuthPolicy or Databricks Apps
+        # auto-SP) gets CAN_CONNECT_AND_CREATE on the instance. Standalone
+        # PostgreSQL hosts have no Databricks-managed resource binding.
+        if self.is_lakebase and self.project:
+            return [
+                DatabricksLakebase(
+                    database_instance_name=self.project,
+                    on_behalf_of_user=self.on_behalf_of_user,
+                )
+            ]
         return []
 
     @model_validator(mode="after")

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -1569,18 +1569,23 @@ def test_database_model_workspace_client_oauth_uses_databricks_host_env():
 
 @pytest.mark.unit
 def test_database_model_as_resources_lakebase():
-    """Test DatabaseModel.as_resources returns empty list for Lakebase.
+    """DatabaseModel.as_resources returns a DatabricksLakebase resource for
+    Lakebase databases so the deploying agent (Model Serving SystemAuthPolicy
+    or Databricks Apps auto-SP) gets CAN_CONNECT_AND_CREATE on the instance.
 
-    Lakebase uses the 'postgres' API scope and does not register
-    as a database instance resource.
+    See tests/dao_ai/test_lakebase_app_resources.py for the broader suite.
     """
+    from mlflow.models.resources import DatabricksLakebase
+
     db = DatabaseModel(
         name="test-db",
         project="test-db",
     )
     assert db.is_lakebase is True
-    resources = db.as_resources()
-    assert len(resources) == 0
+    resources = list(db.as_resources())
+    assert len(resources) == 1
+    assert isinstance(resources[0], DatabricksLakebase)
+    assert resources[0].to_dict()["lakebase"][0]["name"] == "test-db"
     assert db.api_scopes == ["postgres"]
 
 

--- a/tests/dao_ai/test_lakebase_app_resources.py
+++ b/tests/dao_ai/test_lakebase_app_resources.py
@@ -1,0 +1,354 @@
+"""
+Tests for Lakebase database resource extraction across both deployment paths.
+
+When a Lakebase database is configured, the deploying agent should declare
+it as a Databricks resource so the platform grants the deployment's identity
+``CAN_CONNECT_AND_CREATE`` on the Lakebase instance:
+
+- **Model Serving** (``deploy_model_serving_agent``): the model is logged
+  with a ``SystemAuthPolicy`` whose ``resources`` list comes from each
+  resource model's ``as_resources()`` method. ``DatabaseModel.as_resources()``
+  must return a ``DatabricksLakebase`` resource for Lakebase configurations.
+
+- **Databricks Apps** (``deploy_apps_agent``): the deployed ``app.yaml``
+  enumerates resources via ``generate_app_resources()`` (flat-dict format
+  consumed by the bundle generator) and ``generate_sdk_resources()``
+  (SDK ``AppResource`` objects consumed by the direct-deploy path).
+  Both must include a ``database`` resource for each Lakebase.
+
+OBO databases are skipped at extraction time -- the user identity handles
+permissions via ``user_api_scopes`` instead.
+
+Standalone PostgreSQL connections (``host:`` set, no ``project:``) have no
+Databricks-managed resource binding and are also skipped.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# =============================================================================
+# DatabaseModel.as_resources() -- model serving SystemAuthPolicy path
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestDatabaseModelAsResources:
+    """``DatabaseModel.as_resources()`` feeds Model Serving's SystemAuthPolicy."""
+
+    def test_lakebase_non_obo_returns_lakebase_resource(self) -> None:
+        from mlflow.models.resources import DatabricksLakebase
+
+        from dao_ai.config import DatabaseModel
+
+        db = DatabaseModel(name="retail-consumer-goods", project="retail-consumer-goods")
+        resources = list(db.as_resources())
+        assert len(resources) == 1
+        r = resources[0]
+        assert isinstance(r, DatabricksLakebase)
+        # to_dict produces the MLflow-resources YAML shape used in the model package
+        d = r.to_dict()
+        assert "lakebase" in d
+        assert d["lakebase"][0]["name"] == "retail-consumer-goods"
+        assert d["lakebase"][0]["on_behalf_of_user"] is False
+
+    def test_lakebase_obo_carries_on_behalf_of_user_true(self) -> None:
+        from dao_ai.config import DatabaseModel
+
+        db = DatabaseModel(
+            name="x", project="x", on_behalf_of_user=True
+        )
+        resources = list(db.as_resources())
+        assert len(resources) == 1
+        d = resources[0].to_dict()
+        assert d["lakebase"][0]["on_behalf_of_user"] is True
+
+    def test_standalone_postgres_returns_empty(self) -> None:
+        """Non-Lakebase PG has no Databricks-managed resource binding."""
+        from dao_ai.config import DatabaseModel
+
+        # PG requires explicit auth -- supply a PAT to satisfy validation.
+        db = DatabaseModel(
+            name="pg",
+            host="pg.example.com",
+            user="me",
+        )
+        assert db.is_lakebase is False
+        assert list(db.as_resources()) == []
+
+    def test_lakebase_resource_uses_project_as_instance_name(self) -> None:
+        """``DatabricksLakebase.database_instance_name`` is the project field,
+        not the freeform ``name`` (which can differ for Lakebase logical names)."""
+        from dao_ai.config import DatabaseModel
+
+        db = DatabaseModel(name="logical-name", project="instance-actual")
+        d = list(db.as_resources())[0].to_dict()
+        assert d["lakebase"][0]["name"] == "instance-actual"
+
+
+# =============================================================================
+# _extract_database_resources -- flat-dict format consumed by app.yaml bundle gen
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestExtractDatabaseResourcesFlat:
+    """Flat-dict extractor used when generating ``app.yaml`` for the bundle."""
+
+    def test_lakebase_non_obo_emits_database_resource(self) -> None:
+        from dao_ai.apps.resources import _extract_database_resources
+        from dao_ai.config import DatabaseModel
+
+        db = DatabaseModel(name="retail-consumer-goods", project="retail-consumer-goods")
+        out = _extract_database_resources({"workshop_db": db})
+        assert len(out) == 1
+        r = out[0]
+        assert r["type"] == "database"
+        assert r["name"] == "workshop_db"
+        assert r["instance_name"] == "retail-consumer-goods"
+        assert r["database_name"] == "retail-consumer-goods"
+        assert r["permissions"] == [{"level": "CAN_CONNECT_AND_CREATE"}]
+
+    def test_lakebase_obo_skipped(self) -> None:
+        from dao_ai.apps.resources import _extract_database_resources
+        from dao_ai.config import DatabaseModel
+
+        db = DatabaseModel(name="x", project="x", on_behalf_of_user=True)
+        assert _extract_database_resources({"k": db}) == []
+
+    def test_standalone_postgres_skipped(self) -> None:
+        from dao_ai.apps.resources import _extract_database_resources
+        from dao_ai.config import DatabaseModel
+
+        db = DatabaseModel(
+            name="pg",
+            host="pg.example.com",
+            user="me",
+        )
+        assert _extract_database_resources({"k": db}) == []
+
+    def test_database_name_falls_back_to_project_when_name_omitted(self) -> None:
+        """Lakebase ``name`` defaults to ``project`` per DatabaseModel; the
+        extractor preserves that even if the inputs were partial."""
+        from dao_ai.apps.resources import _extract_database_resources
+        from dao_ai.config import DatabaseModel
+
+        db = DatabaseModel(project="project-only")
+        out = _extract_database_resources({"k": db})
+        assert out[0]["instance_name"] == "project-only"
+        assert out[0]["database_name"] == "project-only"
+
+    def test_resource_name_is_sanitized(self) -> None:
+        """Underscores and other punctuation in the YAML key get sanitized
+        for Databricks resource-name rules (matches volumes/tables behavior)."""
+        from dao_ai.apps.resources import _extract_database_resources
+        from dao_ai.config import DatabaseModel
+
+        db = DatabaseModel(name="x", project="x")
+        out = _extract_database_resources({"workshop_DB.shared": db})
+        # Whatever sanitization rule is applied, the result should be a single
+        # entry with a non-empty 'name' that's safe to use as a resource id.
+        assert len(out) == 1
+        assert out[0]["name"]
+        assert "/" not in out[0]["name"]
+
+    def test_multiple_lakebases_each_get_a_resource(self) -> None:
+        from dao_ai.apps.resources import _extract_database_resources
+        from dao_ai.config import DatabaseModel
+
+        out = _extract_database_resources(
+            {
+                "memory_db": DatabaseModel(project="p1"),
+                "checkpoints_db": DatabaseModel(project="p2"),
+            }
+        )
+        assert {r["instance_name"] for r in out} == {"p1", "p2"}
+
+    def test_empty_dict_returns_empty(self) -> None:
+        from dao_ai.apps.resources import _extract_database_resources
+
+        assert _extract_database_resources({}) == []
+
+
+# =============================================================================
+# _extract_sdk_database_resources -- SDK AppResource format for direct deploy
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestExtractDatabaseResourcesSDK:
+    """SDK ``AppResource`` extractor used by the direct-deploy path."""
+
+    def test_lakebase_non_obo_emits_appresource_database(self) -> None:
+        from databricks.sdk.service.apps import (
+            AppResource,
+            AppResourceDatabase,
+            AppResourceDatabaseDatabasePermission,
+        )
+
+        from dao_ai.apps.resources import _extract_sdk_database_resources
+        from dao_ai.config import DatabaseModel
+
+        db = DatabaseModel(name="retail-consumer-goods", project="retail-consumer-goods")
+        out = _extract_sdk_database_resources({"workshop_db": db})
+        assert len(out) == 1
+        r = out[0]
+        assert isinstance(r, AppResource)
+        assert isinstance(r.database, AppResourceDatabase)
+        assert r.database.instance_name == "retail-consumer-goods"
+        assert r.database.database_name == "retail-consumer-goods"
+        assert (
+            r.database.permission
+            is AppResourceDatabaseDatabasePermission.CAN_CONNECT_AND_CREATE
+        )
+
+    def test_lakebase_obo_skipped(self) -> None:
+        from dao_ai.apps.resources import _extract_sdk_database_resources
+        from dao_ai.config import DatabaseModel
+
+        db = DatabaseModel(name="x", project="x", on_behalf_of_user=True)
+        assert _extract_sdk_database_resources({"k": db}) == []
+
+    def test_standalone_postgres_skipped(self) -> None:
+        from dao_ai.apps.resources import _extract_sdk_database_resources
+        from dao_ai.config import DatabaseModel
+
+        db = DatabaseModel(
+            name="pg",
+            host="pg.example.com",
+            user="me",
+        )
+        assert _extract_sdk_database_resources({"k": db}) == []
+
+
+# =============================================================================
+# Integration: full generate_app_resources / generate_sdk_resources
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestAppResourcesIntegration:
+    """End-to-end: a config with a Lakebase + an LLM produces both resource
+    types in the right output formats."""
+
+    def _build_config(self, *, on_behalf_of_user: bool = False):
+        from dao_ai.config import (
+            AgentModel,
+            AppConfig,
+            AppModel,
+            DatabaseModel,
+            DeploymentTarget,
+            LLMModel,
+            ResourcesModel,
+        )
+
+        llm = LLMModel(name="databricks-claude-sonnet-4-5")
+        db = DatabaseModel(
+            name="workshop-db",
+            project="workshop-db",
+            on_behalf_of_user=on_behalf_of_user,
+        )
+        agent = AgentModel(name="a", model=llm)
+        return AppConfig(
+            resources=ResourcesModel(
+                llms={"default_llm": llm},
+                databases={"workshop_db": db},
+            ),
+            agents={"a": agent},
+            app=AppModel(
+                name="lakebase-test",
+                deployment_target=DeploymentTarget.APPS,
+                agents=[agent],
+            ),
+        )
+
+    def test_flat_app_resources_contain_database_alongside_llm(self) -> None:
+        from dao_ai.apps.resources import generate_app_resources
+
+        resources = generate_app_resources(self._build_config())
+        types = {r["type"] for r in resources}
+        assert "serving-endpoint" in types
+        assert "database" in types
+        # The database resource has the right shape
+        db_r = next(r for r in resources if r["type"] == "database")
+        assert db_r["instance_name"] == "workshop-db"
+        assert db_r["permissions"] == [{"level": "CAN_CONNECT_AND_CREATE"}]
+
+    def test_flat_app_resources_skips_database_when_obo(self) -> None:
+        from dao_ai.apps.resources import generate_app_resources
+
+        resources = generate_app_resources(self._build_config(on_behalf_of_user=True))
+        types = {r["type"] for r in resources}
+        assert "database" not in types
+
+    def test_sdk_app_resources_contain_appresourcedatabase(self) -> None:
+        from databricks.sdk.service.apps import AppResource, AppResourceDatabase
+
+        from dao_ai.apps.resources import generate_sdk_resources
+
+        resources = generate_sdk_resources(self._build_config())
+        db_resources = [
+            r for r in resources
+            if isinstance(r, AppResource) and r.database is not None
+        ]
+        assert len(db_resources) == 1
+        assert isinstance(db_resources[0].database, AppResourceDatabase)
+        assert db_resources[0].database.instance_name == "workshop-db"
+
+    def test_sdk_app_resources_skips_database_when_obo(self) -> None:
+        from databricks.sdk.service.apps import AppResource
+
+        from dao_ai.apps.resources import generate_sdk_resources
+
+        resources = generate_sdk_resources(self._build_config(on_behalf_of_user=True))
+        db_resources = [
+            r for r in resources
+            if isinstance(r, AppResource) and r.database is not None
+        ]
+        assert db_resources == []
+
+
+# =============================================================================
+# Integration: model-serving system_resources path picks up the Lakebase
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestModelServingSystemResources:
+    """The ``deploy_model_serving_agent`` path collects ``as_resources()``
+    from each resource model into a SystemAuthPolicy. Confirm that path
+    surfaces a Lakebase database for Model Serving deploys."""
+
+    def test_lakebase_appears_in_as_resources_aggregate(self) -> None:
+        """Reproduce the aggregation step of deploy_model_serving_agent."""
+        from mlflow.models.resources import DatabricksLakebase
+
+        from dao_ai.config import DatabaseModel, LLMModel
+
+        llm = LLMModel(name="databricks-claude-sonnet-4-5")
+        db = DatabaseModel(name="x", project="x")
+
+        all_resources = []
+        for r in [llm, db]:
+            all_resources.extend(r.as_resources())
+
+        # Database resource is present
+        lakebase_resources = [
+            r for r in all_resources if isinstance(r, DatabricksLakebase)
+        ]
+        assert len(lakebase_resources) == 1
+        # The non-OBO database goes into the SystemAuthPolicy filter
+        # (the deploy path filters out on_behalf_of_user=True resources)
+        system_resources = [r for r in all_resources if not r.on_behalf_of_user]
+        assert any(isinstance(r, DatabricksLakebase) for r in system_resources)
+
+    def test_obo_lakebase_excluded_from_system_resources(self) -> None:
+        from mlflow.models.resources import DatabricksLakebase
+
+        from dao_ai.config import DatabaseModel
+
+        db = DatabaseModel(name="x", project="x", on_behalf_of_user=True)
+        resources = list(db.as_resources())
+        system_resources = [r for r in resources if not r.on_behalf_of_user]
+        assert all(not isinstance(r, DatabricksLakebase) for r in system_resources)


### PR DESCRIPTION
## Summary

Lakebase databases were being silently dropped from the deploying agent's resource list -- in both the **Model Serving** SystemAuthPolicy *and* the **Databricks Apps** app.yaml. The stale comments in `DatabaseModel.as_resources()` and `_extract_*_database_resources` said *"Lakebase does not register as a database instance resource"*, but the SDK and MLflow resources both expose a Lakebase binding:

- `mlflow.models.resources.DatabricksLakebase(database_instance_name, on_behalf_of_user)`
- `databricks.sdk.service.apps.AppResourceDatabase(instance_name, database_name, permission=CAN_CONNECT_AND_CREATE)`

Registering either lets the Apps platform / Model Serving grant the auto-generated identity `CAN_CONNECT_AND_CREATE` on the Lakebase instance -- no pre-created service principal, no manual secret-scope wiring. Without this, the workshop's Lab 7 (and any other Lakebase-using config) had to fall back to client_id/client_secret variables on the database (the sporting_goods pattern), which required per-workspace ops setup.

## Change

Three sites:

1. `dao_ai.config.DatabaseModel.as_resources()` -- now returns `[DatabricksLakebase(...)]` for Lakebase, propagating `on_behalf_of_user` so the deploy_model_serving_agent path's "filter system_resources" step keeps non-OBO Lakebase in `SystemAuthPolicy.resources`.
2. `dao_ai.apps.resources._extract_database_resources(databases)` -- emits flat-dict `{type: "database", instance_name, database_name, permissions: [CAN_CONNECT_AND_CREATE]}` for non-OBO Lakebase.
3. `dao_ai.apps.resources._extract_sdk_database_resources(databases)` -- emits `AppResource(database=AppResourceDatabase(..., permission=CAN_CONNECT_AND_CREATE))` for non-OBO Lakebase.

Standalone PostgreSQL connections (no `project:`) and OBO databases continue to be skipped at extraction. The OBO path uses `user_api_scopes` (the existing `postgres` scope handling is unchanged).

## Test plan

20 new tests in `tests/dao_ai/test_lakebase_app_resources.py`:

- `TestDatabaseModelAsResources` -- model-serving path
- `TestExtractDatabaseResourcesFlat` -- app.yaml bundle path
- `TestExtractDatabaseResourcesSDK` -- direct-deploy AppResource path
- `TestAppResourcesIntegration` -- end-to-end through `generate_app_resources` + `generate_sdk_resources` (with both non-OBO and OBO permutations)
- `TestModelServingSystemResources` -- reproduces `deploy_model_serving_agent`'s aggregation + OBO filter

The existing `test_database_model_as_resources_lakebase` (which asserted the previous-behavior empty list) is updated to reflect the new contract.

```
tests/dao_ai/test_lakebase_app_resources.py        20 passed
tests/dao_ai/test_databricks.py                    72 passed (1 skipped)
tests/dao_ai/test_memory_tools.py                  24 passed
tests/dao_ai/test_deterministic_handoffs.py        51 passed
                                            ---
                                            167 passed, 1 skipped
```

Pending end-to-end live verification: deploy the workshop's `L200-real-agents/lab-7-memory/` notebook against a real Lakebase instance and confirm the deployed app's auto-SP can connect without manual secret-scope wiring.

This pull request and its description were written by Isaac.