### PR TITLE
Swarm: handoff constraints (`requires`) on agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CLI: renamed `dao-ai bundle` to `dao-ai pipeline`** to disambiguate from the underlying Databricks Asset Bundle (DAB) feature it wraps. The old verb is no longer recognized — running `dao-ai bundle` now exits with `argparse: invalid choice: 'bundle'`. Help, examples, and documentation have been updated accordingly. The separate `dao-ai generate-bundle` subcommand keeps its name since it generates a literal Databricks Asset Bundle artifact.
 
 ### Added
+- **Swarm handoff constraints (`requires`)**: New optional field on the agent model declaring prerequisite agents that must have run before this agent can be reached via handoff. Enforced inside swarm handoff tools — when prereqs are unmet, the tool returns a refusal `ToolMessage` naming the missing agents and `active_agent` stays unchanged so the LLM can self-correct. Validated at config-build time (unknown agents, self-reference, cycles in the `requires` DAG, and deterministic handoffs to constrained targets are all rejected). Swarm-only in this release; supervisor adoption is planned. See `docs/architecture.md` → "Swarm Pattern" → "Handoff constraints" for details.
+
 - **MCP Tool Filtering**: Control which tools are loaded from MCP servers
   - `include_tools`: Optional allowlist with glob pattern support (e.g., `["query_*", "list_*"]`)
   - `exclude_tools`: Optional denylist with glob pattern support (e.g., `["drop_*", "delete_*"]`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -327,6 +327,54 @@ graph TB
 - **Orange**: Standard agents with handoff capabilities  
 - **Green** (Inventory): Terminal agent (no outbound handoffs)
 
+#### Handoff constraints (`requires`)
+
+Agents can declare prerequisite agents that must have run before they can be reached. This prevents the LLM from peer-routing past required intermediate agents — for example, jumping straight to `checkout` without ever visiting `cart`.
+
+Declare prereqs on the constrained agent:
+
+```yaml
+agents:
+  checkout: &checkout
+    name: checkout
+    model: *default_llm
+    prompt: ...
+    requires: [cart]   # cannot be reached until 'cart' has appeared in message history
+```
+
+The swarm graph is unchanged in shape — the constraint is a property of the target agent, not of any specific handoff edge:
+
+```yaml
+orchestration:
+  swarm:
+    default_agent: *triage
+    handoffs:
+      triage:   [cart, checkout]    # 'checkout' edge allowed; refused at runtime
+      cart:     [checkout, triage]
+      checkout: [triage]
+```
+
+**Behavior:**
+- `triage → cart → checkout` proceeds normally.
+- `triage → checkout` (skipping `cart`) returns a refusal `ToolMessage`:
+  ```
+  Cannot hand off to 'checkout' — requires [cart]; called so far: [triage].
+  Pick a different handoff or continue working.
+  ```
+  `active_agent` stays on `triage`; the LLM self-corrects on its next step.
+
+**Semantics:** any-order, all-of. Every agent in `requires` must appear in message history (any order) before the handoff is allowed.
+
+**Validation (config-build time):**
+- `requires` entries must reference declared agents.
+- Self-reference (`A.requires` containing `A`) is rejected.
+- Cycles in the `requires` DAG are rejected (unsatisfiable).
+- Deterministic handoffs to a target with non-empty `requires` are rejected — deterministic edges fire unconditionally, which contradicts the constraint. Use an agentic handoff for constrained targets.
+
+The check uses the agent name tagged on each `AIMessage` (`message.name`), iterating `state["messages"]` to determine which agents have run. No new state schema; no graph topology change.
+
+> Currently swarm-only. The same field will apply to supervisor routing in a future release.
+
 ---
 
 ## Navigation

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -117,6 +117,10 @@ agents:
     guardrails: [*guardrail_ref]
     prompt: string | *prompt_ref
     handoff_prompt: string      # For swarm routing
+    requires: [*agent_name]     # Swarm only: prerequisite agents that must have
+                                # run before this agent can be reached. Empty by
+                                # default. See architecture.md → Swarm Pattern →
+                                # Handoff constraints.
     middleware: [*middleware_ref]
     response_format: *response_format_ref | string | null
 

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -5113,6 +5113,29 @@ class AgentModel(BaseModel):
             "agents. When None, uses LangGraph's default (25)."
         ),
     )
