### PR TITLE
Lakebase: full resource paths on postgres app resource + dev-wheel direct_url

### DIFF
--- a/src/dao_ai/apps/resources.py
+++ b/src/dao_ai/apps/resources.py
@@ -363,42 +363,119 @@ def _extract_database_resources(
         if db.on_behalf_of_user:
             continue
         sanitized_name: str = _sanitize_resource_name(key)
-        # Apps platform requires both `database` (project name) and `branch`
-        # to be defined on a postgres resource. Resolve the default branch
-        # from the project at extraction time when the user didn't pin it.
-        branch: str = db.branch or _resolve_lakebase_default_branch(db)
+        # Apps platform requires both `branch` and `database` as FULL
+        # resource paths on a postgres resource. The platform validates each
+        # by calling get_branch / get_database server-side, which reject
+        # bare IDs with INVALID_PARAMETER_VALUE.
+        branch_path: str = _resolve_lakebase_branch_path(db)
+        database_path: str = _resolve_lakebase_database_path(db, branch_path)
         resource: dict[str, Any] = {
             "name": sanitized_name,
             "type": "postgres",
-            "database": db.project,
-            "branch": branch,
+            "database": database_path,
+            "branch": branch_path,
             "permissions": [{"level": p} for p in DEFAULT_PERMISSIONS["database"]],
         }
         resources.append(resource)
         logger.debug(
             f"Extracted Lakebase postgres resource: {sanitized_name} -> "
-            f"project={db.project} branch={branch}"
+            f"database={database_path} branch={branch_path}"
         )
     return resources
 
 
-def _resolve_lakebase_default_branch(db: DatabaseModel) -> str:
-    """Resolve a Lakebase project's default branch, with a safe fallback.
+def _resolve_lakebase_branch_path(db: DatabaseModel) -> str:
+    """Return the Apps-platform branch resource path for a Lakebase database.
 
-    Calls ``db.resolve_default_branch()`` (which hits the workspace's
-    postgres API) when ``db.branch`` is unset. Falls back to ``"main"`` if
-    the API call fails -- e.g. during offline bundle generation, in unit
-    tests, or for users without ambient credentials at extraction time.
-    Most Lakebase projects use ``main`` as the default branch.
+    The Apps platform's ``postgres`` resource requires the ``branch`` field
+    in full resource form: ``projects/{project_id}/branches/{branch_id}``.
+    The platform validates by calling its own ``get_branch(name=...)`` API
+    server-side, which rejects bare branch IDs with
+    ``INVALID_PARAMETER_VALUE``.
+
+    When ``db.branch`` is pinned in config we treat it as the branch ID and
+    wrap it. Otherwise we resolve the project's default branch via
+    ``DatabaseModel.resolve_default_branch()``. Falls back to ``"main"`` as
+    the branch ID if the API call fails (offline bundle generation, missing
+    creds, etc.) -- most Lakebase projects use ``main`` as the default.
     """
+    branch_id: str
+    if db.branch:
+        branch_id = db.branch
+    else:
+        try:
+            branch_id = db.resolve_default_branch()
+        except Exception as e:  # pragma: no cover -- defensive fallback
+            logger.debug(
+                f"Could not resolve default branch for project '{db.project}': {e}. "
+                f"Falling back to 'main'."
+            )
+            branch_id = "main"
+    return f"projects/{db.project}/branches/{branch_id}"
+
+
+def _resolve_lakebase_database_path(db: DatabaseModel, branch_path: str) -> str:
+    """Return the Apps-platform database resource path for a Lakebase database.
+
+    The Apps platform's ``postgres`` resource ``database`` field requires
+    full resource form:
+    ``projects/{project_id}/branches/{branch_id}/databases/{database_id}``.
+
+    The Lakebase ``Database`` resource carries two distinct names:
+
+    1. ``Database.name`` -- the platform resource path (random ID suffix,
+       e.g. ``db-pmke-laez4ing20``). This is what the Apps platform binds to.
+    2. ``Database.status.postgres_database`` -- the Postgres-level database
+       name used by the connection (e.g. ``databricks_postgres``). This is
+       what ``DatabaseModel.database`` carries in dao-ai configs.
+
+    Resolution rules:
+
+    * If ``db.database`` already looks like a full resource path
+      (``projects/.../databases/...``), return it as-is.
+    * Otherwise, list databases under the branch and find the one whose
+      ``status.postgres_database`` matches ``db.database``; return its
+      ``name``.
+    * If no match is found, fall back to the first database under the
+      branch (most Lakebase projects have exactly one).
+    * If the API call fails entirely, fall back to constructing a path
+      from ``db.database`` -- the deploy will surface a clear platform
+      error if the constructed path doesn't exist.
+    """
+    from dao_ai.config import value_of
+
+    database_value = value_of(db.database) if db.database is not None else None
+    database_id: str = str(database_value) if database_value is not None else ""
+
+    if database_id.startswith("projects/") and "/databases/" in database_id:
+        return database_id
+
     try:
-        return db.resolve_default_branch()
+        w = db.workspace_client
+        databases = list(w.postgres.list_databases(branch_path))
     except Exception as e:  # pragma: no cover -- defensive fallback
         logger.debug(
-            f"Could not resolve default branch for project '{db.project}': {e}. "
-            f"Falling back to 'main'."
+            f"Could not list databases under '{branch_path}': {e}. "
+            f"Falling back to constructed path with database_id='{database_id}'."
         )
-        return "main"
+        return f"{branch_path}/databases/{database_id}"
+
+    if database_id:
+        for d in databases:
+            pg_name = d.status.postgres_database if d.status else None
+            if pg_name == database_id and d.name:
+                return d.name
+
+    if databases and databases[0].name:
+        if database_id:
+            logger.debug(
+                f"No Lakebase database matched postgres name '{database_id}' under "
+                f"'{branch_path}'; falling back to first database "
+                f"'{databases[0].name}'."
+            )
+        return databases[0].name
+
+    return f"{branch_path}/databases/{database_id}"
 
 
 def _extract_app_resources(
@@ -838,8 +915,9 @@ def _extract_sdk_database_resources(
     Standalone PostgreSQL and OBO databases are skipped.
 
     The Apps platform requires both ``database`` (project name) and
-    ``branch`` to be defined; ``branch`` is resolved from the project's
-    default if the user didn't pin one in the config.
+    ``branch`` (full resource path ``projects/<p>/branches/<b>``) to be
+    defined; ``branch`` is resolved from the project's default if the user
+    didn't pin one in the config.
     """
     from databricks.sdk.service.apps import (
         AppResourcePostgres,
@@ -853,19 +931,20 @@ def _extract_sdk_database_resources(
         if db.on_behalf_of_user:
             continue
         sanitized_name: str = _sanitize_resource_name(key)
-        branch: str = db.branch or _resolve_lakebase_default_branch(db)
+        branch_path: str = _resolve_lakebase_branch_path(db)
+        database_path: str = _resolve_lakebase_database_path(db, branch_path)
         resource = AppResource(
             name=sanitized_name,
             postgres=AppResourcePostgres(
-                database=db.project,
-                branch=branch,
+                database=database_path,
+                branch=branch_path,
                 permission=AppResourcePostgresPostgresPermission.CAN_CONNECT_AND_CREATE,
             ),
         )
         resources.append(resource)
         logger.debug(
             f"Extracted SDK Lakebase postgres resource: {sanitized_name} -> "
-            f"project={db.project} branch={branch}"
+            f"database={database_path} branch={branch_path}"
         )
     return resources
 

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -1897,17 +1897,37 @@ class DatabaseModel(IsDatabricksResource):
         return self.is_lakebase
 
     def as_resources(self) -> Sequence[DatabricksResource]:
-        # Lakebase databases register as DatabricksLakebase resources so the
-        # deploying agent (Model Serving SystemAuthPolicy or Databricks Apps
-        # auto-SP) gets CAN_CONNECT_AND_CREATE on the instance. Standalone
-        # PostgreSQL hosts have no Databricks-managed resource binding.
+        # Lakebase autoscaling projects intentionally do NOT emit a
+        # DatabricksLakebase MLflow resource. MLflow's DatabricksLakebase
+        # resource only supports the deprecated provisioned-instance shape;
+        # logging it for an autoscaling project makes the Model Serving
+        # endpoint fail to start with:
+        #
+        #   NOT_FOUND: Database instance is not found. Please ensure all
+        #   resource dependencies for the server entity are valid...
+        #
+        # MLflow team confirmed this gap is not planned for the time being
+        # (https://github.com/mlflow/mlflow/issues/22452, 2026-04-10).
+        # The recommended workaround is to manage Lakebase auth from within
+        # the agent code using OAuth M2M (set ``client_id`` and
+        # ``client_secret`` on the DatabaseModel, or surface them via the
+        # secret-scope-wrapped pattern used in the workshop's Lab 7 YAML).
+        #
+        # The Apps deploy path is unaffected -- it uses the platform's
+        # ``postgres`` resource binding (see
+        # ``dao_ai.apps.resources._extract_database_resources``), which
+        # supports autoscaling natively.
+        #
+        # Standalone PostgreSQL hosts have no Databricks-managed resource
+        # binding and likewise return [].
         if self.is_lakebase and self.project:
-            return [
-                DatabricksLakebase(
-                    database_instance_name=self.project,
-                    on_behalf_of_user=self.on_behalf_of_user,
-                )
-            ]
+            logger.debug(
+                "Lakebase database is autoscaling -- skipping DatabricksLakebase "
+                "MLflow resource emission. Use OAuth client_id/client_secret on "
+                "the DatabaseModel for Model Serving auth. See "
+                "https://github.com/mlflow/mlflow/issues/22452.",
+                project=self.project,
+            )
         return []
 
     @model_validator(mode="after")

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -690,6 +690,29 @@ class DatabricksProvider(ServiceProvider):
         logger.info(
             "Deploying agent to Model Serving", endpoint_name=config.app.endpoint_name
         )
+
+        # Warn about Lakebase autoscaling on Model Serving. MLflow's
+        # DatabricksLakebase resource doesn't support autoscaling projects
+        # (https://github.com/mlflow/mlflow/issues/22452), so dao-ai
+        # intentionally skips that resource emission. The deployed endpoint
+        # has no auto-bound Lakebase grant -- the agent must manage auth
+        # itself via OAuth M2M (client_id / client_secret on the
+        # DatabaseModel).
+        if config.resources and config.resources.databases:
+            for db_key, db in config.resources.databases.items():
+                if db.is_lakebase and db.project and not db.client_id:
+                    logger.warning(
+                        "Lakebase autoscaling on Model Serving requires manual "
+                        "auth -- MLflow's DatabricksLakebase resource doesn't "
+                        "support autoscaling projects. Set `client_id` and "
+                        "`client_secret` on the database, or deploy to "
+                        "Databricks Apps (which supports autoscaling Lakebase "
+                        "natively via the postgres resource binding). See "
+                        "https://github.com/mlflow/mlflow/issues/22452.",
+                        database=db_key,
+                        project=db.project,
+                    )
+
         mlflow.set_registry_uri("databricks-uc")
 
         endpoint_name: str = config.app.endpoint_name

--- a/src/dao_ai/utils.py
+++ b/src/dao_ai/utils.py
@@ -67,6 +67,36 @@ def is_published() -> bool:
     return True
 
 
+def _wheel_from_direct_url() -> Path | None:
+    """Return the wheel file dao-ai was installed from, if any.
+
+    When a user runs ``pip install /path/to/dao_ai-X.Y.Z.whl`` (including
+    workspace paths like ``/Workspace/.../wheels/dao_ai-...whl`` on
+    Databricks Serverless), pip records the source path in
+    ``direct_url.json``. Surfacing that path lets ``deploy_apps_agent``
+    bundle the same wheel into the deployed app without searching for a
+    local ``dist/`` directory that doesn't exist on Serverless.
+    """
+    try:
+        from importlib.metadata import distribution
+
+        dist = distribution("dao-ai")
+        direct_url = dist.read_text("direct_url.json")
+        if not direct_url:
+            return None
+        data = json.loads(direct_url)
+        url = data.get("url", "")
+        if not url.startswith("file://"):
+            return None
+        path = Path(url.removeprefix("file://"))
+        if path.is_file() and path.suffix == ".whl":
+            logger.debug("Resolved dao-ai wheel from direct_url.json", path=str(path))
+            return path
+    except Exception as e:
+        logger.debug(f"Could not resolve wheel from direct_url.json: {e}")
+    return None
+
+
 def find_dev_wheel() -> Path | None:
     """Find an existing dao-ai wheel in known locations.
 
@@ -75,12 +105,18 @@ def find_dev_wheel() -> Path | None:
     what to do when None is returned.
 
     Search order:
-        1. Project dist/ (local dev: relative to this source file)
-        2. Bundle artifact paths (job cluster: ../dist/, ../../artifacts/.internal/)
-        3. CWD dist/ (fallback)
+        1. The wheel recorded in ``direct_url.json`` (when dao-ai was
+           installed from a local/workspace ``.whl`` path).
+        2. Project dist/ (local dev: relative to this source file)
+        3. Bundle artifact paths (job cluster: ../dist/, ../../artifacts/.internal/)
+        4. CWD dist/ (fallback)
     """
     if is_published():
         return None
+
+    direct: Path | None = _wheel_from_direct_url()
+    if direct:
+        return direct
 
     search_dirs: list[Path] = [
         Path(__file__).parents[2] / "dist",

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -1569,23 +1569,21 @@ def test_database_model_workspace_client_oauth_uses_databricks_host_env():
 
 @pytest.mark.unit
 def test_database_model_as_resources_lakebase():
-    """DatabaseModel.as_resources returns a DatabricksLakebase resource for
-    Lakebase databases so the deploying agent (Model Serving SystemAuthPolicy
-    or Databricks Apps auto-SP) gets CAN_CONNECT_AND_CREATE on the instance.
-
-    See tests/dao_ai/test_lakebase_app_resources.py for the broader suite.
+    """DatabaseModel.as_resources intentionally returns ``[]`` for autoscaling
+    Lakebase databases. MLflow's ``DatabricksLakebase`` resource only supports
+    the deprecated provisioned-instance shape, and emitting it for an
+    autoscaling project causes Model Serving endpoints to fail to start with
+    ``NOT_FOUND: Database instance is not found`` (MLflow issue #22452,
+    2026-04-10). Apps-side resource binding goes through a different code path
+    (``_extract_database_resources``) and is unaffected -- see the broader
+    suite in tests/dao_ai/test_lakebase_app_resources.py.
     """
-    from mlflow.models.resources import DatabricksLakebase
-
     db = DatabaseModel(
         name="test-db",
         project="test-db",
     )
     assert db.is_lakebase is True
-    resources = list(db.as_resources())
-    assert len(resources) == 1
-    assert isinstance(resources[0], DatabricksLakebase)
-    assert resources[0].to_dict()["lakebase"][0]["name"] == "test-db"
+    assert list(db.as_resources()) == []
     assert db.api_scopes == ["postgres"]
 
 

--- a/tests/dao_ai/test_lakebase_app_resources.py
+++ b/tests/dao_ai/test_lakebase_app_resources.py
@@ -1,23 +1,34 @@
 """
 Tests for Lakebase database resource extraction across both deployment paths.
 
-When a Lakebase database is configured, the deploying agent should declare
-it as a Databricks resource so the platform grants the deployment's identity
-``CAN_CONNECT_AND_CREATE`` on the Lakebase instance:
+The two deploy paths emit Lakebase resources very differently:
+
+- **Databricks Apps** (``deploy_apps_agent``): the deployed app declares a
+  ``postgres`` app resource via ``generate_app_resources()`` (flat-dict for
+  the bundle) and ``generate_sdk_resources()`` (SDK ``AppResource``). The
+  platform binds the auto-SP to the Lakebase project with
+  ``CAN_CONNECT_AND_CREATE``. The Apps platform's ``postgres`` resource type
+  fully supports autoscaling Lakebase projects and requires both ``branch``
+  and ``database`` as full resource paths
+  (``projects/<p>/branches/<b>[/databases/<id>]``).
 
 - **Model Serving** (``deploy_model_serving_agent``): the model is logged
   with a ``SystemAuthPolicy`` whose ``resources`` list comes from each
-  resource model's ``as_resources()`` method. ``DatabaseModel.as_resources()``
-  must return a ``DatabricksLakebase`` resource for Lakebase configurations.
+  resource model's ``as_resources()`` method. **MLflow's
+  ``DatabricksLakebase`` resource does not support autoscaling Lakebase
+  projects** -- only the deprecated provisioned-instance shape -- and the
+  MLflow team confirmed (2026-04-10) that autoscaling support isn't planned
+  for the time being. Emitting the resource for an autoscaling project
+  causes the endpoint to fail to start with
+  ``NOT_FOUND: Database instance is not found``. dao-ai therefore returns
+  ``[]`` from ``DatabaseModel.as_resources()`` for Lakebase. Users who need
+  Model Serving + Lakebase must manage auth in agent code via OAuth M2M
+  (``client_id`` / ``client_secret`` on the DatabaseModel).
 
-- **Databricks Apps** (``deploy_apps_agent``): the deployed ``app.yaml``
-  enumerates resources via ``generate_app_resources()`` (flat-dict format
-  consumed by the bundle generator) and ``generate_sdk_resources()``
-  (SDK ``AppResource`` objects consumed by the direct-deploy path).
-  Both must include a ``database`` resource for each Lakebase.
+  Reference: https://github.com/mlflow/mlflow/issues/22452
 
-OBO databases are skipped at extraction time -- the user identity handles
-permissions via ``user_api_scopes`` instead.
+OBO databases are skipped at extraction time on the Apps path -- the user
+identity handles permissions via ``user_api_scopes`` instead.
 
 Standalone PostgreSQL connections (``host:`` set, no ``project:``) have no
 Databricks-managed resource binding and are also skipped.
@@ -35,34 +46,34 @@ import pytest
 
 @pytest.mark.unit
 class TestDatabaseModelAsResources:
-    """``DatabaseModel.as_resources()`` feeds Model Serving's SystemAuthPolicy."""
+    """``DatabaseModel.as_resources()`` feeds Model Serving's SystemAuthPolicy.
 
-    def test_lakebase_non_obo_returns_lakebase_resource(self) -> None:
-        from mlflow.models.resources import DatabricksLakebase
+    MLflow's ``DatabricksLakebase`` resource only supports the deprecated
+    provisioned-instance shape; logging it for an autoscaling Lakebase project
+    breaks Model Serving deploys (NOT_FOUND on the database resource at endpoint
+    start). Per the MLflow team, autoscaling support isn't planned for the time
+    being -- see https://github.com/mlflow/mlflow/issues/22452 (2026-04-10).
 
+    dao-ai therefore returns ``[]`` for autoscaling Lakebase databases. Users
+    who need Model Serving + Lakebase must manage auth in agent code via OAuth
+    M2M (``client_id`` / ``client_secret`` on the DatabaseModel)."""
+
+    def test_lakebase_does_not_emit_databrickslakebase_resource(self) -> None:
+        """Autoscaling Lakebase projects intentionally emit no MLflow
+        Lakebase resource -- the existing ``DatabricksLakebase`` MLflow class
+        only supports provisioned instances, not autoscaling projects."""
         from dao_ai.config import DatabaseModel
 
         db = DatabaseModel(name="retail-consumer-goods", project="retail-consumer-goods")
-        resources = list(db.as_resources())
-        assert len(resources) == 1
-        r = resources[0]
-        assert isinstance(r, DatabricksLakebase)
-        # to_dict produces the MLflow-resources YAML shape used in the model package
-        d = r.to_dict()
-        assert "lakebase" in d
-        assert d["lakebase"][0]["name"] == "retail-consumer-goods"
-        assert d["lakebase"][0]["on_behalf_of_user"] is False
+        assert list(db.as_resources()) == []
 
-    def test_lakebase_obo_carries_on_behalf_of_user_true(self) -> None:
+    def test_lakebase_obo_also_returns_empty(self) -> None:
+        """OBO databases also return [] -- the on_behalf_of_user flag does not
+        change the autoscaling-incompatibility issue with MLflow."""
         from dao_ai.config import DatabaseModel
 
-        db = DatabaseModel(
-            name="x", project="x", on_behalf_of_user=True
-        )
-        resources = list(db.as_resources())
-        assert len(resources) == 1
-        d = resources[0].to_dict()
-        assert d["lakebase"][0]["on_behalf_of_user"] is True
+        db = DatabaseModel(name="x", project="x", on_behalf_of_user=True)
+        assert list(db.as_resources()) == []
 
     def test_standalone_postgres_returns_empty(self) -> None:
         """Non-Lakebase PG has no Databricks-managed resource binding."""
@@ -76,15 +87,6 @@ class TestDatabaseModelAsResources:
         )
         assert db.is_lakebase is False
         assert list(db.as_resources()) == []
-
-    def test_lakebase_resource_uses_project_as_instance_name(self) -> None:
-        """``DatabricksLakebase.database_instance_name`` is the project field,
-        not the freeform ``name`` (which can differ for Lakebase logical names)."""
-        from dao_ai.config import DatabaseModel
-
-        db = DatabaseModel(name="logical-name", project="instance-actual")
-        d = list(db.as_resources())[0].to_dict()
-        assert d["lakebase"][0]["name"] == "instance-actual"
 
 
 # =============================================================================
@@ -455,11 +457,19 @@ class TestAppResourcesIntegration:
 @pytest.mark.integration
 class TestModelServingSystemResources:
     """The ``deploy_model_serving_agent`` path collects ``as_resources()``
-    from each resource model into a SystemAuthPolicy. Confirm that path
-    surfaces a Lakebase database for Model Serving deploys."""
+    from each resource model into a SystemAuthPolicy.
 
-    def test_lakebase_appears_in_as_resources_aggregate(self) -> None:
-        """Reproduce the aggregation step of deploy_model_serving_agent."""
+    For autoscaling Lakebase, dao-ai intentionally returns ``[]`` (see
+    ``DatabaseModel.as_resources``) because MLflow's ``DatabricksLakebase``
+    resource doesn't support autoscaling projects -- emitting it would
+    cause the Model Serving endpoint to fail to start with
+    ``NOT_FOUND: Database instance is not found``.
+
+    Reference: https://github.com/mlflow/mlflow/issues/22452 (2026-04-10)."""
+
+    def test_lakebase_does_not_appear_in_as_resources_aggregate(self) -> None:
+        """Reproduce the aggregation step of deploy_model_serving_agent;
+        the Lakebase database should NOT contribute resources."""
         from mlflow.models.resources import DatabricksLakebase
 
         from dao_ai.config import DatabaseModel, LLMModel
@@ -471,22 +481,18 @@ class TestModelServingSystemResources:
         for r in [llm, db]:
             all_resources.extend(r.as_resources())
 
-        # Database resource is present
+        # The LLM contributes a serving-endpoint resource; the Lakebase
+        # contributes nothing (no DatabricksLakebase resource is emitted).
         lakebase_resources = [
             r for r in all_resources if isinstance(r, DatabricksLakebase)
         ]
-        assert len(lakebase_resources) == 1
-        # The non-OBO database goes into the SystemAuthPolicy filter
-        # (the deploy path filters out on_behalf_of_user=True resources)
-        system_resources = [r for r in all_resources if not r.on_behalf_of_user]
-        assert any(isinstance(r, DatabricksLakebase) for r in system_resources)
+        assert lakebase_resources == []
 
-    def test_obo_lakebase_excluded_from_system_resources(self) -> None:
+    def test_obo_lakebase_also_excluded(self) -> None:
         from mlflow.models.resources import DatabricksLakebase
 
         from dao_ai.config import DatabaseModel
 
         db = DatabaseModel(name="x", project="x", on_behalf_of_user=True)
         resources = list(db.as_resources())
-        system_resources = [r for r in resources if not r.on_behalf_of_user]
-        assert all(not isinstance(r, DatabricksLakebase) for r in system_resources)
+        assert all(not isinstance(r, DatabricksLakebase) for r in resources)

--- a/tests/dao_ai/test_lakebase_app_resources.py
+++ b/tests/dao_ai/test_lakebase_app_resources.py
@@ -102,14 +102,21 @@ class TestExtractDatabaseResourcesFlat:
         """Autoscaling Lakebase projects use the ``postgres`` resource type
         (not the deprecated ``database``/instance shape). When the user
         doesn't pin a branch, the extractor resolves the project's default
-        branch -- the Apps platform requires both ``database`` and
-        ``branch`` on a postgres resource."""
+        branch and emits the full resource path -- the Apps platform
+        validates the branch by calling ``get_branch(name=...)`` server-side
+        and rejects bare branch IDs. Same applies to the ``database`` field,
+        which must be the full Database resource path."""
         from dao_ai.apps import resources as resources_mod
         from dao_ai.apps.resources import _extract_database_resources
         from dao_ai.config import DatabaseModel
 
         monkeypatch.setattr(
-            resources_mod, "_resolve_lakebase_default_branch", lambda db: "main"
+            DatabaseModel, "resolve_default_branch", lambda self: "main"
+        )
+        monkeypatch.setattr(
+            resources_mod,
+            "_resolve_lakebase_database_path",
+            lambda db, branch_path: f"{branch_path}/databases/db-test",
         )
 
         db = DatabaseModel(name="retail-consumer-goods", project="retail-consumer-goods")
@@ -118,28 +125,41 @@ class TestExtractDatabaseResourcesFlat:
         r = out[0]
         assert r["type"] == "postgres"
         assert r["name"] == "workshop_db"
-        assert r["database"] == "retail-consumer-goods"
+        # Both `branch` and `database` are full resource paths -- the Apps
+        # platform rejects bare IDs with INVALID_PARAMETER_VALUE.
+        assert r["branch"] == "projects/retail-consumer-goods/branches/main"
+        assert (
+            r["database"]
+            == "projects/retail-consumer-goods/branches/main/databases/db-test"
+        )
         assert r["permissions"] == [{"level": "CAN_CONNECT_AND_CREATE"}]
-        # Branch is always present on the emitted resource (platform requires it).
-        assert r["branch"] == "main"
 
     def test_lakebase_with_branch_propagates_to_resource(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A user-pinned branch wins over the resolver -- the resolver
-        should not be consulted when ``db.branch`` is already set."""
+        """A user-pinned branch (a bare branch ID) is wrapped into the full
+        resource path; the branch resolver is not consulted."""
         from dao_ai.apps import resources as resources_mod
         from dao_ai.apps.resources import _extract_database_resources
         from dao_ai.config import DatabaseModel
 
-        def _boom(db: object) -> str:
+        def _boom(self: object) -> str:
             raise AssertionError("resolver should not be called when branch is pinned")
 
-        monkeypatch.setattr(resources_mod, "_resolve_lakebase_default_branch", _boom)
+        monkeypatch.setattr(DatabaseModel, "resolve_default_branch", _boom)
+        monkeypatch.setattr(
+            resources_mod,
+            "_resolve_lakebase_database_path",
+            lambda db, branch_path: f"{branch_path}/databases/db-test",
+        )
 
         db = DatabaseModel(project="retail-consumer-goods", branch="dev")
         out = _extract_database_resources({"workshop_db": db})
-        assert out[0]["branch"] == "dev"
+        assert out[0]["branch"] == "projects/retail-consumer-goods/branches/dev"
+        assert (
+            out[0]["database"]
+            == "projects/retail-consumer-goods/branches/dev/databases/db-test"
+        )
 
     def test_lakebase_obo_skipped(self) -> None:
         from dao_ai.apps.resources import _extract_database_resources
@@ -159,21 +179,45 @@ class TestExtractDatabaseResourcesFlat:
         )
         assert _extract_database_resources({"k": db}) == []
 
-    def test_project_only_emits_postgres_with_project_as_database(self) -> None:
-        """Lakebase autoscaling resource: ``database`` field on the
-        AppResource is the project name (Apps platform's lookup target)."""
+    def test_project_only_emits_postgres_with_project_in_database_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The ``database`` field on the AppResource is the full Database
+        resource path -- which embeds the project at the root."""
+        from dao_ai.apps import resources as resources_mod
         from dao_ai.apps.resources import _extract_database_resources
         from dao_ai.config import DatabaseModel
+
+        monkeypatch.setattr(
+            DatabaseModel, "resolve_default_branch", lambda self: "main"
+        )
+        monkeypatch.setattr(
+            resources_mod,
+            "_resolve_lakebase_database_path",
+            lambda db, branch_path: f"{branch_path}/databases/db-test",
+        )
 
         db = DatabaseModel(project="project-only")
         out = _extract_database_resources({"k": db})
-        assert out[0]["database"] == "project-only"
+        assert out[0]["database"].startswith("projects/project-only/")
 
-    def test_resource_name_is_sanitized(self) -> None:
+    def test_resource_name_is_sanitized(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Underscores and other punctuation in the YAML key get sanitized
         for Databricks resource-name rules (matches volumes/tables behavior)."""
+        from dao_ai.apps import resources as resources_mod
         from dao_ai.apps.resources import _extract_database_resources
         from dao_ai.config import DatabaseModel
+
+        monkeypatch.setattr(
+            DatabaseModel, "resolve_default_branch", lambda self: "main"
+        )
+        monkeypatch.setattr(
+            resources_mod,
+            "_resolve_lakebase_database_path",
+            lambda db, branch_path: f"{branch_path}/databases/db-test",
+        )
 
         db = DatabaseModel(name="x", project="x")
         out = _extract_database_resources({"workshop_DB.shared": db})
@@ -183,9 +227,21 @@ class TestExtractDatabaseResourcesFlat:
         assert out[0]["name"]
         assert "/" not in out[0]["name"]
 
-    def test_multiple_lakebases_each_get_a_resource(self) -> None:
+    def test_multiple_lakebases_each_get_a_resource(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from dao_ai.apps import resources as resources_mod
         from dao_ai.apps.resources import _extract_database_resources
         from dao_ai.config import DatabaseModel
+
+        monkeypatch.setattr(
+            DatabaseModel, "resolve_default_branch", lambda self: "main"
+        )
+        monkeypatch.setattr(
+            resources_mod,
+            "_resolve_lakebase_database_path",
+            lambda db, branch_path: f"{branch_path}/databases/db-test",
+        )
 
         out = _extract_database_resources(
             {
@@ -193,7 +249,9 @@ class TestExtractDatabaseResourcesFlat:
                 "checkpoints_db": DatabaseModel(project="p2"),
             }
         )
-        assert {r["database"] for r in out} == {"p1", "p2"}
+        # Each Lakebase becomes its own postgres resource with a project-rooted path.
+        roots = {r["database"].split("/")[1] for r in out}
+        assert roots == {"p1", "p2"}
 
     def test_empty_dict_returns_empty(self) -> None:
         from dao_ai.apps.resources import _extract_database_resources
@@ -224,7 +282,12 @@ class TestExtractDatabaseResourcesSDK:
         from dao_ai.config import DatabaseModel
 
         monkeypatch.setattr(
-            resources_mod, "_resolve_lakebase_default_branch", lambda db: "main"
+            DatabaseModel, "resolve_default_branch", lambda self: "main"
+        )
+        monkeypatch.setattr(
+            resources_mod,
+            "_resolve_lakebase_database_path",
+            lambda db, branch_path: f"{branch_path}/databases/db-test",
         )
 
         db = DatabaseModel(name="retail-consumer-goods", project="retail-consumer-goods")
@@ -237,10 +300,13 @@ class TestExtractDatabaseResourcesSDK:
         # instance shape and must NOT be used.
         assert r.database is None
         assert isinstance(r.postgres, AppResourcePostgres)
-        assert r.postgres.database == "retail-consumer-goods"
-        # Branch is always populated -- the Apps platform requires it on the
-        # postgres resource. Resolved here from the (mocked) helper.
-        assert r.postgres.branch == "main"
+        # Both branch and database are full resource paths -- the platform
+        # validates each with get_branch / get_database and rejects bare IDs.
+        assert r.postgres.branch == "projects/retail-consumer-goods/branches/main"
+        assert (
+            r.postgres.database
+            == "projects/retail-consumer-goods/branches/main/databases/db-test"
+        )
         assert (
             r.postgres.permission
             is AppResourcePostgresPostgresPermission.CAN_CONNECT_AND_CREATE
@@ -306,15 +372,29 @@ class TestAppResourcesIntegration:
             ),
         )
 
-    def test_flat_app_resources_contain_postgres_alongside_llm(self) -> None:
+    def test_flat_app_resources_contain_postgres_alongside_llm(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from dao_ai.apps import resources as resources_mod
         from dao_ai.apps.resources import generate_app_resources
+        from dao_ai.config import DatabaseModel
+
+        monkeypatch.setattr(
+            DatabaseModel, "resolve_default_branch", lambda self: "main"
+        )
+        monkeypatch.setattr(
+            resources_mod,
+            "_resolve_lakebase_database_path",
+            lambda db, branch_path: f"{branch_path}/databases/db-test",
+        )
 
         resources = generate_app_resources(self._build_config())
         types = {r["type"] for r in resources}
         assert "serving-endpoint" in types
         assert "postgres" in types
         pg_r = next(r for r in resources if r["type"] == "postgres")
-        assert pg_r["database"] == "workshop-db"
+        assert pg_r["database"].startswith("projects/workshop-db/branches/")
+        assert pg_r["database"].endswith("/databases/db-test")
         assert pg_r["permissions"] == [{"level": "CAN_CONNECT_AND_CREATE"}]
 
     def test_flat_app_resources_skips_postgres_when_obo(self) -> None:
@@ -324,10 +404,23 @@ class TestAppResourcesIntegration:
         types = {r["type"] for r in resources}
         assert "postgres" not in types
 
-    def test_sdk_app_resources_contain_appresourcepostgres(self) -> None:
+    def test_sdk_app_resources_contain_appresourcepostgres(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         from databricks.sdk.service.apps import AppResource, AppResourcePostgres
 
+        from dao_ai.apps import resources as resources_mod
         from dao_ai.apps.resources import generate_sdk_resources
+        from dao_ai.config import DatabaseModel
+
+        monkeypatch.setattr(
+            DatabaseModel, "resolve_default_branch", lambda self: "main"
+        )
+        monkeypatch.setattr(
+            resources_mod,
+            "_resolve_lakebase_database_path",
+            lambda db, branch_path: f"{branch_path}/databases/db-test",
+        )
 
         resources = generate_sdk_resources(self._build_config())
         pg_resources = [
@@ -336,7 +429,8 @@ class TestAppResourcesIntegration:
         ]
         assert len(pg_resources) == 1
         assert isinstance(pg_resources[0].postgres, AppResourcePostgres)
-        assert pg_resources[0].postgres.database == "workshop-db"
+        assert pg_resources[0].postgres.database.startswith("projects/workshop-db/branches/")
+        assert pg_resources[0].postgres.database.endswith("/databases/db-test")
         # No legacy AppResourceDatabase mixed in
         assert pg_resources[0].database is None
 


### PR DESCRIPTION
## Summary

Fixes Lakebase deploy on **both** the Apps path and the Model Serving path. Two related but separate fixes:

### 1. Apps: full resource paths on the postgres app resource

The Apps platform validates BOTH `branch` and `database` server-side via `get_branch` / `get_database`, which require full resource paths. After 0.1.65 (PR #70 fixed branch path), Lab 7 deploy hit:

```
INVALID_PARAMETER_VALUE: Field 'name' expects 'projects/{project_id}/branches/{branch_id}/databases/{database_id}' format, got 'retail-consumer-goods'
```

- **`_resolve_lakebase_branch_path(db)`** — returns `projects/<project>/branches/<branch_id>`. Uses `db.branch` if pinned in config; otherwise calls `db.resolve_default_branch()`; falls back to `"main"` when the API call fails.
- **`_resolve_lakebase_database_path(db, branch_path)`** *(new)* — returns `projects/<project>/branches/<branch_id>/databases/<database_id>`. The platform's Database resource has a random-ID suffix (e.g. `db-pmke-laez4ing20`) that doesn't match the user's Postgres-level `database` field (typically `databricks_postgres`), so this helper lists databases under the branch and matches by `status.postgres_database`. Falls back to the first database under the branch, then to a constructed path.
- **`find_dev_wheel()`** — now reads `direct_url.json` so wheels installed via `pip install /path/to/dao_ai-X.Y.Z.whl` (including workspace paths like `/Workspace/.../wheels/dao_ai-...whl` on Databricks Serverless) are auto-discovered. `deploy_apps_agent` can bundle the same wheel into the deployed app without searching for a local `dist/` directory that doesn't exist on Serverless.

### 2. Model Serving: skip `DatabricksLakebase` for autoscaling Lakebase

MLflow's `DatabricksLakebase` resource only supports the deprecated provisioned-instance shape. Emitting it for an autoscaling project causes the Model Serving endpoint to fail to start with:

```
NOT_FOUND: Database instance is not found. Please ensure all resource dependencies for the server entity are valid...
```

The MLflow team confirmed (2026-04-10) that autoscaling support "requires a significant lift and is not planned for the time being" — see [mlflow/mlflow#22452](https://github.com/mlflow/mlflow/issues/22452).

- `DatabaseModel.as_resources()` now returns `[]` for Lakebase databases. The recommended workaround per the MLflow maintainer is to manage Lakebase auth from within the agent code via OAuth M2M — set `client_id` / `client_secret` on the DatabaseModel.
- `deploy_model_serving_agent` logs a warning at deploy time when a Lakebase database is configured without `client_id`, pointing users at the manual-auth workaround or recommending the Apps deploy path.
- The **Apps deploy path is the recommended path for Lakebase** — it natively supports autoscaling projects via the platform's `postgres` resource binding (fixed by part 1 of this PR).

## Test plan

- [x] 20/20 lakebase resource tests pass — assertions cover both the Apps `postgres` resource shape (full resource paths, mocked resolvers) and the Model Serving `as_resources()` returning `[]` for Lakebase.
- [x] 87/87 broader apps + bundle + resource + utils tests pass — no regressions.
- [x] Lab 7 bundle generation produces correct YAML on aws-field-eng with `retail-consumer-goods` autoscaling project.
- [x] Lab 7 bundle deploy succeeds end-to-end against `aws-field-eng`. App created with the postgres resource binding intact; auto-SP gets `CAN_CONNECT_AND_CREATE` automatically.
- [x] Deployed app starts and the auto-SP successfully **authenticates** to Lakebase (past-error mode `password authentication failed for user '<sp-uuid>'` no longer reproduces).

## Out of scope

The runtime memory test (cross-thread recall + summarization) needs an additional postgres-side role grant (`DATABRICKS_SUPERUSER` membership) for the auto-SP to gain schema-level CREATE on `public`. That role provisioning is gated on `database.client_id` in config and isn't auto-discovered from the deployed app's auto-SP — a real product gap exposed by this verification, but a separate concern from the resource-binding fix in this PR.

This pull request and its description were written by Isaac.