### PR TITLE
Lakebase: resolve default branch for postgres app resource

### DIFF
--- a/src/dao_ai/apps/resources.py
+++ b/src/dao_ai/apps/resources.py
@@ -363,20 +363,42 @@ def _extract_database_resources(
         if db.on_behalf_of_user:
             continue
         sanitized_name: str = _sanitize_resource_name(key)
+        # Apps platform requires both `database` (project name) and `branch`
+        # to be defined on a postgres resource. Resolve the default branch
+        # from the project at extraction time when the user didn't pin it.
+        branch: str = db.branch or _resolve_lakebase_default_branch(db)
         resource: dict[str, Any] = {
             "name": sanitized_name,
             "type": "postgres",
             "database": db.project,
+            "branch": branch,
             "permissions": [{"level": p} for p in DEFAULT_PERMISSIONS["database"]],
         }
-        if db.branch:
-            resource["branch"] = db.branch
         resources.append(resource)
         logger.debug(
             f"Extracted Lakebase postgres resource: {sanitized_name} -> "
-            f"project={db.project} branch={db.branch or '(default)'}"
+            f"project={db.project} branch={branch}"
         )
     return resources
+
+
+def _resolve_lakebase_default_branch(db: DatabaseModel) -> str:
+    """Resolve a Lakebase project's default branch, with a safe fallback.
+
+    Calls ``db.resolve_default_branch()`` (which hits the workspace's
+    postgres API) when ``db.branch`` is unset. Falls back to ``"main"`` if
+    the API call fails -- e.g. during offline bundle generation, in unit
+    tests, or for users without ambient credentials at extraction time.
+    Most Lakebase projects use ``main`` as the default branch.
+    """
+    try:
+        return db.resolve_default_branch()
+    except Exception as e:  # pragma: no cover -- defensive fallback
+        logger.debug(
+            f"Could not resolve default branch for project '{db.project}': {e}. "
+            f"Falling back to 'main'."
+        )
+        return "main"
 
 
 def _extract_app_resources(
@@ -814,6 +836,10 @@ def _extract_sdk_database_resources(
     Uses ``AppResourcePostgres`` (autoscaling) rather than
     ``AppResourceDatabase`` (deprecated provisioned-instance shape).
     Standalone PostgreSQL and OBO databases are skipped.
+
+    The Apps platform requires both ``database`` (project name) and
+    ``branch`` to be defined; ``branch`` is resolved from the project's
+    default if the user didn't pin one in the config.
     """
     from databricks.sdk.service.apps import (
         AppResourcePostgres,
@@ -827,18 +853,19 @@ def _extract_sdk_database_resources(
         if db.on_behalf_of_user:
             continue
         sanitized_name: str = _sanitize_resource_name(key)
+        branch: str = db.branch or _resolve_lakebase_default_branch(db)
         resource = AppResource(
             name=sanitized_name,
             postgres=AppResourcePostgres(
                 database=db.project,
-                branch=db.branch,
+                branch=branch,
                 permission=AppResourcePostgresPostgresPermission.CAN_CONNECT_AND_CREATE,
             ),
         )
         resources.append(resource)
         logger.debug(
             f"Extracted SDK Lakebase postgres resource: {sanitized_name} -> "
-            f"project={db.project} branch={db.branch or '(default)'}"
+            f"project={db.project} branch={branch}"
         )
     return resources
 

--- a/tests/dao_ai/test_lakebase_app_resources.py
+++ b/tests/dao_ai/test_lakebase_app_resources.py
@@ -96,11 +96,21 @@ class TestDatabaseModelAsResources:
 class TestExtractDatabaseResourcesFlat:
     """Flat-dict extractor used when generating ``app.yaml`` for the bundle."""
 
-    def test_lakebase_non_obo_emits_postgres_resource(self) -> None:
+    def test_lakebase_non_obo_emits_postgres_resource(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Autoscaling Lakebase projects use the ``postgres`` resource type
-        (not the deprecated ``database``/instance shape)."""
+        (not the deprecated ``database``/instance shape). When the user
+        doesn't pin a branch, the extractor resolves the project's default
+        branch -- the Apps platform requires both ``database`` and
+        ``branch`` on a postgres resource."""
+        from dao_ai.apps import resources as resources_mod
         from dao_ai.apps.resources import _extract_database_resources
         from dao_ai.config import DatabaseModel
+
+        monkeypatch.setattr(
+            resources_mod, "_resolve_lakebase_default_branch", lambda db: "main"
+        )
 
         db = DatabaseModel(name="retail-consumer-goods", project="retail-consumer-goods")
         out = _extract_database_resources({"workshop_db": db})
@@ -110,11 +120,22 @@ class TestExtractDatabaseResourcesFlat:
         assert r["name"] == "workshop_db"
         assert r["database"] == "retail-consumer-goods"
         assert r["permissions"] == [{"level": "CAN_CONNECT_AND_CREATE"}]
-        assert "branch" not in r
+        # Branch is always present on the emitted resource (platform requires it).
+        assert r["branch"] == "main"
 
-    def test_lakebase_with_branch_propagates_to_resource(self) -> None:
+    def test_lakebase_with_branch_propagates_to_resource(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A user-pinned branch wins over the resolver -- the resolver
+        should not be consulted when ``db.branch`` is already set."""
+        from dao_ai.apps import resources as resources_mod
         from dao_ai.apps.resources import _extract_database_resources
         from dao_ai.config import DatabaseModel
+
+        def _boom(db: object) -> str:
+            raise AssertionError("resolver should not be called when branch is pinned")
+
+        monkeypatch.setattr(resources_mod, "_resolve_lakebase_default_branch", _boom)
 
         db = DatabaseModel(project="retail-consumer-goods", branch="dev")
         out = _extract_database_resources({"workshop_db": db})
@@ -189,15 +210,22 @@ class TestExtractDatabaseResourcesFlat:
 class TestExtractDatabaseResourcesSDK:
     """SDK ``AppResource`` extractor used by the direct-deploy path."""
 
-    def test_lakebase_non_obo_emits_appresource_postgres(self) -> None:
+    def test_lakebase_non_obo_emits_appresource_postgres(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         from databricks.sdk.service.apps import (
             AppResource,
             AppResourcePostgres,
             AppResourcePostgresPostgresPermission,
         )
 
+        from dao_ai.apps import resources as resources_mod
         from dao_ai.apps.resources import _extract_sdk_database_resources
         from dao_ai.config import DatabaseModel
+
+        monkeypatch.setattr(
+            resources_mod, "_resolve_lakebase_default_branch", lambda db: "main"
+        )
 
         db = DatabaseModel(name="retail-consumer-goods", project="retail-consumer-goods")
         out = _extract_sdk_database_resources({"workshop_db": db})
@@ -210,7 +238,9 @@ class TestExtractDatabaseResourcesSDK:
         assert r.database is None
         assert isinstance(r.postgres, AppResourcePostgres)
         assert r.postgres.database == "retail-consumer-goods"
-        assert r.postgres.branch is None
+        # Branch is always populated -- the Apps platform requires it on the
+        # postgres resource. Resolved here from the (mocked) helper.
+        assert r.postgres.branch == "main"
         assert (
             r.postgres.permission
             is AppResourcePostgresPostgresPermission.CAN_CONNECT_AND_CREATE


### PR DESCRIPTION
## Summary

- Fixes deploy failure on 0.1.64: `BadRequest: Invalid postgres resource parameters. Please make sure that branch ID and database name are defined.`
- Adds `_resolve_lakebase_default_branch(db)` that consults the workspace's postgres API (`db.resolve_default_branch()`) when the user hasn't pinned a branch, with a safe fallback to `"main"` if the lookup fails (offline bundle gen, missing creds, etc.).
- Both extraction paths (flat-dict for `app.yaml` bundle and SDK `AppResource` for direct deploy) now always emit a `branch` on the postgres resource — the Apps platform requires it.

## Background

PR #69 switched Lakebase emission to `AppResourcePostgres` (the autoscaling shape) but passed `branch=db.branch`, which is `None` when not pinned in config. The platform rejects that as invalid, and there's no useful default at the SDK level — the actual default branch lives in the project itself (e.g., `production` for `retail-consumer-goods` on `aws-field-eng`).

## Test plan

- [x] `pytest tests/dao_ai/test_lakebase_app_resources.py` — 21/21 pass
- [x] `pytest -k "apps or bundle or resource or lakebase" -m "not integration"` — 72/72 pass
- [x] Updated assertions: the two tests that previously checked `branch is None` now mock the resolver and assert the resolved value propagates.
- [x] Added a guard test: when `db.branch` is pinned the resolver is **not** called.
- [ ] (post-merge) Cut a new release and re-run Lab 7 verify against `retail-consumer-goods` on `aws-field-eng` to confirm end-to-end deploy + Lakebase connectivity from the auto-SP.

This pull request and its description were written by Isaac.