### PR TITLE
generate-bundle: split databricks.yaml + resources/app.yml with wildcard include

### DIFF
--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -314,39 +314,15 @@ def _convert_to_bundle_resources(
     return result
 
 
-def generate_databricks_yaml(
+def _build_app_block(
     config: AppConfig,
-    development: bool = False,
-    config_filename: str = "dao_ai.yaml",
-) -> str:
-    """Generate a complete databricks.yaml bundle definition from an AppConfig.
+    config_filename: str,
+) -> tuple[str, dict[str, Any], dict[str, Any]]:
+    """Build the App + experiment dicts shared by `databricks.yaml` and
+    `resources/app.yml`.
 
-    Reuses generate_app_resources(), _extract_env_vars_from_config(), and
-    generate_user_api_scopes() from resources.py -- only the format translation
-    to the bundle schema is new.
-
-    When development=True, omits the artifacts section so the pre-built
-    dao-ai wheel is uploaded as a regular source file (not intercepted as
-    an artifact).
-
-    Note on deployment_target:
-        The emitted bundle is always Databricks-Apps-shaped
-        (`resources.apps.<name>` with its `resources` list and optional
-        `user_api_scopes`). This bundle works regardless of
-        `app.deployment_target`:
-
-        - `apps`           → the App IS the deployment target.
-        - `model_serving`  → the App process registers the MLflow model
-                             and creates the serving endpoint at runtime
-                             (via `dao_ai.apps.server`). No separate
-                             bundle is needed; users who only want the
-                             serving endpoint typically use
-                             `dao-ai deploy-agent` instead of
-                             `generate-bundle` + `databricks bundle deploy`.
-
-        `generate-bundle` therefore intentionally ignores
-        `app.deployment_target`; the enum selects the runtime code path,
-        not the bundle layout.
+    Returns:
+        (app_name, experiments_block, apps_block)
     """
     app_name: str = config.app.name.lower().replace("_", "-")
 
@@ -414,21 +390,65 @@ def generate_databricks_yaml(
     if user_api_scopes:
         app_def["user_api_scopes"] = user_api_scopes
 
+    experiments_block: dict[str, Any] = {
+        experiment_key: {
+            "name": f"/Users/${{workspace.current_user.userName}}/{app_name}",
+        },
+    }
+    apps_block: dict[str, Any] = {
+        app_name: app_def,
+    }
+    return app_name, experiments_block, apps_block
+
+
+def generate_databricks_yaml(
+    config: AppConfig,
+    development: bool = False,
+    config_filename: str = "dao_ai.yaml",
+) -> str:
+    """Generate the trimmed root `databricks.yaml` for a dao-ai bundle.
+
+    Emits only the bundle-level concerns: ``bundle:`` (with ``include:
+    [resources/*.yml]``), ``targets:``, and either ``artifacts:`` or
+    ``sync:`` depending on ``development``. The App + experiment block
+    lives in ``resources/app.yml`` (see :func:`generate_resources_app_yaml`)
+    so users can drop sibling ``resources/*.yml`` files (Workflow Jobs,
+    Pipelines, etc.) into the bundle without having to edit the
+    regen-owned ``databricks.yaml``.
+
+    When development=True, omits the artifacts section so the pre-built
+    dao-ai wheel is uploaded as a regular source file (not intercepted as
+    an artifact).
+
+    Note on deployment_target:
+        The emitted bundle is always Databricks-Apps-shaped
+        (``resources.apps.<name>`` with its ``resources`` list and optional
+        ``user_api_scopes``). This bundle works regardless of
+        ``app.deployment_target``:
+
+        - ``apps``           → the App IS the deployment target.
+        - ``model_serving``  → the App process registers the MLflow model
+                               and creates the serving endpoint at runtime
+                               (via ``dao_ai.apps.server``). No separate
+                               bundle is needed; users who only want the
+                               serving endpoint typically use
+                               ``dao-ai deploy-agent`` instead of
+                               ``generate-bundle`` + ``databricks bundle deploy``.
+
+        ``generate-bundle`` therefore intentionally ignores
+        ``app.deployment_target``; the enum selects the runtime code path,
+        not the bundle layout.
+    """
+    app_name, _experiments_block, _apps_block = _build_app_block(
+        config, config_filename
+    )
+
     bundle: dict[str, Any] = {
         "bundle": {
             "name": app_name,
             "engine": "direct",
         },
-        "resources": {
-            "experiments": {
-                experiment_key: {
-                    "name": f"/Users/${{workspace.current_user.userName}}/{app_name}",
-                },
-            },
-            "apps": {
-                app_name: app_def,
-            },
-        },
+        "include": ["resources/*.yml"],
         "targets": {
             "dev": {
                 "default": True,
@@ -454,6 +474,29 @@ def generate_databricks_yaml(
         }
 
     return yaml.dump(bundle, default_flow_style=False, sort_keys=False)
+
+
+def generate_resources_app_yaml(
+    config: AppConfig,
+    config_filename: str = "dao_ai.yaml",
+) -> str:
+    """Generate ``resources/app.yml`` — the App + experiment block.
+
+    This file is owned by ``generate-bundle``; sibling ``resources/*.yml``
+    files (e.g. ``resources/jobs.yml``, ``resources/pipelines.yml``) are
+    written by users and are never touched by the generator.
+    """
+    _app_name, experiments_block, apps_block = _build_app_block(
+        config, config_filename
+    )
+
+    resources_doc: dict[str, Any] = {
+        "resources": {
+            "experiments": experiments_block,
+            "apps": apps_block,
+        },
+    }
+    return yaml.dump(resources_doc, default_flow_style=False, sort_keys=False)
 
 
 def _write_file(path: Path, content: str, force: bool) -> bool:
@@ -506,6 +549,16 @@ def write_bundle(
         generate_databricks_yaml(
             config, development=development, config_filename=config_filename
         ),
+    )
+
+    # The App + experiment block lives in resources/app.yml so users can drop
+    # sibling resources/*.yml files (jobs, pipelines, etc.) into the bundle
+    # without conflicting with the regen-owned databricks.yaml.
+    resources_dir = output_dir / "resources"
+    resources_dir.mkdir(parents=True, exist_ok=True)
+    _track(
+        resources_dir / "app.yml",
+        generate_resources_app_yaml(config, config_filename=config_filename),
     )
 
     if source_config:

--- a/tests/dao_ai/test_config_vars.py
+++ b/tests/dao_ai/test_config_vars.py
@@ -718,15 +718,74 @@ def test_write_bundle_emits_requirements_txt_and_uv_run_command(
     req = (out_dir / "requirements.txt").read_text().strip().splitlines()
     assert req == ["uv"], f"requirements.txt should contain only `uv`; got {req!r}"
 
+    # The trimmed databricks.yaml carries bundle/include/targets/artifacts only;
+    # the App + experiment block lives in resources/app.yml so users can drop
+    # sibling resources/*.yml files (jobs, pipelines, etc.) without conflicting
+    # with regen.
     db_yaml = yaml.safe_load((out_dir / "databricks.yaml").read_text())
-    app_name = next(iter(db_yaml["resources"]["apps"]))
-    cmd = db_yaml["resources"]["apps"][app_name]["config"]["command"]
+    assert db_yaml["include"] == ["resources/*.yml"], (
+        f"databricks.yaml must wildcard-include resources/*.yml; got {db_yaml.get('include')!r}"
+    )
+    assert "resources" not in db_yaml or "apps" not in db_yaml.get("resources", {}), (
+        "databricks.yaml must not carry the App block; it lives in resources/app.yml"
+    )
+
+    app_yaml = yaml.safe_load((out_dir / "resources" / "app.yml").read_text())
+    app_name = next(iter(app_yaml["resources"]["apps"]))
+    cmd = app_yaml["resources"]["apps"][app_name]["config"]["command"]
     assert cmd[:2] == ["uv", "run"], (
         f"App command must start with `uv run`; got {cmd!r}"
     )
     assert cmd[2:] == ["python", "-m", "dao_ai.apps.start_app"], (
         f"App command tail unexpected: {cmd!r}"
     )
+
+
+@pytest.mark.unit
+def test_write_bundle_preserves_user_resources_yml(
+    parameterised_config_path: Path, tmp_path: Path
+) -> None:
+    """A user-authored resources/jobs.yml must survive a re-run of write_bundle.
+
+    The whole point of the wildcard include is that users can drop sibling
+    resources/*.yml files into the bundle without `--force` clobbering them.
+    """
+    from dao_ai.apps.bundle import write_bundle
+
+    config = AppConfig.from_file(
+        parameterised_config_path,
+        params={"module_id": "09", "catalog": "nfleming"},
+        initialize=False,
+    )
+    out_dir = tmp_path / "bundle"
+    out_dir.mkdir()
+
+    write_bundle(config, out_dir, force=True, development=False)
+
+    user_resource = out_dir / "resources" / "jobs.yml"
+    user_payload = (
+        "resources:\n"
+        "  jobs:\n"
+        "    user_job:\n"
+        "      name: user_job\n"
+        "      tasks: []\n"
+    )
+    user_resource.write_text(user_payload)
+
+    write_bundle(config, out_dir, force=True, development=False)
+
+    assert user_resource.exists(), (
+        "User-authored resources/jobs.yml must not be deleted by write_bundle"
+    )
+    assert user_resource.read_text() == user_payload, (
+        "User-authored resources/jobs.yml must not be modified by write_bundle"
+    )
+
+    # And the regen-owned files are still present + correct.
+    db_yaml = yaml.safe_load((out_dir / "databricks.yaml").read_text())
+    assert db_yaml["include"] == ["resources/*.yml"]
+    app_yaml = yaml.safe_load((out_dir / "resources" / "app.yml").read_text())
+    assert "apps" in app_yaml["resources"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`generate-bundle` today emits a monolithic `databricks.yaml` containing the bundle root, `targets`, `artifacts`, **and** the App + experiment block. Users who want to add their own Workflow Jobs, Pipelines, or other DAB resources have to edit `databricks.yaml` directly — and lose those edits on the next regen — or add a manual \`include:\` block that the next regen also overwrites.

This PR splits the generator output along the standard DAB convention:

- \`databricks.yaml\` → only \`bundle:\` + \`include: [resources/*.yml]\` + \`targets:\` + (\`artifacts:\` or \`sync:\`).
- \`resources/app.yml\` → the App + experiment block, owned by the generator.
- Sibling \`resources/*.yml\` (\`jobs.yml\`, \`pipelines.yml\`, \`clusters.yml\`, etc.) are **user-owned** and are never touched by \`write_bundle\`.

## Why

The current behavior bit me when building a real customer project on top of dao-ai (a multi-agent ML factory). I wanted to ship `resources/jobs.yml` with three Workflow Jobs (provisioning + per-cell training + test suite). Every regen wiped my hand-added `include:` line, so I had to re-paste it after every `dao-ai generate-bundle`. That's not how DAB conventions are supposed to work — the standard pattern is `include: [resources/*.yml]` and untouched user files alongside the generator's.

This change aligns dao-ai with that pattern.

## Implementation

- Extract App + experiment construction into private \`_build_app_block(config, config_filename)\` helper in \`src/dao_ai/apps/bundle.py\`.
- Add \`generate_resources_app_yaml\` alongside \`generate_databricks_yaml\`. The two share \`_build_app_block\` so we don't duplicate the env-var/resource translation logic.
- \`generate_databricks_yaml\` now returns the trimmed bundle root with \`include: [resources/*.yml]\` baked in.
- \`write_bundle\` writes both files; ensures \`resources/\` exists; never touches sibling \`resources/*.yml\`.

## Tests

- Updated \`test_write_bundle_emits_requirements_txt_and_uv_run_command\` to read the App command from \`resources/app.yml\` and assert that \`databricks.yaml\` carries the wildcard include and **does not** carry the App block.
- New \`test_write_bundle_preserves_user_resources_yml\` writes a hand-authored \`resources/jobs.yml\`, runs \`write_bundle\` with \`force=True\`, and asserts the user file is byte-identical afterwards.

Affected unit tests:

\`\`\`
$ uv run pytest tests/dao_ai/test_config_vars.py tests/dao_ai/test_lakebase_app_resources.py tests/dao_ai/test_apps_obo_partition.py -m unit -q
================ 87 passed, 11 deselected, 16 warnings in 2.39s ================
\`\`\`

Full unit suite (excluding 4 pre-existing pyspark-import collection failures unrelated to this change):

| Branch | Result |
| --- | --- |
| \`main\` | 34 failed, 929 passed, 1 skipped |
| \`feature/generate-bundle-resources-dir\` | 34 failed, **930** passed, 1 skipped |

Same 34 pre-existing failures on both branches (test_optimization, test_genie_provisioning, test_reranking, test_vector_store_refresh — none related to bundle generation). My branch adds one passing test and zero new failures.

## End-to-end verification

Rebuilt an external project (\`american-airlines-dao\`) that uses dao-ai \`generate-bundle\`:

- \`resources/jobs.yml\` (3 user-authored Workflow Jobs) was preserved across regen.
- \`databricks.yaml\` was rewritten with the trimmed root + \`include: [resources/*.yml]\`.
- \`resources/app.yml\` was rewritten with the App + experiment block.
- \`databricks bundle validate -p aws-field-eng\` returned **Validation OK!** picking up Jobs + App + experiments + securables together via the include.

## Migration notes

- This is a structural change: existing bundles regenerated with \`--force\` will see the App block move from \`databricks.yaml\` into a new \`resources/app.yml\`. Functionally equivalent, but anyone who has manually edited the old \`databricks.yaml\` should re-apply edits in the new locations.
- Sibling \`resources/*.yml\` files (jobs, pipelines, etc.) are now persistently safe across regens — they were never *generated* before, but the wildcard include now lets users drop them in without touching \`databricks.yaml\`.

## Test plan

- [x] Unit tests pass on the feature branch (no new failures vs main)
- [x] New test locks in user-resource preservation across regen
- [x] End-to-end rebuild of an external dao-ai project succeeds
- [x] \`databricks bundle validate\` passes on the regenerated bundle

This pull request and its description were written by Isaac.