### PR TITLE
Orchestration: fix code-review findings + 3 deploy-time bugs caught during verification

### DIFF
--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -4483,6 +4483,16 @@
           ],
           "default": null,
           "description": "Memory configuration scoped to the orchestration layer (checkpointer, store, extraction)."
+        },
+        "output_mode": {
+          "default": "full_history",
+          "description": "How an agent's response flows back into parent state. ``full_history`` returns the agent's full local history including intermediate AI/tool messages, which lets the same agent see its own prior tool results across multi-turn conversations. ``last_message`` returns only the final AI response, which trims tokens but loses intermediate content. Default flipped to ``full_history`` so per-agent ToolMessage tagging actually has messages to identify.",
+          "enum": [
+            "full_history",
+            "last_message"
+          ],
+          "title": "Output Mode",
+          "type": "string"
         }
       },
       "title": "OrchestrationModel",
@@ -5535,6 +5545,13 @@
           ],
           "description": "Mapping of agent names to their allowed handoff targets. Each target can be an agent name (str), an AgentModel, or a HandoffRouteModel for deterministic routing. Use null (~) to allow handoffs to all agents.",
           "title": "Handoffs"
+        },
+        "max_hops": {
+          "default": 25,
+          "description": "Cross-agent hop ceiling for the parent swarm graph. Two agents agentic-handing-off to each other are bounded only by this value (set via LangGraph's recursion_limit on the compiled parent graph). Independent of per-worker recursion limits. Defaults to LangGraph's own default of 25.",
+          "minimum": 1,
+          "title": "Max Hops",
+          "type": "integer"
         }
       },
       "title": "SwarmModel",

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -4245,6 +4245,17 @@ class SwarmModel(BaseModel):
             "Use null (~) to allow handoffs to all agents."
         ),
     )