+    requires: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Names of prerequisite agents that must have run (i.e. produced an "
+            "AIMessage tagged with their name) before this agent can be reached "
+            "via a swarm handoff. When unmet, the handoff tool returns a refusal "
+            "ToolMessage and 'active_agent' stays unchanged so the LLM can "
+            "self-correct on its next step. Semantics: any-order, all-of. "
+            "Currently enforced in the swarm pattern only; the supervisor pattern "
+            "ignores this field. Cross-agent validation (unknown name, "
+            "self-reference, cycles in the requires DAG) runs at config-build time."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_requires_no_self_reference(self) -> Self:
+        """Reject ``requires`` entries that reference the agent itself."""
+        if self.name in self.requires:
+            raise ValueError(
+                f"Agent '{self.name}' has a self-reference in 'requires'. "
+                f"An agent cannot require itself as a prerequisite."
+            )
+        return self
 
     @model_validator(mode="after")
     def validate_response_format(self) -> Self:
@@ -5955,6 +5978,57 @@ class AppModel(BaseModel):
         return self
 
     @model_validator(mode="after")
+    def validate_agent_requires(self) -> Self:
+        """Validate cross-agent ``requires`` references on every agent.
+
+        Checks:
+          * Each name in any agent's ``requires`` references a declared agent.
+          * The ``requires`` DAG is acyclic. A cycle is unsatisfiable -- no
+            traversal can ever satisfy it -- so we reject at config-build time.
+
+        Self-reference is caught earlier on ``AgentModel`` itself.
+        """
+        agent_names: set[str] = {a.name for a in self.agents}
+
+        # Unknown-name check.
+        for agent in self.agents:
+            for required in agent.requires:
+                if required not in agent_names:
+                    raise ValueError(
+                        f"Agent '{agent.name}' has a 'requires' entry "
+                        f"'{required}' that does not match any declared agent. "
+                        f"Known agents: {sorted(agent_names)}."
+                    )
+
+        # Cycle detection over the requires DAG via DFS with a recursion stack.
+        graph: dict[str, list[str]] = {a.name: list(a.requires) for a in self.agents}
+        WHITE, GRAY, BLACK = 0, 1, 2
+        color: dict[str, int] = {name: WHITE for name in graph}
+
+        def visit(node: str, path: list[str]) -> None:
+            color[node] = GRAY
+            for nxt in graph.get(node, []):
+                if color[nxt] == GRAY:
+                    cycle_start = path.index(nxt) if nxt in path else 0
+                    cycle = path[cycle_start:] + [nxt]
+                    raise ValueError(
+                        f"Cycle detected in agent 'requires' DAG: "
+                        f"{' -> '.join(cycle)}. A cycle is unsatisfiable -- no "
+                        f"path through the swarm can ever satisfy a circular "
+                        f"prerequisite. Break the cycle by removing one of the "
+                        f"'requires' entries."
+                    )
+                if color[nxt] == WHITE:
+                    visit(nxt, path + [nxt])
+            color[node] = BLACK
+
+        for name in graph:
+            if color[name] == WHITE:
+                visit(name, [name])
+
+        return self
+
+    @model_validator(mode="after")
     def validate_registered_model_required_for_serving(self) -> Self:
         """Ensure registered_model is provided when deployment target is not apps."""
         if (
@@ -6035,6 +6109,58 @@ class AppModel(BaseModel):
         if self.orchestration.swarm and not self.orchestration.swarm.default_agent:
             self.orchestration.swarm.default_agent = default_agent_name
 
+        return self
+
+    @model_validator(mode="after")
+    def validate_no_deterministic_handoff_to_constrained(self) -> Self:
+        """Reject deterministic handoffs to agents that declare ``requires``.
+
+        Deterministic edges fire unconditionally via static ``add_edge`` in
+        the swarm graph. Layering a runtime ``requires`` check on top is a
+        contradiction -- the edge would either fire and bypass the check, or
+        the check would block an edge that's supposed to be unconditional.
+
+        Catch this at config-build time and direct the user to use an
+        agentic handoff for constrained targets instead.
+        """
+        if not self.orchestration or not self.orchestration.swarm:
+            return self
+        if not self.orchestration.swarm.handoffs:
+            return self
+
+        # Build a name -> requires map so we can resolve target requires by
+        # name regardless of how the handoff entry referenced the agent.
+        requires_by_name: dict[str, list[str]] = {
+            a.name: list(a.requires) for a in self.agents
+        }
+
+        for source, targets in self.orchestration.swarm.handoffs.items():
+            if not targets:
+                continue
+            for entry in targets:
+                if isinstance(entry, HandoffRouteModel):
+                    target_obj = entry.agent
+                    is_det = entry.is_deterministic
+                else:
+                    target_obj = entry
+                    is_det = False
+                if not is_det:
+                    continue
+                target_name: str = (
+                    target_obj.name
+                    if hasattr(target_obj, "name")
+                    else str(target_obj)
+                )
+                target_requires: list[str] = requires_by_name.get(target_name, [])
+                if target_requires:
+                    raise ValueError(
+                        f"Agent '{source}' has a deterministic handoff to "
+                        f"'{target_name}', but '{target_name}' declares "
+                        f"requires={target_requires}. Deterministic edges "
+                        f"fire unconditionally and cannot honor a runtime "
+                        f"prerequisite check. Use an agentic handoff "
+                        f"(default) for constrained targets."
+                    )
         return self
 
     @model_validator(mode="after")

--- a/src/dao_ai/orchestration/core.py
+++ b/src/dao_ai/orchestration/core.py
@@ -382,6 +382,7 @@ def create_agent_node_handler(
 def create_handoff_tool(
     target_agent_name: str,
     description: str,
+    requires: list[str] | None = None,
 ) -> BaseTool:
     """
     Create a handoff tool that transfers control to another agent.
@@ -392,10 +393,16 @@ def create_handoff_tool(
     Args:
         target_agent_name: The name of the agent to hand off to
         description: Description of what this agent handles
+        requires: Optional list of agent names that must have appeared in
+            ``state["messages"]`` (as ``AIMessage.name``) before the handoff
+            is allowed. When unmet, the tool returns a refusal ``ToolMessage``
+            naming the missing prereqs and ``active_agent`` stays unchanged.
+            Empty/None means no constraint (existing behavior).
 
     Returns:
         A tool that triggers a handoff to the target agent via Command
     """
+    required_agents: tuple[str, ...] = tuple(requires or ())
 
     @tool
     def handoff_tool(runtime: ToolRuntime[Context, AgentState]) -> Command:
@@ -410,6 +417,40 @@ def create_handoff_tool(
         triggering_ai_message: AIMessage | None = last_ai_message_with_tool_calls(
             messages
         )
+
+        # Enforce ``requires`` (handoff constraints): refuse if any required
+        # agent has not yet produced a tagged AIMessage in this conversation.
+        if required_agents:
+            called_agents: set[str] = {
+                m.name
+                for m in messages
+                if isinstance(m, AIMessage) and m.name
+            }
+            missing: list[str] = [a for a in required_agents if a not in called_agents]
+            if missing:
+                logger.debug(
+                    "Handoff refused: prerequisites unmet",
+                    target_agent=target_agent_name,
+                    missing=missing,
+                    called=sorted(called_agents),
+                )
+                refusal_messages: list[BaseMessage] = []
+                if triggering_ai_message:
+                    refusal_messages.append(triggering_ai_message)
+                refusal_messages.append(
+                    ToolMessage(
+                        content=(
+                            f"Cannot hand off to '{target_agent_name}' — "
+                            f"requires {list(required_agents)}; called so far: "
+                            f"{sorted(called_agents)}. Missing: {missing}. "
+                            f"Pick a different handoff or continue working."
+                        ),
+                        tool_call_id=tool_call_id,
+                    )
+                )
+                # Return-only update: no goto, no active_agent change. Source
+                # agent stays in control and sees the refusal in-band.
+                return Command(update={"messages": refusal_messages})
 
         # Build message list with proper pairing
         update_messages: list[BaseMessage] = []

--- a/src/dao_ai/orchestration/swarm.py
+++ b/src/dao_ai/orchestration/swarm.py
@@ -171,12 +171,14 @@ def _handoffs_for_agent(
                 "Creating handoff tool",
                 from_agent=agent.name,
                 to_agent=handoff_to_agent.name,
+                requires=handoff_to_agent.requires,
             )
             handoff_description: str = get_handoff_description(handoff_to_agent)
             handoff_tools.append(
                 create_handoff_tool(
                     target_agent_name=handoff_to_agent.name,
                     description=handoff_description,
+                    requires=list(handoff_to_agent.requires),
                 )
             )
 

--- a/tests/dao_ai/test_handoff_constraints.py
+++ b/tests/dao_ai/test_handoff_constraints.py
@@ -1,0 +1,322 @@
+"""
+Tests for swarm handoff_constraints (the ``requires`` field on AgentModel).
+
+Covers:
+- Config-time validators: self-reference, unknown agent, cycle in requires DAG,
+  deterministic handoff to constrained target.
+- Runtime behavior of ``create_handoff_tool``: refusal when prereqs are unmet,
+  pass-through when satisfied, no constraint when ``requires`` is empty/None.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from dao_ai.config import AgentModel, AppConfig, LLMModel
+from dao_ai.orchestration.core import create_handoff_tool
+
+
+# =============================================================================
+# AgentModel.requires — local validators (self-reference)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRequiresFieldOnAgentModel:
+    """Tests for the ``requires`` field on AgentModel."""
+
+    def test_requires_defaults_to_empty_list(self) -> None:
+        agent = AgentModel(name="a", model=LLMModel(name="m"))
+        assert agent.requires == []
+
+    def test_requires_accepts_list_of_names(self) -> None:
+        agent = AgentModel(
+            name="checkout", model=LLMModel(name="m"), requires=["browse", "cart"]
+        )
+        assert agent.requires == ["browse", "cart"]
+
+    def test_self_reference_rejected(self) -> None:
+        with pytest.raises(ValueError, match="self-reference"):
+            AgentModel(name="loop", model=LLMModel(name="m"), requires=["loop"])
+
+
+# =============================================================================
+# AppModel.validate_agent_requires — cross-agent validators
+# =============================================================================
+
+
+def _minimal_app(agents: list[dict], handoffs: dict | None = None) -> dict:
+    """Build a minimal AppConfig dict with the given agents and handoffs."""
+    swarm: dict = {"default_agent": agents[0]["name"]}
+    if handoffs is not None:
+        swarm["handoffs"] = handoffs
+    return {
+        "app": {
+            "name": "test_app",
+            "registered_model": {"name": "test_model"},
+            "agents": agents,
+            "orchestration": {"swarm": swarm},
+        }
+    }
+
+
+@pytest.mark.unit
+class TestRequiresCrossAgentValidators:
+    """Tests for AppModel-level validators on agent ``requires``."""
+
+    def test_unknown_agent_in_requires_is_rejected(self) -> None:
+        cfg = _minimal_app(
+            agents=[
+                {"name": "a", "model": {"name": "m"}},
+                {
+                    "name": "b",
+                    "model": {"name": "m"},
+                    "requires": ["does_not_exist"],
+                },
+            ],
+        )
+        with pytest.raises(ValueError, match="does_not_exist"):
+            AppConfig(**cfg)
+
+    def test_known_agent_in_requires_is_accepted(self) -> None:
+        cfg = _minimal_app(
+            agents=[
+                {"name": "a", "model": {"name": "m"}},
+                {"name": "b", "model": {"name": "m"}, "requires": ["a"]},
+            ],
+        )
+        # No exception
+        config = AppConfig(**cfg)
+        b = next(x for x in config.app.agents if x.name == "b")
+        assert b.requires == ["a"]
+
+    def test_two_node_cycle_is_rejected(self) -> None:
+        # A requires B, B requires A
+        cfg = _minimal_app(
+            agents=[
+                {"name": "a", "model": {"name": "m"}, "requires": ["b"]},
+                {"name": "b", "model": {"name": "m"}, "requires": ["a"]},
+            ],
+        )
+        with pytest.raises(ValueError, match="Cycle detected"):
+            AppConfig(**cfg)
+
+    def test_three_node_cycle_is_rejected(self) -> None:
+        # A -> B -> C -> A
+        cfg = _minimal_app(
+            agents=[
+                {"name": "a", "model": {"name": "m"}, "requires": ["b"]},
+                {"name": "b", "model": {"name": "m"}, "requires": ["c"]},
+                {"name": "c", "model": {"name": "m"}, "requires": ["a"]},
+            ],
+        )
+        with pytest.raises(ValueError, match="Cycle detected"):
+            AppConfig(**cfg)
+
+    def test_dag_without_cycle_is_accepted(self) -> None:
+        # checkout requires cart; cart requires browse — chain, no cycle
+        cfg = _minimal_app(
+            agents=[
+                {"name": "browse", "model": {"name": "m"}},
+                {"name": "cart", "model": {"name": "m"}, "requires": ["browse"]},
+                {"name": "checkout", "model": {"name": "m"}, "requires": ["cart"]},
+            ],
+        )
+        # No exception
+        AppConfig(**cfg)
+
+
+# =============================================================================
+# Deterministic handoff to constrained target
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestDeterministicHandoffValidator:
+    """Tests for ``validate_no_deterministic_handoff_to_constrained``."""
+
+    def test_deterministic_handoff_to_constrained_target_rejected(self) -> None:
+        cfg = _minimal_app(
+            agents=[
+                {"name": "a", "model": {"name": "m"}},
+                {"name": "cart", "model": {"name": "m"}},
+                {
+                    "name": "checkout",
+                    "model": {"name": "m"},
+                    "requires": ["cart"],
+                },
+            ],
+            handoffs={
+                "a": [
+                    {"agent": "checkout", "is_deterministic": True},
+                ],
+            },
+        )
+        with pytest.raises(
+            ValueError, match="deterministic handoff to 'checkout'"
+        ):
+            AppConfig(**cfg)
+
+    def test_agentic_handoff_to_constrained_target_allowed(self) -> None:
+        # Same shape as above but is_deterministic: false (default).
+        cfg = _minimal_app(
+            agents=[
+                {"name": "a", "model": {"name": "m"}},
+                {"name": "cart", "model": {"name": "m"}},
+                {
+                    "name": "checkout",
+                    "model": {"name": "m"},
+                    "requires": ["cart"],
+                },
+            ],
+            handoffs={
+                "a": ["checkout"],  # agentic shorthand
+            },
+        )
+        # No exception
+        AppConfig(**cfg)
+
+    def test_deterministic_handoff_to_unconstrained_target_allowed(self) -> None:
+        # Constrained target exists but the deterministic edge points elsewhere.
+        cfg = _minimal_app(
+            agents=[
+                {"name": "a", "model": {"name": "m"}},
+                {"name": "cart", "model": {"name": "m"}},
+                {
+                    "name": "checkout",
+                    "model": {"name": "m"},
+                    "requires": ["cart"],
+                },
+            ],
+            handoffs={
+                "a": [
+                    {"agent": "cart", "is_deterministic": True},
+                ],
+            },
+        )
+        # No exception
+        AppConfig(**cfg)
+
+
+# =============================================================================
+# Runtime: create_handoff_tool with requires
+# =============================================================================
+
+
+def _runtime(messages: list, tool_call_id: str = "call_test") -> SimpleNamespace:
+    """Build a minimal stand-in for ToolRuntime.
+
+    The handoff tool body uses only ``runtime.tool_call_id`` and
+    ``runtime.state.get("messages", [])``. SimpleNamespace + dict is enough.
+    """
+    return SimpleNamespace(tool_call_id=tool_call_id, state={"messages": messages})
+
+
+@pytest.mark.unit
+class TestHandoffToolRuntimeCheck:
+    """Tests for the ``requires`` runtime check inside ``create_handoff_tool``."""
+
+    def test_no_requires_proceeds_normally(self) -> None:
+        """Backward compatibility: tools without requires behave as before."""
+        tool = create_handoff_tool("checkout", "checkout agent")
+        runtime = _runtime([HumanMessage(content="hi")])
+
+        result = tool.func(runtime)
+
+        assert result.goto == "checkout"
+        assert result.update["active_agent"] == "checkout"
+
+    def test_requires_satisfied_proceeds_normally(self) -> None:
+        tool = create_handoff_tool("checkout", "checkout agent", requires=["cart"])
+        runtime = _runtime(
+            [
+                HumanMessage(content="hi"),
+                AIMessage(content="picking items", name="cart"),
+            ]
+        )
+
+        result = tool.func(runtime)
+
+        assert result.goto == "checkout"
+        assert result.update["active_agent"] == "checkout"
+
+    def test_requires_unmet_returns_refusal(self) -> None:
+        tool = create_handoff_tool("checkout", "checkout agent", requires=["cart"])
+        runtime = _runtime(
+            [
+                HumanMessage(content="ready to pay"),
+                AIMessage(content="routing", name="triage"),
+            ]
+        )
+
+        result = tool.func(runtime)
+
+        # No routing / no active_agent change.
+        assert getattr(result, "goto", ()) in ((), None)
+        assert "active_agent" not in result.update
+
+        # Refusal ToolMessage in the update.
+        msgs = result.update["messages"]
+        tool_msgs = [m for m in msgs if isinstance(m, ToolMessage)]
+        assert len(tool_msgs) == 1
+        content = tool_msgs[0].content
+        assert "Cannot hand off to 'checkout'" in content
+        assert "cart" in content
+        assert "Missing" in content
+
+    def test_partial_coverage_lists_only_missing(self) -> None:
+        """When some prereqs are met and some aren't, refusal names the missing."""
+        tool = create_handoff_tool(
+            "checkout", "checkout agent", requires=["cart", "verify_age"]
+        )
+        runtime = _runtime(
+            [
+                HumanMessage(content="ready"),
+                AIMessage(content="picked items", name="cart"),
+                # verify_age has NOT run
+            ]
+        )
+
+        result = tool.func(runtime)
+
+        msgs = result.update["messages"]
+        tool_msgs = [m for m in msgs if isinstance(m, ToolMessage)]
+        content = tool_msgs[0].content
+        # The refusal must explicitly identify the missing prereq.
+        assert "verify_age" in content
+        # And ``cart`` must show up in the "called so far" report.
+        assert "cart" in content
+
+    def test_empty_requires_list_is_unconstrained(self) -> None:
+        """Explicit empty list behaves like no constraint."""
+        tool = create_handoff_tool("checkout", "checkout agent", requires=[])
+        runtime = _runtime([HumanMessage(content="hi")])
+
+        result = tool.func(runtime)
+
+        assert result.goto == "checkout"
+        assert result.update["active_agent"] == "checkout"
+
+    def test_unnamed_aimessages_do_not_satisfy_requires(self) -> None:
+        """An AIMessage without a name doesn't count toward prereqs.
+
+        This protects against false positives if some upstream agent emits
+        an AIMessage without the agent-name tag.
+        """
+        tool = create_handoff_tool("checkout", "checkout agent", requires=["cart"])
+        runtime = _runtime(
+            [
+                HumanMessage(content="hi"),
+                AIMessage(content="orphan"),  # no name
+            ]
+        )
+
+        result = tool.func(runtime)
+
+        # Should refuse — cart is not in called_agents because the AIMessage
+        # has no name to attribute to.
+        assert getattr(result, "goto", ()) in ((), None)
+        assert "active_agent" not in result.update


### PR DESCRIPTION
## Summary
- Adds optional `requires: list[str]` on `AgentModel` — declares prerequisite agents that must have run before the target can be reached via a swarm handoff.
- Enforced inside `create_handoff_tool`: when prereqs are unmet, the tool returns a refusal `ToolMessage` and `active_agent` stays unchanged so the LLM self-corrects in-band. No new state schema, no graph topology change. Reuses the existing `AIMessage.name` tagging substrate.
- Config-build-time validators reject self-reference, unknown agent names, cycles in the `requires` DAG, and deterministic handoffs to constrained targets (a contradiction, since deterministic edges fire unconditionally).
- Swarm-only in this release; the field is on the generic agent model so supervisor adoption is additive in a future PR.

## Example

```yaml
agents:
  checkout: &checkout
    name: checkout
    model: *llm
    requires: [cart]   # cannot be reached until 'cart' has appeared in message history

app:
  agents: [*triage, *cart, *checkout]
  orchestration:
    swarm:
      default_agent: *triage
      handoffs:
        triage:   [cart, checkout]    # 'checkout' edge allowed; refused at runtime if cart hasn't run
        cart:     [checkout, triage]
        checkout: [triage]
```

`triage → checkout` (skipping `cart`) yields a `ToolMessage`:
```
Cannot hand off to 'checkout' — requires ['cart']; called so far: ['triage']. Missing: ['cart']. Pick a different handoff or continue working.
```

## Files changed
- `src/dao_ai/config.py` — `requires` field + `validate_requires_no_self_reference`, `validate_agent_requires` (unknown + cycle), `validate_no_deterministic_handoff_to_constrained`.
- `src/dao_ai/orchestration/core.py` — `create_handoff_tool(..., requires=...)` runtime check.
- `src/dao_ai/orchestration/swarm.py` — `_handoffs_for_agent` passes `handoff_to_agent.requires` through.
- `tests/dao_ai/test_handoff_constraints.py` — 17 cases (field, validators, runtime).
- `docs/architecture.md` — new "Handoff constraints" subsection under Swarm Pattern.
- `docs/configuration-reference.md` — `requires` documented on the agent schema.
- `CHANGELOG.md` — `[Unreleased] → Added` entry.

## Test plan
- [x] `uv run pytest tests/dao_ai/test_handoff_constraints.py` — 17/17 pass
- [x] `uv run pytest tests/dao_ai/test_swarm_middleware.py tests/dao_ai/test_deterministic_handoffs.py tests/hardware_store/test_graph.py -m unit` — 79/79 pass (no regression in swarm-adjacent tests)
- [x] Full unit run (`pytest -m unit`): 1064 passed, 8 unrelated pre-existing failures in `test_genie_provisioning.py` (genie schema `version: 1 vs 2` fixture drift, unrelated to this PR)
- [x] End-to-end: documented YAML config parses cleanly; the three negative cases (self-reference, unknown agent, deterministic-to-constrained) are rejected as designed
- [ ] Reviewer sanity check on the docs example

This pull request and its description were written by Isaac.