### PR TITLE
Orchestration: allow memory-only orchestration without supervisor/swarm

### DIFF
--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -4441,7 +4441,7 @@
     },
     "OrchestrationModel": {
       "additionalProperties": false,
-      "description": "Multi-agent orchestration configuration. Exactly one of supervisor or swarm must be specified.",
+      "description": "Multi-agent orchestration configuration.\n\n`supervisor` and `swarm` are mutually exclusive. If neither is set\n(e.g. the user only supplies `memory:`), AppConfig will auto-pick a\nsensible router at the AppConfig level based on the number of agents.",
       "properties": {
         "supervisor": {
           "anyOf": [

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -4345,7 +4345,12 @@ class SwarmModel(BaseModel):
 
 
 class OrchestrationModel(BaseModel):
-    """Multi-agent orchestration configuration. Exactly one of supervisor or swarm must be specified."""
+    """Multi-agent orchestration configuration.
+
+    `supervisor` and `swarm` are mutually exclusive. If neither is set
+    (e.g. the user only supplies `memory:`), AppConfig will auto-pick a
+    sensible router at the AppConfig level based on the number of agents.
+    """
 
     model_config = ConfigDict(use_enum_values=True, extra="forbid")
     supervisor: Optional[SupervisorModel] = Field(
@@ -4368,11 +4373,12 @@ class OrchestrationModel(BaseModel):
         if self.swarm is True:
             self.swarm = SwarmModel()
 
-        # Validate mutually exclusive
+        # Validate mutually exclusive. Allowing neither -- AppConfig fills
+        # in a default router (supervisor for >1 agent, swarm for 1) so
+        # that `orchestration: { memory: ... }` is valid for single-agent
+        # apps that only want the memory wiring.
         if self.supervisor is not None and self.swarm is not None:
             raise ValueError("Cannot specify both supervisor and swarm")
-        if self.supervisor is None and self.swarm is None:
-            raise ValueError("Must specify either supervisor or swarm")
         return self
 
 
@@ -4973,19 +4979,23 @@ class AppModel(BaseModel):
 
     @model_validator(mode="after")
     def set_default_orchestration(self) -> Self:
+        if not self.agents:
+            raise ValueError("At least one agent must be specified")
+
         if self.orchestration is None:
+            self.orchestration = OrchestrationModel()
+
+        # If neither supervisor nor swarm is set (e.g. user only supplied
+        # `orchestration: { memory: ... }`), pick a sensible default based
+        # on agent count.
+        if self.orchestration.supervisor is None and self.orchestration.swarm is None:
+            default_agent: AgentModel = self.agents[0]
             if len(self.agents) > 1:
-                default_agent: AgentModel = self.agents[0]
-                self.orchestration = OrchestrationModel(
-                    supervisor=SupervisorModel(model=default_agent.model)
-                )
-            elif len(self.agents) == 1:
-                default_agent: AgentModel = self.agents[0]
-                self.orchestration = OrchestrationModel(
-                    swarm=SwarmModel(default_agent=default_agent)
+                self.orchestration.supervisor = SupervisorModel(
+                    model=default_agent.model
                 )
             else:
-                raise ValueError("At least one agent must be specified")
+                self.orchestration.swarm = SwarmModel(default_agent=default_agent)
 
         return self
 


### PR DESCRIPTION
## Summary
- `OrchestrationModel.validate_and_normalize` previously required either `supervisor` or `swarm` to be set, but a single-agent app that just wants the `memory:` wiring (checkpointer / store / extraction) has no router work to do.
- Forcing the user to also write a no-op `swarm: { default_agent: *the_only_agent }` is a footgun, especially since `AppConfig` already auto-picks a router when `orchestration` is omitted entirely. Today this fails:

  \`\`\`yaml
  app:
    agents: [*support_agent]
    orchestration:
      memory: *memory      # ValueError: Must specify either supervisor or swarm
  \`\`\`

- Relax `OrchestrationModel` to only require that `supervisor` and `swarm` aren't both set. Move the router-defaulting logic up to `AppConfig.set_default_orchestration` so it kicks in whenever neither is set on the configured `OrchestrationModel`, not only when `orchestration` is None.
- Regenerated `schemas/model_config_schema.json` via `dao-ai schema`.

## Test plan
- [ ] Existing configs with `orchestration: { swarm: ... }` still validate.
- [ ] Existing configs that omit `orchestration:` entirely still get the auto-router (single agent → swarm; multi-agent → supervisor).
- [ ] New: `orchestration: { memory: ... }` for a single-agent app validates and AppConfig auto-fills `swarm` with that agent.
- [ ] New: `orchestration: { memory: ... }` for a multi-agent app validates and AppConfig auto-fills `supervisor` with the first agent's model.
- [ ] `orchestration: { supervisor: ..., swarm: ... }` still raises (mutual exclusivity preserved).

This pull request and its description were written by Isaac.