### PR TITLE
Lakebase: use AppResourcePostgres for autoscaling projects, not AppResourceDatabase

### DIFF
--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -37,6 +37,7 @@ _BUNDLE_RESOURCE_CONVERTERS: dict[str, str] = {
     "genie-space": "genie_space",
     "secret": "secret",
     "app": "app",
+    "postgres": "postgres",
     "table": "uc_securable",
     "volume": "uc_securable",
     "function": "uc_securable",
@@ -50,6 +51,7 @@ _DEDUP_KEY_EXTRACTORS: dict[str, Any] = {
     "genie_space": lambda r: r["genie_space"]["space_id"],
     "secret": lambda r: (r["secret"]["scope"], r["secret"]["key"]),
     "app": lambda r: r["app"]["name"],
+    "postgres": lambda r: (r["postgres"]["database"], r["postgres"].get("branch")),
     "uc_securable": lambda r: r["uc_securable"]["securable_full_name"],
 }
 
@@ -175,6 +177,17 @@ def _convert_single_resource(resource: dict[str, Any]) -> dict[str, Any] | None:
             "name": resource["app_name"],
             "permission": permission,
         }
+    elif resource_type == "postgres":
+        # Lakebase autoscaling project. The platform grants the app SP
+        # CAN_CONNECT_AND_CREATE on the project once this resource binds.
+        postgres_block: dict[str, Any] = {
+            "database": resource["database"],
+            "permission": permission,
+        }
+        branch = resource.get("branch")
+        if branch:
+            postgres_block["branch"] = branch
+        result["postgres"] = postgres_block
     elif resource_type in (
         "table",
         "volume",

--- a/src/dao_ai/apps/resources.py
+++ b/src/dao_ai/apps/resources.py
@@ -95,7 +95,8 @@ DEFAULT_PERMISSIONS: dict[str, list[str]] = {
     "volume": ["CAN_READ"],
     "function": ["CAN_EXECUTE"],
     "connection": ["USE_CONNECTION"],
-    "database": ["CAN_CONNECT_AND_CREATE"],
+    "database": ["CAN_CONNECT_AND_CREATE"],   # deprecated provisioned Lakebase
+    "postgres": ["CAN_CONNECT_AND_CREATE"],    # autoscaling Lakebase project
     "app": ["CAN_VIEW"],
 }
 
@@ -336,15 +337,22 @@ def _extract_connection_resources(
 def _extract_database_resources(
     databases: dict[str, DatabaseModel],
 ) -> list[dict[str, Any]]:
-    """Extract Lakebase database resources from DatabaseModels.
+    """Extract Lakebase autoscaling-project resources from DatabaseModels.
 
-    When a Lakebase database is registered as an App resource, the
-    Databricks Apps platform grants the app's auto-generated service
-    principal ``CAN_CONNECT_AND_CREATE`` on that database instance --
-    no pre-created SP or secret-scope wiring needed.
+    When a Lakebase project is registered as a Databricks App resource
+    of type ``postgres``, the platform grants the app's auto-generated
+    service principal ``CAN_CONNECT_AND_CREATE`` on that project -- no
+    pre-created SP or secret-scope wiring needed.
+
+    Resource shape: Databricks Apps exposes two database-shaped
+    resource types -- ``database`` (deprecated, provisioned-instance
+    Lakebase) and ``postgres`` (autoscaling Lakebase projects). Lakebase
+    provisioned instances are deprecated; only the autoscaling project
+    flow is supported going forward, so this emits the ``postgres``
+    shape and points it at the project name.
 
     Standalone PostgreSQL connections (``host:`` set, no ``project:``)
-    have no Databricks-managed resource binding and are skipped here.
+    have no Databricks-managed resource binding and are skipped.
     OBO databases are skipped too -- the user identity handles
     permissions via ``user_api_scopes``.
     """
@@ -357,15 +365,16 @@ def _extract_database_resources(
         sanitized_name: str = _sanitize_resource_name(key)
         resource: dict[str, Any] = {
             "name": sanitized_name,
-            "type": "database",
-            "instance_name": db.project,
-            "database_name": db.name or db.project,
+            "type": "postgres",
+            "database": db.project,
             "permissions": [{"level": p} for p in DEFAULT_PERMISSIONS["database"]],
         }
+        if db.branch:
+            resource["branch"] = db.branch
         resources.append(resource)
         logger.debug(
-            f"Extracted Lakebase database resource: {sanitized_name} -> "
-            f"instance={db.project} database={db.name or db.project}"
+            f"Extracted Lakebase postgres resource: {sanitized_name} -> "
+            f"project={db.project} branch={db.branch or '(default)'}"
         )
     return resources
 
@@ -799,14 +808,16 @@ def _extract_sdk_genie_resources(
 def _extract_sdk_database_resources(
     databases: dict[str, DatabaseModel],
 ) -> list[AppResource]:
-    """Extract SDK AppResource objects for Lakebase databases.
+    """Extract SDK AppResource objects for Lakebase autoscaling projects.
 
     Mirror of ``_extract_database_resources`` for SDK-format deploys.
+    Uses ``AppResourcePostgres`` (autoscaling) rather than
+    ``AppResourceDatabase`` (deprecated provisioned-instance shape).
     Standalone PostgreSQL and OBO databases are skipped.
     """
     from databricks.sdk.service.apps import (
-        AppResourceDatabase,
-        AppResourceDatabaseDatabasePermission,
+        AppResourcePostgres,
+        AppResourcePostgresPostgresPermission,
     )
 
     resources: list[AppResource] = []
@@ -818,16 +829,16 @@ def _extract_sdk_database_resources(
         sanitized_name: str = _sanitize_resource_name(key)
         resource = AppResource(
             name=sanitized_name,
-            database=AppResourceDatabase(
-                instance_name=db.project,
-                database_name=db.name or db.project,
-                permission=AppResourceDatabaseDatabasePermission.CAN_CONNECT_AND_CREATE,
+            postgres=AppResourcePostgres(
+                database=db.project,
+                branch=db.branch,
+                permission=AppResourcePostgresPostgresPermission.CAN_CONNECT_AND_CREATE,
             ),
         )
         resources.append(resource)
         logger.debug(
-            f"Extracted SDK Lakebase database resource: {sanitized_name} -> "
-            f"instance={db.project} database={db.name or db.project}"
+            f"Extracted SDK Lakebase postgres resource: {sanitized_name} -> "
+            f"project={db.project} branch={db.branch or '(default)'}"
         )
     return resources
 

--- a/tests/dao_ai/test_lakebase_app_resources.py
+++ b/tests/dao_ai/test_lakebase_app_resources.py
@@ -96,7 +96,9 @@ class TestDatabaseModelAsResources:
 class TestExtractDatabaseResourcesFlat:
     """Flat-dict extractor used when generating ``app.yaml`` for the bundle."""
 
-    def test_lakebase_non_obo_emits_database_resource(self) -> None:
+    def test_lakebase_non_obo_emits_postgres_resource(self) -> None:
+        """Autoscaling Lakebase projects use the ``postgres`` resource type
+        (not the deprecated ``database``/instance shape)."""
         from dao_ai.apps.resources import _extract_database_resources
         from dao_ai.config import DatabaseModel
 
@@ -104,11 +106,19 @@ class TestExtractDatabaseResourcesFlat:
         out = _extract_database_resources({"workshop_db": db})
         assert len(out) == 1
         r = out[0]
-        assert r["type"] == "database"
+        assert r["type"] == "postgres"
         assert r["name"] == "workshop_db"
-        assert r["instance_name"] == "retail-consumer-goods"
-        assert r["database_name"] == "retail-consumer-goods"
+        assert r["database"] == "retail-consumer-goods"
         assert r["permissions"] == [{"level": "CAN_CONNECT_AND_CREATE"}]
+        assert "branch" not in r
+
+    def test_lakebase_with_branch_propagates_to_resource(self) -> None:
+        from dao_ai.apps.resources import _extract_database_resources
+        from dao_ai.config import DatabaseModel
+
+        db = DatabaseModel(project="retail-consumer-goods", branch="dev")
+        out = _extract_database_resources({"workshop_db": db})
+        assert out[0]["branch"] == "dev"
 
     def test_lakebase_obo_skipped(self) -> None:
         from dao_ai.apps.resources import _extract_database_resources
@@ -128,16 +138,15 @@ class TestExtractDatabaseResourcesFlat:
         )
         assert _extract_database_resources({"k": db}) == []
 
-    def test_database_name_falls_back_to_project_when_name_omitted(self) -> None:
-        """Lakebase ``name`` defaults to ``project`` per DatabaseModel; the
-        extractor preserves that even if the inputs were partial."""
+    def test_project_only_emits_postgres_with_project_as_database(self) -> None:
+        """Lakebase autoscaling resource: ``database`` field on the
+        AppResource is the project name (Apps platform's lookup target)."""
         from dao_ai.apps.resources import _extract_database_resources
         from dao_ai.config import DatabaseModel
 
         db = DatabaseModel(project="project-only")
         out = _extract_database_resources({"k": db})
-        assert out[0]["instance_name"] == "project-only"
-        assert out[0]["database_name"] == "project-only"
+        assert out[0]["database"] == "project-only"
 
     def test_resource_name_is_sanitized(self) -> None:
         """Underscores and other punctuation in the YAML key get sanitized
@@ -163,7 +172,7 @@ class TestExtractDatabaseResourcesFlat:
                 "checkpoints_db": DatabaseModel(project="p2"),
             }
         )
-        assert {r["instance_name"] for r in out} == {"p1", "p2"}
+        assert {r["database"] for r in out} == {"p1", "p2"}
 
     def test_empty_dict_returns_empty(self) -> None:
         from dao_ai.apps.resources import _extract_database_resources
@@ -180,11 +189,11 @@ class TestExtractDatabaseResourcesFlat:
 class TestExtractDatabaseResourcesSDK:
     """SDK ``AppResource`` extractor used by the direct-deploy path."""
 
-    def test_lakebase_non_obo_emits_appresource_database(self) -> None:
+    def test_lakebase_non_obo_emits_appresource_postgres(self) -> None:
         from databricks.sdk.service.apps import (
             AppResource,
-            AppResourceDatabase,
-            AppResourceDatabaseDatabasePermission,
+            AppResourcePostgres,
+            AppResourcePostgresPostgresPermission,
         )
 
         from dao_ai.apps.resources import _extract_sdk_database_resources
@@ -195,12 +204,16 @@ class TestExtractDatabaseResourcesSDK:
         assert len(out) == 1
         r = out[0]
         assert isinstance(r, AppResource)
-        assert isinstance(r.database, AppResourceDatabase)
-        assert r.database.instance_name == "retail-consumer-goods"
-        assert r.database.database_name == "retail-consumer-goods"
+        # Autoscaling Lakebase -> AppResourcePostgres (the platform shape
+        # for projects); AppResourceDatabase is the deprecated provisioned
+        # instance shape and must NOT be used.
+        assert r.database is None
+        assert isinstance(r.postgres, AppResourcePostgres)
+        assert r.postgres.database == "retail-consumer-goods"
+        assert r.postgres.branch is None
         assert (
-            r.database.permission
-            is AppResourceDatabaseDatabasePermission.CAN_CONNECT_AND_CREATE
+            r.postgres.permission
+            is AppResourcePostgresPostgresPermission.CAN_CONNECT_AND_CREATE
         )
 
     def test_lakebase_obo_skipped(self) -> None:
@@ -263,50 +276,51 @@ class TestAppResourcesIntegration:
             ),
         )
 
-    def test_flat_app_resources_contain_database_alongside_llm(self) -> None:
+    def test_flat_app_resources_contain_postgres_alongside_llm(self) -> None:
         from dao_ai.apps.resources import generate_app_resources
 
         resources = generate_app_resources(self._build_config())
         types = {r["type"] for r in resources}
         assert "serving-endpoint" in types
-        assert "database" in types
-        # The database resource has the right shape
-        db_r = next(r for r in resources if r["type"] == "database")
-        assert db_r["instance_name"] == "workshop-db"
-        assert db_r["permissions"] == [{"level": "CAN_CONNECT_AND_CREATE"}]
+        assert "postgres" in types
+        pg_r = next(r for r in resources if r["type"] == "postgres")
+        assert pg_r["database"] == "workshop-db"
+        assert pg_r["permissions"] == [{"level": "CAN_CONNECT_AND_CREATE"}]
 
-    def test_flat_app_resources_skips_database_when_obo(self) -> None:
+    def test_flat_app_resources_skips_postgres_when_obo(self) -> None:
         from dao_ai.apps.resources import generate_app_resources
 
         resources = generate_app_resources(self._build_config(on_behalf_of_user=True))
         types = {r["type"] for r in resources}
-        assert "database" not in types
+        assert "postgres" not in types
 
-    def test_sdk_app_resources_contain_appresourcedatabase(self) -> None:
-        from databricks.sdk.service.apps import AppResource, AppResourceDatabase
+    def test_sdk_app_resources_contain_appresourcepostgres(self) -> None:
+        from databricks.sdk.service.apps import AppResource, AppResourcePostgres
 
         from dao_ai.apps.resources import generate_sdk_resources
 
         resources = generate_sdk_resources(self._build_config())
-        db_resources = [
+        pg_resources = [
             r for r in resources
-            if isinstance(r, AppResource) and r.database is not None
+            if isinstance(r, AppResource) and r.postgres is not None
         ]
-        assert len(db_resources) == 1
-        assert isinstance(db_resources[0].database, AppResourceDatabase)
-        assert db_resources[0].database.instance_name == "workshop-db"
+        assert len(pg_resources) == 1
+        assert isinstance(pg_resources[0].postgres, AppResourcePostgres)
+        assert pg_resources[0].postgres.database == "workshop-db"
+        # No legacy AppResourceDatabase mixed in
+        assert pg_resources[0].database is None
 
-    def test_sdk_app_resources_skips_database_when_obo(self) -> None:
+    def test_sdk_app_resources_skips_postgres_when_obo(self) -> None:
         from databricks.sdk.service.apps import AppResource
 
         from dao_ai.apps.resources import generate_sdk_resources
 
         resources = generate_sdk_resources(self._build_config(on_behalf_of_user=True))
-        db_resources = [
+        pg_resources = [
             r for r in resources
-            if isinstance(r, AppResource) and r.database is not None
+            if isinstance(r, AppResource) and r.postgres is not None
         ]
-        assert db_resources == []
+        assert pg_resources == []
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

PR #68 emitted `AppResourceDatabase` / `type: "database"` for Lakebase configs. The Apps platform on `aws-field-eng` resolves that resource shape against the **deprecated provisioned-instance API** and rejects autoscaling Lakebase project names with:

```
NotFound: Failed to add resource workshop_db.
Database instance retail-consumer-goods does not exist.
```

`retail-consumer-goods` is a valid autoscaling Lakebase **project** on the workspace (`w.postgres.list_projects()` confirms). It just isn't a provisioned **instance**.

Per @natefleming: Lakebase provisioned instances are deprecated; only autoscaling Lakebase (addressed via the postgres API as `projects/<name>`) is supported going forward. The matching App resource type is `AppResourcePostgres` — `database` (project name) + optional `branch`, same `CAN_CONNECT_AND_CREATE` permission.

## Change

Three sites switch from the database/instance shape to the postgres/project shape:

1. **`_extract_database_resources`** — emits `{type: "postgres", database: <project>, branch?: <branch>, permissions: [CAN_CONNECT_AND_CREATE]}` instead of `type: "database"`.
2. **`_extract_sdk_database_resources`** — emits `AppResource(postgres=AppResourcePostgres(database=<project>, branch=<branch>, permission=CAN_...))` instead of `AppResource(database=AppResourceDatabase(instance_name=...))`.
3. **`_BUNDLE_RESOURCE_CONVERTERS`** — adds a `"postgres" -> "postgres"` mapping with a `(database, branch)` dedup key, plus a `_convert_single_resource` branch that emits the nested `{postgres: {database, branch?, permission}}` block. **Without this branch the bundle generator silently dropped Lakebase resources** — `"database"` was never in the converter map either.

`DEFAULT_PERMISSIONS["postgres"] = ["CAN_CONNECT_AND_CREATE"]` added; the legacy `"database"` entry kept for backward compat but no longer emitted by the Lakebase extractors.

`DatabaseModel.as_resources()` in `config.py` is unchanged — it already emits `DatabricksLakebase` for Model Serving, which is correct for the autoscaling path on the Model Serving side.

## Test plan

`tests/dao_ai/test_lakebase_app_resources.py` updated end-to-end. Every assertion that previously checked `AppResourceDatabase` / `type: "database"` now checks `AppResourcePostgres` / `type: "postgres"`. Added a test that `branch` propagates through to the resource. **21 / 21 lakebase tests pass.** Full sweep across the touched suites: **168 passed, 1 skipped.**

```
tests/dao_ai/test_lakebase_app_resources.py        21 passed
tests/dao_ai/test_databricks.py                    72 passed (1 skipped)
tests/dao_ai/test_memory_tools.py                  24 passed
tests/dao_ai/test_deterministic_handoffs.py        51 passed
                                                ----
                                                168 passed
```

End-to-end live verify still pending — it'll happen automatically once 0.1.64 ships and the workshop's Lab 7 picks up the new pin.

This pull request and its description were written by Isaac.