### PR TITLE
Fix generate-bundle: ship requirements.txt + uv run command, preserve anchors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dependencies = [
     "python-dotenv>=1.2.1",
     "pyyaml>=6.0.2",
     "rich>=14.2.0",
+    "ruamel.yaml>=0.18,<0.19",
     "scipy>=1.14.0",
     "sqlparse>=0.5.4",
     "tomli>=2.3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -213,6 +213,8 @@ rfc3987-syntax==1.1.0
 rich==14.3.3
 rpds-py==0.30.0
 rstr==3.2.2
+ruamel-yaml==0.18.17
+ruamel-yaml-clib==0.2.15
 ruff==0.15.9
 s3transfer==0.16.0
 scikit-learn==1.8.0

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -15,6 +15,7 @@ Usage:
     write_bundle(config, Path("./my-bundle"), force=False)
 """
 
+import io
 import shutil
 import subprocess
 from importlib.metadata import version as pkg_version
@@ -23,6 +24,7 @@ from typing import Any
 
 import yaml
 from loguru import logger
+from ruamel.yaml import YAML
 
 from dao_ai.apps.resources import (
     _extract_env_vars_from_config,
@@ -87,6 +89,11 @@ bundle_config_schema.json
 dao_ai_schema.json
 """
 
+# Databricks Apps' runtime auto-installs Python deps from requirements.txt.
+# We ship just `uv` so the rest of the dependency graph (including dao-ai)
+# resolves from pyproject.toml + uv.lock at app startup via `uv run`.
+_REQUIREMENTS_TXT_CONTENT = "uv\n"
+
 _PYPROJECT_TEMPLATE = """\
 [build-system]
 requires = ["hatchling"]
@@ -135,6 +142,50 @@ def _get_dao_ai_version() -> str:
         return pkg_version("dao-ai")
     except Exception:
         return "0.1.0"
+
+
+def _strip_parameters_block(rendered_yaml: str) -> str:
+    """Drop the top-level ``parameters:`` block from a rendered config while
+    preserving anchor names, comments, key order, and merge keys.
+
+    PyYAML's ``safe_load`` -> ``safe_dump`` round-trip discards original
+    anchor names (rewriting ``&hardware_store_schema`` as ``&id001`` etc.),
+    drops comments, and may reorder keys. ruamel.yaml's round-trip mode
+    keeps all of that intact, so the deployed config stays readable.
+
+    Args:
+        rendered_yaml: YAML text after ``${param.NAME}`` substitution.
+
+    Returns:
+        YAML text with the top-level ``parameters:`` key removed.
+        If parsing fails or the structure isn't a mapping, the input is
+        returned unchanged so we never silently corrupt the user's config.
+    """
+    rt = YAML(typ="rt")
+    rt.preserve_quotes = True
+    # Avoid line-wrapping long anchored strings on dump.
+    rt.width = 4096
+
+    try:
+        data = rt.load(rendered_yaml)
+    except Exception as exc:
+        logger.warning(
+            f"ruamel parse failed; emitting rendered YAML unchanged: {exc}"
+        )
+        return rendered_yaml
+
+    # Only mappings have a top-level `parameters:` key. A document whose root
+    # is a list, scalar, or None is returned untouched.
+    from collections.abc import MutableMapping
+
+    if not isinstance(data, MutableMapping):
+        return rendered_yaml
+
+    data.pop("parameters", None)
+
+    buf = io.StringIO()
+    rt.dump(data, buf)
+    return buf.getvalue()
 
 
 def _convert_single_resource(resource: dict[str, Any]) -> dict[str, Any] | None:
@@ -346,9 +397,9 @@ def generate_databricks_yaml(
     user_api_scopes = generate_user_api_scopes(config)
 
     app_command: list[str] = (
-        ["python", "-m", "dao_ai.apps.start_app"]
+        ["uv", "run", "python", "-m", "dao_ai.apps.start_app"]
         if enable_chat_proxy
-        else ["python", "-m", "dao_ai.apps.server"]
+        else ["uv", "run", "python", "-m", "dao_ai.apps.server"]
     )
 
     app_def: dict[str, Any] = {
@@ -473,9 +524,7 @@ def write_bundle(
             # a plain copy if the config wasn't loaded via from_file.
             rendered: str | None = getattr(config, "_rendered_yaml", None)
             if rendered is not None:
-                rendered_dict: dict[str, Any] = yaml.safe_load(rendered) or {}
-                rendered_dict.pop("parameters", None)
-                dest.write_text(yaml.safe_dump(rendered_dict, sort_keys=False))
+                dest.write_text(_strip_parameters_block(rendered))
                 logger.info(
                     f"Wrote rendered config as {config_filename} (parameters baked in)"
                 )
@@ -619,6 +668,7 @@ def write_bundle(
         _GITIGNORE_DEV_CONTENT if development else _GITIGNORE_CONTENT,
     )
     _track(output_dir / ".python-version", "3.11\n")
+    _track(output_dir / "requirements.txt", _REQUIREMENTS_TXT_CONTENT)
 
     print(f"\nBundle generated in {output_dir}/\n")
     for name in written:

--- a/tests/dao_ai/test_config_vars.py
+++ b/tests/dao_ai/test_config_vars.py
@@ -695,6 +695,354 @@ def test_write_bundle_bakes_resolved_values_and_drops_parameters(
     assert "${param." not in raw
 
 
+@pytest.mark.unit
+def test_write_bundle_emits_requirements_txt_and_uv_run_command(
+    parameterised_config_path: Path, tmp_path: Path
+) -> None:
+    """The generated bundle must ship a requirements.txt (so Databricks Apps
+    auto-installs `uv`) and an app `command:` that starts with `uv run`.
+    Without both, the App container's runtime venv is missing dao_ai.
+    """
+    from dao_ai.apps.bundle import write_bundle
+
+    config = AppConfig.from_file(
+        parameterised_config_path,
+        params={"module_id": "09", "catalog": "nfleming"},
+        initialize=False,
+    )
+    out_dir = tmp_path / "bundle"
+    out_dir.mkdir()
+
+    write_bundle(config, out_dir, force=True, development=False)
+
+    req = (out_dir / "requirements.txt").read_text().strip().splitlines()
+    assert req == ["uv"], f"requirements.txt should contain only `uv`; got {req!r}"
+
+    db_yaml = yaml.safe_load((out_dir / "databricks.yaml").read_text())
+    app_name = next(iter(db_yaml["resources"]["apps"]))
+    cmd = db_yaml["resources"]["apps"][app_name]["config"]["command"]
+    assert cmd[:2] == ["uv", "run"], (
+        f"App command must start with `uv run`; got {cmd!r}"
+    )
+    assert cmd[2:] == ["python", "-m", "dao_ai.apps.start_app"], (
+        f"App command tail unexpected: {cmd!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bundle config round-trip: ruamel-based _strip_parameters_block must
+# preserve descriptive anchor names, aliases, comments, key order, and
+# merge keys, while still dropping the parameters: block and baking in
+# ${param.NAME} substitutions.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def anchored_config_path(tmp_path: Path) -> Path:
+    """Config exercising anchors, aliases, merge keys, comments, and params.
+
+    Anchors land only in pydantic-valid fields:
+    - `&hardware_store_schema` on a schemas entry, referenced by another
+      schemas entry via a YAML merge key
+    - `&default_llm` on an LLM resource, referenced by `agents.hello.model`
+    - `&hello` on an agent, referenced by `app.agents[0]`
+    """
+    p = tmp_path / "anchored.yaml"
+    p.write_text(
+        dedent(
+            """
+            # Top-of-file comment that should survive round-trip
+            parameters:
+              catalog:
+                description: UC catalog
+                default: main
+              module_id:
+                description: workshop module id
+
+            schemas:  # shared schema definitions reused across resources
+              hardware: &hardware_store_schema
+                catalog_name: ${var.catalog}
+                schema_name: dao_ai_${var.module_id}
+              clothing:
+                <<: *hardware_store_schema
+                schema_name: dao_ai_clothing_${var.module_id}
+
+            resources:
+              llms:
+                default_llm: &default_llm
+                  name: databricks-test-llm
+                  temperature: 0.0
+
+            agents:
+              hello: &hello  # primary greeter agent
+                name: hello
+                description: hello agent for module ${var.module_id}
+                model: *default_llm
+                prompt: |
+                  Welcome to module ${var.module_id}.
+
+            app:
+              name: dao_ai_test_${var.module_id}
+              description: "test"
+              deployment_target: apps
+              agents:
+                - *hello
+            """
+        ).lstrip()
+    )
+    return p
+
+
+def _emitted_config_text(
+    config_path: Path,
+    out_dir: Path,
+    params: dict[str, str],
+) -> str:
+    """Helper: run write_bundle and return the emitted config YAML text."""
+    from dao_ai.apps.bundle import write_bundle
+
+    config = AppConfig.from_file(config_path, params=params, initialize=False)
+    out_dir.mkdir(exist_ok=True)
+    write_bundle(config, out_dir, force=True, development=False)
+    return (out_dir / config_path.name).read_text()
+
+
+@pytest.mark.unit
+def test_round_trip_preserves_descriptive_anchor_names(
+    anchored_config_path: Path, tmp_path: Path
+) -> None:
+    """Source uses `&hardware_store_schema`; emitted YAML must keep that
+    literal name, not auto-generate `&id001`."""
+    text = _emitted_config_text(
+        anchored_config_path,
+        tmp_path / "bundle",
+        params={"module_id": "09", "catalog": "nfleming"},
+    )
+    assert "&hardware_store_schema" in text, (
+        f"descriptive anchor name lost — got:\n{text}"
+    )
+    assert "&default_llm" in text
+    assert "&hello" in text
+    # No PyYAML-style auto-generated anchor noise.
+    assert "&id001" not in text
+    assert "&id002" not in text
+
+
+@pytest.mark.unit
+def test_round_trip_preserves_aliases_pointing_at_descriptive_anchors(
+    anchored_config_path: Path, tmp_path: Path
+) -> None:
+    """Aliases like `*hardware_store_schema` must stay textual aliases (not
+    inlined copies), and they must point at the original anchor name."""
+    text = _emitted_config_text(
+        anchored_config_path,
+        tmp_path / "bundle",
+        params={"module_id": "09", "catalog": "nfleming"},
+    )
+    assert "*hardware_store_schema" in text, (
+        f"alias was inlined or renamed — got:\n{text}"
+    )
+    assert "*default_llm" in text
+    assert "*hello" in text
+
+
+@pytest.mark.unit
+def test_round_trip_preserves_merge_keys(
+    anchored_config_path: Path, tmp_path: Path
+) -> None:
+    """The clothing schema uses `<<: *hardware_store_schema` — both the merge
+    syntax and the alias name must survive."""
+    text = _emitted_config_text(
+        anchored_config_path,
+        tmp_path / "bundle",
+        params={"module_id": "09", "catalog": "nfleming"},
+    )
+    assert "<<: *hardware_store_schema" in text, (
+        f"merge key did not survive — got:\n{text}"
+    )
+
+
+@pytest.mark.unit
+def test_round_trip_aliases_resolve_to_same_data_after_load(
+    anchored_config_path: Path, tmp_path: Path
+) -> None:
+    """Semantic check: parse the emitted YAML and confirm the alias target
+    equals the anchor source. Anchor preservation is cosmetic; this proves
+    we didn't accidentally fork the references."""
+    text = _emitted_config_text(
+        anchored_config_path,
+        tmp_path / "bundle",
+        params={"module_id": "09", "catalog": "nfleming"},
+    )
+    parsed = yaml.safe_load(text)
+    # `&hello` is referenced by `app.agents[0]` via `*hello`.
+    assert (
+        parsed["app"]["agents"][0] == parsed["agents"]["hello"]
+    ), "alias resolved to a different value than the anchor source"
+    # `&default_llm` is referenced by `agents.hello.model` via `*default_llm`.
+    assert (
+        parsed["agents"]["hello"]["model"] == parsed["resources"]["llms"]["default_llm"]
+    )
+    # Merge key: clothing schema inherits catalog_name from hardware but
+    # overrides schema_name.
+    assert parsed["schemas"]["clothing"]["catalog_name"] == "nfleming"
+    assert parsed["schemas"]["clothing"]["schema_name"] == "dao_ai_clothing_09"
+
+
+@pytest.mark.unit
+def test_round_trip_drops_parameters_block_with_anchors_present(
+    anchored_config_path: Path, tmp_path: Path
+) -> None:
+    """The parameters: removal path must coexist with anchors elsewhere."""
+    text = _emitted_config_text(
+        anchored_config_path,
+        tmp_path / "bundle",
+        params={"module_id": "09", "catalog": "nfleming"},
+    )
+    parsed = yaml.safe_load(text)
+    assert "parameters" not in parsed, (
+        "parameters: block must be stripped from the emitted bundle YAML"
+    )
+
+
+@pytest.mark.unit
+def test_round_trip_bakes_in_param_substitutions_with_anchors(
+    anchored_config_path: Path, tmp_path: Path
+) -> None:
+    """`${var.…}` and `${param.…}` references must be substituted, even
+    inside anchored mappings."""
+    text = _emitted_config_text(
+        anchored_config_path,
+        tmp_path / "bundle",
+        params={"module_id": "09", "catalog": "nfleming"},
+    )
+    assert "${var." not in text
+    assert "${param." not in text
+    parsed = yaml.safe_load(text)
+    assert parsed["schemas"]["hardware"]["catalog_name"] == "nfleming"
+    assert parsed["schemas"]["hardware"]["schema_name"] == "dao_ai_09"
+    assert parsed["app"]["name"] == "dao_ai_test_09"
+
+
+@pytest.mark.unit
+def test_round_trip_preserves_top_level_key_order(
+    anchored_config_path: Path, tmp_path: Path
+) -> None:
+    """ruamel rt mode preserves key order; PyYAML safe_dump did not."""
+    text = _emitted_config_text(
+        anchored_config_path,
+        tmp_path / "bundle",
+        params={"module_id": "09", "catalog": "nfleming"},
+    )
+    # Source order (after parameters: removed): schemas, resources, agents, app
+    expected_order = ["schemas", "resources", "agents", "app"]
+    actual_order = [
+        line.split(":", 1)[0]
+        for line in text.splitlines()
+        if line and not line.startswith((" ", "\t", "#"))
+    ]
+    actual_order = [k for k in actual_order if k in expected_order]
+    assert actual_order == expected_order, (
+        f"key order changed: expected {expected_order}, got {actual_order}"
+    )
+
+
+@pytest.mark.unit
+def test_round_trip_preserves_comments(
+    anchored_config_path: Path, tmp_path: Path
+) -> None:
+    """ruamel rt mode preserves comments (PyYAML does not)."""
+    text = _emitted_config_text(
+        anchored_config_path,
+        tmp_path / "bundle",
+        params={"module_id": "09", "catalog": "nfleming"},
+    )
+    assert "# Top-of-file comment that should survive round-trip" in text
+    # Inline-on-key comments are the most robustly-anchored kind; both
+    # should survive even though the parameters: block (a sibling of
+    # schemas:) was removed.
+    assert "# shared schema definitions reused across resources" in text
+    assert "# primary greeter agent" in text
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests for the round-trip helper.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_strip_parameters_block_drops_top_level_parameters() -> None:
+    from dao_ai.apps.bundle import _strip_parameters_block
+
+    src = dedent(
+        """
+        parameters:
+          foo:
+            default: bar
+        app:
+          name: x
+        """
+    ).lstrip()
+    out = _strip_parameters_block(src)
+    parsed = yaml.safe_load(out)
+    assert "parameters" not in parsed
+    assert parsed["app"]["name"] == "x"
+
+
+@pytest.mark.unit
+def test_strip_parameters_block_no_op_when_parameters_absent() -> None:
+    """If no top-level parameters: key, output is semantically identical."""
+    from dao_ai.apps.bundle import _strip_parameters_block
+
+    src = dedent(
+        """
+        # leading comment
+        schemas:
+          s: &s
+            name: a
+        agents:
+          a:
+            schema: *s
+        """
+    ).lstrip()
+    out = _strip_parameters_block(src)
+    assert "&s" in out
+    assert "*s" in out
+    assert "# leading comment" in out
+    parsed = yaml.safe_load(out)
+    assert parsed["agents"]["a"]["schema"] == parsed["schemas"]["s"]
+
+
+@pytest.mark.unit
+def test_strip_parameters_block_returns_input_on_parse_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Malformed YAML must not corrupt: returned unchanged so the caller
+    isn't silently handed broken output."""
+    from dao_ai.apps.bundle import _strip_parameters_block
+
+    bad = "key: [unclosed\n"
+    assert _strip_parameters_block(bad) == bad
+
+
+@pytest.mark.unit
+def test_strip_parameters_block_handles_empty_string() -> None:
+    from dao_ai.apps.bundle import _strip_parameters_block
+
+    assert _strip_parameters_block("") == ""
+
+
+@pytest.mark.unit
+def test_strip_parameters_block_handles_top_level_list() -> None:
+    """If the document root is a list (no top-level mapping), pop is a no-op
+    and the input must come back functionally intact."""
+    from dao_ai.apps.bundle import _strip_parameters_block
+
+    src = "- one\n- two\n"
+    out = _strip_parameters_block(src)
+    assert yaml.safe_load(out) == ["one", "two"]
+
+
 # ---------------------------------------------------------------------------
 # CLI integration: parse_args + handler call against tmp configs.
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -897,6 +897,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "ruamel-yaml" },
     { name = "scipy" },
     { name = "sqlparse" },
     { name = "tomli" },