+    max_hops: int = Field(
+        default=25,
+        ge=1,
+        description=(
+            "Cross-agent hop ceiling for the parent swarm graph. Two agents "
+            "agentic-handing-off to each other are bounded only by this "
+            "value (set via LangGraph's recursion_limit on the compiled "
+            "parent graph). Independent of per-worker recursion limits. "
+            "Defaults to LangGraph's own default of 25."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_no_deterministic_handoff_in_cycle(self) -> Self:
@@ -4364,6 +4375,19 @@ class OrchestrationModel(BaseModel):
     memory: Optional[MemoryModel] = Field(
         default=None,
         description="Memory configuration scoped to the orchestration layer (checkpointer, store, extraction).",
+    )
+    output_mode: Literal["full_history", "last_message"] = Field(
+        default="full_history",
+        description=(
+            "How an agent's response flows back into parent state. "
+            "``full_history`` returns the agent's full local history including "
+            "intermediate AI/tool messages, which lets the same agent see its "
+            "own prior tool results across multi-turn conversations. "
+            "``last_message`` returns only the final AI response, which trims "
+            "tokens but loses intermediate content. Default flipped to "
+            "``full_history`` so per-agent ToolMessage tagging actually has "
+            "messages to identify."
+        ),
     )
 
     @model_validator(mode="after")

--- a/src/dao_ai/messages.py
+++ b/src/dao_ai/messages.py
@@ -197,6 +197,27 @@ def last_ai_message(messages: Sequence[BaseMessage]) -> Optional[AIMessage]:
     )
 
 
+def last_ai_message_with_tool_calls(
+    messages: Sequence[BaseMessage],
+) -> Optional[AIMessage]:
+    """
+    Find the last AIMessage that carries one or more tool calls.
+
+    Used by handoff tools that need to emit a ToolMessage paired with the
+    AIMessage that triggered the handoff (LLMs require tool_use/tool_result
+    pairing across providers).
+
+    Args:
+        messages: A sequence of LangChain message objects to search through
+
+    Returns:
+        The last AIMessage with non-empty ``tool_calls``, or None if not found
+    """
+    return last_message(
+        messages, lambda m: isinstance(m, AIMessage) and bool(m.tool_calls)
+    )
+
+
 def last_tool_message(messages: Sequence[BaseMessage]) -> Optional[ToolMessage]:
     """
     Find the last message from a tool in the message history.

--- a/src/dao_ai/orchestration/__init__.py
+++ b/src/dao_ai/orchestration/__init__.py
@@ -27,6 +27,7 @@ from dao_ai.orchestration.core import (
     OutputMode,
     create_agent_node_handler,
     create_checkpointer,
+    create_extraction_manager_and_executor,
     create_handoff_tool,
     create_orchestration_graph,
     create_store,
@@ -45,6 +46,7 @@ __all__ = [
     "filter_messages_for_agent",
     "extract_agent_response",
     "create_agent_node_handler",
+    "create_extraction_manager_and_executor",
     "create_handoff_tool",
     "get_handoff_description",
     # Main factory

--- a/src/dao_ai/orchestration/core.py
+++ b/src/dao_ai/orchestration/core.py
@@ -12,6 +12,7 @@ This module provides the foundational utilities for multi-agent orchestration:
 from typing import Any, Awaitable, Callable, Literal
 
 from langchain.tools import ToolRuntime, tool
+from langchain_core.language_models import LanguageModelLike
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
 from langchain_core.tools import BaseTool
 from langgraph.checkpoint.base import BaseCheckpointSaver
@@ -26,9 +27,10 @@ from loguru import logger
 from dao_ai.config import (
     AgentModel,
     AppConfig,
+    MemoryModel,
     OrchestrationModel,
 )
-from dao_ai.messages import last_ai_message
+from dao_ai.messages import last_ai_message, last_ai_message_with_tool_calls
 from dao_ai.state import AgentState, Context
 
 # Constant for supervisor node name
@@ -78,19 +80,31 @@ def create_checkpointer(
     return None
 
 
-def filter_messages_for_agent(messages: list[BaseMessage]) -> list[BaseMessage]:
+def filter_messages_for_agent(
+    messages: list[BaseMessage],
+    current_agent_name: str | None = None,
+) -> list[BaseMessage]:
     """
     Filter messages for a worker agent to avoid tool_use/tool_result pairing errors.
 
-    When the supervisor hands off to an agent, the agent should only see:
+    When agents share parent-graph state, each agent should only see:
     - HumanMessage (user queries)
-    - AIMessage with content (previous responses, but not tool calls)
+    - AIMessage with content from any agent (peer responses, with tool_calls
+      stripped so the model doesn't see orphaned tool_use blocks)
+    - Its own AIMessage(tool_calls=...) and matching ToolMessages, identified
+      by the ``name`` field on the message
 
-    This prevents the agent from seeing orphaned ToolMessages or AIMessages
-    with tool_calls that don't belong to the agent's context.
+    Tool exchanges produced by other agents (tagged with their own ``name``)
+    or by orchestration plumbing (handoff tools, untagged) are dropped so the
+    re-entering agent doesn't trip pairing checks on tool_call_ids it didn't
+    issue.
 
     Args:
         messages: The full message history from parent state
+        current_agent_name: The name of the agent receiving the filtered
+            history. When set, the agent's own tool exchanges (matching
+            ``msg.name``) are preserved. When ``None`` (legacy callers), all
+            tool exchanges are stripped — preserves the pre-refactor behaviour.
 
     Returns:
         Filtered messages safe for the agent to process
@@ -101,13 +115,33 @@ def filter_messages_for_agent(messages: list[BaseMessage]) -> list[BaseMessage]:
             # Always include user messages
             filtered.append(msg)
         elif isinstance(msg, AIMessage):
-            # Include AI messages but strip tool_calls to avoid confusion
-            if msg.content and not msg.tool_calls:
+            is_own = (
+                current_agent_name is not None
+                and msg.name == current_agent_name
+            )
+            if msg.tool_calls:
+                if is_own:
+                    # Keep agent's own tool-call message intact so it pairs
+                    # with the matching ToolMessage(s) below.
+                    filtered.append(msg)
+                elif msg.content:
+                    # Strip tool_calls from peer/orchestration messages but
+                    # preserve content (and name, so a peer's identity flows
+                    # through subsequent turns).
+                    filtered.append(
+                        AIMessage(content=msg.content, id=msg.id, name=msg.name)
+                    )
+                # else: drop silent tool-call-only message from peers
+            elif msg.content:
                 filtered.append(msg)
-            elif msg.content and msg.tool_calls:
-                # Include content but create clean AIMessage without tool_calls
-                filtered.append(AIMessage(content=msg.content, id=msg.id))
-        # Skip ToolMessages - they belong to the supervisor's context
+        elif isinstance(msg, ToolMessage):
+            if (
+                current_agent_name is not None
+                and msg.name == current_agent_name
+            ):
+                # Keep agent's own tool result so it pairs with its tool_call.
+                filtered.append(msg)
+            # else: drop peer or orchestration tool result
     return filtered
 
 
@@ -172,9 +206,13 @@ def create_agent_node_handler(
     """
 
     async def handler(state: AgentState, runtime: Runtime[Context]) -> AgentState:
-        # Filter messages to avoid tool_use/tool_result pairing errors
+        # Filter messages to avoid tool_use/tool_result pairing errors.
+        # Passing agent_name preserves the agent's own tool exchanges from
+        # prior turns while still hiding peers' tool exchanges.
         original_messages = state.get("messages", [])
-        filtered_messages = filter_messages_for_agent(original_messages)
+        filtered_messages = filter_messages_for_agent(
+            original_messages, current_agent_name=agent_name
+        )
 
         logger.trace(
             "Agent receiving filtered messages",
@@ -292,6 +330,18 @@ def create_agent_node_handler(
         result_messages = result.get("messages", [])
         response_messages = extract_agent_response(result_messages, output_mode)
 
+        # Tag the agent's own tool-call AIMessages and ToolMessages so a later
+        # filter pass can preserve same-agent tool pairs while hiding peers'.
+        # Untagged messages from this agent get the agent's name; messages
+        # already carrying a name (e.g. peer tool exchanges that flowed
+        # through full_history mode) keep their existing tag.
+        response_messages = [
+            msg.model_copy(update={"name": agent_name})
+            if isinstance(msg, (AIMessage, ToolMessage)) and not msg.name
+            else msg
+            for msg in response_messages
+        ]
+
         logger.debug(
             "Agent completed",
             agent=agent_name,
@@ -355,16 +405,14 @@ def create_handoff_tool(
         # LLMs expect tool calls to be paired with their responses, so we must include both
         # the AIMessage containing the tool call and the ToolMessage acknowledging it.
         messages: list[BaseMessage] = runtime.state.get("messages", [])
-        last_ai_message: AIMessage | None = None
-        for msg in reversed(messages):
-            if isinstance(msg, AIMessage) and msg.tool_calls:
-                last_ai_message = msg
-                break
+        triggering_ai_message: AIMessage | None = last_ai_message_with_tool_calls(
+            messages
+        )
 
         # Build message list with proper pairing
         update_messages: list[BaseMessage] = []
-        if last_ai_message:
-            update_messages.append(last_ai_message)
+        if triggering_ai_message:
+            update_messages.append(triggering_ai_message)
         update_messages.append(
             ToolMessage(
                 content=f"Transferred to {target_agent_name}",
@@ -406,6 +454,78 @@ def get_handoff_description(agent: AgentModel) -> str:
         or agent.description
         or f"Handles {agent.name} related tasks and inquiries"
     )
+
+
+def create_extraction_manager_and_executor(
+    memory: MemoryModel | None,
+    store: BaseStore | None,
+    fallback_model: LanguageModelLike,
+    graph_label: str,
+) -> tuple[Any | None, Any | None]:
+    """
+    Build the shared extraction manager and optional reflection executor.
+
+    Both the supervisor and swarm graphs need a single extraction manager
+    shared across all nodes. The fallback model differs (the supervisor's
+    own model vs. the first worker's model in swarm), so it's parameterised.
+
+    Args:
+        memory: The orchestration memory configuration, if any.
+        store: The shared LangGraph store, if any.
+        fallback_model: Chat model to use when ``memory.extraction.extraction_model``
+            is not set.
+        graph_label: Human-readable label used only in log messages
+            (e.g. ``"supervisor graph"``).
+
+    Returns:
+        ``(extraction_manager, reflection_executor)``. Either or both may
+        be ``None`` when extraction is not configured or background
+        extraction is disabled.
+    """
+    needs_extraction = (
+        memory
+        and memory.store
+        and memory.extraction
+        and store
+        and (memory.extraction.background_extraction or memory.extraction.auto_inject)
+    )
+    if not needs_extraction:
+        return None, None
+
+    # Lazy imports avoid an import cycle with dao_ai.memory and dao_ai.nodes.
+    from dao_ai.memory.extraction import (
+        create_extraction_manager,
+        create_reflection_executor,
+    )
+    from dao_ai.nodes import _build_memory_namespace
+
+    extraction_ns = _build_memory_namespace(memory)
+    extraction_model: LanguageModelLike = (
+        memory.extraction.extraction_model.as_chat_model()
+        if memory.extraction.extraction_model
+        else fallback_model
+    )
+    query_model: LanguageModelLike | None = (
+        memory.extraction.query_model.as_chat_model()
+        if memory.extraction.query_model
+        else None
+    )
+
+    extraction_manager = create_extraction_manager(
+        model=extraction_model,
+        store=store,
+        namespace=extraction_ns,
+        schemas=memory.extraction.schemas,
+        instructions=memory.extraction.instructions,
+        query_model=query_model,
+    )
+
+    reflection_executor = None
+    if memory.extraction.background_extraction:
+        reflection_executor = create_reflection_executor(extraction_manager, store)
+        logger.info(f"Background memory extraction enabled for {graph_label}")
+
+    return extraction_manager, reflection_executor
 
 
 def create_orchestration_graph(config: AppConfig) -> CompiledStateGraph:

--- a/src/dao_ai/orchestration/core.py
+++ b/src/dao_ai/orchestration/core.py
@@ -91,28 +91,31 @@ def filter_messages_for_agent(
     - HumanMessage (user queries)
     - AIMessage with content from any agent (peer responses, with tool_calls
       stripped so the model doesn't see orphaned tool_use blocks)
-    - Its own AIMessage(tool_calls=...) and matching ToolMessages, identified
-      by the ``name`` field on the message
+    - Its own AIMessage(tool_calls=...) and the matching ToolMessage(s), so a
+      multi-turn agent can see its own prior tool results
 
-    Tool exchanges produced by other agents (tagged with their own ``name``)
-    or by orchestration plumbing (handoff tools, untagged) are dropped so the
-    re-entering agent doesn't trip pairing checks on tool_call_ids it didn't
-    issue.
+    Ownership rules:
+    - AIMessages are tagged with the agent's name by ``create_agent`` (and as
+      a fallback by ``create_agent_node_handler``). ``msg.name ==
+      current_agent_name`` identifies an own AIMessage.
+    - ToolMessages carry the **tool's** name in ``msg.name`` (e.g.
+      ``product_vector_search_tool``) — *not* the agent's. To attribute a
+      ToolMessage to an agent, we pair it via ``tool_call_id`` against the
+      surrounding ``AIMessage(tool_calls=…)`` we already decided to keep.
 
     Args:
         messages: The full message history from parent state
         current_agent_name: The name of the agent receiving the filtered
-            history. When set, the agent's own tool exchanges (matching
-            ``msg.name``) are preserved. When ``None`` (legacy callers), all
-            tool exchanges are stripped — preserves the pre-refactor behaviour.
+            history. When set, the agent's own tool exchanges are preserved.
+            When ``None`` (legacy callers), all tool exchanges are stripped.
 
     Returns:
         Filtered messages safe for the agent to process
     """
     filtered: list[BaseMessage] = []
+    own_tool_call_ids: set[str] = set()
     for msg in messages:
         if isinstance(msg, HumanMessage):
-            # Always include user messages
             filtered.append(msg)
         elif isinstance(msg, AIMessage):
             is_own = (
@@ -121,13 +124,14 @@ def filter_messages_for_agent(
             )
             if msg.tool_calls:
                 if is_own:
-                    # Keep agent's own tool-call message intact so it pairs
-                    # with the matching ToolMessage(s) below.
                     filtered.append(msg)
+                    for tc in msg.tool_calls:
+                        tc_id = tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
+                        if tc_id:
+                            own_tool_call_ids.add(tc_id)
                 elif msg.content:
-                    # Strip tool_calls from peer/orchestration messages but
-                    # preserve content (and name, so a peer's identity flows
-                    # through subsequent turns).
+                    # Peer/orchestration message: keep visible content but
+                    # strip tool_calls so the model doesn't see orphans.
                     filtered.append(
                         AIMessage(content=msg.content, id=msg.id, name=msg.name)
                     )
@@ -135,13 +139,10 @@ def filter_messages_for_agent(
             elif msg.content:
                 filtered.append(msg)
         elif isinstance(msg, ToolMessage):
-            if (
-                current_agent_name is not None
-                and msg.name == current_agent_name
-            ):
-                # Keep agent's own tool result so it pairs with its tool_call.
+            if msg.tool_call_id in own_tool_call_ids:
+                # Pair with a kept own AIMessage(tool_calls=…).
                 filtered.append(msg)
-            # else: drop peer or orchestration tool result
+            # else: peer / handoff / orchestration tool result — drop
     return filtered
 
 
@@ -330,14 +331,15 @@ def create_agent_node_handler(
         result_messages = result.get("messages", [])
         response_messages = extract_agent_response(result_messages, output_mode)
 
-        # Tag the agent's own tool-call AIMessages and ToolMessages so a later
-        # filter pass can preserve same-agent tool pairs while hiding peers'.
-        # Untagged messages from this agent get the agent's name; messages
-        # already carrying a name (e.g. peer tool exchanges that flowed
-        # through full_history mode) keep their existing tag.
+        # Defensive fallback: if any AIMessage came back without ``name``
+        # set, tag it with the agent's name so ``filter_messages_for_agent``
+        # can identify it as own on re-entry. ``create_agent(name=…)``
+        # normally sets this already, so this is rarely a no-op. ToolMessages
+        # carry the tool's name (not the agent's) and get attributed via
+        # tool_call_id pairing in the filter.
         response_messages = [
             msg.model_copy(update={"name": agent_name})
-            if isinstance(msg, (AIMessage, ToolMessage)) and not msg.name
+            if isinstance(msg, AIMessage) and not msg.name
             else msg
             for msg in response_messages
         ]

--- a/src/dao_ai/orchestration/supervisor.py
+++ b/src/dao_ai/orchestration/supervisor.py
@@ -29,6 +29,7 @@ from dao_ai.config import (
     PromptModel,
     SupervisorModel,
 )
+from dao_ai.messages import last_ai_message_with_tool_calls
 from dao_ai.middleware.base import AgentMiddleware
 from dao_ai.middleware.core import create_factory_middleware
 from dao_ai.nodes import create_agent_node
@@ -36,6 +37,7 @@ from dao_ai.orchestration import (
     SUPERVISOR_NODE,
     create_agent_node_handler,
     create_checkpointer,
+    create_extraction_manager_and_executor,
     create_handoff_tool,
     create_store,
     get_handoff_description,
@@ -79,16 +81,14 @@ def _create_handoff_back_to_supervisor_tool() -> BaseTool:
         # LLMs expect tool calls to be paired with their responses, so we must include both
         # the AIMessage containing the tool call and the ToolMessage acknowledging it.
         messages: list[BaseMessage] = runtime.state.get("messages", [])
-        last_ai_message: AIMessage | None = None
-        for msg in reversed(messages):
-            if isinstance(msg, AIMessage) and msg.tool_calls:
-                last_ai_message = msg
-                break
+        triggering_ai_message: AIMessage | None = last_ai_message_with_tool_calls(
+            messages
+        )
 
         # Build message list with proper pairing
         update_messages: list[BaseMessage] = []
-        if last_ai_message:
-            update_messages.append(last_ai_message)
+        if triggering_ai_message:
+            update_messages.append(triggering_ai_message)
         update_messages.append(
             ToolMessage(
                 content=f"Task completed: {summary}",
@@ -98,6 +98,7 @@ def _create_handoff_back_to_supervisor_tool() -> BaseTool:
 
         return Command(
             update={
+                "active_agent": SUPERVISOR_NODE,
                 "messages": update_messages,
             },
             goto=SUPERVISOR_NODE,
@@ -202,6 +203,19 @@ def create_supervisor_graph(config: AppConfig) -> CompiledStateGraph:
     orchestration: OrchestrationModel = config.app.orchestration
     supervisor_config: SupervisorModel = orchestration.supervisor
 
+    # Reject worker agents that would collide with the reserved supervisor
+    # node name. The collision is silent at graph compile time but produces
+    # confusing routing failures at runtime, so fail fast at config time.
+    colliding_agents: list[str] = [
+        a.name for a in config.app.agents if a.name == SUPERVISOR_NODE
+    ]
+    if colliding_agents:
+        raise ValueError(
+            f"Worker agent name(s) {colliding_agents!r} collide with the "
+            f"reserved supervisor node name {SUPERVISOR_NODE!r}. Rename the "
+            f"agent(s) in config.app.agents."
+        )
+
     logger.info(
         "Creating supervisor graph",
         pattern="handoff",
@@ -266,47 +280,13 @@ def create_supervisor_graph(config: AppConfig) -> CompiledStateGraph:
     # Set up shared extraction manager and background reflection executor.
     # A single extraction manager is shared across the supervisor and all
     # worker agents to avoid creating redundant model instances.
-    extraction_manager = None
-    reflection_executor = None
     memory: MemoryModel | None = orchestration.memory
-    needs_extraction = (
-        memory
-        and memory.store
-        and memory.extraction
-        and store
-        and (memory.extraction.background_extraction or memory.extraction.auto_inject)
+    extraction_manager, reflection_executor = create_extraction_manager_and_executor(
+        memory=memory,
+        store=store,
+        fallback_model=supervisor_config.model.as_chat_model(),
+        graph_label="supervisor graph",
     )
-    if needs_extraction:
-        from dao_ai.memory.extraction import (
-            create_extraction_manager,
-            create_reflection_executor,
-        )
-        from dao_ai.nodes import _build_memory_namespace
-
-        extraction_ns = _build_memory_namespace(memory)
-        extraction_model: LanguageModelLike = (
-            memory.extraction.extraction_model.as_chat_model()
-            if memory.extraction.extraction_model
-            else supervisor_config.model.as_chat_model()
-        )
-        query_model: LanguageModelLike | None = (
-            memory.extraction.query_model.as_chat_model()
-            if memory.extraction.query_model
-            else None
-        )
-
-        extraction_manager = create_extraction_manager(
-            model=extraction_model,
-            store=store,
-            namespace=extraction_ns,
-            schemas=memory.extraction.schemas,
-            instructions=memory.extraction.instructions,
-            query_model=query_model,
-        )
-
-        if memory.extraction.background_extraction:
-            reflection_executor = create_reflection_executor(extraction_manager, store)
-            logger.info("Background memory extraction enabled for supervisor graph")
 
     if (
         needs_extraction
@@ -388,7 +368,7 @@ def create_supervisor_graph(config: AppConfig) -> CompiledStateGraph:
         handler = create_agent_node_handler(
             agent_name=agent_name,
             agent=agent_subgraph,
-            output_mode="last_message",
+            output_mode=orchestration.output_mode,
             reflection_executor=reflection_executor,
             recursion_limit=agent_recursion_limits.get(agent_name),
         )

--- a/src/dao_ai/orchestration/supervisor.py
+++ b/src/dao_ai/orchestration/supervisor.py
@@ -288,9 +288,12 @@ def create_supervisor_graph(config: AppConfig) -> CompiledStateGraph:
         graph_label="supervisor graph",
     )
 
+    # extraction_manager is non-None iff create_extraction_manager_and_executor
+    # determined extraction is needed; use it as the gate for downstream wiring.
     if (
-        needs_extraction
-        and extraction_manager
+        extraction_manager
+        and memory
+        and memory.extraction
         and memory.extraction.auto_inject
         and memory.extraction.supervisor_auto_inject
     ):
@@ -305,7 +308,12 @@ def create_supervisor_graph(config: AppConfig) -> CompiledStateGraph:
             "Memory context injection enabled for supervisor",
             auto_inject_limit=memory.extraction.auto_inject_limit,
         )
-    elif needs_extraction and extraction_manager and memory.extraction.auto_inject:
+    elif (
+        extraction_manager
+        and memory
+        and memory.extraction
+        and memory.extraction.auto_inject
+    ):
         logger.info(
             "Memory context injection skipped for supervisor (supervisor_auto_inject=False)"
         )

--- a/src/dao_ai/orchestration/swarm.py
+++ b/src/dao_ai/orchestration/swarm.py
@@ -23,12 +23,12 @@ from typing import TYPE_CHECKING, Callable, Sequence
 if TYPE_CHECKING:
     from langgraph.runtime import Runtime
 
-from langchain_core.language_models import LanguageModelLike
 from langchain_core.tools import BaseTool
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.graph import StateGraph
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.store.base import BaseStore
+from langgraph.types import Command
 from loguru import logger
 
 from dao_ai.config import (
@@ -43,6 +43,7 @@ from dao_ai.nodes import create_agent_node
 from dao_ai.orchestration import (
     create_agent_node_handler,
     create_checkpointer,
+    create_extraction_manager_and_executor,
     create_handoff_tool,
     create_store,
     get_handoff_description,
@@ -59,7 +60,7 @@ class HandoffResult:
     deterministic handoff target (always-routed).
     """
 
-    tools: list[BaseTool] = field(default_factory=list)
+    tools: tuple[BaseTool, ...] = field(default_factory=tuple)
     deterministic_target: str | None = None
 
 
@@ -180,7 +181,7 @@ def _handoffs_for_agent(
             )
 
     return HandoffResult(
-        tools=handoff_tools,
+        tools=tuple(handoff_tools),
         deterministic_target=deterministic_target,
     )
 
@@ -240,16 +241,18 @@ def _create_deterministic_handler(
     """
     Wrap an agent node handler to set ``active_agent`` for deterministic routing.
 
-    After the inner handler completes, ``active_agent`` is unconditionally set
-    to *target_agent_name* so that:
+    After the inner handler completes, ``active_agent`` is set to
+    *target_agent_name* so that:
 
     1. The ``add_edge`` in the parent graph routes to the deterministic target.
     2. The swarm router correctly resumes at the target on re-entry
        (e.g. after checkpoint restore).
 
-    If the agent invoked an agentic handoff tool during its turn, the resulting
-    ``Command(graph=Command.PARENT)`` takes precedence over the static edge,
-    so this wrapper is effectively a no-op in that case.
+    If the agent invoked an agentic handoff tool during its turn, the inner
+    handler returns a ``Command(graph=Command.PARENT)`` carrying its own
+    routing and ``active_agent`` update. That Command is passed through
+    unchanged — the agentic target takes precedence over the deterministic
+    edge.
 
     Args:
         inner_handler: The original handler produced by ``create_agent_node_handler``.
@@ -260,7 +263,14 @@ def _create_deterministic_handler(
     """
 
     async def handler(state: AgentState, runtime: Runtime[Context]) -> AgentState:
-        result: AgentState = await inner_handler(state, runtime)
+        result = await inner_handler(state, runtime)
+        if isinstance(result, Command):
+            logger.debug(
+                "Deterministic handoff overridden by agentic Command",
+                deterministic_target=target_agent_name,
+                agentic_goto=result.goto,
+            )
+            return result
         result["active_agent"] = target_agent_name
         logger.debug(
             "Deterministic handoff: setting active_agent",
@@ -347,46 +357,12 @@ def create_swarm_graph(config: AppConfig) -> CompiledStateGraph:
 
     # Set up shared extraction manager and background reflection executor
     # before creating agents so the manager can be shared across all nodes.
-    extraction_manager = None
-    reflection_executor = None
-    needs_extraction = (
-        memory
-        and memory.store
-        and memory.extraction
-        and store
-        and (memory.extraction.background_extraction or memory.extraction.auto_inject)
+    extraction_manager, reflection_executor = create_extraction_manager_and_executor(
+        memory=memory,
+        store=store,
+        fallback_model=config.app.agents[0].model.as_chat_model(),
+        graph_label="swarm graph",
     )
-    if needs_extraction:
-        from dao_ai.memory.extraction import (
-            create_extraction_manager,
-            create_reflection_executor,
-        )
-        from dao_ai.nodes import _build_memory_namespace
-
-        extraction_ns = _build_memory_namespace(memory)
-        extraction_model: LanguageModelLike = (
-            memory.extraction.extraction_model.as_chat_model()
-            if memory.extraction.extraction_model
-            else config.app.agents[0].model.as_chat_model()
-        )
-        query_model: LanguageModelLike | None = (
-            memory.extraction.query_model.as_chat_model()
-            if memory.extraction.query_model
-            else None
-        )
-
-        extraction_manager = create_extraction_manager(
-            model=extraction_model,
-            store=store,
-            namespace=extraction_ns,
-            schemas=memory.extraction.schemas,
-            instructions=memory.extraction.instructions,
-            query_model=query_model,
-        )
-
-        if memory.extraction.background_extraction:
-            reflection_executor = create_reflection_executor(extraction_manager, store)
-            logger.info("Background memory extraction enabled for swarm graph")
 
     for registered_agent in config.app.agents:
         # Resolve handoff configuration for this agent
@@ -460,7 +436,7 @@ def create_swarm_graph(config: AppConfig) -> CompiledStateGraph:
         handler = create_agent_node_handler(
             agent_name=agent_name,
             agent=agent_subgraph,
-            output_mode="last_message",
+            output_mode=orchestration.output_mode,
             reflection_executor=reflection_executor,
             recursion_limit=agent_recursion_limits.get(agent_name),
         )
@@ -500,4 +476,9 @@ def create_swarm_graph(config: AppConfig) -> CompiledStateGraph:
     # This is the key pattern from langgraph-swarm-py
     workflow.set_conditional_entry_point(router)
 
-    return workflow.compile(checkpointer=checkpointer, store=store)
+    compiled = workflow.compile(checkpointer=checkpointer, store=store)
+
+    # Apply the cross-agent hop ceiling at the parent graph level. This is
+    # the only bound on agentic ping-pong between peers; per-worker
+    # recursion_limit only protects within a single agent's turn.
+    return compiled.with_config({"recursion_limit": swarm.max_hops})

--- a/src/dao_ai/state.py
+++ b/src/dao_ai/state.py
@@ -144,6 +144,27 @@ def merge_session(current: SessionState, new: SessionState) -> SessionState:
     return merged  # type: ignore[return-value]
 
 
+def last_active_agent(current: Optional[str], new: Optional[str]) -> Optional[str]:
+    """Reducer that tolerates concurrent writes to ``active_agent``.
+
+    In swarm configs that mix deterministic edges with agentic handoff
+    tools (e.g. ``deterministic_handoff_pattern.yaml``), an agentic
+    ``Command(goto=X, graph=PARENT)`` and the parent graph's static
+    ``add_edge`` from the same source can both fire in one step. Each
+    writes ``active_agent``, and the default ``LastValue`` channel raises
+    ``InvalidUpdateError: At key 'active_agent': Can receive only one
+    value per step.``
+
+    The Command path is the source of truth (it carries the LLM's chosen
+    target); the static-edge update is bookkeeping. We resolve concurrent
+    writes by preferring whichever value is non-None, falling back to the
+    new value.
+    """
+    if new is not None:
+        return new
+    return current
+
+
 class AgentState(MessagesState, total=False):
     """
     Primary state schema for DAO AI agents.
@@ -169,7 +190,7 @@ class AgentState(MessagesState, total=False):
     """
 
     context: NotRequired[str]
-    active_agent: NotRequired[str]
+    active_agent: NotRequired[Annotated[str, last_active_agent]]
     is_valid: NotRequired[bool]
     message_error: NotRequired[str]
     session: NotRequired[Annotated[SessionState, merge_session]]

--- a/src/dao_ai/state.py
+++ b/src/dao_ai/state.py
@@ -99,19 +99,49 @@ class SessionState(BaseModel):
     # other_tool_state: OtherToolState = Field(default_factory=OtherToolState)
 
 
+def _merge_basemodel(current: BaseModel, new: BaseModel) -> BaseModel:
+    """Recursively merge two same-typed BaseModel instances.
+
+    Rules:
+    - Nested BaseModel of the same type: recurse.
+    - Dict-valued fields: union with ``new`` winning on key conflict.
+    - All other fields: ``new`` wins (last-update semantics).
+
+    Different runtime types short-circuit to ``new``, since merging unlike
+    schemas can't be done coherently.
+    """
+    if type(current) is not type(new):
+        return new
+
+    updates: dict[str, Any] = {}
+    for field_name in type(current).model_fields:
+        cur_val = getattr(current, field_name)
+        new_val = getattr(new, field_name)
+        if (
+            isinstance(cur_val, BaseModel)
+            and isinstance(new_val, BaseModel)
+            and type(cur_val) is type(new_val)
+        ):
+            updates[field_name] = _merge_basemodel(cur_val, new_val)
+        elif isinstance(cur_val, dict) and isinstance(new_val, dict):
+            updates[field_name] = {**cur_val, **new_val}
+        else:
+            updates[field_name] = new_val
+    return type(current)(**updates)
+
+
 def merge_session(current: SessionState, new: SessionState) -> SessionState:
     """Reducer that merges SessionState values from concurrent tool updates.
 
-    When multiple tools (e.g., parallel Genie calls) write to ``session``
-    in the same LangGraph step, the default ``LastValue`` channel would
-    raise ``InvalidUpdateError``. This reducer deep-merges the
-    ``genie.spaces`` dictionaries so each tool's space update is preserved.
+    When multiple tools (e.g., parallel Genie calls) write to ``session`` in
+    the same LangGraph step, the default ``LastValue`` channel would raise
+    ``InvalidUpdateError``. This reducer recursively walks ``SessionState``,
+    union-merging dict fields and recursing into nested ``BaseModel`` fields,
+    so newly added stateful tool state automatically participates in merging
+    without bespoke reducer code.
     """
-    merged_spaces: dict[str, GenieSpaceState] = {
-        **current.genie.spaces,
-        **new.genie.spaces,
-    }
-    return SessionState(genie=GenieState(spaces=merged_spaces))
+    merged = _merge_basemodel(current, new)
+    return merged  # type: ignore[return-value]
 
 
 class AgentState(MessagesState, total=False):

--- a/tests/dao_ai/test_deterministic_handoffs.py
+++ b/tests/dao_ai/test_deterministic_handoffs.py
@@ -198,7 +198,7 @@ class TestHandoffResult:
         from dao_ai.orchestration.swarm import HandoffResult
 
         result = HandoffResult()
-        assert result.tools == []
+        assert result.tools == ()
         assert result.deterministic_target is None
 
     def test_handoff_result_with_values(self) -> None:
@@ -207,7 +207,7 @@ class TestHandoffResult:
 
         mock_tool = MagicMock()
         result = HandoffResult(
-            tools=[mock_tool],
+            tools=(mock_tool,),
             deterministic_target="agent_b",
         )
         assert len(result.tools) == 1
@@ -285,7 +285,7 @@ class TestHandoffsForAgent:
         )
 
         result = _handoffs_for_agent(agents[0], config)
-        assert result.tools == []
+        assert result.tools == ()
         assert result.deterministic_target == "agent_b"
 
     def test_mixed_agentic_and_deterministic_handoffs(self) -> None:
@@ -412,7 +412,7 @@ class TestHandoffsForAgent:
 
         result = _handoffs_for_agent(agents[0], config)
         assert result.deterministic_target == "agent_b"
-        assert result.tools == []
+        assert result.tools == ()
 
     def test_unknown_agent_reference_is_skipped(self) -> None:
         """Test that an unknown agent name in handoffs is skipped with warning."""
@@ -429,7 +429,7 @@ class TestHandoffsForAgent:
         )
 
         result = _handoffs_for_agent(agents[0], config)
-        assert result.tools == []
+        assert result.tools == ()
         assert result.deterministic_target is None
 
 

--- a/tests/dao_ai/test_orchestration_review_fixes.py
+++ b/tests/dao_ai/test_orchestration_review_fixes.py
@@ -453,6 +453,60 @@ class TestSupervisorNoStaleNeedsExtractionReference:
 
 
 @pytest.mark.unit
+class TestActiveAgentReducerToleratesConcurrentWrites:
+    """Regression for a bug surfaced by the C2 (deterministic +
+    agentic combo) deploy test on 2026-05-01: when an agent has both a
+    static deterministic edge and an agentic handoff tool, both can fire
+    in one parent step, each writing ``active_agent``. Without a
+    reducer, the default ``LastValue`` channel raises
+    ``InvalidUpdateError: At key 'active_agent': Can receive only one
+    value per step.``"""
+
+    def test_last_active_agent_prefers_non_none_new(self) -> None:
+        from dao_ai.state import last_active_agent
+
+        # New value wins when present
+        assert last_active_agent("a", "b") == "b"
+        # Falls back to current when new is None (e.g. dict update with
+        # active_agent unset)
+        assert last_active_agent("a", None) == "a"
+        # New value wins when current is None
+        assert last_active_agent(None, "b") == "b"
+        # Both None is fine
+        assert last_active_agent(None, None) is None
+
+    def test_active_agent_field_has_reducer_annotation(self) -> None:
+        import typing
+        from dao_ai.state import AgentState, last_active_agent
+
+        hints = typing.get_type_hints(AgentState, include_extras=True)
+        active = hints.get("active_agent")
+        # active_agent should be Annotated with the reducer (wrapped in
+        # NotRequired). This guard makes sure a future refactor doesn't
+        # silently drop the reducer.
+        assert active is not None
+        # Walk past NotRequired/Optional wrappers
+        # NotRequired is detected via __metadata__-less check; just look for
+        # the reducer in any of typing's metadata.
+        from typing import get_args
+        # Recurse through nested generics until we find Annotated metadata.
+        def find_metadata(t):
+            args = get_args(t)
+            for a in args:
+                if hasattr(a, "__call__") and a is last_active_agent:
+                    return True
+                if find_metadata(a):
+                    return True
+            return False
+
+        assert find_metadata(active), (
+            "active_agent must be Annotated with last_active_agent so "
+            "concurrent writes from deterministic edge + agentic Command "
+            "don't crash the parent graph."
+        )
+
+
+@pytest.mark.unit
 class TestToolMessageNameIsToolNotAgent:
     """Document the LangChain semantics that originally tripped commit
     2777cb8: ``ToolMessage.name`` carries the *tool's* name, not the

--- a/tests/dao_ai/test_orchestration_review_fixes.py
+++ b/tests/dao_ai/test_orchestration_review_fixes.py
@@ -1,0 +1,395 @@
+"""
+Regression tests for the orchestration code-review findings fixed on
+``fix/orchestration-review-findings``.
+
+Each test class corresponds to one finding from the original review. Test
+names match the verification section of the plan so it's obvious what each
+guards against.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from langchain.tools import ToolRuntime
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.tools import BaseTool
+from langgraph.types import Command
+
+from dao_ai.config import (
+    AgentModel,
+    AppConfig,
+    AppModel,
+    LLMModel,
+    OrchestrationModel,
+    SupervisorModel,
+    SwarmModel,
+)
+from dao_ai.messages import (
+    last_ai_message,
+    last_ai_message_with_tool_calls,
+)
+from dao_ai.orchestration.core import (
+    SUPERVISOR_NODE,
+    filter_messages_for_agent,
+)
+from dao_ai.orchestration.swarm import _create_deterministic_handler
+from dao_ai.state import (
+    GenieSpaceState,
+    GenieState,
+    SessionState,
+    merge_session,
+)
+
+
+def _basic_app_config(agent_names: list[str]) -> AppConfig:
+    """Build a minimal AppConfig with the given agent names.
+
+    ``deployment_target='apps'`` lets us skip the ``registered_model`` field
+    that's otherwise required.
+    """
+    agents = [
+        AgentModel(name=name, model=LLMModel(name="test-model"))
+        for name in agent_names
+    ]
+    return AppConfig(
+        app=AppModel(
+            name="dao_ai_test",
+            deployment_target="apps",
+            agents=agents,
+            orchestration=OrchestrationModel(
+                supervisor=SupervisorModel(model=LLMModel(name="test-model"))
+            ),
+        )
+    )
+
+
+def _make_tool_runtime(
+    *, tool_call_id: str, state: dict[str, Any]
+) -> ToolRuntime:
+    """Build a ToolRuntime suitable for invoking @tool-decorated handoffs in tests."""
+    return ToolRuntime(
+        state=state,
+        context=None,
+        config=None,
+        stream_writer=lambda *_: None,
+        tool_call_id=tool_call_id,
+        store=None,
+        execution_info=None,
+        server_info=None,
+    )
+
+
+# =============================================================================
+# Finding #1: deterministic handler must pass through Command unchanged
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestDeterministicHandlerCommandPassthrough:
+    """The deterministic-handoff wrapper must not crash when the inner
+    handler returns a Command from the agentic-handoff (ParentCommand) path."""
+
+    def test_returns_command_unchanged_when_inner_returns_command(self) -> None:
+        agentic_command = Command(
+            goto="agent_x",
+            graph=Command.PARENT,
+            update={"active_agent": "agent_x", "messages": []},
+        )
+
+        async def inner_handler(state: dict, runtime: Any) -> Command:
+            return agentic_command
+
+        wrapped = _create_deterministic_handler(inner_handler, "agent_y")
+        result = asyncio.run(wrapped({"messages": []}, runtime=MagicMock()))
+
+        assert isinstance(result, Command)
+        # Agentic target wins; deterministic target must NOT have overwritten it.
+        assert result.update["active_agent"] == "agent_x"
+        assert result.goto == "agent_x"
+
+    def test_sets_active_agent_when_inner_returns_dict(self) -> None:
+        async def inner_handler(state: dict, runtime: Any) -> dict:
+            return {"messages": [], "active_agent": "stale"}
+
+        wrapped = _create_deterministic_handler(inner_handler, "agent_y")
+        result = asyncio.run(wrapped({"messages": []}, runtime=MagicMock()))
+
+        assert isinstance(result, dict)
+        assert result["active_agent"] == "agent_y"
+
+
+# =============================================================================
+# Finding #2: filter_messages_for_agent preserves agent's own ToolMessages
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestFilterMessagesForAgentTagging:
+    """Agents must see their own prior tool exchanges; peers' must be hidden."""
+
+    def test_keeps_own_tool_exchange_drops_peer_tool_exchange(self) -> None:
+        own_call = AIMessage(
+            content="checking inventory",
+            name="agent_a",
+            tool_calls=[
+                {"name": "lookup", "args": {"sku": "1"}, "id": "call_a1"}
+            ],
+        )
+        own_result = ToolMessage(
+            content="42 in stock", tool_call_id="call_a1", name="agent_a"
+        )
+        peer_call = AIMessage(
+            content="forecasting demand",
+            name="agent_b",
+            tool_calls=[{"name": "forecast", "args": {}, "id": "call_b1"}],
+        )
+        peer_result = ToolMessage(
+            content="trending up", tool_call_id="call_b1", name="agent_b"
+        )
+
+        history = [
+            HumanMessage(content="how many widgets?"),
+            own_call,
+            own_result,
+            peer_call,
+            peer_result,
+        ]
+
+        filtered = filter_messages_for_agent(history, current_agent_name="agent_a")
+
+        types = [type(m).__name__ for m in filtered]
+        assert "ToolMessage" in types
+        # agent_a's tool exchange present
+        assert own_call in filtered
+        assert own_result in filtered
+        # agent_b's ToolMessage stripped (no name match)
+        assert peer_result not in filtered
+        # peer AIMessage with content survives but with tool_calls stripped
+        peer_in_filtered = next(
+            (m for m in filtered if isinstance(m, AIMessage) and m.name == "agent_b"),
+            None,
+        )
+        assert peer_in_filtered is not None
+        assert not peer_in_filtered.tool_calls
+
+    def test_legacy_no_agent_name_strips_all_tool_messages(self) -> None:
+        """When called with no agent name, behaviour matches the pre-refactor
+        contract: all ToolMessages dropped, all tool_calls stripped."""
+        history = [
+            AIMessage(
+                content="hi",
+                tool_calls=[{"name": "x", "args": {}, "id": "c1"}],
+            ),
+            ToolMessage(content="result", tool_call_id="c1"),
+        ]
+        filtered = filter_messages_for_agent(history)
+        assert all(not isinstance(m, ToolMessage) for m in filtered)
+        for m in filtered:
+            if isinstance(m, AIMessage):
+                assert not m.tool_calls
+
+
+# =============================================================================
+# Finding #4: handoff_to_supervisor sets active_agent
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestHandoffToSupervisorSetsActiveAgent:
+    def test_command_update_includes_supervisor_active_agent(self) -> None:
+        # Build the supervisor handoff tool and invoke it with a synthetic
+        # runtime that supplies the required tool_call_id and message state.
+        from dao_ai.orchestration.supervisor import (
+            _create_handoff_back_to_supervisor_tool,
+        )
+
+        tool: BaseTool = _create_handoff_back_to_supervisor_tool()
+
+        runtime = _make_tool_runtime(
+            tool_call_id="tc_1",
+            state={
+                "messages": [
+                    AIMessage(
+                        content="done",
+                        tool_calls=[
+                            {
+                                "name": "handoff_to_supervisor",
+                                "args": {"summary": "ok"},
+                                "id": "tc_1",
+                            }
+                        ],
+                    )
+                ]
+            },
+        )
+
+        result = tool.invoke({"summary": "ok", "runtime": runtime})
+
+        assert isinstance(result, Command)
+        assert result.update["active_agent"] == SUPERVISOR_NODE
+        assert result.goto == SUPERVISOR_NODE
+
+
+# =============================================================================
+# Finding #5: last_ai_message_with_tool_calls helper
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestLastAIMessageWithToolCalls:
+    def test_returns_most_recent_with_tool_calls(self) -> None:
+        msgs = [
+            HumanMessage(content="hi"),
+            AIMessage(content="ok"),
+            AIMessage(
+                content="picking a tool",
+                tool_calls=[{"name": "t1", "args": {}, "id": "c1"}],
+            ),
+            AIMessage(content="follow up"),
+            AIMessage(
+                content="picking another tool",
+                tool_calls=[{"name": "t2", "args": {}, "id": "c2"}],
+            ),
+            AIMessage(content="final reply"),
+        ]
+        result = last_ai_message_with_tool_calls(msgs)
+        assert result is not None
+        assert result.tool_calls[0]["id"] == "c2"
+
+    def test_returns_none_when_no_tool_calls(self) -> None:
+        msgs = [
+            HumanMessage(content="hi"),
+            AIMessage(content="hello"),
+        ]
+        assert last_ai_message_with_tool_calls(msgs) is None
+
+    def test_does_not_match_plain_ai_message(self) -> None:
+        # Plain AIMessage (no tool_calls) is NOT what this helper wants.
+        msgs = [AIMessage(content="hello")]
+        assert last_ai_message_with_tool_calls(msgs) is None
+        # Sanity: last_ai_message would still find it.
+        assert last_ai_message(msgs) is not None
+
+
+# =============================================================================
+# Finding #7: SUPERVISOR_NODE name collision rejected
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSupervisorNodeNameCollision:
+    def test_create_supervisor_graph_rejects_supervisor_named_worker(
+        self,
+    ) -> None:
+        from dao_ai.orchestration.supervisor import create_supervisor_graph
+
+        config = _basic_app_config(["billing", SUPERVISOR_NODE])
+
+        with pytest.raises(ValueError) as exc:
+            create_supervisor_graph(config)
+
+        msg = str(exc.value)
+        assert SUPERVISOR_NODE in msg
+        assert "collide" in msg.lower()
+
+
+# =============================================================================
+# Finding #9: SwarmModel.max_hops surfaces and applies
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSwarmMaxHops:
+    def test_default_is_25(self) -> None:
+        assert SwarmModel().max_hops == 25
+
+    def test_custom_value_round_trips(self) -> None:
+        assert SwarmModel(max_hops=4).max_hops == 4
+
+    def test_rejects_non_positive(self) -> None:
+        with pytest.raises(Exception):
+            SwarmModel(max_hops=0)
+
+
+# =============================================================================
+# Finding #10: merge_session generalizes across SessionState fields
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestMergeSessionGeneric:
+    def test_genie_spaces_still_merge(self) -> None:
+        a = SessionState(
+            genie=GenieState(
+                spaces={"sp_a": GenieSpaceState(conversation_id="conv_a")}
+            )
+        )
+        b = SessionState(
+            genie=GenieState(
+                spaces={"sp_b": GenieSpaceState(conversation_id="conv_b")}
+            )
+        )
+        merged = merge_session(a, b)
+        assert set(merged.genie.spaces.keys()) == {"sp_a", "sp_b"}
+
+    def test_overlapping_keys_take_new(self) -> None:
+        a = SessionState(
+            genie=GenieState(
+                spaces={"sp": GenieSpaceState(conversation_id="conv_old")}
+            )
+        )
+        b = SessionState(
+            genie=GenieState(
+                spaces={"sp": GenieSpaceState(conversation_id="conv_new")}
+            )
+        )
+        merged = merge_session(a, b)
+        assert merged.genie.spaces["sp"].conversation_id == "conv_new"
+
+    def test_basemodel_walker_handles_arbitrary_dict_field(self) -> None:
+        """The reducer's recursive walker should handle a hypothetical new
+        SessionState field that's a BaseModel containing a dict, without
+        special-casing."""
+        from dao_ai.state import _merge_basemodel
+        from pydantic import BaseModel, Field
+
+        class FakeToolState(BaseModel):
+            entries: dict[str, str] = Field(default_factory=dict)
+
+        a = FakeToolState(entries={"k1": "v1_old"})
+        b = FakeToolState(entries={"k1": "v1_new", "k2": "v2"})
+        merged = _merge_basemodel(a, b)
+        assert isinstance(merged, FakeToolState)
+        assert merged.entries == {"k1": "v1_new", "k2": "v2"}
+
+
+# =============================================================================
+# Finding #3: OrchestrationModel.output_mode plumbed and configurable
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestOrchestrationOutputMode:
+    def test_default_is_full_history(self) -> None:
+        m = OrchestrationModel(
+            supervisor=SupervisorModel(model=LLMModel(name="test-model"))
+        )
+        assert m.output_mode == "full_history"
+
+    def test_accepts_last_message(self) -> None:
+        m = OrchestrationModel(
+            supervisor=SupervisorModel(model=LLMModel(name="test-model")),
+            output_mode="last_message",
+        )
+        assert m.output_mode == "last_message"
+
+    def test_rejects_unknown_value(self) -> None:
+        with pytest.raises(Exception):
+            OrchestrationModel(
+                supervisor=SupervisorModel(model=LLMModel(name="test-model")),
+                output_mode="garbage",
+            )

--- a/tests/dao_ai/test_orchestration_review_fixes.py
+++ b/tests/dao_ai/test_orchestration_review_fixes.py
@@ -414,3 +414,77 @@ class TestOrchestrationOutputMode:
                 supervisor=SupervisorModel(model=LLMModel(name="test-model")),
                 output_mode="garbage",
             )
+
+
+# =============================================================================
+# Regression for the deploy-time bugs caught only by `dao-ai validate` /
+# real endpoint (commits 84cabde, 2777cb8). Unit-tests-only would have
+# missed these — these tests exist so a future refactor doesn't reintroduce
+# them.
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSupervisorNoStaleNeedsExtractionReference:
+    """Static check that supervisor.py never references the removed
+    ``needs_extraction`` local. The original bug (commit 84cabde) had
+    `needs_extraction` referenced in the auto-inject branch after the
+    factory refactor (#6) deleted the local. Failed at
+    `dao-ai validate -c sporting_goods_store.yaml` with NameError."""
+
+    def test_supervisor_module_has_no_orphan_needs_extraction(self) -> None:
+        import inspect
+        from dao_ai.orchestration import supervisor
+
+        source = inspect.getsource(supervisor)
+        # The substring should NOT appear as a bare identifier anywhere.
+        # Tolerate "needs_extraction" inside a comment or docstring (none
+        # currently exist; if one is added, this test will tighten the rule).
+        for lineno, line in enumerate(source.splitlines(), start=1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            assert "needs_extraction" not in line, (
+                f"supervisor.py:{lineno}: bare reference to "
+                f"`needs_extraction` resurfaced — this was deleted in "
+                f"the factory refactor and any reference is a NameError "
+                f"at validate time. Line: {line.rstrip()}"
+            )
+
+
+@pytest.mark.unit
+class TestToolMessageNameIsToolNotAgent:
+    """Document the LangChain semantics that originally tripped commit
+    2777cb8: ``ToolMessage.name`` carries the *tool's* name, not the
+    *agent's* name. Future fixture authors should set ``name=<tool_name>``
+    when constructing ToolMessage in tests, matching production traces."""
+
+    def test_tool_message_default_name_is_tool_identifier(self) -> None:
+        # When langchain wraps a tool's return value into a ToolMessage,
+        # it sets `.name` to the tool's identifier. Tests SHOULD reflect
+        # this — fixtures using `name=<agent_name>` masked the original
+        # filter bug.
+        msg = ToolMessage(
+            content="result",
+            tool_call_id="tc_x",
+            name="product_vector_search_tool",
+        )
+        assert msg.name == "product_vector_search_tool"
+        # Filter pairs by tool_call_id, not by name. Confirm with own
+        # AIMessage.
+        own_call = AIMessage(
+            content="searching",
+            name="general",
+            tool_calls=[
+                {
+                    "name": "product_vector_search_tool",
+                    "args": {"q": "x"},
+                    "id": "tc_x",
+                }
+            ],
+        )
+        history = [HumanMessage(content="?"), own_call, msg]
+        kept = filter_messages_for_agent(history, current_agent_name="general")
+        # ToolMessage retained because tc_x pairs with own_call's tool_calls,
+        # NOT because msg.name matches "general".
+        assert msg in kept

--- a/tests/dao_ai/test_orchestration_review_fixes.py
+++ b/tests/dao_ai/test_orchestration_review_fixes.py
@@ -129,9 +129,15 @@ class TestDeterministicHandlerCommandPassthrough:
 
 @pytest.mark.unit
 class TestFilterMessagesForAgentTagging:
-    """Agents must see their own prior tool exchanges; peers' must be hidden."""
+    """Agents must see their own prior tool exchanges; peers' must be hidden.
+
+    Ownership: AIMessage by ``msg.name``, ToolMessage by ``tool_call_id``
+    pairing against an own AIMessage(tool_calls=…).
+    """
 
     def test_keeps_own_tool_exchange_drops_peer_tool_exchange(self) -> None:
+        # ToolMessage.name carries the *tool*'s name (set by langchain), not
+        # the agent's — pairing works via tool_call_id.
         own_call = AIMessage(
             content="checking inventory",
             name="agent_a",
@@ -140,7 +146,7 @@ class TestFilterMessagesForAgentTagging:
             ],
         )
         own_result = ToolMessage(
-            content="42 in stock", tool_call_id="call_a1", name="agent_a"
+            content="42 in stock", tool_call_id="call_a1", name="lookup"
         )
         peer_call = AIMessage(
             content="forecasting demand",
@@ -148,7 +154,7 @@ class TestFilterMessagesForAgentTagging:
             tool_calls=[{"name": "forecast", "args": {}, "id": "call_b1"}],
         )
         peer_result = ToolMessage(
-            content="trending up", tool_call_id="call_b1", name="agent_b"
+            content="trending up", tool_call_id="call_b1", name="forecast"
         )
 
         history = [
@@ -161,12 +167,10 @@ class TestFilterMessagesForAgentTagging:
 
         filtered = filter_messages_for_agent(history, current_agent_name="agent_a")
 
-        types = [type(m).__name__ for m in filtered]
-        assert "ToolMessage" in types
-        # agent_a's tool exchange present
+        # agent_a's tool exchange present (paired by tool_call_id)
         assert own_call in filtered
         assert own_result in filtered
-        # agent_b's ToolMessage stripped (no name match)
+        # agent_b's ToolMessage dropped (no matching kept AIMessage)
         assert peer_result not in filtered
         # peer AIMessage with content survives but with tool_calls stripped
         peer_in_filtered = next(
@@ -176,6 +180,23 @@ class TestFilterMessagesForAgentTagging:
         assert peer_in_filtered is not None
         assert not peer_in_filtered.tool_calls
 
+    def test_pairs_multiple_tool_calls_in_one_aimessage(self) -> None:
+        own_call = AIMessage(
+            content="parallel fetches",
+            name="agent_a",
+            tool_calls=[
+                {"name": "lookup", "args": {"sku": "1"}, "id": "tc1"},
+                {"name": "lookup", "args": {"sku": "2"}, "id": "tc2"},
+            ],
+        )
+        result1 = ToolMessage(content="r1", tool_call_id="tc1", name="lookup")
+        result2 = ToolMessage(content="r2", tool_call_id="tc2", name="lookup")
+        history = [HumanMessage(content="q"), own_call, result1, result2]
+
+        filtered = filter_messages_for_agent(history, current_agent_name="agent_a")
+        assert result1 in filtered
+        assert result2 in filtered
+
     def test_legacy_no_agent_name_strips_all_tool_messages(self) -> None:
         """When called with no agent name, behaviour matches the pre-refactor
         contract: all ToolMessages dropped, all tool_calls stripped."""
@@ -184,7 +205,7 @@ class TestFilterMessagesForAgentTagging:
                 content="hi",
                 tool_calls=[{"name": "x", "args": {}, "id": "c1"}],
             ),
-            ToolMessage(content="result", tool_call_id="c1"),
+            ToolMessage(content="result", tool_call_id="c1", name="x"),
         ]
         filtered = filter_messages_for_agent(history)
         assert all(not isinstance(m, ToolMessage) for m in filtered)


### PR DESCRIPTION
## Summary

- Resolves the 9 orchestration code-review findings from the prior review on `src/dao_ai/orchestration/` (supervisor + swarm).
- Adds 3 follow-up fixes for bugs that surfaced only during real Databricks deploy verification — unit tests didn't catch them.
- 23 unit tests in `tests/dao_ai/test_orchestration_review_fixes.py` (all passing); 976 unit tests in the wider `dao_ai` suite still pass (3 pre-existing `test_databricks` Mock failures unchanged).

## Commits

| SHA | Title |
|---|---|
| `04c8c9b` | Orchestration: fix review findings across supervisor + swarm |
| `84cabde` | Orchestration: drop stale needs_extraction reference in supervisor |
| `2777cb8` | Orchestration: pair ToolMessage with AIMessage by tool_call_id |
| `51129bb` | Orchestration: regression tests for the two deploy-time bugs |
| `4b12920` | Orchestration: reducer for active_agent to tolerate concurrent writes |

## Original 9 review findings

1. **[BUG] Deterministic handler crash on agentic handoff** (swarm.py) — Command path now passed through unchanged.
2. **filter_messages_for_agent strips own ToolMessages** — pair by `tool_call_id` against own AIMessage's `tool_calls`. **Verified end-to-end on the v10 sporting-goods endpoint**: turn-2 same-agent re-entry returns HTTP 200 with grounded answer (v6 with the buggy filter returned HTTP 400).
3. **output_mode default flipped to `full_history`** — exposed via `OrchestrationModel.output_mode`. Required for #2 to flow tool exchanges back to parent state.
4. **handoff_to_supervisor sets active_agent** — one-line addition to the Command's update dict.
5. **`last_ai_message_with_tool_calls` helper extracted** to `dao_ai.messages`.
6. **`create_extraction_manager_and_executor` factory** extracted to `dao_ai.orchestration.core`.
7. **SUPERVISOR_NODE name collision validation** in `create_supervisor_graph`.
8. **`HandoffResult.tools` is a tuple** (honors `frozen=True`).
9. **Swarm `max_hops` ceiling** added to `SwarmModel`.
10. **Generic `merge_session` reducer** that walks `SessionState` recursively.

## Three follow-up fixes caught by deploy verification

11. **`needs_extraction` regression** (commit `84cabde`) — extraction-manager-factory refactor (#6) deleted a local var the auto-inject branch still referenced. `dao-ai validate` failed with `name 'needs_extraction' is not defined`. Fix: gate downstream code on `extraction_manager` truthiness.
12. **`ToolMessage.name` semantic** (commit `2777cb8`) — original filter checked `msg.name == agent_name`, but `ToolMessage.name` carries the **tool's** name (e.g. `product_vector_search_tool`), not the agent's. Same-agent re-entry under `output_mode="full_history"` always dropped the tool result → HTTP 400. Fix: identify own ToolMessages by pairing `tool_call_id` against an own AIMessage's `tool_calls`.
13. **Concurrent writes to `active_agent`** (commit `4b12920`) — when a swarm agent has both a deterministic `add_edge` and an agentic `Command(goto=X, graph=PARENT)`, both fire in the same parent step, both write `active_agent`. The default `LastValue` channel raises `InvalidUpdateError`. Fix: declare `AgentState.active_agent` as `Annotated[str, last_active_agent]` with a reducer (matches the existing `session: Annotated[..., merge_session]` pattern).

## Production verification (aws-field-eng)

- `sporting_goods_store_dao` v10: multi-turn same-agent retention, parallel tool pairing, 5-turn long-running conversation, service-principal auth — all HTTP 200 with grounded answers.
- `deterministic_handoff_dao` v3: deterministic+agentic combo prompt fires both `handoff_to_resolution_agent` and `handoff_to_escalation_agent` in one trace, no crash, no `InvalidUpdateError`. This is the #1 fix runtime exercise.

## Test plan

- [x] `make unit` passes (101+ relevant tests)
- [x] Multi-turn same-agent retention verified on real model_serving endpoint
- [x] Deterministic+agentic combo verified on real model_serving endpoint (the #1 fix path)
- [x] Service-principal OAuth M2M auth smoke
- [x] Trace inspection: AIMessages tagged, paired tool_call_ids, no orphans, no `TypeError` / `InvalidUpdateError` in endpoint logs

This pull request and its description were written by Isaac.