### PR TITLE
Name-resolution safety + serving-load forward compat fix

### DIFF
--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -1030,17 +1030,33 @@ class WarehouseModel(IsDatabricksResource):
         return self._warehouse_details
 
     def _resolve_warehouse_id_by_name(self, name: str) -> str:
-        """Look up a warehouse ID by iterating all warehouses and matching by name."""
+        """Look up a warehouse ID by iterating all warehouses and matching by name.
+
+        Raises:
+            ValueError: if zero or more than one warehouse match ``name``.
+                The Databricks docs claim warehouse names "must be unique
+                within an org," but the platform does **not** enforce this
+                — duplicates are routinely created. Pass ``warehouse_id``
+                directly to disambiguate.
+        """
         logger.info(f"Resolving warehouse by name: '{name}'")
-        warehouses: Iterator[EndpointInfo] = self.workspace_client.warehouses.list()
-        for warehouse in warehouses:
-            if warehouse.name == name:
-                logger.info(f"Resolved warehouse '{name}' to id '{warehouse.id}'")
-                return warehouse.id
-        raise ValueError(
-            f"No warehouse found with name '{name}'. "
-            "Verify the name matches an existing SQL warehouse in your workspace."
-        )
+        matches: list[str] = [
+            warehouse.id
+            for warehouse in self.workspace_client.warehouses.list()
+            if warehouse.name == name
+        ]
+        if not matches:
+            raise ValueError(
+                f"No warehouse found with name '{name}'. "
+                "Verify the name matches an existing SQL warehouse in your workspace."
+            )
+        if len(matches) > 1:
+            raise ValueError(
+                f"Multiple warehouses ({len(matches)}) found with name '{name}': "
+                f"{matches}. Pass warehouse_id directly to disambiguate."
+            )
+        logger.info(f"Resolved warehouse '{name}' to id '{matches[0]}'")
+        return matches[0]
 
     @property
     def api_scopes(self) -> Sequence[str]:
@@ -1326,7 +1342,17 @@ class GenieRoomModel(IsDatabricksResource, ManagedResource):
     )
     space_id: Optional[AnyVariable] = Field(
         default=None,
-        description="Databricks Genie space ID. Required when on_behalf_of_user is true. If omitted, looked up by name or created by .create().",
+        description=(
+            "Databricks-assigned Genie space identifier. The only field "
+            "guaranteed unique by the platform; titles are not enforced unique. "
+            "Lifecycle: "
+            "(a) Reference mode — set by the user in YAML; readable immediately. "
+            "(b) Spec mode — left None, populated by .create() once the space "
+            "is provisioned. Downstream consumers reading *room_anchor.space_id "
+            "must wait until .create() has run. "
+            "Required when on_behalf_of_user is true (name-based lookup cannot "
+            "authenticate at Model Serving startup)."
+        ),
     )
     parent_path: Optional[AnyVariable] = Field(
         default=None,
@@ -1411,8 +1437,15 @@ class GenieRoomModel(IsDatabricksResource, ManagedResource):
         return self._space_details
 
     def _resolve_space_id_by_name(self, name: str) -> str:
-        """Look up a Genie space ID by iterating all spaces and matching by title."""
+        """Look up a Genie space ID by iterating all spaces and matching by title.
+
+        Raises:
+            ValueError: if zero spaces or more than one space match ``name``.
+                Genie titles are not enforced unique by Databricks; pass
+                ``space_id`` directly to disambiguate.
+        """
         logger.info(f"Resolving Genie space by name: '{name}'")
+        matches: list[str] = []
         page_token: Optional[str] = None
         while True:
             response: GenieListSpacesResponse = self.workspace_client.genie.list_spaces(
@@ -1421,17 +1454,24 @@ class GenieRoomModel(IsDatabricksResource, ManagedResource):
             if response.spaces:
                 for space in response.spaces:
                     if space.title == name:
-                        logger.info(
-                            f"Resolved Genie space '{name}' to space_id '{space.space_id}'"
-                        )
-                        return space.space_id
+                        matches.append(space.space_id)
             if not response.next_page_token:
                 break
             page_token = response.next_page_token
-        raise ValueError(
-            f"No Genie space found with title '{name}'. "
-            "Verify the name matches an existing Genie space in your workspace."
-        )
+
+        if not matches:
+            raise ValueError(
+                f"No Genie space found with title '{name}'. "
+                "Verify the name matches an existing Genie space in your workspace."
+            )
+        if len(matches) > 1:
+            raise ValueError(
+                f"Multiple Genie spaces ({len(matches)}) found with title '{name}': "
+                f"{matches}. Genie titles are not enforced unique by Databricks; "
+                "pass space_id directly to disambiguate."
+            )
+        logger.info(f"Resolved Genie space '{name}' to space_id '{matches[0]}'")
+        return matches[0]
 
     def _parse_serialized_space(self) -> dict[str, Any]:
         """Parse the serialized_space JSON string and return the parsed data."""

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -585,7 +585,17 @@ class DatabricksProvider(ServiceProvider):
                 logged_agent_info: ModelInfo = mlflow.pyfunc.log_model(
                     python_model=model_path.as_posix(),
                     code_paths=code_paths,
-                    model_config=config.model_dump(mode="json", by_alias=True),
+                    # exclude_none=True keeps the serialized config compatible
+                    # with older dao-ai versions that may be installed in the
+                    # Model Serving container — the registry can lag the
+                    # development branch by several versions, and any new
+                    # ``Optional`` field on a Pydantic model with ``extra=
+                    # "forbid"`` becomes a load-time error if it's persisted
+                    # as null and the deployed code doesn't know the field
+                    # name yet. Dropping null values is forward-compatible.
+                    model_config=config.model_dump(
+                        mode="json", by_alias=True, exclude_none=True
+                    ),
                     name="agent",
                     conda_env=conda_env,
                     input_example=input_example,

--- a/tests/dao_ai/test_genie_room_model.py
+++ b/tests/dao_ai/test_genie_room_model.py
@@ -1035,20 +1035,37 @@ class TestGenieRoomModelNameResolution:
             assert genie_room.space_id == "target_id"
             assert mock_workspace_client.genie.list_spaces.call_count == 2
 
-    def test_resolve_space_by_name_short_circuits(self, mock_workspace_client):
-        """Test that resolution short-circuits on first match without fetching more pages."""
+    def test_resolve_space_by_name_raises_on_duplicates(self, mock_workspace_client):
+        """Resolution raises clearly when multiple spaces share the same title.
+
+        Genie titles are not enforced unique by Databricks; the resolver
+        must scan the whole workspace and surface the ambiguity rather
+        than silently returning the first match.
+        """
         page1 = _make_list_spaces_response(
-            [_make_genie_space_summary("Target Space", "target_id")],
+            [
+                _make_genie_space_summary("Shared Title", "first_id"),
+                _make_genie_space_summary("Other Space", "other_id"),
+            ],
             next_page_token="page2_token",
         )
-        mock_workspace_client.genie.list_spaces.return_value = page1
+        page2 = _make_list_spaces_response(
+            [_make_genie_space_summary("Shared Title", "second_id")],
+            next_page_token=None,
+        )
+        mock_workspace_client.genie.list_spaces.side_effect = [page1, page2]
 
         with patch("dao_ai.config.WorkspaceClient", return_value=mock_workspace_client):
-            genie_room = GenieRoomModel(name="Target Space")
-            genie_room.ensure_resolved()
-
-            assert genie_room.space_id == "target_id"
-            assert mock_workspace_client.genie.list_spaces.call_count == 1
+            model = GenieRoomModel(name="Shared Title")
+            with pytest.raises(
+                ValueError,
+                match=r"Multiple Genie spaces \(2\) found with title 'Shared Title'",
+            ) as exc_info:
+                model.ensure_resolved()
+            # Both colliding ids should appear in the error so the user can
+            # disambiguate.
+            assert "first_id" in str(exc_info.value)
+            assert "second_id" in str(exc_info.value)
 
     def test_resolve_space_by_name_not_found(self, mock_workspace_client):
         """Test that ValueError is raised when no space matches the name."""

--- a/tests/dao_ai/test_warehouse_model.py
+++ b/tests/dao_ai/test_warehouse_model.py
@@ -195,28 +195,32 @@ class TestWarehouseModelNameResolution:
             assert warehouse.warehouse_id == "prod_id"
             assert warehouse.name == "Production Warehouse"
 
-    def test_resolve_warehouse_by_name_first_match(self, mock_workspace_client):
-        """Test that resolution short-circuits on first match."""
-        call_count = 0
-        endpoints = [
-            _make_endpoint_info("Target Warehouse", "target_id"),
-            _make_endpoint_info("Other Warehouse", "other_id"),
-        ]
+    def test_resolve_warehouse_by_name_raises_on_duplicates(
+        self, mock_workspace_client
+    ):
+        """Resolution raises clearly when multiple warehouses share the same name.
 
-        def counting_iter():
-            nonlocal call_count
-            for ep in endpoints:
-                call_count += 1
-                yield ep
-
-        mock_workspace_client.warehouses.list.return_value = counting_iter()
+        Databricks docs claim warehouse names "must be unique within an
+        org" but the platform does not enforce this; the resolver must
+        surface duplicates rather than silently returning the first.
+        """
+        mock_workspace_client.warehouses.list.return_value = iter(
+            [
+                _make_endpoint_info("Shared Warehouse", "first_id"),
+                _make_endpoint_info("Other Warehouse", "other_id"),
+                _make_endpoint_info("Shared Warehouse", "second_id"),
+            ]
+        )
 
         with patch("dao_ai.config.WorkspaceClient", return_value=mock_workspace_client):
-            warehouse = WarehouseModel(name="Target Warehouse")
-            warehouse.ensure_resolved()
-
-            assert warehouse.warehouse_id == "target_id"
-            assert call_count == 1
+            warehouse = WarehouseModel(name="Shared Warehouse")
+            with pytest.raises(
+                ValueError,
+                match=r"Multiple warehouses \(2\) found with name 'Shared Warehouse'",
+            ) as exc_info:
+                warehouse.ensure_resolved()
+            assert "first_id" in str(exc_info.value)
+            assert "second_id" in str(exc_info.value)
 
     def test_resolve_warehouse_by_name_not_found(self, mock_workspace_client):
         """Test that ValueError is raised when no warehouse matches the name."""


### PR DESCRIPTION
## Summary

Two small follow-ups to #75, both born out of investigation into a real serving-endpoint failure on `sporting_goods_store_dao` in `aws-field-eng`:

1. **Name resolution detects duplicates instead of silent first-match.** Databricks does not enforce uniqueness on Genie space titles or SQL warehouse names. The Go SDK README warns: *"some Databricks APIs don't enforce unique names on objects."* Today's resolvers return the first match silently in long-lived workspaces. Now they scan the full collection and raise on >1 with all colliding IDs in the message.

2. **`create_agent` excludes null fields from the persisted model_config.** PR #75 added several `Optional` fields to `GenieRoomModel` (`text_instructions`, `warehouse`, `table_sources`, `benchmarks`, `entitlements`, `example_sqls`, etc.). `model_dump(by_alias=True)` emits these as `null`. When the Model Serving container deserializes the model_config using whatever dao-ai version is pinned in its conda env, an older GenieRoomModel rejects the unknown field names with `extra="forbid"` → `extra_forbidden` → exit 1 → DEPLOYMENT_FAILED.

## Discovery story for #2

During post-merge testing of PR #75 in `aws-field-eng`, `sporting_goods_store_dao` v11 entered `DEPLOYMENT_FAILED`. The serving endpoint events surfaced *"Model server failed to load the model. Please see service logs for more information."* The container logs revealed Pydantic validation errors:

```
resources.genie_rooms.merchandising_analytics_room.text_instructions
  Extra inputs are not permitted [type=extra_forbidden]
resources.genie_rooms.merchandising_analytics_room.warehouse
resources.genie_rooms.sales_pricing_room.benchmarks
resources.genie_rooms.sales_pricing_room.entitlements
resources.genie_rooms.sales_pricing_room.example_sqls
```

Every one of those is a field PR #75 introduced. The deployed container's `dao-ai` predates PR #75 and rejects them. Adding `exclude_none=True` is forward-compatible regardless of the registry's `dao-ai` version.

## Performance (change #1)

| Scenario | Before | After |
|---|---|---|
| Single match in first page | 1 list call | 1 list call (also scans subsequent pages to verify uniqueness) |
| Workspace with duplicate names | Silently returns first | Raises `ValueError` with all colliding ids |

For typical workspaces (<100 Genie spaces, <50 warehouses) the cost is sub-second and incurred once per `ensure_resolved()`. No caching added — premature for current shapes; revisit if real workspaces show amplification.

## Test plan

- [x] Replaced `test_resolve_*_short_circuits` (asserted the now-removed silent short-circuit) with `test_resolve_*_raises_on_duplicates` covering the new behavior.
- [x] All 58 genie+warehouse model tests pass.
- [x] All 140 tests in the broader sweep (genie/protocol/refresh/config) pass.
- [x] Verified `model_dump(exclude_none=True)` drops the offending fields on the sporting_goods config: genie rooms now serialize with only `on_behalf_of_user`, `name`, `description`, `space_id`.

This pull request and its description were written by Isaac.