@@ -1015,6 +1016,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "rich", specifier = ">=14.2.0" },
+    { name = "ruamel-yaml", specifier = ">=0.18,<0.19" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.9" },
     { name = "scipy", specifier = ">=1.14.0" },
     { name = "sqlparse", specifier = ">=0.5.4" },
@@ -5695,6 +5697,66 @@ source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/80/d7449656d45a776b7a443ce3af4eb97c4debe416a1a80f60311c7cfd02ff/rstr-3.2.2.tar.gz", hash = "sha256:c4a564d4dfb4472d931d145c43d1cf1ad78c24592142e7755b8866179eeac012", size = 13560, upload-time = "2023-10-11T20:07:57.422Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/8c/a0f14f2fcdd846839c478048032b2fc93293deaa936ff6751f27dcf50995/rstr-3.2.2-py3-none-any.whl", hash = "sha256:f39195d38da1748331eeec52f1276e71eb6295e7949beea91a5e9af2340d7b3b", size = 10030, upload-time = "2023-10-11T20:07:55.873Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.18.17"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
+dependencies = [
+    { name = "ruamel-yaml-clib", marker = "python_full_version < '3.15' and platform_python_implementation == 'CPython'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/2b/7a1f1ebcd6b3f14febdc003e658778d81e76b40df2267904ee6b13f0c5c6/ruamel_yaml-0.18.17.tar.gz", hash = "sha256:9091cd6e2d93a3a4b157ddb8fabf348c3de7f1fb1381346d985b6b247dcd8d3c", size = 149602, upload-time = "2025-12-17T20:02:55.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/fe/b6045c782f1fd1ae317d2a6ca1884857ce5c20f59befe6ab25a8603c43a7/ruamel_yaml-0.18.17-py3-none-any.whl", hash = "sha256:9c8ba9eb3e793efdf924b60d521820869d5bf0cb9c6f1b82d82de8295e290b9d", size = 121594, upload-time = "2025-12-17T20:02:07.657Z" },
+]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.15"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/97/60fda20e2fb54b83a61ae14648b0817c8f5d84a3821e40bfbdae1437026a/ruamel_yaml_clib-0.2.15.tar.gz", hash = "sha256:46e4cc8c43ef6a94885f72512094e482114a8a706d3c555a34ed4b0d20200600", size = 225794, upload-time = "2025-11-16T16:12:59.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/80/8ce7b9af532aa94dd83360f01ce4716264db73de6bc8efd22c32341f6658/ruamel_yaml_clib-0.2.15-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c583229f336682b7212a43d2fa32c30e643d3076178fb9f7a6a14dde85a2d8bd", size = 147998, upload-time = "2025-11-16T16:13:13.241Z" },
+    { url = "https://files.pythonhosted.org/packages/53/09/de9d3f6b6701ced5f276d082ad0f980edf08ca67114523d1b9264cd5e2e0/ruamel_yaml_clib-0.2.15-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:56ea19c157ed8c74b6be51b5fa1c3aff6e289a041575f0556f66e5fb848bb137", size = 132743, upload-time = "2025-11-16T16:13:14.265Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f7/73a9b517571e214fe5c246698ff3ed232f1ef863c8ae1667486625ec688a/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5fea0932358e18293407feb921d4f4457db837b67ec1837f87074667449f9401", size = 731459, upload-time = "2025-11-16T20:22:44.338Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/a2/0dc0013169800f1c331a6f55b1282c1f4492a6d32660a0cf7b89e6684919/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef71831bd61fbdb7aa0399d5c4da06bea37107ab5c79ff884cc07f2450910262", size = 749289, upload-time = "2025-11-16T16:13:15.633Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ed/3fb20a1a96b8dc645d88c4072df481fe06e0289e4d528ebbdcc044ebc8b3/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:617d35dc765715fa86f8c3ccdae1e4229055832c452d4ec20856136acc75053f", size = 777630, upload-time = "2025-11-16T16:13:16.898Z" },
+    { url = "https://files.pythonhosted.org/packages/60/50/6842f4628bc98b7aa4733ab2378346e1441e150935ad3b9f3c3c429d9408/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b45498cc81a4724a2d42273d6cfc243c0547ad7c6b87b4f774cb7bcc131c98d", size = 744368, upload-time = "2025-11-16T16:13:18.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/128ae8e19a7d794c2e36130a72b3bb650ce1dd13fb7def6cf10656437dcf/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:def5663361f6771b18646620fca12968aae730132e104688766cf8a3b1d65922", size = 745233, upload-time = "2025-11-16T20:22:45.833Z" },
+    { url = "https://files.pythonhosted.org/packages/75/05/91130633602d6ba7ce3e07f8fc865b40d2a09efd4751c740df89eed5caf9/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:014181cdec565c8745b7cbc4de3bf2cc8ced05183d986e6d1200168e5bb59490", size = 770963, upload-time = "2025-11-16T16:13:19.344Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4b/fd4542e7f33d7d1bc64cc9ac9ba574ce8cf145569d21f5f20133336cdc8c/ruamel_yaml_clib-0.2.15-cp311-cp311-win32.whl", hash = "sha256:d290eda8f6ada19e1771b54e5706b8f9807e6bb08e873900d5ba114ced13e02c", size = 102640, upload-time = "2025-11-16T16:13:20.498Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/eb/00ff6032c19c7537371e3119287999570867a0eafb0154fccc80e74bf57a/ruamel_yaml_clib-0.2.15-cp311-cp311-win_amd64.whl", hash = "sha256:bdc06ad71173b915167702f55d0f3f027fc61abd975bd308a0968c02db4a4c3e", size = 121996, upload-time = "2025-11-16T16:13:21.855Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4b/5fde11a0722d676e469d3d6f78c6a17591b9c7e0072ca359801c4bd17eee/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cb15a2e2a90c8475df45c0949793af1ff413acfb0a716b8b94e488ea95ce7cff", size = 149088, upload-time = "2025-11-16T16:13:22.836Z" },
+    { url = "https://files.pythonhosted.org/packages/85/82/4d08ac65ecf0ef3b046421985e66301a242804eb9a62c93ca3437dc94ee0/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:64da03cbe93c1e91af133f5bec37fd24d0d4ba2418eaf970d7166b0a26a148a2", size = 134553, upload-time = "2025-11-16T16:13:24.151Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/cb/22366d68b280e281a932403b76da7a988108287adff2bfa5ce881200107a/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f6d3655e95a80325b84c4e14c080b2470fe4f33b6846f288379ce36154993fb1", size = 737468, upload-time = "2025-11-16T20:22:47.335Z" },
+    { url = "https://files.pythonhosted.org/packages/71/73/81230babf8c9e33770d43ed9056f603f6f5f9665aea4177a2c30ae48e3f3/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:71845d377c7a47afc6592aacfea738cc8a7e876d586dfba814501d8c53c1ba60", size = 753349, upload-time = "2025-11-16T16:13:26.269Z" },
+    { url = "https://files.pythonhosted.org/packages/61/62/150c841f24cda9e30f588ef396ed83f64cfdc13b92d2f925bb96df337ba9/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11e5499db1ccbc7f4b41f0565e4f799d863ea720e01d3e99fa0b7b5fcd7802c9", size = 788211, upload-time = "2025-11-16T16:13:27.441Z" },
+    { url = "https://files.pythonhosted.org/packages/30/93/e79bd9cbecc3267499d9ead919bd61f7ddf55d793fb5ef2b1d7d92444f35/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4b293a37dc97e2b1e8a1aec62792d1e52027087c8eea4fc7b5abd2bdafdd6642", size = 743203, upload-time = "2025-11-16T16:13:28.671Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/06/1eb640065c3a27ce92d76157f8efddb184bd484ed2639b712396a20d6dce/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:512571ad41bba04eac7268fe33f7f4742210ca26a81fe0c75357fa682636c690", size = 747292, upload-time = "2025-11-16T20:22:48.584Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/21/ee353e882350beab65fcc47a91b6bdc512cace4358ee327af2962892ff16/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5e9f630c73a490b758bf14d859a39f375e6999aea5ddd2e2e9da89b9953486a", size = 771624, upload-time = "2025-11-16T16:13:29.853Z" },
+    { url = "https://files.pythonhosted.org/packages/57/34/cc1b94057aa867c963ecf9ea92ac59198ec2ee3a8d22a126af0b4d4be712/ruamel_yaml_clib-0.2.15-cp312-cp312-win32.whl", hash = "sha256:f4421ab780c37210a07d138e56dd4b51f8642187cdfb433eb687fe8c11de0144", size = 100342, upload-time = "2025-11-16T16:13:31.067Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/e5/8925a4208f131b218f9a7e459c0d6fcac8324ae35da269cb437894576366/ruamel_yaml_clib-0.2.15-cp312-cp312-win_amd64.whl", hash = "sha256:2b216904750889133d9222b7b873c199d48ecbb12912aca78970f84a5aa1a4bc", size = 119013, upload-time = "2025-11-16T16:13:32.164Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5e/2f970ce4c573dc30c2f95825f2691c96d55560268ddc67603dc6ea2dd08e/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dcec721fddbb62e60c2801ba08c87010bd6b700054a09998c4d09c08147b8fb", size = 147450, upload-time = "2025-11-16T16:13:33.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/03/a1baa5b94f71383913f21b96172fb3a2eb5576a4637729adbf7cd9f797f8/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:65f48245279f9bb301d1276f9679b82e4c080a1ae25e679f682ac62446fac471", size = 133139, upload-time = "2025-11-16T16:13:34.587Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/19/40d676802390f85784235a05788fd28940923382e3f8b943d25febbb98b7/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:46895c17ead5e22bea5e576f1db7e41cb273e8d062c04a6a49013d9f60996c25", size = 731474, upload-time = "2025-11-16T20:22:49.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/bb/6ef5abfa43b48dd55c30d53e997f8f978722f02add61efba31380d73e42e/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3eb199178b08956e5be6288ee0b05b2fb0b5c1f309725ad25d9c6ea7e27f962a", size = 748047, upload-time = "2025-11-16T16:13:35.633Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/5d/e4f84c9c448613e12bd62e90b23aa127ea4c46b697f3d760acc32cb94f25/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d1032919280ebc04a80e4fb1e93f7a738129857eaec9448310e638c8bccefcf", size = 782129, upload-time = "2025-11-16T16:13:36.781Z" },
+    { url = "https://files.pythonhosted.org/packages/de/4b/e98086e88f76c00c88a6bcf15eae27a1454f661a9eb72b111e6bbb69024d/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab0df0648d86a7ecbd9c632e8f8d6b21bb21b5fc9d9e095c796cacf32a728d2d", size = 736848, upload-time = "2025-11-16T16:13:37.952Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5c/5964fcd1fd9acc53b7a3a5d9a05ea4f95ead9495d980003a557deb9769c7/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:331fb180858dd8534f0e61aa243b944f25e73a4dae9962bd44c46d1761126bbf", size = 741630, upload-time = "2025-11-16T20:22:51.718Z" },
+    { url = "https://files.pythonhosted.org/packages/07/1e/99660f5a30fceb58494598e7d15df883a07292346ef5696f0c0ae5dee8c6/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd4c928ddf6bce586285daa6d90680b9c291cfd045fc40aad34e445d57b1bf51", size = 766619, upload-time = "2025-11-16T16:13:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/36/2f/fa0344a9327b58b54970e56a27b32416ffbcfe4dcc0700605516708579b2/ruamel_yaml_clib-0.2.15-cp313-cp313-win32.whl", hash = "sha256:bf0846d629e160223805db9fe8cc7aec16aaa11a07310c50c8c7164efa440aec", size = 100171, upload-time = "2025-11-16T16:13:40.456Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c4/c124fbcef0684fcf3c9b72374c2a8c35c94464d8694c50f37eef27f5a145/ruamel_yaml_clib-0.2.15-cp313-cp313-win_amd64.whl", hash = "sha256:45702dfbea1420ba3450bb3dd9a80b33f0badd57539c6aac09f42584303e0db6", size = 118845, upload-time = "2025-11-16T16:13:41.481Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/bd/ab8459c8bb759c14a146990bf07f632c1cbec0910d4853feeee4be2ab8bb/ruamel_yaml_clib-0.2.15-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:753faf20b3a5906faf1fc50e4ddb8c074cb9b251e00b14c18b28492f933ac8ef", size = 147248, upload-time = "2025-11-16T16:13:42.872Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f2/c4cec0a30f1955510fde498aac451d2e52b24afdbcb00204d3a951b772c3/ruamel_yaml_clib-0.2.15-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:480894aee0b29752560a9de46c0e5f84a82602f2bc5c6cde8db9a345319acfdf", size = 133764, upload-time = "2025-11-16T16:13:43.932Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c7/2480d062281385a2ea4f7cc9476712446e0c548cd74090bff92b4b49e898/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4d3b58ab2454b4747442ac76fab66739c72b1e2bb9bd173d7694b9f9dbc9c000", size = 730537, upload-time = "2025-11-16T20:22:52.918Z" },
+    { url = "https://files.pythonhosted.org/packages/75/08/e365ee305367559f57ba6179d836ecc3d31c7d3fdff2a40ebf6c32823a1f/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bfd309b316228acecfa30670c3887dcedf9b7a44ea39e2101e75d2654522acd4", size = 746944, upload-time = "2025-11-16T16:13:45.338Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5c/8b56b08db91e569d0a4fbfa3e492ed2026081bdd7e892f63ba1c88a2f548/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2812ff359ec1f30129b62372e5f22a52936fac13d5d21e70373dbca5d64bb97c", size = 778249, upload-time = "2025-11-16T16:13:46.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1d/70dbda370bd0e1a92942754c873bd28f513da6198127d1736fa98bb2a16f/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7e74ea87307303ba91073b63e67f2c667e93f05a8c63079ee5b7a5c8d0d7b043", size = 737140, upload-time = "2025-11-16T16:13:48.349Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/87/822d95874216922e1120afb9d3fafa795a18fdd0c444f5c4c382f6dac761/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:713cd68af9dfbe0bb588e144a61aad8dcc00ef92a82d2e87183ca662d242f524", size = 741070, upload-time = "2025-11-16T20:22:54.151Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/17/4e01a602693b572149f92c983c1f25bd608df02c3f5cf50fd1f94e124a59/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:542d77b72786a35563f97069b9379ce762944e67055bea293480f7734b2c7e5e", size = 765882, upload-time = "2025-11-16T16:13:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/17/7999399081d39ebb79e807314de6b611e1d1374458924eb2a489c01fc5ad/ruamel_yaml_clib-0.2.15-cp314-cp314-win32.whl", hash = "sha256:424ead8cef3939d690c4b5c85ef5b52155a231ff8b252961b6516ed7cf05f6aa", size = 102567, upload-time = "2025-11-16T16:13:50.78Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/67/be582a7370fdc9e6846c5be4888a530dcadd055eef5b932e0e85c33c7d73/ruamel_yaml_clib-0.2.15-cp314-cp314-win_amd64.whl", hash = "sha256:ac9b8d5fa4bb7fd2917ab5027f60d4234345fd366fe39aa711d5dca090aa1467", size = 122847, upload-time = "2025-11-16T16:13:51.807Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bundle generator now ships a one-line `requirements.txt` (`uv`) and emits an app `command:` of `uv run python -m dao_ai.apps.<entrypoint>`. Fixes a bug where deployed Apps crashed with `ModuleNotFoundError: dao_ai` because the Apps runtime never installed deps from the emitted `pyproject.toml` / `uv.lock`.
- Switched the rendered-config round-trip in `write_bundle()` from PyYAML to `ruamel.yaml` (round-trip mode) so descriptive anchor names (`&hardware_store_schema`), aliases, comments, key order, and merge keys (`<<:`) survive into the deployed config. Previously they were rewritten as `&id001`/`&id002`.

## Why

### `requirements.txt` + `uv run`
Databricks Apps' runtime auto-installs Python deps from `requirements.txt`. It does **not** auto-resolve a generated `pyproject.toml`. The previous bundle shipped only `pyproject.toml` + `uv.lock` and an app `command:` of `python -m dao_ai.apps.start_app`, so the runtime venv had no project deps and the App crashed at boot.

Now the bundle ships `requirements.txt` containing just `uv`. The platform installs uv at container start, then `uv run` consumes the existing `pyproject.toml` + `uv.lock` to provision the venv. `pyproject.toml` stays the single source of dep truth — no drift between two parallel dep specs.

### Anchor name preservation
`bundle.py` was using `yaml.safe_load(rendered) -> rendered_dict.pop("parameters", None) -> yaml.safe_dump(rendered_dict, sort_keys=False)` to drop the `parameters:` block from the rendered config. PyYAML doesn't preserve original anchor names through that round-trip — they come out as auto-generated `&id001`, `&id002`, etc. — and it also drops comments. Cosmetic, but real readability cost when inspecting the deployed config.

A new `_strip_parameters_block(rendered_yaml: str) -> str` helper does the same job via `ruamel.yaml.YAML(typ='rt')`, which preserves anchors, aliases, comments, key order, and merge keys. Falls back to returning the input unchanged if parsing fails or the document root isn't a mapping.

## Tests

12 new unit tests in `tests/dao_ai/test_config_vars.py`:

- **End-to-end through `write_bundle`** (8): requirements.txt is shipped and contains exactly `uv`; app `command:` starts with `uv run`; descriptive anchor names preserved; no `&id001` noise; aliases stay textual (not inlined); merge keys survive; semantic alias-target equality after round-trip; `parameters:` dropped without disturbing anchors elsewhere; `${param.}`/`${var.}` substitutions baked in; top-level key order preserved; comments preserved.
- **`_strip_parameters_block` direct unit tests** (5): drops top-level `parameters:`; no-op when absent (anchors and comments still preserved); returns input unchanged on malformed YAML; handles empty string; handles top-level list root (caught a real bug — `list.pop` has a different signature).

Adds `ruamel.yaml>=0.18,<0.19` to dependencies.

## Test plan

- [x] `uv run pytest tests/dao_ai/test_config_vars.py` — 57/57 passing
- [x] `uv run pytest tests/dao_ai/ -m unit -k "bundle or yaml or config"` — 115/115 passing
- [x] End-to-end against `vega_lite_visualization.yaml` on `aws-field-eng`: bundle deploys, app reaches RUNNING / SUCCEEDED, emitted `vega_lite_visualization.yaml` keeps source anchor names verbatim (`&hardware_store_schema`, `&default_llm`, `&analytics_warehouse`, `&chart_tool`, `&get_department_sales`, `&analyst_with_charts`).

## Out of scope

- The `artifacts: { type: whl, build: "uv build" }` block in the emitted `databricks.yaml` is now redundant (nothing in the App runtime consumes the built wheel) but left alone — flagged for follow-up cleanup.

This pull request and its description were written by Isaac.