### PR TITLE
Lakebase autoscaling role: clearer error when client_id resolves to None

### DIFF
--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -2112,7 +2112,17 @@ class DatabricksProvider(ServiceProvider):
             )
             return
 
-        client_id: str = value_of(database.client_id)
+        client_id: str | None = value_of(database.client_id)
+        if not client_id:
+            logger.warning(
+                "client_id resolved to None; skipping autoscaling role creation. "
+                "Check that the configured source (secret scope, env var, etc.) "
+                "is populated.",
+                project=database.project,
+                client_id_spec=database.client_id,
+            )
+            return
+
         workspace_client: WorkspaceClient = database.workspace_client
 
         # Roles are created on a branch, not on the project


### PR DESCRIPTION
## Summary
- `create_lakebase_autoscaling_role` already guards against `database.client_id` being unset on the model, but the check passes when `client_id` is an `AnyVariable` whose source (secret scope / env var) resolves to `None`.
- The unguarded `client_id.lower()` a few lines later then crashes with `AttributeError: 'NoneType' object has no attribute 'lower'` — confusing for users who haven't realized their secret scope is missing or empty.
- Add a value-level guard after `value_of(...)` that warns and returns cleanly, pointing the user at the configured source to populate. Matches the existing pattern at the OTEL-grants callsite (`grantee = value_of(...); if not grantee: return`).

## Repro
- A workshop lab with `client_id: { options: [{ scope: ..., secret: ... }, { env: ... }] }` declared, but neither the secret scope nor env var populated.
- `database.create()` blows up at `providers/databricks.py:2127` instead of warning.

## Test plan
- [ ] Run a workshop lab without the secret scope populated → expect a clean warning (`client_id resolved to None; skipping autoscaling role creation. Check that the configured source ...`) instead of `AttributeError`.
- [ ] Run the same lab with the scope populated → role creation proceeds as before.

This pull request and its description were written by Isaac.