### PR TITLE
Rename resources.llms → resources.models, LLMModel → InferenceEndpointModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.75]
+
+### Changed
+- **Renamed `resources.llms` → `resources.models` and `LLMModel` → `InferenceEndpointModel`** for accuracy. The same class is reused for chat LLMs, embedding endpoints, judge / extraction / reflection / query models, and custom agent endpoints — anything reachable via `/serving-endpoints/<name>/invocations`. The previous names were specific to chat LLMs and actively misled new readers. Both renames are **fully backward compatible**:
+  - The Pydantic field carries `alias="llms"` on `ResourcesModel.models` and `ResourcesModel.model_config` sets `populate_by_name=True`, so existing YAML configs with `resources.llms:` keep parsing unchanged.
+  - The class has a module-level alias (`LLMModel = InferenceEndpointModel`), so `from dao_ai.config import LLMModel` keeps working and `isinstance(x, LLMModel)` continues to return `True`.
+  - Reading the legacy `ResourcesModel.llms` attribute now returns `self.models` and emits a `DeprecationWarning`.
+  - The generated JSON schema documents `models:` as the canonical key (via `model_json_schema(by_alias=False)`). IDE schema linting (yaml-language-server) will flag `llms:` as unknown after this release; the runtime still accepts it. Bulk-migrate your configs at your own pace, or let dao-ai-builder rewrite them on the next save.
+  - All shipped example configs under `config/examples/**` were migrated to the new key. The 27 existing test files were left as-is — they still pass via the alias, which is the regression guard.
+  - The legacy names will be removed in a future major release.
+
+## [0.1.74]
+
 ### Changed
 - **CLI: renamed `dao-ai bundle` to `dao-ai pipeline`** to disambiguate from the underlying Databricks Asset Bundle (DAB) feature it wraps. The old verb is no longer recognized — running `dao-ai bundle` now exits with `argparse: invalid choice: 'bundle'`. Help, examples, and documentation have been updated accordingly. The separate `dao-ai generate-bundle` subcommand keeps its name since it generates a literal Databricks Asset Bundle artifact.
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ distclean: clean
 	$(FIND) $(SRC_DIR) $(TEST_DIR) \( -name __pycache__ -a -type d \) -prune -exec rm -rf {} \;
 
 schema: depends
-	@$(PYTHON) -c "from dao_ai.config import AppConfig; import json; print(json.dumps(AppConfig.model_json_schema(), indent=2))"
+	@$(PYTHON) -c "from dao_ai.config import AppConfig; import json; print(json.dumps(AppConfig.model_json_schema(by_alias=False), indent=2))"
 
 test: 
 	$(PYTEST) -ra --tb=short $(TEST_DIR)

--- a/config/examples/01_getting_started/minimal.yaml
+++ b/config/examples/01_getting_started/minimal.yaml
@@ -18,7 +18,7 @@ schemas:
     schema_name: ${var.schema}                    # Schema within the catalog
 
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4  # Databricks serving endpoint name
 
@@ -46,7 +46,8 @@ tools:
       args:                                         # Arguments passed to factory
         name: my_genie_tool
         description: My Answers questions about genie
-        genie_room: *retail_genie_room              # Reference to Genie room config
+        genie_room: *retail_genie_room
+                                                    # Reference to Genie room config
 
   vector_search_tool: &vector_search_tool
     name: vector_search
@@ -61,10 +62,11 @@ tools:
 agents:
   simple_agent: &simple_agent
     name: simple_agent                                     # Agent identifier
-    model: *default_llm                             # Reference to LLM configuration
+    model: *default_llm
+                                                    # Reference to LLM configuration
     tools:                                          # Tools available to this agent
-      - *genie_tool
-      - *vector_search_tool
+    - *genie_tool
+    - *vector_search_tool
     prompt: |                                       # System prompt defining agent behavior
       You are a helpful retail assistant. Answer questions about products and inventory using your available tools.
 
@@ -74,7 +76,9 @@ app:
   name: minimal_dao             # Application name  
   log_level: TRACE                                   # Logging level for the application
   registered_model:                                 # MLflow registered model configuration
-    schema: *retail_schema                          # Schema where model will be registered
+    schema: *retail_schema
+                                                    # Schema where model will be registered
     name: minimal_dao             # Model name in MLflow registry
   agents:                                           # List of agents included in the system
-    - *simple_agent                                       # Order management agent
+  - *simple_agent
+                                                          # Order management agent

--- a/config/examples/02_mcp/custom_mcp.yaml
+++ b/config/examples/02_mcp/custom_mcp.yaml
@@ -13,58 +13,67 @@ parameters:
     default: retail_consumer_goods
 
 variables:
-  client_id: &client_id                          # Service principal client ID
+  client_id: &client_id
+                                                 # Service principal client ID
     options:
-      - env: RETAIL_AI_DATABRICKS_CLIENT_ID
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_CLIENT_ID
-  client_secret: &client_secret                  # Service principal secret
+    - env: RETAIL_AI_DATABRICKS_CLIENT_ID
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_ID
+  client_secret: &client_secret
+                                                 # Service principal secret
     options:
-      - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
-  workspace_host: &workspace_host                # Databricks workspace URL
+    - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+  workspace_host: &workspace_host
+                                                 # Databricks workspace URL
     options:
-      - env: RETAIL_AI_DATABRICKS_HOST
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_HOST
+    - env: RETAIL_AI_DATABRICKS_HOST
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_HOST
 
 schemas:
-  retail_consumer_goods_schema: &retail_consumer_goods_schema                  # Unity Catalog schema configuration
+  retail_consumer_goods_schema: &retail_consumer_goods_schema
+                                                                               # Unity Catalog schema configuration
     catalog_name: ${var.catalog}                       # Unity Catalog name
     schema_name: ${var.schema}                       # Schema within the catalog
 
 resources:
-  llms:
-    default_llm: &default_llm                    # Default LLM configuration
+  models:
+    default_llm: &default_llm
+                                                 # Default LLM configuration
       name: databricks-claude-3-7-sonnet        # Databricks serving endpoint name
 
 tools:
-  jira_mcp: &jira_mcp          # Unity Catalog MCP tool configuration
-    name: jira_mcp                                  
+  jira_mcp: &jira_mcp
+                               # Unity Catalog MCP tool configuration
+    name: jira_mcp
     function:
       type: mcp                                  # MCP function type
-      url:  https://mcp-harbor-freight-984752964297111.11.azure.databricksapps.com/mcp/
+      url: https://mcp-harbor-freight-984752964297111.11.azure.databricksapps.com/mcp/
       client_id: *client_id
       client_secret: *client_secret
       workspace_host: *workspace_host
 
 agents:
-  jira_agent: &jira_agent                          # MCP agent configuration
+  jira_agent: &jira_agent
+                                                   # MCP agent configuration
     name: jira_agent                              # Agent identifier
-    model: *default_llm                          # Reference to LLM configuration
+    model: *default_llm
+                                                 # Reference to LLM configuration
     tools:                                       # Tools available to this agent
-      - *jira_mcp
-      
-      
+    - *jira_mcp
 app:
   name: custom_mcp_dao                                # Application name  
   log_level: DEBUG                               # Logging level for the application
   registered_model:                              # MLflow registered model configuration
     name: custom_mcp_dao
-    schema: *retail_consumer_goods_schema                       # Schema where model will be registered
+    schema: *retail_consumer_goods_schema
+                                                                # Schema where model will be registered
   agents:                                        # List of agents included in the system
-    - *jira_agent                                 # MCP agent
+  - *jira_agent
+                                                  # MCP agent
   orchestration:                                 # Agent orchestration configuration
     swarm:                                       # Supervisor orchestration pattern
-      default_agent: *jira_agent                 # Default agent for routing
+      default_agent: *jira_agent
+                                                 # Default agent for routing

--- a/config/examples/02_mcp/external_mcp.yaml
+++ b/config/examples/02_mcp/external_mcp.yaml
@@ -13,17 +13,19 @@ parameters:
     default: retail_ai
 
 schemas:
-  retail_schema: &retail_schema                  # Unity Catalog schema configuration
+  retail_schema: &retail_schema
+                                                 # Unity Catalog schema configuration
     catalog_name: ${var.catalog}                       # Unity Catalog name
     schema_name: ${var.schema}                       # Schema within the catalog
 
 resources:
-  llms:
-    default_llm: &default_llm                    # Default LLM configuration
+  models:
+    default_llm: &default_llm
+                                                 # Default LLM configuration
       name: databricks-claude-sonnet-4           # Databricks serving endpoint name
-  
   connections:
-    github_connection: &github_connection        # UC Connection for GitHub
+    github_connection: &github_connection
+                                                 # UC Connection for GitHub
       name: github_pat_connection_nfleming       # UC Connection name
 
 tools:
@@ -32,7 +34,8 @@ tools:
     name: github_mcp                                # Tool name for agent reference
     function:
       type: mcp                                     # Tool type: MCP server
-      connection: *github_connection                # Reference to UC Connection (provides OAuth auth)
+      connection: *github_connection
+                                                    # Reference to UC Connection (provides OAuth auth)
       # Note: URL is auto-generated from connection, no need to specify
 
 
@@ -44,28 +47,32 @@ prompts:
     default_template: |
       You are a GitHub integration agent that can interact with GitHub repositories, issues, 
       pull requests, and other GitHub resources via the Model Context Protocol (MCP).
-      
+
       Use the github_mcp tool to help users with GitHub-related tasks such as:
       - Searching for repositories, issues, or pull requests
       - Reading file contents from repositories
       - Creating or updating issues
       - Reviewing pull request information
-      
+
       Always be helpful and provide clear explanations of GitHub data.
 
 agents:
-  mcp_agent: &mcp_agent                          # MCP agent configuration
+  mcp_agent: &mcp_agent
+                                                 # MCP agent configuration
     name: mcp_agent                              # Agent identifier
-    model: *default_llm                          # Reference to LLM configuration
+    model: *default_llm
+                                                 # Reference to LLM configuration
     tools:                                       # Tools available to this agent
-      - *github_mcp_uc                           # GitHub MCP via UC Connection
+    - *github_mcp_uc
+                                                 # GitHub MCP via UC Connection
     prompt: *mcp_agent_prompt
-      
 app:
   name: external_mcp_dao                         # Application name  
   log_level: DEBUG                               # Logging level for the application
   registered_model:                              # MLflow registered model configuration
-    schema: *retail_schema                       # Schema where model will be registered
+    schema: *retail_schema
+                                                 # Schema where model will be registered
     name: external_mcp_dao                       # Model name in MLflow registry
   agents:                                        # List of agents included in the system
-    - *mcp_agent                                 # MCP agent
+  - *mcp_agent
+                                                 # MCP agent

--- a/config/examples/02_mcp/filtered_mcp.yaml
+++ b/config/examples/02_mcp/filtered_mcp.yaml
@@ -68,7 +68,7 @@ schemas:
 # =============================================================================
 
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1

--- a/config/examples/02_mcp/managed_mcp.yaml
+++ b/config/examples/02_mcp/managed_mcp.yaml
@@ -13,34 +13,40 @@ parameters:
     default: hardware_store
 
 variables:
-  client_id: &client_id                          # Service principal client ID
+  client_id: &client_id
+                                                 # Service principal client ID
     options:
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_CLIENT_ID
-      - env: RETAIL_AI_DATABRICKS_CLIENT_ID
-  client_secret: &client_secret                  # Service principal secret
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_ID
+    - env: RETAIL_AI_DATABRICKS_CLIENT_ID
+  client_secret: &client_secret
+                                                 # Service principal secret
     options:
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
-      - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET
-  workspace_host: &workspace_host                # Databricks workspace URL
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+    - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+  workspace_host: &workspace_host
+                                                 # Databricks workspace URL
     options:
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_HOST
-      - env: RETAIL_AI_DATABRICKS_HOST
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_HOST
+    - env: RETAIL_AI_DATABRICKS_HOST
 
 schemas:
-  retail_schema: &retail_schema                  # Unity Catalog schema configuration
+  retail_schema: &retail_schema
+                                                 # Unity Catalog schema configuration
     catalog_name: ${var.catalog}                       # Unity Catalog name
     schema_name: ${var.schema}                       # Schema within the catalog
 
 resources:
-  llms:
-    default_llm: &default_llm                    # Default LLM configuration
+  models:
+    default_llm: &default_llm
+                                                 # Default LLM configuration
       name: databricks-claude-3-7-sonnet        # Databricks serving endpoint name
 
   genie_rooms:
-    retail_genie_room: &retail_genie_room        # Genie room configuration
+    retail_genie_room: &retail_genie_room
+                                                 # Genie room configuration
       name: "Retail AI Genie Room"               # Human-readable name
       description: "Genie room for retail queries"
       space_id:
@@ -48,34 +54,41 @@ resources:
         default_value: 01f01c91f1f414d59daaefd2b7ec82ea
 
   tables:
-    product_table: &product_table                # Table configuration for vector store
+    product_table: &product_table
+                                                 # Table configuration for vector store
       schema: *retail_schema
       name: products
 
   vector_stores:
-    retail_vector_store: &retail_vector_store    # Vector store configuration
-      source_table: *product_table               # Source table for vector search
+    retail_vector_store: &retail_vector_store
+                                                 # Vector store configuration
+      source_table: *product_table
+                                                 # Source table for vector search
       embedding_source_column: description       # Column containing embeddings
-      endpoint: 
+      endpoint:
         name: dbdemos_vs_endpoint
       index:
-        schema: *retail_schema                   # Schema for vector search index
+        schema: *retail_schema
+                                                 # Schema for vector search index
         name: products_index                      # Vector search index name
 
 tools:
 
 
   # Example 2: Using convenience object (recommended - automatic URL generation)
-  vector_search_mcp: &vector_search_mcp          # Vector search MCP tool configuration
-    name: vector_search_mcp                                  
+  vector_search_mcp: &vector_search_mcp
+                                                 # Vector search MCP tool configuration
+    name: vector_search_mcp
     function:
       type: mcp                                  # MCP function type
-      vector_search: *retail_vector_store        # Use vector search convenience object
+      vector_search: *retail_vector_store
+                                                 # Use vector search convenience object
       client_id: *client_id
       client_secret: *client_secret
       workspace_host: *workspace_host
 
-  sql_mcp: &sql_mcp                              # DBSQL MCP tool configuration
+  sql_mcp: &sql_mcp
+                                                 # DBSQL MCP tool configuration
     name: sql_mcp
     function:
       type: mcp                                  # MCP function type
@@ -84,52 +97,61 @@ tools:
       client_secret: *client_secret
       workspace_host: *workspace_host
 
-  functions_mcp: &functions_mcp                  # Unity Catalog Functions MCP tool configuration
-    name: functions_mcp                                  
+  functions_mcp: &functions_mcp
+                                                 # Unity Catalog Functions MCP tool configuration
+    name: functions_mcp
     function:
       type: mcp                                  # MCP function type
-      functions: *retail_schema                  # Use functions (UC Functions) convenience object
+      functions: *retail_schema
+                                                 # Use functions (UC Functions) convenience object
       client_id: *client_id
       client_secret: *client_secret
       workspace_host: *workspace_host
 
-  genie_mcp: &genie_mcp                          # Genie MCP tool configuration
-    name: genie_mcp                                  
+  genie_mcp: &genie_mcp
+                                                 # Genie MCP tool configuration
+    name: genie_mcp
     function:
       type: mcp                                  # MCP function type
-      genie_room: *retail_genie_room             # Use genie_room convenience object
+      genie_room: *retail_genie_room
+                                                 # Use genie_room convenience object
       client_id: *client_id
       client_secret: *client_secret
       workspace_host: *workspace_host
 
 agents:
-  mcp_agent: &mcp_agent                          # MCP agent configuration
+  mcp_agent: &mcp_agent
+                                                 # MCP agent configuration
     name: mcp_agent                              # Agent identifier
-    model: *default_llm                          # Reference to LLM configuration
+    model: *default_llm
+                                                 # Reference to LLM configuration
     tools:                                       # Tools available to this agent
       # Note: generic_mcp and vector_search_mcp both point to vector search
       # Only one should be used in practice (shown here for demonstration)
-      - *vector_search_mcp                       # Example: Convenience object approach
-      - *sql_mcp
-      - *functions_mcp
-      - *genie_mcp
+    - *vector_search_mcp
+    - *sql_mcp
+    - *functions_mcp
+    - *genie_mcp
     prompt: |                                    # System prompt defining agent behavior
       You are a multi-purpose agent that can perform vector search, execute SQL queries via DBSQL,
       call Unity Catalog functions, and interact with Genie rooms. Use the tools provided to answer
       questions and perform tasks. You may need to use the tools in combination to achieve complex tasks.
-      
+
 app:
   name: managed_mcp_dao                                # Application name  
   log_level: TRACE                               # Logging level for the application
   registered_model:                              # MLflow registered model configuration
-    schema: *retail_schema                       # Schema where model will be registered
+    schema: *retail_schema
+                                                 # Schema where model will be registered
     name: mcp_agent_dao                          # Model name in MLflow registry
   environment_vars:
     RETAIL_AI_DATABRICKS_CLIENT_ID: *client_id
     RETAIL_AI_DATABRICKS_CLIENT_SECRET: *client_secret
     RETAIL_AI_DATABRICKS_HOST: *workspace_host
   agents:                                        # List of agents included in the system
-    - *mcp_agent                                 # MCP agent
+  - *mcp_agent
+                                                 # MCP agent
   orchestration:                                 # Agent orchestration configuration
     swarm:                                       # Supervisor orchestration pattern
-      default_agent: *mcp_agent                  # Default agent for routing
+      default_agent: *mcp_agent
+                                                 # Default agent for routing

--- a/config/examples/03_reranking/instruction_aware_reranking.yaml
+++ b/config/examples/03_reranking/instruction_aware_reranking.yaml
@@ -27,7 +27,7 @@ schemas:
     schema_name: ${var.schema}
 
 resources:
-  llms:
+  models:
     # Primary LLM for agent reasoning
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
@@ -57,23 +57,9 @@ resources:
         schema: *retail_schema
         name: products
       primary_key: product_id
-      doc_uri: ~
+      doc_uri:
       embedding_source_column: description
       columns:
-        - product_id
-        - sku
-        - upc
-        - brand_name
-        - product_name
-        - merchandise_class
-        - class_cd
-        - description
-
-retrievers:
-  # FlashRank + Instruction-Aware Reranking
-  instruction_aware_retriever: &instruction_aware_retriever
-    vector_store: *products_vector_store
-    columns:
       - product_id
       - sku
       - upc
@@ -82,6 +68,20 @@ retrievers:
       - merchandise_class
       - class_cd
       - description
+
+retrievers:
+  # FlashRank + Instruction-Aware Reranking
+  instruction_aware_retriever: &instruction_aware_retriever
+    vector_store: *products_vector_store
+    columns:
+    - product_id
+    - sku
+    - upc
+    - brand_name
+    - product_name
+    - merchandise_class
+    - class_cd
+    - description
     search_parameters:
       num_results: 50
       query_type: HYBRID
@@ -89,48 +89,48 @@ retrievers:
       # Column metadata is the single source of truth for schema context.
       # Each pipeline component generates the context it needs from this data.
       columns:
-        - name: product_id
-          type: number
-          description: "Unique product identifier"
-        - name: sku
-          type: string
-          description: "Stock keeping unit - internal product code"
-        - name: upc
-          type: string
-          description: "Universal Product Code - barcode number"
-        - name: brand_name
-          type: string
-          description: "Brand/manufacturer (MILWAUKEE, DEWALT, MAKITA, etc.)"
-        - name: product_name
-          type: string
-          description: "Product display name"
-        - name: merchandise_class
-          type: string
-          description: "Product category (POWER TOOLS, HAND TOOLS, PAINT, etc.)"
-        - name: class_cd
-          type: string
-          description: "Category code"
-        - name: description
-          type: string
-          description: "Detailed product description"
+      - name: product_id
+        type: number
+        description: "Unique product identifier"
+      - name: sku
+        type: string
+        description: "Stock keeping unit - internal product code"
+      - name: upc
+        type: string
+        description: "Universal Product Code - barcode number"
+      - name: brand_name
+        type: string
+        description: "Brand/manufacturer (MILWAUKEE, DEWALT, MAKITA, etc.)"
+      - name: product_name
+        type: string
+        description: "Product display name"
+      - name: merchandise_class
+        type: string
+        description: "Product category (POWER TOOLS, HAND TOOLS, PAINT, etc.)"
+      - name: class_cd
+        type: string
+        description: "Category code"
+      - name: description
+        type: string
+        description: "Detailed product description"
       constraints:
-        - "Use merchandise_class for category filtering"
-        - "Use brand_name for brand filtering"
-        - "Only use columns listed above"
+      - "Use merchandise_class for category filtering"
+      - "Use brand_name for brand filtering"
+      - "Only use columns listed above"
       decomposition:
         model: *reranker_llm
         normalize_filter_case: uppercase
         max_subqueries: 3
         rrf_k: 60
         examples:
-          - query: "Milwaukee drills"
-            filters: {"brand_name": "MILWAUKEE"}
-          - query: "cordless power tools excluding DeWalt"
-            filters: {"product_name LIKE": "cordless", "brand_name NOT": "DEWALT"}
-          - query: "paint products"
-            filters: {"merchandise_class": "PAINT"}
-          - query: "Milwaukee or DeWalt tools"
-            filters: {"brand_name": ["MILWAUKEE", "DEWALT"]}
+        - query: "Milwaukee drills"
+          filters: {"brand_name": "MILWAUKEE"}
+        - query: "cordless power tools excluding DeWalt"
+          filters: {"product_name LIKE": "cordless", "brand_name NOT": "DEWALT"}
+        - query: "paint products"
+          filters: {"merchandise_class": "PAINT"}
+        - query: "Milwaukee or DeWalt tools"
+          filters: {"brand_name": ["MILWAUKEE", "DEWALT"]}
       # Instruction-Aware LLM reranking (uses schema context above)
       rerank:
         model: *reranker_llm
@@ -171,7 +171,7 @@ agents:
     description: "Product search with constraint-aware reranking"
     model: *default_llm
     tools:
-      - *instruction_aware_search_tool
+    - *instruction_aware_search_tool
     prompt: |
       You are a product search assistant with constraint-aware reranking.
       Use the instruction_aware_product_search tool for queries with:
@@ -194,19 +194,19 @@ app:
     demo: instruction_aware_reranking
     feature: reranking
   permissions:
-    - principals: [users]
-      entitlements:
-        - CAN_QUERY
+  - principals: [users]
+    entitlements:
+    - CAN_QUERY
   agents:
 
-    - *instruction_aware_search_agent
+  - *instruction_aware_search_agent
   orchestration:
     supervisor:
       model: *default_llm
   input_example:
     input:
-      - role: user
-        content: Find me Milwaukee brand drills
+    - role: user
+      content: Find me Milwaukee brand drills
     custom_inputs:
       configurable:
         user_id: demo_user

--- a/config/examples/03_reranking/vector_search_with_reranking.yaml
+++ b/config/examples/03_reranking/vector_search_with_reranking.yaml
@@ -18,7 +18,7 @@ schemas:
     schema_name: ${var.schema}                # Schema within the catalog
 
 resources:
-  llms:
+  models:
     # Primary LLM for general tasks
     default_llm: &default_llm
       name: databricks-claude-sonnet-4             # Databricks serving endpoint name
@@ -31,34 +31,22 @@ resources:
   vector_stores:
     # Product information vector store for similarity search
     products_vector_store: &products_vector_store
-      embedding_model: *embedding_model             # Reference to embedding model above
+      embedding_model: *embedding_model
+                                                    # Reference to embedding model above
       endpoint:                                     # Vector search endpoint configuration
         name: one-env-shared-endpoint-0             # Databricks vector search endpoint
         type: STANDARD                              # Endpoint type (STANDARD or OPTIMIZED_STORAGE)
       index:                                        # Vector search index configuration
-        schema: *retail_schema                      # Unity Catalog schema for the index
+        schema: *retail_schema
+                                                    # Unity Catalog schema for the index
         name: retail_vectorstore                    # Index name
       source_table:                                 # Table containing source data
         schema: *retail_schema
         name: products
       primary_key: product_id                        # Primary key column
-      doc_uri: ~                                    # Optional document URI column (null in this case)
+      doc_uri:                                      # Optional document URI column (null in this case)
       embedding_source_column: description          # Column to create embeddings from
       columns:                                      # Columns to include in vector store
-        - product_id
-        - sku
-        - upc
-        - brand_name
-        - product_name
-        - merchandise_class
-        - class_cd
-        - description
-
-retrievers:
-  # Retriever WITH default reranking
-  default_reranked_retriever: &default_reranked_retriever
-    vector_store: *products_vector_store
-    columns:
       - product_id
       - sku
       - upc
@@ -67,6 +55,20 @@ retrievers:
       - merchandise_class
       - class_cd
       - description
+
+retrievers:
+  # Retriever WITH default reranking
+  default_reranked_retriever: &default_reranked_retriever
+    vector_store: *products_vector_store
+    columns:
+    - product_id
+    - sku
+    - upc
+    - brand_name
+    - product_name
+    - merchandise_class
+    - class_cd
+    - description
     search_parameters:
       num_results: 50                               # Retrieve more candidates for reranking
       filters: {}
@@ -77,14 +79,14 @@ retrievers:
   fast_reranked_retriever: &fast_reranked_retriever
     vector_store: *products_vector_store
     columns:
-      - product_id
-      - sku
-      - upc
-      - brand_name
-      - product_name
-      - merchandise_class
-      - class_cd
-      - description
+    - product_id
+    - sku
+    - upc
+    - brand_name
+    - product_name
+    - merchandise_class
+    - class_cd
+    - description
     search_parameters:
       num_results: 100                              # Cast wide net for reranking
       filters: {}
@@ -98,14 +100,14 @@ retrievers:
   accurate_reranked_retriever: &accurate_reranked_retriever
     vector_store: *products_vector_store
     columns:
-      - product_id
-      - sku
-      - upc
-      - brand_name
-      - product_name
-      - merchandise_class
-      - class_cd
-      - description
+    - product_id
+    - sku
+    - upc
+    - brand_name
+    - product_name
+    - merchandise_class
+    - class_cd
+    - description
     search_parameters:
       num_results: 50
       filters: {}
@@ -165,7 +167,7 @@ agents:
     description: "Product search agent with reranking for improved accuracy"
     model: *default_llm
     tools:
-      - *default_reranked_tool
+    - *default_reranked_tool
     prompt: |
       You are an enhanced product search assistant with reranking capabilities.
       Use the reranked_product_search tool to find the most relevant products.
@@ -179,7 +181,7 @@ agents:
     description: "Product search agent with fast reranking"
     model: *default_llm
     tools:
-      - *fast_reranked_tool
+    - *fast_reranked_tool
     prompt: |
       You are a fast product search assistant. Use the fast_reranked_search tool
       to quickly find the most relevant products from a large candidate set.
@@ -192,7 +194,7 @@ agents:
     description: "Product search agent with hybrid search and accurate reranking"
     model: *default_llm
     tools:
-      - *accurate_reranked_tool
+    - *accurate_reranked_tool
     prompt: |
       You are a high-accuracy product search assistant. Use the accurate_product_search
       tool which combines hybrid search with reranking for the best possible results.
@@ -211,14 +213,15 @@ app:
     demo: reranking
     feature: vector_search
   permissions:
-    - principals: [users]
-      entitlements:
-        - CAN_QUERY
+  - principals: [users]
+    entitlements:
+    - CAN_QUERY
   agents:
     # Include agents with different reranking configurations
-    - *reranked_search_agent        # Default reranking
-    - *fast_search_agent            # Fast reranking
-    - *accurate_search_agent        # Accurate reranking with hybrid
+  - *reranked_search_agent
+  - *fast_search_agent
+  - *accurate_search_agent
+                                    # Accurate reranking with hybrid
   orchestration:
     supervisor:
       model: *default_llm

--- a/config/examples/04_genie/cache_threshold_optimization.yaml
+++ b/config/examples/04_genie/cache_threshold_optimization.yaml
@@ -30,12 +30,12 @@ parameters:
 #   3. Apply the optimized thresholds to your cache configuration
 
 schemas:
-  quick_serve_restaurant_schema: &quick_serve_restaurant_schema
+  quick_serve_restaurant_schema:
     catalog_name: ${var.catalog}
     schema_name: ${var.schema}
 
 resources:
-  llms:
+  models:
     # Judge model for semantic equivalence evaluation
     # Used when expected_match is not provided for an entry
     judge_model: &judge_model
@@ -69,7 +69,7 @@ optimizations:
     # ---------------------------------------------------------------------------
     optimize_retail_cache_thresholds:
       name: optimize_retail_cache_thresholds
-      
+
       # Current thresholds to improve (optional - uses defaults if not provided)
       cache_parameters:
         database: *context_aware_cache_db
@@ -79,7 +79,7 @@ optimizations:
         context_similarity_threshold: 0.80   # Context matching threshold
         question_weight: 0.6                 # Weight for question (context = 1 - question)
         time_to_live_seconds: 86400
-      
+
       # Evaluation dataset with question pairs
       # Each entry contains:
       #   - question/context: The incoming query
@@ -127,10 +127,8 @@ optimizations:
         #     cached_context: "Previous: Filter by electronics"
         #     cached_context_embedding: [0.1, 0.4, ...]
         #     # expected_match omitted - will use LLM judge
-      
       # LLM for judging unlabeled entries
       judge_model: *judge_model
-      
       # Optimization parameters
       n_trials: 50                              # Number of Optuna trials (more = better results)
       metric: f1                                # Metric to optimize: f1, precision, recall, fbeta

--- a/config/examples/04_genie/genie_basic.yaml
+++ b/config/examples/04_genie/genie_basic.yaml
@@ -20,13 +20,13 @@ schemas:
     schema_name: ${var.schema}                    # Schema within the catalog
 
 resources:
-  llms:
+  models:
     # Primary LLM for general tasks
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
-      on_behalf_of_user: False
+      on_behalf_of_user: false
 
   genie_rooms:
     # Genie space for retail data queries
@@ -53,16 +53,18 @@ tools:
       args:                                         # Arguments passed to factory
         name: my_genie_tool
         description: Answers questions about retail products and inventory
-        genie_room: *retail_genie_room              # Reference to Genie room config
+        genie_room: *retail_genie_room
+                                                    # Reference to Genie room config
 
 
 agents:
   genie: &genie
     name: genie                                     # Agent identifier
     description: "Genie Agent"
-    model: *default_llm                             # Reference to LLM configuration
+    model: *default_llm
+                                                    # Reference to LLM configuration
     tools:                                          # Tools available to this agent
-      - *genie_tool
+    - *genie_tool
     prompt: |                                       # System prompt defining agent behavior
       Answers questions about retail products and inventory
 
@@ -72,9 +74,11 @@ app:
   name: genie_basic_dao                      # Application name  
   description: "Multi-agent system that talks to genie"
   registered_model:                                 # MLflow registered model configuration
-    schema: *quick_serve_restaurant_schema                          # Schema where model will be registered
+    schema: *quick_serve_restaurant_schema
+                                                                    # Schema where model will be registered
     name: genie_basic_dao
   endpoint_name: dao_genie                    # Model serving endpoint name
   agents:                                           # List of agents included in the system
-    - *genie                                        # Genie agent
+  - *genie
+                                                    # Genie agent
 

--- a/config/examples/04_genie/genie_context_aware_cache.yaml
+++ b/config/examples/04_genie/genie_context_aware_cache.yaml
@@ -27,18 +27,18 @@ schemas:
     schema_name: ${var.schema}                    # Schema within the catalog
 
 resources:
-  llms:
+  models:
     # Primary LLM for general tasks
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
-      on_behalf_of_user: False
+      on_behalf_of_user: false
 
     # Embedding model for context-aware similarity search
     embedding_model: &embedding_model
       name: databricks-gte-large-en                 # Text embedding model
-      on_behalf_of_user: False
+      on_behalf_of_user: false
 
   warehouses:
     # Warehouse for executing SQL queries (used by context-aware cache)
@@ -46,7 +46,7 @@ resources:
       name: "Shared Endpoint Warehouse"             # Human-readable name
       description: "A warehouse for shared endpoints"  # Description
       warehouse_id: 148ccb90800933a1                # Databricks warehouse ID
-      on_behalf_of_user: False
+      on_behalf_of_user: false
 
   databases:
     # Lakebase (PostgreSQL) database for context-aware cache storage
@@ -69,7 +69,7 @@ resources:
     items_description_vs_index:
       schema: *quick_serve_restaurant_schema
       name: items_description_vs_index
-      
+
 # =============================================================================
 # MEMORY CONFIGURATION
 # =============================================================================
@@ -77,7 +77,7 @@ resources:
 
 memory: &memory
   # Conversation checkpointing for state persistence
-  checkpointer: 
+  checkpointer:
     name: default_checkpointer                      # Checkpointer identifier (type inferred as memory - no database)
 
 
@@ -90,19 +90,24 @@ tools:
       args:                                         # Arguments passed to factory
         name: my_genie_tool
         description: Answers questions about retail products and inventory
-        genie_room: *retail_genie_room              # Reference to Genie room config
+        genie_room: *retail_genie_room
+                                                    # Reference to Genie room config
 
         # L1 Cache: LRU (Least Recently Used) - Fast exact match
         lru_cache_parameters:
-          warehouse: *shared_endpoint_warehouse     # Warehouse to re-execute cached SQL
+          warehouse: *shared_endpoint_warehouse
+                                                    # Warehouse to re-execute cached SQL
           capacity: 100                             # Maximum number of cached entries
           time_to_live_seconds: 3600                # Cache entries expire after 1 hour
 
         # L2 Cache: Context-Aware - Similarity-based lookup
         context_aware_cache_parameters:
-          database: *context_aware_cache_db         # PostgreSQL database for cache storage
-          warehouse: *shared_endpoint_warehouse     # Warehouse used to re-execute cached SQL
-          embedding_model: *embedding_model         # Reference to embedding model
+          database: *context_aware_cache_db
+                                                    # PostgreSQL database for cache storage
+          warehouse: *shared_endpoint_warehouse
+                                                    # Warehouse used to re-execute cached SQL
+          embedding_model: *embedding_model
+                                                    # Reference to embedding model
           # embedding_dims: 1024                    # Auto-detected if omitted (recommended)
           similarity_threshold: 0.85                # Minimum similarity (L2 distance converted to 0-1)
           time_to_live_seconds: 86400               # Cache entries expire after 1 day
@@ -116,9 +121,10 @@ agents:
   genie: &genie
     name: genie                                     # Agent identifier
     description: "Genie Agent"
-    model: *default_llm                             # Reference to LLM configuration
+    model: *default_llm
+                                                    # Reference to LLM configuration
     tools:                                          # Tools available to this agent
-      - *genie_tool
+    - *genie_tool
     prompt: |                                       # System prompt defining agent behavior
       Answers questions about retail products and inventory
 
@@ -132,19 +138,23 @@ app:
     RETAIL_AI_DATABRICKS_CLIENT_SECRET: "{{secrets/retail_consumer_goods/RETAIL_AI_DATABRICKS_CLIENT_SECRET}}"
     RETAIL_AI_DATABRICKS_HOST: "{{secrets/retail_consumer_goods/RETAIL_AI_DATABRICKS_HOST}}"
   registered_model:                                 # MLflow registered model configuration
-    schema: *quick_serve_restaurant_schema          # Schema where model will be registered
+    schema: *quick_serve_restaurant_schema
+                                                    # Schema where model will be registered
     name: dao_genie_context_aware_cache             # Model name in MLflow registry
   endpoint_name: dao_genie_context_aware_cache      # Model serving endpoint name
   tags:                                             # Tags for resource organization
     business: rcg                                   # Business unit identifier
     streaming: true                                 # Indicates streaming capabilities
   permissions:                                      # Model serving permissions
-    - principals: [users]                           # Grant access to all users
-      entitlements:
-        - CAN_QUERY                                 # Full management permissions
+  - principals: [users]                             # Grant access to all users
+    entitlements:
+    - CAN_QUERY                                     # Full management permissions
   agents:                                           # List of agents included in the system
-    - *genie                                        # Order management agent
+  - *genie
+                                                    # Order management agent
   orchestration:                                    # Agent orchestration configuration
-    memory: *memory                                 # In-memory conversation persistence
+    memory: *memory
+                                                    # In-memory conversation persistence
     swarm:                                          # Swarm orchestration pattern
-      default_agent: *genie                         # Default agent for routing
+      default_agent: *genie
+                                                    # Default agent for routing

--- a/config/examples/04_genie/genie_in_memory_context_aware_cache.yaml
+++ b/config/examples/04_genie/genie_in_memory_context_aware_cache.yaml
@@ -33,18 +33,18 @@ schemas:
     schema_name: ${var.schema}                    # Schema within the catalog
 
 resources:
-  llms:
+  models:
     # Primary LLM for general tasks
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
-      on_behalf_of_user: False
+      on_behalf_of_user: false
 
     # Embedding model for context-aware similarity search
     embedding_model: &embedding_model
       name: databricks-gte-large-en                 # Text embedding model
-      on_behalf_of_user: False
+      on_behalf_of_user: false
 
   warehouses:
     # Warehouse for executing SQL queries (used by context-aware cache)
@@ -52,7 +52,7 @@ resources:
       name: "Shared Endpoint Warehouse"             # Human-readable name
       description: "A warehouse for shared endpoints"  # Description
       warehouse_id: 148ccb90800933a1                # Databricks warehouse ID
-      on_behalf_of_user: False
+      on_behalf_of_user: false
 
   genie_rooms:
     # Genie space for retail data queries
@@ -77,7 +77,7 @@ resources:
 
 memory: &memory
   # Conversation checkpointing for state persistence
-  checkpointer: 
+  checkpointer:
     name: default_checkpointer                      # Checkpointer identifier (type inferred as memory - no database)
 
 
@@ -90,7 +90,8 @@ tools:
       args:                                         # Arguments passed to factory
         name: my_genie_tool
         description: Answers questions about retail products and inventory
-        genie_room: *retail_genie_room              # Reference to Genie room config
+        genie_room: *retail_genie_room
+                                                    # Reference to Genie room config
 
         # Optional L1 Cache: LRU (Least Recently Used) - Fast exact match
         # Uncomment to enable LRU cache in front of context-aware cache
@@ -106,8 +107,10 @@ tools:
         #   - TTL: 1 week (accommodates weekly work patterns)
         #   - Memory: ~4-5% of 8GB system
         in_memory_context_aware_cache_parameters:
-          warehouse: *shared_endpoint_warehouse     # Warehouse used to re-execute cached SQL
-          embedding_model: *embedding_model         # Reference to embedding model
+          warehouse: *shared_endpoint_warehouse
+                                                    # Warehouse used to re-execute cached SQL
+          embedding_model: *embedding_model
+                                                    # Reference to embedding model
           # embedding_dims: 1024                    # Auto-detected if omitted (recommended)
           similarity_threshold: 0.85                # Minimum similarity for question matching (L2 distance to 0-1)
           context_similarity_threshold: 0.80        # Minimum similarity for context matching
@@ -131,9 +134,10 @@ agents:
   genie: &genie
     name: genie                                     # Agent identifier
     description: "Genie Agent with In-Memory Context-Aware Cache"
-    model: *default_llm                             # Reference to LLM configuration
+    model: *default_llm
+                                                    # Reference to LLM configuration
     tools:                                          # Tools available to this agent
-      - *genie_tool
+    - *genie_tool
     prompt: |                                       # System prompt defining agent behavior
       Answers questions about retail products and inventory using natural language.
       You have access to a context-aware cache that remembers similar questions to provide faster responses.
@@ -148,19 +152,23 @@ app:
     RETAIL_AI_DATABRICKS_CLIENT_SECRET: "{{secrets/retail_consumer_goods/RETAIL_AI_DATABRICKS_CLIENT_SECRET}}"
     RETAIL_AI_DATABRICKS_HOST: "{{secrets/retail_consumer_goods/RETAIL_AI_DATABRICKS_HOST}}"
   registered_model:                                 # MLflow registered model configuration
-    schema: *quick_serve_restaurant_schema          # Schema where model will be registered
+    schema: *quick_serve_restaurant_schema
+                                                    # Schema where model will be registered
     name: dao_genie_in_memory_context_aware_cache   # Model name in MLflow registry
   endpoint_name: dao_genie_in_memory_context_aware_cache # Model serving endpoint name
   tags:                                             # Tags for resource organization
     business: rcg                                   # Business unit identifier
     streaming: true                                 # Indicates streaming capabilities
   permissions:                                      # Model serving permissions
-    - principals: [users]                           # Grant access to all users
-      entitlements:
-        - CAN_QUERY                                 # Query permissions
+  - principals: [users]                             # Grant access to all users
+    entitlements:
+    - CAN_QUERY                                     # Query permissions
   agents:                                           # List of agents included in the system
-    - *genie                                        # Genie agent with in-memory cache
+  - *genie
+                                                    # Genie agent with in-memory cache
   orchestration:                                    # Agent orchestration configuration
-    memory: *memory                                 # In-memory conversation persistence
+    memory: *memory
+                                                    # In-memory conversation persistence
     swarm:                                          # Swarm orchestration pattern
-      default_agent: *genie                         # Default agent for routing
+      default_agent: *genie
+                                                    # Default agent for routing

--- a/config/examples/04_genie/genie_lru_cache.yaml
+++ b/config/examples/04_genie/genie_lru_cache.yaml
@@ -20,13 +20,13 @@ schemas:
     schema_name: ${var.schema}                    # Schema within the catalog
 
 resources:
-  llms:
+  models:
     # Primary LLM for general tasks
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
-      on_behalf_of_user: False
+      on_behalf_of_user: false
 
   warehouses:
 
@@ -34,7 +34,7 @@ resources:
       name: "Shared Endpoint Warehouse"             # Human-readable name
       description: "A warehouse for shared endpoints"  # Description
       warehouse_id: 148ccb90800933a1                # Databricks warehouse ID
-      on_behalf_of_user: False
+      on_behalf_of_user: false
 
   genie_rooms:
     # Genie space for retail data queries
@@ -51,7 +51,7 @@ resources:
     items_description_vs_index:
       schema: *quick_serve_restaurant_schema
       name: items_description_vs_index
-      
+
 # =============================================================================
 # MEMORY CONFIGURATION
 # =============================================================================
@@ -59,7 +59,7 @@ resources:
 
 memory: &memory
   # Conversation checkpointing for state persistence
-  checkpointer: 
+  checkpointer:
     name: default_checkpointer                      # Checkpointer identifier (type inferred as memory - no database)
 
 
@@ -72,9 +72,11 @@ tools:
       args:                                         # Arguments passed to factory
         name: my_genie_tool
         description: Answers questions about retail products and inventory
-        genie_room: *retail_genie_room              # Reference to Genie room config
+        genie_room: *retail_genie_room
+                                                    # Reference to Genie room config
         lru_cache_parameters:                       # LRU cache configuration for SQL query caching
-          warehouse: *shared_endpoint_warehouse     # Warehouse used to re-execute cached SQL
+          warehouse: *shared_endpoint_warehouse
+                                                    # Warehouse used to re-execute cached SQL
           capacity: 100                             # Maximum number of queries to cache
           time_to_live_seconds: 86400               # Cache entries expire after 1 day (default)
         persist_conversation: true
@@ -84,9 +86,10 @@ agents:
   genie: &genie
     name: genie                                     # Agent identifier
     description: "Genie Agent"
-    model: *default_llm                             # Reference to LLM configuration
+    model: *default_llm
+                                                    # Reference to LLM configuration
     tools:                                          # Tools available to this agent
-      - *genie_tool
+    - *genie_tool
     prompt: |                                       # System prompt defining agent behavior
       Answers questions about retail products and inventory
 
@@ -96,21 +99,25 @@ app:
   description: "Multi-agent system that talks to genie"
   log_level: DEBUG                                   # Logging level for the application
   registered_model:                                 # MLflow registered model configuration
-    schema: *quick_serve_restaurant_schema                          # Schema where model will be registered
+    schema: *quick_serve_restaurant_schema
+                                                                    # Schema where model will be registered
     name: genie_lru_cache_dao
   endpoint_name: dao_genie_lru_cache                    # Model serving endpoint name
   tags:                                             # Tags for resource organization
     business: rcg                                   # Business unit identifier
     streaming: true                                 # Indicates streaming capabilities
   permissions:                                      # Model serving permissions
-    - principals: [users]                           # Grant access to all users
-      entitlements:
-        - CAN_QUERY                                # Full management permissions
+  - principals: [users]                             # Grant access to all users
+    entitlements:
+    - CAN_QUERY                                    # Full management permissions
   agents:                                           # List of agents included in the system
-    - *genie                                        # Order management agent
+  - *genie
+                                                    # Order management agent
   orchestration:                                    # Agent orchestration configuration
-    memory: *memory                                 # In-memory conversation persistence
+    memory: *memory
+                                                    # In-memory conversation persistence
     swarm:                                          # Swarm orchestration pattern
-      default_agent: *genie                         # Default agent for routing
+      default_agent: *genie
+                                                    # Default agent for routing
 
 

--- a/config/examples/04_genie/genie_with_context_management.yaml
+++ b/config/examples/04_genie/genie_with_context_management.yaml
@@ -13,7 +13,7 @@
 #   export DATABRICKS_CONFIG_PROFILE=aws-field-eng
 
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4-5
       temperature: 0.1
@@ -56,9 +56,9 @@ agents:
     description: "Sales & Pricing Analytics Agent for Sporting Goods"
     model: *default_llm
     tools:
-      - *genie_tool
+    - *genie_tool
     middleware:
-      - *context_editor
+    - *context_editor
     prompt: |
       You are a sales and pricing analytics assistant for a sporting goods retailer.
       You help users explore sales performance, pricing strategies, profit margins,
@@ -80,7 +80,7 @@ app:
   log_level: DEBUG
   deployment_target: apps
   agents:
-    - *genie_agent
+  - *genie_agent
 
   chat_history:
     model: *summarization_llm
@@ -89,8 +89,8 @@ app:
 
   input_example:
     messages:
-      - role: user
-        content: What were our top-selling product categories last quarter?
+    - role: user
+      content: What were our top-selling product categories last quarter?
     custom_inputs:
       configurable:
         user_id: demo_user

--- a/config/examples/04_genie/genie_with_conversation_id.yaml
+++ b/config/examples/04_genie/genie_with_conversation_id.yaml
@@ -11,59 +11,59 @@ schemas:
     schema_name: quick_serve_restaurant                    # Schema within the catalog
 
 resources:
-  llms:
+  models:
     # Primary LLM for general tasks
     default_llm: &default_llm
       name: databricks-claude-3-7-sonnet # Databricks serving endpoint name
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
-      on_behalf_of_user: False
+      on_behalf_of_user: false
       fallbacks:                                  # Fallback LLMs in case of issues
-        - databricks-claude-sonnet-4
-        - databricks-claude-sonnet-4
+      - databricks-claude-sonnet-4
+      - databricks-claude-sonnet-4
 
   databases:
     # PostgreSQL database for agent memory and checkpoints
     retail_database: &retail_database
       name: "retail-consumer-goods"
-      description: "Database for agent memory and checkpoints" 
-      
+      description: "Database for agent memory and checkpoints"
+
       # Database connection parameters
       # These can be set via environment variables or Databricks secrets
-      host:                                                 
-        default_value: localhost                                             
+      host:
+        default_value: localhost
         options:
-          - env: PGHOST                              # Environment variable
-          - scope: retail_ai                         # Databricks secret scope
-            secret: PGHOST                           # Secret name
-      port: 
+        - env: PGHOST                                # Environment variable
+        - scope: retail_ai                           # Databricks secret scope
+          secret: PGHOST                             # Secret name
+      port:
         default_value: 5432
         options:
-        - env: PGPORT 
+        - env: PGPORT
         - scope: retail_ai
           secret: PGPORT
-      database: 
+      database:
         default_value: databricks_postgres           # Default database name
         options:
-        - env: PGDATABASE 
+        - env: PGDATABASE
         - scope: retail_ai
           secret: PGDATABASE
 
       client_id:
         options:
-          - env: RETAIL_AI_DATABRICKS_CLIENT_ID      # Service principal client ID
-          - scope: retail_ai
-            secret: RETAIL_AI_DATABRICKS_CLIENT_ID
+        - env: RETAIL_AI_DATABRICKS_CLIENT_ID        # Service principal client ID
+        - scope: retail_ai
+          secret: RETAIL_AI_DATABRICKS_CLIENT_ID
       client_secret:
         options:
-          - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET  # Service principal secret
-          - scope: retail_ai
-            secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+        - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET    # Service principal secret
+        - scope: retail_ai
+          secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
       workspace_host:
         options:
-          - env: RETAIL_AI_DATABRICKS_HOST           # Databricks workspace URL
-          - scope: retail_ai
-            secret: RETAIL_AI_DATABRICKS_HOST
+        - env: RETAIL_AI_DATABRICKS_HOST             # Databricks workspace URL
+        - scope: retail_ai
+          secret: RETAIL_AI_DATABRICKS_HOST
 
   genie_rooms:
     # Genie space for retail data queries
@@ -84,14 +84,16 @@ resources:
 
 memory: &memory
   # Conversation checkpointing for state persistence
-  checkpointer: 
+  checkpointer:
     name: default_checkpointer                      # Checkpointer identifier
-    database: *retail_database                     # Reference to database configuration (type inferred from presence)
+    database: *retail_database
+                                                   # Reference to database configuration (type inferred from presence)
 
   # Long-term memory store for agent context
-  store: 
+  store:
     name: default_store                             # Store identifier
-    database: *retail_database                      # Database for persistence (type inferred from presence)
+    database: *retail_database
+                                                    # Database for persistence (type inferred from presence)
     namespace: "{user_id}"
 
 tools:
@@ -103,7 +105,8 @@ tools:
       args:                                         # Arguments passed to factory
         name: my_genie_tool
         description: "Answer questions about quick serve restaurant, ingredients, inventory, processes and operations."
-        genie_room: *retail_genie_room              # Reference to Genie room config
+        genie_room: *retail_genie_room
+                                                    # Reference to Genie room config
         persist_conversation: true
 
 
@@ -111,9 +114,10 @@ agents:
   genie: &genie
     name: genie                                     # Agent identifier
     description: "Genie Agent"
-    model: *default_llm                             # Reference to LLM configuration
+    model: *default_llm
+                                                    # Reference to LLM configuration
     tools:                                          # Tools available to this agent
-      - *genie_tool
+    - *genie_tool
     prompt: |                                       # System prompt defining agent behavior
       Answer questions about quick serve restaurant, ingredients, inventory, processes and operations.
 
@@ -123,23 +127,26 @@ app:
   description: "Multi-agent system that talks to genie"
   log_level: DEBUG                                   # Logging level for the application
   registered_model:                                 # MLflow registered model configuration
-    schema: *retail_schema                          # Schema where model will be registered
+    schema: *retail_schema
+                                                    # Schema where model will be registered
     name: retail_ai_agenie_dao                      # Model name in MLflow registry
   endpoint_name: retail_ai_genie_dao                # Model serving endpoint name
   tags:                                             # Tags for resource organization
     business: rcg                                   # Business unit identifier
     streaming: true                                 # Indicates streaming capabilities
   permissions:                                      # Model serving permissions
-    - principals: [users]                           # Grant access to all users
-      entitlements:
-        - CAN_QUERY                                # Full management permissions
+  - principals: [users]                             # Grant access to all users
+    entitlements:
+    - CAN_QUERY                                    # Full management permissions
   agents:                                           # List of agents included in the system
-    - *genie                                        # Order management agent  
-  
+  - *genie
+                                                    # Order management agent  
   orchestration:                                    # Agent orchestration configuration
-    memory: *memory                            # Memory store for conversation context
+    memory: *memory
+                                               # Memory store for conversation context
     swarm:                                     # Supervisor orchestration pattern
-      default_agent: *genie                    # Default agent for routing
+      default_agent: *genie
+                                               # Default agent for routing
 
 
 

--- a/config/examples/05_memory/conversation_summarization.yaml
+++ b/config/examples/05_memory/conversation_summarization.yaml
@@ -43,7 +43,7 @@ resources:
   # ---------------------------------------------------------------------------
   # LANGUAGE MODELS
   # ---------------------------------------------------------------------------
-  llms:
+  models:
     # Primary LLM for conversation
     default_llm: &default_llm
       name: databricks-claude-sonnet-4

--- a/config/examples/05_memory/in_memory_basic.yaml
+++ b/config/examples/05_memory/in_memory_basic.yaml
@@ -20,7 +20,7 @@
 # RESOURCES
 # =============================================================================
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.7
@@ -38,7 +38,7 @@ agents:
       You are a helpful assistant. You can remember context from earlier in the
       conversation, but your memory is ephemeral - it won't persist after the
       session ends.
-      
+
       Engage naturally and reference previous parts of the conversation when relevant.
 
 # =============================================================================
@@ -54,20 +54,19 @@ app:
   name: in_memory_basic_dao
   description: "Chat agent with in-memory state (no persistence)"
   log_level: INFO
-  
+
   registered_model:
     name: in_memory_basic_dao
 
-  
+
   agents:
-    - *chat_agent
-  
+  - *chat_agent
   input_example:
     messages:
-      - role: user
-        content: "My name is Alice. I work as a data engineer."
-      - role: assistant
-        content: "Nice to meet you, Alice! As a data engineer, you must work with databases and data pipelines. How can I help you today?"
-      - role: user
-        content: "What's my name?"
+    - role: user
+      content: "My name is Alice. I work as a data engineer."
+    - role: assistant
+      content: "Nice to meet you, Alice! As a data engineer, you must work with databases and data pipelines. How can I help you today?"
+    - role: user
+      content: "What's my name?"
 

--- a/config/examples/05_memory/lakebase_persistence.yaml
+++ b/config/examples/05_memory/lakebase_persistence.yaml
@@ -34,7 +34,7 @@ parameters:
 # SCHEMAS
 # =============================================================================
 schemas:
-  demo_schema: &demo_schema
+  demo_schema:
     catalog_name: ${var.catalog}
     schema_name: ${var.schema}
 
@@ -42,14 +42,14 @@ schemas:
 # RESOURCES
 # =============================================================================
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.7
       max_tokens: 4096
-    
+
     # Optional: Separate model for summarization (more cost-effective)
-    summary_llm: &summary_llm
+    summary_llm:
       name: databricks-claude-sonnet-4
       temperature: 0.1
       max_tokens: 512
@@ -90,7 +90,7 @@ agents:
       You are a helpful assistant with persistent memory. Your conversation
       history is saved to a database, so you can resume conversations even
       after restarts.
-      
+
       When users return, you can reference previous conversations and maintain
       context across sessions. Be natural and reference past interactions when
       appropriate.
@@ -102,17 +102,16 @@ app:
   name: lakebase_persistence_dao
   description: "Chat agent with Lakebase persistence"
   log_level: INFO
-  
+
   registered_model:
     name: lakebase_persistence_dao
-  
+
   agents:
-    - *persistent_agent
-  
+  - *persistent_agent
   input_example:
     messages:
-      - role: user
-        content: "Remember that I prefer technical explanations with code examples"
+    - role: user
+      content: "Remember that I prefer technical explanations with code examples"
     custom_inputs:
       configurable:
         # Thread ID for conversation grouping - same thread_id resumes conversation

--- a/config/examples/05_memory/postgres_persistence.yaml
+++ b/config/examples/05_memory/postgres_persistence.yaml
@@ -33,7 +33,7 @@ parameters:
 # SCHEMAS
 # =============================================================================
 schemas:
-  demo_schema: &demo_schema
+  demo_schema:
     catalog_name: ${var.catalog}
     schema_name: ${var.schema}
 
@@ -41,13 +41,13 @@ schemas:
 # RESOURCES
 # =============================================================================
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.7
       max_tokens: 4096
-    
-    summary_llm: &summary_llm
+
+    summary_llm:
       name: databricks-claude-sonnet-4
       temperature: 0.1
       max_tokens: 512
@@ -59,7 +59,7 @@ resources:
     postgres_db: &postgres_db
       name: "conversations_db"
       description: "PostgreSQL database for conversation persistence"
-      
+
       # Option 1: Connection via environment variables (recommended)
       # Set these in your environment:
       #   export PGHOST=localhost
@@ -67,7 +67,6 @@ resources:
       #   export PGDATABASE=conversations
       #   export PGUSER=your_username
       #   export PGPASSWORD=your_password
-      
       host:
         env: PGHOST
         default_value: localhost
@@ -82,7 +81,7 @@ resources:
         default_value: postgres
       password:
         env: PGPASSWORD
-      
+
       # Option 2: Direct connection string (less secure, not recommended for production)
       # Uncomment to use a connection string instead:
       # connection_string:
@@ -114,7 +113,7 @@ agents:
     model: *default_llm
     prompt: |
       You are a helpful assistant with persistent memory backed by PostgreSQL.
-      
+
       Your capabilities:
       - Remember conversations across sessions
       - Maintain context across multiple sessions
@@ -127,17 +126,16 @@ app:
   name: postgres_persistence_dao
   description: "Chat agent with PostgreSQL persistence"
   log_level: INFO
-  
+
   registered_model:
     name: postgres_persistence_dao
-  
+
   agents:
-    - *postgres_agent
-  
+  - *postgres_agent
   input_example:
     messages:
-      - role: user
-        content: "Let's start a long conversation about machine learning best practices"
+    - role: user
+      content: "Let's start a long conversation about machine learning best practices"
     custom_inputs:
       configurable:
         # Thread ID groups related messages - use same ID to resume conversation

--- a/config/examples/06_on_behalf_of_user/obo_basic.yaml
+++ b/config/examples/06_on_behalf_of_user/obo_basic.yaml
@@ -42,7 +42,7 @@ schemas:
 # RESOURCES
 # =============================================================================
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.7
@@ -73,7 +73,7 @@ resources:
       schema: *demo_schema
       name: find_product_by_sku
       on_behalf_of_user: true
-    
+
     find_product_upc: &find_product_upc
       schema: *demo_schema
       name: find_product_by_upc
@@ -100,22 +100,19 @@ tools:
     function:
       type: unity_catalog
       resource: *find_product_sku
-  
   product_upc_lookup: &product_upc_lookup
     name: product_upc_lookup
-    function: 
+    function:
       type: unity_catalog
       resource: *find_product_upc
-  
   inventory_sku_lookup: &inventory_sku_lookup
     name: inventory_sku_lookup
-    function: 
+    function:
       type: unity_catalog
       resource: *find_inventory_sku
-  
   inventory_upc_lookup: &inventory_upc_lookup
     name: inventory_upc_lookup
-    function: 
+    function:
       type: unity_catalog
       resource: *find_inventory_upc
 
@@ -128,7 +125,8 @@ tools:
       args:
         name: retail_data_query
         description: "Query retail data using natural language. Access is controlled by user permissions."
-        genie_room: *retail_genie  # OBO inherited from genie_room resource
+        genie_room: *retail_genie
+                                   # OBO inherited from genie_room resource
 
 # =============================================================================
 # PROMPTS
@@ -140,14 +138,14 @@ prompts:
     description: "Retail assistant with OBO"
     default_template: |
       You are a helpful retail assistant with access to product and inventory data.
-      
+
       You have two types of tools available:
       1. UC Functions for precise product and inventory lookups by SKU or UPC
       2. Genie for natural language queries about retail data
-      
+
       All queries will be executed with the user's credentials, so you can only
       access data that the current user has permission to view.
-      
+
       When helping users:
       - Use UC Functions for specific product lookups (SKU/UPC searches)
       - Use Genie for complex queries or when exploring data
@@ -162,11 +160,11 @@ agents:
     name: retail_assistant
     model: *default_llm
     tools:
-      - *product_sku_lookup
-      - *product_upc_lookup
-      - *inventory_sku_lookup
-      - *inventory_upc_lookup
-      - *retail_data_query
+    - *product_sku_lookup
+    - *product_upc_lookup
+    - *inventory_sku_lookup
+    - *inventory_upc_lookup
+    - *retail_data_query
     prompt: *retail_assistant_prompt
 
 # =============================================================================
@@ -179,7 +177,7 @@ app:
     schema: *demo_schema
     name: obo_retail_assistant_dao
   agents:
-    - *retail_assistant
+  - *retail_assistant
 
 # =============================================================================
 # DEPLOYMENT NOTES

--- a/config/examples/07_human_in_the_loop/human_in_the_loop.yaml
+++ b/config/examples/07_human_in_the_loop/human_in_the_loop.yaml
@@ -44,7 +44,7 @@ schemas:
     schema_name: retail_ai                    
 
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4 
       temperature: 0.1

--- a/config/examples/08_guardrails/README.md
+++ b/config/examples/08_guardrails/README.md
@@ -395,11 +395,11 @@ Either `model`+`prompt` (custom judge) or `scorer` (scorer-based) must be provid
 | **Tone** | `model` | `tone` ("professional"), `custom_guidelines`, `num_retries` (2), `fail_on_error` (false) |
 | **Conciseness** | `model` | `max_length` (3000), `min_length` (20), `check_verbosity` (true), `num_retries` (2), `fail_on_error` (false) |
 
-## LLM Configuration
+## Model Configuration
 
 ```yaml
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-3-7-sonnet
       temperature: 0.7            # Higher for creative responses

--- a/config/examples/08_guardrails/guardrails_basic.yaml
+++ b/config/examples/08_guardrails/guardrails_basic.yaml
@@ -46,7 +46,7 @@ resources:
   # ---------------------------------------------------------------------------
   # LANGUAGE MODELS (LLMs)
   # ---------------------------------------------------------------------------
-  llms:
+  models:
     # Primary LLM for agent responses
     # Claude 3.7 Sonnet produces consistently high-quality responses that typically
     # pass guardrails on first try. To see retry behavior, try:
@@ -79,17 +79,17 @@ prompts:
     default_template: |
       Evaluate if the following response is professional, helpful, and appropriate 
       for customer service.
-      
+
       User Request: {{ inputs }}
       Agent Response: {{ outputs }}
-      
+
       The response should:
       - Use professional language (no slang or jargon)
       - Be respectful and courteous
       - Be clear and easy to understand
       - Maintain a helpful, service-oriented tone
       - Avoid being overly casual or too formal
-      
+
       Rate as true if the response meets these criteria, false if it doesn't.
     tags:
       type: guardrail
@@ -103,10 +103,10 @@ prompts:
     description: "Evaluates if responses fully address the user's question"
     default_template: |
       Evaluate if the response fully addresses the user's question.
-      
+
       User Request: {{ inputs }}
       Agent Response: {{ outputs }}
-      
+
       The response should:
       - Should be more than one word.
       - Directly answer the question asked
@@ -114,7 +114,7 @@ prompts:
       - Not omit important relevant information
       - Include next steps or follow-up guidance when appropriate
       - Address all parts of multi-part questions
-      
+
       Rate as true if the response is complete and thorough, false if it's incomplete,
       vague, or doesn't fully address the question.
     tags:
@@ -183,7 +183,7 @@ guardrails:
     model: *judge_llm
     prompt: *completeness_guardrail_prompt
     num_retries: 2
-  
+
   # Tone guardrail - ensures professional, appropriate tone
   tone_guardrail: &tone_guardrail
     name: tone_check
@@ -194,7 +194,7 @@ guardrails:
   # Veracity guardrail - ensures responses are grounded in tool context
   # This guardrail uses tool results (search, SQL, Genie) as reference context
   # to check if the agent's response is factually grounded.
-  veracity_guardrail: &veracity_guardrail
+  veracity_guardrail:
     name: veracity_check
     model: *judge_llm
     prompt: *veracity_guardrail_prompt
@@ -227,7 +227,7 @@ middleware:
 
   # Tone check - validates tone against a preset profile.
   # Profiles: professional, casual, technical, empathetic, concise
-  tone_middleware: &tone_middleware
+  tone_middleware:
     name: dao_ai.middleware.create_tone_guardrail_middleware
     args:
       model: "databricks:/databricks-claude-3-7-sonnet"
@@ -259,34 +259,32 @@ agents:
     name: assistant
     description: "General purpose assistant with comprehensive quality guardrails"
     model: *default_llm
-    
     # All available tools
     tools:
-      - *search_tool
-      - *greeting_tool
+    - *search_tool
+    - *greeting_tool
 
     
     # Prompt-based guardrails (requires writing an evaluation prompt)
     guardrails:
-      - *tone_guardrail
-      - *completeness_guardrail
+    - *tone_guardrail
+    - *completeness_guardrail
 
     # Specialized guardrails (zero-config, built-in expert prompts)
     middleware:
-      - *veracity_middleware
-      - *relevance_middleware
-      - *conciseness_middleware
-    
+    - *veracity_middleware
+    - *relevance_middleware
+    - *conciseness_middleware
     prompt: |
       You are a helpful, knowledgeable assistant designed to provide accurate and 
       professional responses to a wide range of user inquiries.
-      
+
       Your capabilities:
       - Answer questions on various topics with accuracy and completeness
       - Use search tools when you need current information or specific facts
       - Greet users warmly and check the current time when needed
       - Maintain a professional, courteous tone in all interactions
-      
+
       Guidelines:
       - Always maintain a professional, helpful, and respectful tone
       - Never make up information - use search tools or acknowledge limitations
@@ -302,22 +300,20 @@ app:
   name: guardrails_basic_dao
   description: "General purpose assistant with comprehensive guardrails"
   log_level: DEBUG
-  
+
   registered_model:
     schema: *retail_schema
     name: guardrails_example_agent_dao
-  
+
   agents:
-    - *general_agent
-  
+  - *general_agent
   # Single agent - no orchestration needed
   # The agent handles all requests directly
-  
   # Example input for testing
   input_example:
     input:
-      - role: user
-        content: How can I help you today?
+    - role: user
+      content: How can I help you today?
     custom_inputs:
       configurable:
         user_id: test_user

--- a/config/examples/08_guardrails/guardrails_scorers.yaml
+++ b/config/examples/08_guardrails/guardrails_scorers.yaml
@@ -54,9 +54,9 @@ parameters:
 variables:
   guardrailsai_api_key: &guardrailsai_api_key
     options:
-      - scope: retail_consumer_goods
-        secret: GUARDRAILSAI_API_KEY
-      - env: GUARDRAILSAI_API_KEY
+    - scope: retail_consumer_goods
+      secret: GUARDRAILSAI_API_KEY
+    - env: GUARDRAILSAI_API_KEY
 
 schemas:
   retail_schema: &retail_schema
@@ -64,7 +64,7 @@ schemas:
     schema_name: ${var.schema}
 
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-3-7-sonnet
       temperature: 0.7
@@ -87,16 +87,16 @@ prompts:
     default_template: |
       Evaluate if the following response is professional, helpful, and appropriate 
       for customer service.
-      
+
       User Request: {{ inputs }}
       Agent Response: {{ outputs }}
-      
+
       The response should:
       - Use professional language (no slang or jargon)
       - Be respectful and courteous
       - Be clear and easy to understand
       - Maintain a helpful, service-oriented tone
-      
+
       Rate as true if the response meets these criteria, false if it doesn't.
     tags:
       type: guardrail
@@ -192,24 +192,24 @@ agents:
     model: *default_llm
 
     tools:
-      - *search_tool
-      - *greeting_tool
+    - *search_tool
+    - *greeting_tool
 
     # Mix of scorer-based and custom guardrails
     guardrails:
-      - *toxic_language_guardrail
-      - *gibberish_guardrail
-      - *secrets_guardrail
-      - *tone_guardrail
+    - *toxic_language_guardrail
+    - *gibberish_guardrail
+    - *secrets_guardrail
+    - *tone_guardrail
 
     # Specialized middleware guardrails
     middleware:
-      - *veracity_middleware
+    - *veracity_middleware
 
     prompt: |
       You are a helpful, knowledgeable assistant designed to provide accurate and 
       professional responses.
-      
+
       Guidelines:
       - Always maintain a professional, helpful, and respectful tone
       - Never make up information -- use search tools or acknowledge limitations
@@ -233,12 +233,12 @@ app:
     GUARDRAILSAI_API_KEY: *guardrailsai_api_key
 
   agents:
-    - *general_agent
+  - *general_agent
 
   input_example:
     input:
-      - role: user
-        content: What is Python?
+    - role: user
+      content: What is Python?
     custom_inputs:
       configurable:
         user_id: test_user

--- a/config/examples/09_structured_output/structured_output.yaml
+++ b/config/examples/09_structured_output/structured_output.yaml
@@ -21,7 +21,7 @@ schemas:
     schema_name: ${var.schema}
 
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.0
@@ -33,7 +33,7 @@ agents:
     prompt: |
       Extract contact information from the user's message.
       Return the name, email, and phone number (if available).
-    
+
     response_format:
       response_schema: |
         {
@@ -54,7 +54,7 @@ app:
     name: structured_output_dao
     schema: *demo_schema
   agents:
-    - *contact_extractor
+  - *contact_extractor
 
 # Example prompt for testing:
 # "John Doe, john.doe@example.com, (555) 123-4567"

--- a/config/examples/10_agent_integrations/a2a_agent.yaml
+++ b/config/examples/10_agent_integrations/a2a_agent.yaml
@@ -29,18 +29,18 @@ variables:
   # fallback to the pre-1.0 spec's ``/.well-known/agent.json`` on 404.
   a2a_endpoint: &a2a_endpoint
     options:
-      - env: A2A_AGENT_ENDPOINT
-      - scope: a2a_demo
-        secret: A2A_AGENT_ENDPOINT
-      - value: "http://localhost:9999"
+    - env: A2A_AGENT_ENDPOINT
+    - scope: a2a_demo
+      secret: A2A_AGENT_ENDPOINT
+    - value: "http://localhost:9999"
 
   # Bearer token / API key for the A2A agent. Leave unset (and set auth_type
   # to ``none``) for public agents.
   a2a_auth: &a2a_auth
     options:
-      - env: A2A_AGENT_TOKEN
-      - scope: a2a_demo
-        secret: A2A_AGENT_TOKEN
+    - env: A2A_AGENT_TOKEN
+    - scope: a2a_demo
+      secret: A2A_AGENT_TOKEN
 
   # Uncomment for GCP service-account auth (e.g. Vertex-AI-hosted A2A).
   # Accepts a local file path, a Databricks Volume path (/Volumes/...), or
@@ -53,7 +53,7 @@ variables:
   #       secret: GOOGLE_APPLICATION_CREDENTIALS
 
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
@@ -122,7 +122,7 @@ agents:
       any A2A-compatible toolkit.
     model: *default_llm
     tools:
-      - *remote_a2a_tool
+    - *remote_a2a_tool
     prompt: *a2a_delegate_prompt
 
 app:
@@ -133,9 +133,9 @@ app:
   log_level: INFO
   deployment_target: apps
   agents:
-    - *a2a_delegate_agent
+  - *a2a_delegate_agent
 
   input_example:
     messages:
-      - role: user
-        content: "Ask the remote agent what it specializes in."
+    - role: user
+      content: "Ask the remote agent what it specializes in."

--- a/config/examples/10_agent_integrations/agent_bricks.yaml
+++ b/config/examples/10_agent_integrations/agent_bricks.yaml
@@ -29,7 +29,7 @@ schemas:
     schema_name: ${var.schema}
 
 resources:
-  llms:
+  models:
     # Main agent LLM
     main_llm: &main_llm
       name: databricks-claude-sonnet-4
@@ -64,7 +64,7 @@ tools:
           - Processing returns and refunds
           - Managing customer satisfaction concerns
           - Escalation handling
-          
+
           The agent is trained on customer support best practices and your company's policies.
           Pass the customer's question or issue as the prompt.
 
@@ -84,7 +84,7 @@ tools:
           - Product comparisons and recommendations
           - Compatibility questions
           - Usage instructions and best practices
-          
+
           This agent has deep knowledge of your product catalog and can provide
           expert-level guidance on product selection and usage.
 
@@ -94,23 +94,23 @@ agents:
     name: main_orchestrator
     model: *main_llm
     tools:
-      - *customer_support_tool
-      - *product_expert_tool
+    - *customer_support_tool
+    - *product_expert_tool
     prompt: |
       You are an intelligent routing agent for a retail hardware store.
-      
+
       Your role is to understand customer inquiries and delegate them to the appropriate
       specialist agents:
-      
+
       - For customer service issues, complaints, returns, or satisfaction concerns,
         use the customer_support_specialist tool
       - For detailed product information, technical specifications, or recommendations,
         use the product_knowledge_expert tool
-      
+
       When using these tools, formulate clear and complete prompts that give the
       specialist agent all necessary context. After receiving their response,
       provide it to the user in a helpful and professional manner.
-      
+
       If a question requires both customer support and product expertise, you may
       call both tools in sequence and synthesize the responses.
 
@@ -121,4 +121,4 @@ app:
     schema: *retail_schema
     name: agent_bricks_integration_dao
   agents:
-    - *orchestrator_agent
+  - *orchestrator_agent

--- a/config/examples/10_agent_integrations/kasal.yaml
+++ b/config/examples/10_agent_integrations/kasal.yaml
@@ -28,7 +28,7 @@ schemas:
     schema_name: ${var.schema}
 
 resources:
-  llms:
+  models:
     # Main coordinator LLM
     coordinator_llm: &coordinator_llm
       name: databricks-claude-sonnet-4
@@ -65,14 +65,14 @@ tools:
         name: kasal_financial_expert
         description: |
           Access a Kasal financial analyst agent for financial queries and analysis.
-          
+
           Capabilities:
           - Revenue and profit analysis
           - Financial forecasting and projections
           - Budget planning and variance analysis
           - Cost optimization recommendations
           - Financial report generation
-          
+
           The agent has access to financial data and follows GAAP standards.
           Provide your financial question or analysis request as the prompt.
 
@@ -87,14 +87,14 @@ tools:
         name: kasal_compliance_validator
         description: |
           Consult with a Kasal compliance agent to validate regulatory adherence.
-          
+
           Use this for:
           - Regulatory requirement validation
           - Policy compliance checks
           - Audit trail generation
           - Risk assessment
           - Industry standards verification (SOC2, HIPAA, GDPR, etc.)
-          
+
           This agent ensures all recommendations and decisions meet regulatory requirements.
           Describe the action or decision you need validated.
 
@@ -109,14 +109,14 @@ tools:
         name: kasal_privacy_expert
         description: |
           Engage with a Kasal data privacy specialist for PII and data handling guidance.
-          
+
           Capabilities:
           - PII detection and classification
           - Data retention policy guidance
           - Privacy impact assessments
           - GDPR/CCPA compliance validation
           - Data anonymization strategies
-          
+
           The agent helps ensure data privacy best practices are followed.
           Ask your data privacy or PII-related question.
 
@@ -126,38 +126,38 @@ agents:
     name: enterprise_ai_coordinator
     model: *coordinator_llm
     tools:
-      - *financial_analyst_tool
-      - *compliance_checker_tool
-      - *privacy_specialist_tool
+    - *financial_analyst_tool
+    - *compliance_checker_tool
+    - *privacy_specialist_tool
     prompt: |
       You are an enterprise AI coordinator for a large organization.
-      
+
       Your mission is to help users with complex business queries that require
       specialized expertise and strict governance. You have access to three
       Kasal-powered specialist agents:
-      
+
       1. Financial Expert (kasal_financial_expert):
          - Use for any financial analysis, forecasting, or reporting questions
          - Provides data-driven financial insights
-      
+
       2. Compliance Validator (kasal_compliance_validator):
          - Consult before making recommendations that could have regulatory implications
          - Validates that proposed actions meet industry standards and regulations
-      
+
       3. Privacy Expert (kasal_privacy_expert):
          - Consult when dealing with customer data or PII
          - Ensures data handling follows privacy regulations and best practices
-      
+
       IMPORTANT: For questions involving financial decisions, ALWAYS check with the
       compliance validator before providing a final recommendation. For queries
       involving customer data, ALWAYS consult the privacy specialist.
-      
+
       When using these tools:
       - Provide complete context and specific questions
       - Wait for responses before proceeding
       - Synthesize multiple agent responses when needed
       - Clearly communicate any compliance or privacy concerns to the user
-      
+
       Your responses should be professional, accurate, and demonstrate that
       appropriate governance and compliance checks have been performed.
 
@@ -168,4 +168,4 @@ app:
     schema: *enterprise_schema
     name: kasal_integration_dao
   agents:
-    - *enterprise_coordinator
+  - *enterprise_coordinator

--- a/config/examples/10_agent_integrations/vertex_agent_engine.yaml
+++ b/config/examples/10_agent_integrations/vertex_agent_engine.yaml
@@ -39,18 +39,18 @@ variables:
   # automatically.
   gcp_credentials: &gcp_credentials
     options:
-      - env: GOOGLE_APPLICATION_CREDENTIALS
-      - scope: retail_consumer_goods
-        secret: GOOGLE_APPLICATION_CREDENTIALS
+    - env: GOOGLE_APPLICATION_CREDENTIALS
+    - scope: retail_consumer_goods
+      secret: GOOGLE_APPLICATION_CREDENTIALS
 
   vertex_agent_endpoint: &vertex_agent_endpoint
     options:
-      - env: GCP_REASONING_ENGINE_ENDPOINT
-      - scope: retail_consumer_goods
-        secret: GCP_REASONING_ENGINE_ENDPOINT
+    - env: GCP_REASONING_ENGINE_ENDPOINT
+    - scope: retail_consumer_goods
+      secret: GCP_REASONING_ENGINE_ENDPOINT
 
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
@@ -237,8 +237,8 @@ agents:
       carriers, warehouses, tracking).
     model: *default_llm
     tools:
-      - *sales_genie_tool
-      - *logistics_genie_tool
+    - *sales_genie_tool
+    - *logistics_genie_tool
     prompt: *retail_analytics_prompt
 
   # Customer service worker — backed by a Vertex AI Agent Engine ADK agent.
@@ -249,7 +249,7 @@ agents:
       Vertex AI Agent Engine.
     model: *default_llm
     tools:
-      - *customer_service_tool
+    - *customer_service_tool
     prompt: *customer_service_prompt
 
 app:
@@ -260,8 +260,8 @@ app:
   log_level: INFO
   deployment_target: apps
   agents:
-    - *retail_analytics_agent
-    - *customer_service_agent
+  - *retail_analytics_agent
+  - *customer_service_agent
 
   orchestration:
     supervisor:
@@ -270,5 +270,5 @@ app:
 
   input_example:
     messages:
-      - role: user
-        content: "Which product is ordered the most?"
+    - role: user
+      content: "Which product is ordered the most?"

--- a/config/examples/11_prompt_engineering/prompt_optimization.yaml
+++ b/config/examples/11_prompt_engineering/prompt_optimization.yaml
@@ -58,15 +58,15 @@ resources:
   # LANGUAGE MODELS (LLMs)
   # ---------------------------------------------------------------------------
   # Configure different LLMs for various purposes in the agent system
-  llms:
+  models:
 
     # LLM optimized for tool calling and function execution
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-3-7-sonnet 
+      name: databricks-claude-3-7-sonnet
       temperature: 0.1
       max_tokens: 8192
       fallbacks:                                     # Fallback models if primary fails
-        - databricks-claude-sonnet-4
+      - databricks-claude-sonnet-4
 
 
     # LLM for evaluating and judging responses (guardrails)
@@ -86,28 +86,30 @@ resources:
   vector_stores:
     # Product information vector store for similarity search
     products_vector_store: &products_vector_store
-      embedding_model: *embedding_model             # Reference to embedding model above
+      embedding_model: *embedding_model
+                                                    # Reference to embedding model above
       endpoint:                                     # Vector search endpoint configuration
         name: dbdemos_vs_endpoint            # Databricks vector search endpoint
         type: STANDARD                              # Endpoint type (STANDARD or OPTIMIZED_STORAGE)
       index:                                        # Vector search index configuration
-        schema: *retail_schema                      # Unity Catalog schema for the index
+        schema: *retail_schema
+                                                    # Unity Catalog schema for the index
         name: products_index                        # Index name
       source_table:                                 # Table containing source data
         schema: *retail_schema
         name: products
       primary_key: product_id                       # Primary key column
-      doc_uri: ~                                    # Optional document URI column (null in this case)
+      doc_uri:                                      # Optional document URI column (null in this case)
       embedding_source_column: description          # Column to create embeddings from
       columns:                                      # Columns to include in vector store
-        - product_id
-        - sku
-        - upc
-        - brand_name
-        - product_name
-        - merchandise_class
-        - class_cd
-        - description
+      - product_id
+      - sku
+      - upc
+      - brand_name
+      - product_name
+      - merchandise_class
+      - class_cd
+      - description
 
 
 # =============================================================================
@@ -118,16 +120,17 @@ resources:
 retrievers:
   # Product information retriever using vector search
   products_retriever: &products_retriever
-    vector_store: *products_vector_store            # Reference to vector store defined above
+    vector_store: *products_vector_store
+                                                    # Reference to vector store defined above
     columns:                                        # Columns to return in search results
-      - product_id
-      - sku
-      - upc
-      - brand_name
-      - product_name
-      - merchandise_class
-      - class_cd
-      - description
+    - product_id
+    - sku
+    - upc
+    - brand_name
+    - product_name
+    - merchandise_class
+    - class_cd
+    - description
     search_parameters:                              # Search configuration
       num_results: 10                               # Maximum number of results to return
       filters: {}                                   # Additional filters (empty in this case)
@@ -149,7 +152,8 @@ tools:
       type: factory
       name: dao_ai.tools.create_vector_search_tool
       args:
-        retriever: *products_retriever              # Reference to retriever config
+        retriever: *products_retriever
+                                                    # Reference to retriever config
         name: product_vector_search_tool            # Tool instance name
         description: "Search for products by description"  # Tool description
 
@@ -178,7 +182,7 @@ prompts:
     schema: *retail_schema
     name: diy_prompt
     description: "DIY and home improvement expert prompt providing how-to advice, project guidance, and safety recommendations"
-    
+
     # Optional: Specify which version/alias to optimize
     # Three URI schemes are supported:
     # 1. version: 1  # Optimize specific version: "prompts:/qa/1"
@@ -188,7 +192,6 @@ prompts:
     # When optimization completes, the specified alias will be updated to point to the new version
     # If no alias specified, defaults to "latest"
     # alias: "champion"  # Uncomment to use a custom alias
-    
     default_template: |
       ### User Information
       - **User Id**: {user_id}
@@ -212,7 +215,8 @@ agents:
     description: "DIY and home improvement expert providing how-to advice, project guidance, and tool recommendations"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool   # Can search for tools and materials
+    - *find_product_details_by_description_tool
+                                                    # Can search for tools and materials
     prompt: *diy_prompt
 
 
@@ -227,27 +231,29 @@ app:
   description: "Multi-agent system for retail customer service and product assistance"
   log_level: DEBUG                                   # Logging level for the application
   registered_model:                                 # MLflow registered model configuration
-    schema: *retail_schema                          # Schema where model will be registered
+    schema: *retail_schema
+                                                    # Schema where model will be registered
     name: prompt_optimization_dao
   endpoint_name: prompt_optimization_agent_dao                    # Model serving endpoint name
   tags:                                             # Tags for resource organization
     business: rcg                                   # Business unit identifier
     streaming: true                                 # Indicates streaming capabilities
   permissions:                                      # Model serving permissions
-    - principals: [users]                           # Grant access to all users
-      entitlements:
-        - CAN_QUERY                                # Full management permissions
+  - principals: [users]                             # Grant access to all users
+    entitlements:
+    - CAN_QUERY                                    # Full management permissions
   agents:                                           # List of agents included in the system
-    - *diy                                          # DIY and tutorials agent
+  - *diy
+                                                    # DIY and tutorials agent
   input_example:
-      input:
-        - role: user
-          content: Can you recommend a lamp to match my oak side tables?
-      custom_inputs:
-        configurable:
+    input:
+    - role: user
+      content: Can you recommend a lamp to match my oak side tables?
+    custom_inputs:
+      configurable:
           # conversation_id is auto-generated as UUID if not provided
-          user_id: my_user_id
-          store_num: 87887
+        user_id: my_user_id
+        store_num: 87887
     # swarm:
     #   default_agent: *general
 
@@ -272,18 +278,18 @@ evaluation:
 # and data files for initial population of Unity Catalog tables
 
 datasets:
-  - table: 
-      schema: *retail_schema
-      name: products
-    ddl: ../data/hardware_store/products.sql
-    data: ../data/hardware_store/products.snappy.parquet
-    format: parquet
-  - table: 
-      schema: *retail_schema
-      name: inventory
-    ddl: ../data/hardware_store/inventory.sql
-    data: ../data/hardware_store/inventory.snappy.parquet
-    format: parquet
+- table:
+    schema: *retail_schema
+    name: products
+  ddl: ../data/hardware_store/products.sql
+  data: ../data/hardware_store/products.snappy.parquet
+  format: parquet
+- table:
+    schema: *retail_schema
+    name: inventory
+  ddl: ../data/hardware_store/inventory.sql
+  data: ../data/hardware_store/inventory.snappy.parquet
+  format: parquet
 
 
 optimizations:
@@ -296,171 +302,161 @@ optimizations:
       name: hardware_store_diy_dataset
       overwrite: true
       data:
-        - inputs:
-            messages: 
-              - role: user
-                content: "What's the best drill for home use?"
-            custom_inputs:
-              configurable:
-                user_id: my_user_id
-                store_num: 87887
-          expectations:
-            expected_facts:
-              - "The best drill for home use is the Dewalt DCD777B 18V Cordless Drill/Driver with a 1/2-inch hex chuck."
-              - "The Dewalt DCD777B 18V Cordless Drill/Driver is a popular drill for home use."
-        
-        - inputs:
-            messages:
-              - role: user
-                content: "How do I install a ceiling fan?"
-            custom_inputs:
-              configurable:
-                user_id: my_user_id
-                store_num: 87887
-          expectations:
-            expected_facts:
-              - "Turn off power at the circuit breaker before starting any electrical work"
-              - "You'll need a ceiling fan mounting bracket and electrical box rated for fan weight"
-              - "Connect the wiring: black to black (hot), white to white (neutral), green to copper (ground)"
-              - "Ensure the electrical box is securely mounted to a ceiling joist or use a fan brace"
-        
-        - inputs:
-            messages:
-              - role: user
-                content: "What type of paint should I use for my bathroom?"
-            custom_inputs:
-              configurable:
-                user_id: my_user_id
-                store_num: 87887
-          expectations:
-            expected_facts:
-              - "Use moisture-resistant or mildew-resistant paint for bathrooms"
-              - "Semi-gloss or satin finish paints work best in bathrooms due to humidity"
-              - "Look for paints specifically labeled as 'bathroom paint' or with anti-microbial properties"
-        
-        - inputs:
-            messages:
-              - role: user
-                content: "How do I fix a leaky faucet?"
-            custom_inputs:
-              configurable:
-                user_id: my_user_id
-                store_num: 87887
-          expectations:
-            expected_facts:
-              - "Turn off the water supply before starting repairs"
-              - "Common causes include worn washers, O-rings, or valve seats"
-              - "You'll typically need an adjustable wrench, screwdriver, and replacement parts"
-              - "Identify your faucet type (compression, cartridge, ball, or ceramic disk) for proper repair"
-        
-        - inputs:
-            messages:
-              - role: user
-                content: "What tools do I need to hang drywall?"
-            custom_inputs:
-              configurable:
-                user_id: my_user_id
-                store_num: 87887
-          expectations:
-            expected_facts:
-              - "Essential tools include a drywall saw, utility knife, T-square, and screw gun"
-              - "You'll need drywall screws, joint compound, and tape for finishing"
-              - "A drywall lift can be helpful for ceiling installation"
-              - "Sandpaper or sanding screen is needed for finishing joints"
-        
-        - inputs:
-            messages:
-              - role: user
-                content: "How do I install laminate flooring?"
-            custom_inputs:
-              configurable:
-                user_id: my_user_id
-                store_num: 87887
-          expectations:
-            expected_facts:
-              - "Start by ensuring the subfloor is clean, level, and dry"
-              - "Install underlayment before laying laminate planks"
-              - "Leave a 1/4-inch expansion gap around the perimeter"
-              - "Most laminate flooring uses a click-lock installation system"
-              - "Acclimate the flooring to room temperature for 48 hours before installation"
-        
-        - inputs:
-            messages:
-              - role: user
-                content: "What's the difference between a nail gun and a hammer?"
-            custom_inputs:
-              configurable:
-                user_id: my_user_id
-                store_num: 87887
-          expectations:
-            expected_facts:
-              - "A nail gun drives nails much faster and with less physical effort than a hammer"
-              - "Nail guns are powered by compressed air, electricity, or fuel cells"
-              - "Hammers provide more control for precision work and don't require power"
-              - "Nail guns are better for large projects like framing or decking"
-        
-        - inputs:
-            messages:
-              - role: user
-                content: "How do I properly prepare a surface for painting?"
-            custom_inputs:
-              configurable:
-                user_id: my_user_id
-                store_num: 87887
-          expectations:
-            expected_facts:
-              - "Clean the surface to remove dirt, grease, and loose paint"
-              - "Sand the surface to create a smooth base and improve paint adhesion"
-              - "Fill holes and cracks with spackling compound or wood filler"
-              - "Apply primer, especially on bare wood or patched areas"
-              - "Allow proper drying time between prep steps"
-        
-        - inputs:
-            messages:
-              - role: user
-                content: "What safety equipment do I need for woodworking?"
-            custom_inputs:
-              configurable:
-                user_id: my_user_id
-                store_num: 87887
-          expectations:
-            expected_facts:
-              - "Safety glasses or goggles are essential to protect your eyes from debris"
-              - "Hearing protection is important when using power tools"
-              - "A dust mask or respirator protects against sawdust and fumes"
-              - "Work gloves protect hands but should not be worn near rotating tools"
-              - "Closed-toe shoes with good traction are recommended"
-        
-        - inputs:
-            messages:
-              - role: user
-                content: "How do I choose the right sandpaper grit?"
-            custom_inputs:
-              configurable:
-                user_id: my_user_id
-                store_num: 87887
-          expectations:
-            expected_facts:
-              - "Coarse grit (40-60) is for heavy material removal and rough shaping"
-              - "Medium grit (80-120) is for general sanding and smoothing"
-              - "Fine grit (150-220) is for final sanding before finishing"
-              - "Start with coarser grit and progress to finer grits for best results"
-        
-        - inputs:
-            messages:
-              - role: user
-                content: "What's the best way to cut PVC pipe?"
-            custom_inputs:
-              configurable:
-                user_id: my_user_id
-                store_num: 87887
-          expectations:
-            expected_facts:
-              - "A PVC pipe cutter or ratcheting cutter provides the cleanest cuts"
-              - "A hacksaw or miter saw can also be used for cutting PVC"
-              - "Mark the cut line completely around the pipe for a straight cut"
-              - "Deburr the inside and outside edges after cutting"
-              - "Ensure cuts are square to the pipe for proper fittings"
+      - inputs:
+          messages:
+          - role: user
+            content: "What's the best drill for home use?"
+          custom_inputs:
+            configurable:
+              user_id: my_user_id
+              store_num: 87887
+        expectations:
+          expected_facts:
+          - "The best drill for home use is the Dewalt DCD777B 18V Cordless Drill/Driver with a 1/2-inch hex chuck."
+          - "The Dewalt DCD777B 18V Cordless Drill/Driver is a popular drill for home use."
+      - inputs:
+          messages:
+          - role: user
+            content: "How do I install a ceiling fan?"
+          custom_inputs:
+            configurable:
+              user_id: my_user_id
+              store_num: 87887
+        expectations:
+          expected_facts:
+          - "Turn off power at the circuit breaker before starting any electrical work"
+          - "You'll need a ceiling fan mounting bracket and electrical box rated for fan weight"
+          - "Connect the wiring: black to black (hot), white to white (neutral), green to copper (ground)"
+          - "Ensure the electrical box is securely mounted to a ceiling joist or use a fan brace"
+      - inputs:
+          messages:
+          - role: user
+            content: "What type of paint should I use for my bathroom?"
+          custom_inputs:
+            configurable:
+              user_id: my_user_id
+              store_num: 87887
+        expectations:
+          expected_facts:
+          - "Use moisture-resistant or mildew-resistant paint for bathrooms"
+          - "Semi-gloss or satin finish paints work best in bathrooms due to humidity"
+          - "Look for paints specifically labeled as 'bathroom paint' or with anti-microbial properties"
+      - inputs:
+          messages:
+          - role: user
+            content: "How do I fix a leaky faucet?"
+          custom_inputs:
+            configurable:
+              user_id: my_user_id
+              store_num: 87887
+        expectations:
+          expected_facts:
+          - "Turn off the water supply before starting repairs"
+          - "Common causes include worn washers, O-rings, or valve seats"
+          - "You'll typically need an adjustable wrench, screwdriver, and replacement parts"
+          - "Identify your faucet type (compression, cartridge, ball, or ceramic disk) for proper repair"
+      - inputs:
+          messages:
+          - role: user
+            content: "What tools do I need to hang drywall?"
+          custom_inputs:
+            configurable:
+              user_id: my_user_id
+              store_num: 87887
+        expectations:
+          expected_facts:
+          - "Essential tools include a drywall saw, utility knife, T-square, and screw gun"
+          - "You'll need drywall screws, joint compound, and tape for finishing"
+          - "A drywall lift can be helpful for ceiling installation"
+          - "Sandpaper or sanding screen is needed for finishing joints"
+      - inputs:
+          messages:
+          - role: user
+            content: "How do I install laminate flooring?"
+          custom_inputs:
+            configurable:
+              user_id: my_user_id
+              store_num: 87887
+        expectations:
+          expected_facts:
+          - "Start by ensuring the subfloor is clean, level, and dry"
+          - "Install underlayment before laying laminate planks"
+          - "Leave a 1/4-inch expansion gap around the perimeter"
+          - "Most laminate flooring uses a click-lock installation system"
+          - "Acclimate the flooring to room temperature for 48 hours before installation"
+      - inputs:
+          messages:
+          - role: user
+            content: "What's the difference between a nail gun and a hammer?"
+          custom_inputs:
+            configurable:
+              user_id: my_user_id
+              store_num: 87887
+        expectations:
+          expected_facts:
+          - "A nail gun drives nails much faster and with less physical effort than a hammer"
+          - "Nail guns are powered by compressed air, electricity, or fuel cells"
+          - "Hammers provide more control for precision work and don't require power"
+          - "Nail guns are better for large projects like framing or decking"
+      - inputs:
+          messages:
+          - role: user
+            content: "How do I properly prepare a surface for painting?"
+          custom_inputs:
+            configurable:
+              user_id: my_user_id
+              store_num: 87887
+        expectations:
+          expected_facts:
+          - "Clean the surface to remove dirt, grease, and loose paint"
+          - "Sand the surface to create a smooth base and improve paint adhesion"
+          - "Fill holes and cracks with spackling compound or wood filler"
+          - "Apply primer, especially on bare wood or patched areas"
+          - "Allow proper drying time between prep steps"
+      - inputs:
+          messages:
+          - role: user
+            content: "What safety equipment do I need for woodworking?"
+          custom_inputs:
+            configurable:
+              user_id: my_user_id
+              store_num: 87887
+        expectations:
+          expected_facts:
+          - "Safety glasses or goggles are essential to protect your eyes from debris"
+          - "Hearing protection is important when using power tools"
+          - "A dust mask or respirator protects against sawdust and fumes"
+          - "Work gloves protect hands but should not be worn near rotating tools"
+          - "Closed-toe shoes with good traction are recommended"
+      - inputs:
+          messages:
+          - role: user
+            content: "How do I choose the right sandpaper grit?"
+          custom_inputs:
+            configurable:
+              user_id: my_user_id
+              store_num: 87887
+        expectations:
+          expected_facts:
+          - "Coarse grit (40-60) is for heavy material removal and rough shaping"
+          - "Medium grit (80-120) is for general sanding and smoothing"
+          - "Fine grit (150-220) is for final sanding before finishing"
+          - "Start with coarser grit and progress to finer grits for best results"
+      - inputs:
+          messages:
+          - role: user
+            content: "What's the best way to cut PVC pipe?"
+          custom_inputs:
+            configurable:
+              user_id: my_user_id
+              store_num: 87887
+        expectations:
+          expected_facts:
+          - "A PVC pipe cutter or ratcheting cutter provides the cleanest cuts"
+          - "A hacksaw or miter saw can also be used for cutting PVC"
+          - "Mark the cut line completely around the pipe for a straight cut"
+          - "Deburr the inside and outside edges after cutting"
+          - "Ensure cuts are square to the pipe for proper fittings"
 
   prompt_optimizations:
     # Optimize the DIY agent prompt for improved responses
@@ -468,13 +464,11 @@ optimizations:
       name: optimize_diy_prompt
       prompt: *diy_prompt
       agent: *diy
-      
       # Dataset reference - can be:
       # 1. String name referencing training_datasets (above)
       # 2. String name of existing dataset in MLflow
       # 3. Inline EvaluationDatasetModel with data
       dataset: *hardware_store_diy_dataset
-      
       # Option 3: Inline dataset (alternative to referencing training_datasets)
       # dataset:
       #   name: inline_dataset
@@ -483,11 +477,9 @@ optimizations:
       #         text: "Example"  # Must match prompt template variables
       #       expectations:
       #         expected_response: "positive"
-      
       # Optional: Specify reflection model (defaults to agent's model)
       # Can be LLMModel reference or string model name
       reflection_model: "openai:/gpt-5"
       # Or use string: reflection_model: "databricks-claude-sonnet-4-5"
-      
       # Optional: Optimization parameters
       num_candidates: 5  # Number of candidate prompts to generate

--- a/config/examples/11_prompt_engineering/prompt_registry.yaml
+++ b/config/examples/11_prompt_engineering/prompt_registry.yaml
@@ -58,15 +58,15 @@ resources:
   # LANGUAGE MODELS (LLMs)
   # ---------------------------------------------------------------------------
   # Configure different LLMs for various purposes in the agent system
-  llms:
+  models:
 
     # LLM optimized for tool calling and function execution
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-3-7-sonnet 
+      name: databricks-claude-3-7-sonnet
       temperature: 0.1
       max_tokens: 8192
       fallbacks:                                     # Fallback models if primary fails
-        - databricks-claude-sonnet-4
+      - databricks-claude-sonnet-4
 
 
     # LLM for evaluating and judging responses (guardrails)
@@ -86,28 +86,30 @@ resources:
   vector_stores:
     # Product information vector store for similarity search
     products_vector_store: &products_vector_store
-      embedding_model: *embedding_model             # Reference to embedding model above
+      embedding_model: *embedding_model
+                                                    # Reference to embedding model above
       endpoint:                                     # Vector search endpoint configuration
         name: dbdemos_vs_endpoint            # Databricks vector search endpoint
         type: STANDARD                              # Endpoint type (STANDARD or OPTIMIZED_STORAGE)
       index:                                        # Vector search index configuration
-        schema: *retail_schema                      # Unity Catalog schema for the index
+        schema: *retail_schema
+                                                    # Unity Catalog schema for the index
         name: products_index                        # Index name
       source_table:                                 # Table containing source data
         schema: *retail_schema
         name: products
       primary_key: product_id                       # Primary key column
-      doc_uri: ~                                    # Optional document URI column (null in this case)
+      doc_uri:                                      # Optional document URI column (null in this case)
       embedding_source_column: description          # Column to create embeddings from
       columns:                                      # Columns to include in vector store
-        - product_id
-        - sku
-        - upc
-        - brand_name
-        - product_name
-        - merchandise_class
-        - class_cd
-        - description
+      - product_id
+      - sku
+      - upc
+      - brand_name
+      - product_name
+      - merchandise_class
+      - class_cd
+      - description
 
 
   # ---------------------------------------------------------------------------
@@ -117,9 +119,9 @@ resources:
   tables:
     # Product catalog table
     product_table:
-      schema: *retail_schema                        # Reference to schema defined above
+      schema: *retail_schema
+                                                    # Reference to schema defined above
       name: products                                # Table name
-    
     # Inventory tracking table
     inventory_table:
       schema: *retail_schema
@@ -138,7 +140,6 @@ resources:
     find_product_by_upc: &find_product_by_upc
       schema: *retail_schema
       name: find_product_by_upc                     # Function to find products by UPC
-    
     # Inventory lookup functions
     find_inventory_by_sku: &find_inventory_by_sku
       schema: *retail_schema
@@ -146,7 +147,6 @@ resources:
     find_inventory_by_upc: &find_inventory_by_upc
       schema: *retail_schema
       name: find_inventory_by_upc                   # Function to find inventory by UPC
-    
     # Store-specific inventory functions
     find_store_inventory_by_upc: &find_store_inventory_by_upc
       schema: *retail_schema
@@ -167,7 +167,6 @@ resources:
       #   prepare_threshold: 0                        # Disable prepared statements
       #   sslmode: require                            # Require SSL connection
       #   connect_timeout: 10                         # Connection timeout in seconds
-      
       # Optional: Connection pool configuration
       # max_pool_size: 20                             # Maximum connections in pool
       # timeout: 5                                    # Connection timeout in seconds
@@ -180,16 +179,17 @@ resources:
 retrievers:
   # Product information retriever using vector search
   products_retriever: &products_retriever
-    vector_store: *products_vector_store            # Reference to vector store defined above
+    vector_store: *products_vector_store
+                                                    # Reference to vector store defined above
     columns:                                        # Columns to return in search results
-      - product_id
-      - sku
-      - upc
-      - brand_name
-      - product_name
-      - merchandise_class
-      - class_cd
-      - description
+    - product_id
+    - sku
+    - upc
+    - brand_name
+    - product_name
+    - merchandise_class
+    - class_cd
+    - description
     search_parameters:                              # Search configuration
       num_results: 10                               # Maximum number of results to return
       filters: {}                                   # Additional filters (empty in this case)
@@ -211,7 +211,8 @@ tools:
       type: factory
       name: dao_ai.tools.create_vector_search_tool
       args:
-        retriever: *products_retriever              # Reference to retriever config
+        retriever: *products_retriever
+                                                    # Reference to retriever config
         name: product_vector_search_tool            # Tool instance name
         description: "Search for products by description"  # Tool description
 
@@ -219,13 +220,13 @@ tools:
   # UNITY CATALOG TOOLS
   # ---------------------------------------------------------------------------
   # Tools that directly call Unity Catalog functions
-  
   # Product lookup tools using Unity Catalog functions
   find_product_by_sku_tool: &find_product_by_sku_tool
     name: find_product_by_sku_uc
     function:
       type: unity_catalog                           # Tool type: Unity Catalog function
-      resource: *find_product_by_sku                # Reference to function definition
+      resource: *find_product_by_sku
+                                                    # Reference to function definition
 
   find_product_by_upc_tool: &find_product_by_upc_tool
     name: find_product_by_upc_uc
@@ -285,7 +286,6 @@ prompts:
       environment: production
       agent_type: general
     # auto_register: true  # Default behavior - auto-syncs to registry
-    
     # Example: To prevent automatic registration (e.g., for testing or controlled deployment):
     # auto_register: false  # Will only load from registry, never auto-register
     #                       # If not in registry, uses default_template locally
@@ -464,7 +464,7 @@ prompts:
       environment: production
       agent_type: product
 
-  inventory_prompt: &inventory_prompt 
+  inventory_prompt: &inventory_prompt
     schema: *retail_schema
     name: inventory_prompt
     description: "Comprehensive inventory specialist prompt with real-time stock checking, restock tracking, and availability management"
@@ -711,11 +711,13 @@ agents:
   general: &general
     name: general                                   # Agent identifier
     description: "General retail store assistant for home improvement and hardware store inquiries"
-    model: *tool_calling_llm                       # Reference to LLM configuration
+    model: *tool_calling_llm
+                                                   # Reference to LLM configuration
     tools:                                          # Tools available to this agent
-      - *find_product_details_by_description_tool
+    - *find_product_details_by_description_tool
     guardrails: []
-    prompt: *general_prompt                        # Reference to prompt (instead of inline)
+    prompt: *general_prompt
+                                                   # Reference to prompt (instead of inline)
     handoff_prompt: |                               # Conditions for routing to this agent
       General questions about store information, policies, hours, services, or basic product inquiries that don't require specialized expertise
       Example: "What are your store hours?" or "Do you offer installation services?" or "What's your return policy?"
@@ -730,7 +732,8 @@ agents:
     model: *tool_calling_llm
     tools: []                                       # No specific tools assigned (would be added as needed)
     guardrails: []
-    prompt: *orders_prompt                          # Reference to orders_prompt defined above
+    prompt: *orders_prompt
+                                                    # Reference to orders_prompt defined above
     handoff_prompt: |                               # Conditions for routing to this agent
       Questions about tracking orders, delivery status, scheduling deliveries or services, order modifications, cancellations, or returns
       Example: "When will my order arrive?" or "Can I schedule delivery for my new refrigerator?" or "I need to cancel my order"
@@ -744,7 +747,8 @@ agents:
     description: "DIY and home improvement expert providing how-to advice, project guidance, and tool recommendations"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool   # Can search for tools and materials
+    - *find_product_details_by_description_tool
+                                                    # Can search for tools and materials
     guardrails: []
     prompt: *diy_prompt
     handoff_prompt: |
@@ -756,9 +760,9 @@ agents:
     description: "Product specialist providing detailed information about specific products, features, specifications, and intended uses"
     model: *tool_calling_llm
     tools:
-      - *find_product_by_sku_tool
-      - *find_product_by_upc_tool
-      - *find_product_details_by_description_tool
+    - *find_product_by_sku_tool
+    - *find_product_by_upc_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: *product_prompt
     handoff_prompt: |
@@ -770,9 +774,9 @@ agents:
     description: "Inventory management specialist providing information about product availability, stock levels, and store inventory"
     model: *tool_calling_llm
     tools:
-      - *find_inventory_by_sku_tool
-      - *find_inventory_by_upc_tool
-      - *find_product_details_by_description_tool
+    - *find_inventory_by_sku_tool
+    - *find_inventory_by_upc_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: *inventory_prompt
     handoff_prompt: |
@@ -784,8 +788,8 @@ agents:
     description: "Product comparison specialist providing detailed comparisons between different products, highlighting key differences and best use cases"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool
-      - *find_product_by_sku_tool
+    - *find_product_details_by_description_tool
+    - *find_product_by_sku_tool
     guardrails: []
     prompt: *comparison_prompt
     handoff_prompt: |
@@ -797,7 +801,7 @@ agents:
     description: "Product recommendation specialist providing tailored product suggestions based on customer needs, preferences, and budget"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: *recommendation_prompt
     handoff_prompt: |
@@ -816,38 +820,41 @@ app:
   description: "Multi-agent system for retail customer service and product assistance"
   log_level: TRACE                                   # Logging level for the application
   registered_model:                                 # MLflow registered model configuration
-    schema: *retail_schema                          # Schema where model will be registered
+    schema: *retail_schema
+                                                    # Schema where model will be registered
     name: prompt_registry_dao
   endpoint_name: hardware_store_supervisor_dao                    # Model serving endpoint name
   tags:                                             # Tags for resource organization
     business: rcg                                   # Business unit identifier
     streaming: true                                 # Indicates streaming capabilities
   permissions:                                      # Model serving permissions
-    - principals: [users]                           # Grant access to all users
-      entitlements:
-        - CAN_QUERY                                # Full management permissions
+  - principals: [users]                             # Grant access to all users
+    entitlements:
+    - CAN_QUERY                                    # Full management permissions
   agents:                                           # List of agents included in the system
-    - *orders                                       # Order management agent
-    - *diy                                          # DIY and tutorials agent
-    - *product                                      # Product information agent
-    - *inventory                                    # Inventory management agent
-    - *comparison                                   # Product comparison agent
-    - *recommendation                               # Product recommendation agent
-    - *general                                      # General purpose agent
+  - *orders
+  - *diy
+  - *product
+  - *inventory
+  - *comparison
+  - *recommendation
+  - *general
+                                                    # General purpose agent
   orchestration:                                    # Agent orchestration configuration
     #memory: *memory                                 # Reference to memory configuration
     supervisor:                                     # Supervisor orchestration pattern
-      model: *tool_calling_llm                      # LLM for routing decisions
+      model: *tool_calling_llm
+                                                    # LLM for routing decisions
   input_example:
-      input:
-        - role: user
-          content: Can you recommend a lamp to match my oak side tables?
-      custom_inputs:
-        configurable:
+    input:
+    - role: user
+      content: Can you recommend a lamp to match my oak side tables?
+    custom_inputs:
+      configurable:
           # conversation_id is auto-generated as UUID if not provided
-          user_id: my_user_id
-          store_num: 87887
-        session: {}
+        user_id: my_user_id
+        store_num: 87887
+      session: {}
     # swarm:
     #   default_agent: *general
 
@@ -858,39 +865,38 @@ app:
 # These functions provide data access capabilities for the agent tools
 
 unity_catalog_functions:
-  - function: *find_inventory_by_sku
-    ddl: ../functions/hardware_store/find_inventory_by_sku.sql
-    test:
-      parameters:
-        sku: ["00176279"] 
-  - function: *find_inventory_by_upc
-    ddl: ../functions/hardware_store/find_inventory_by_upc.sql
-    test:
-      parameters:
-        upc: ["0017627748017"]
-  - function: *find_product_by_sku
-    ddl: ../functions/hardware_store/find_product_by_sku.sql
-    test:
-      parameters:
-        sku: ["00176279"]
-  - function: *find_product_by_upc
-    ddl: ../functions/hardware_store/find_product_by_upc.sql
-    test:
-      parameters:
-        upc: ["0017627748017"] 
-  - function: *find_store_inventory_by_sku
-    ddl: ../functions/hardware_store/find_store_inventory_by_sku.sql
-    test:
-      parameters:
-        store: "35048"
-        sku: ["00176279"]
-  - function: *find_store_inventory_by_upc
-    ddl: ../functions/hardware_store/find_store_inventory_by_upc.sql
-    test:
-      parameters:
-        store: "35048"
-        upc: ["0017627748017"]
- 
+- function: *find_inventory_by_sku
+  ddl: ../functions/hardware_store/find_inventory_by_sku.sql
+  test:
+    parameters:
+      sku: ["00176279"]
+- function: *find_inventory_by_upc
+  ddl: ../functions/hardware_store/find_inventory_by_upc.sql
+  test:
+    parameters:
+      upc: ["0017627748017"]
+- function: *find_product_by_sku
+  ddl: ../functions/hardware_store/find_product_by_sku.sql
+  test:
+    parameters:
+      sku: ["00176279"]
+- function: *find_product_by_upc
+  ddl: ../functions/hardware_store/find_product_by_upc.sql
+  test:
+    parameters:
+      upc: ["0017627748017"]
+- function: *find_store_inventory_by_sku
+  ddl: ../functions/hardware_store/find_store_inventory_by_sku.sql
+  test:
+    parameters:
+      store: "35048"
+      sku: ["00176279"]
+- function: *find_store_inventory_by_upc
+  ddl: ../functions/hardware_store/find_store_inventory_by_upc.sql
+  test:
+    parameters:
+      store: "35048"
+      upc: ["0017627748017"]
 # =============================================================================
 # EVALUATION CONFIGURATION
 # =============================================================================
@@ -916,15 +922,15 @@ evaluation:
 # and data files for initial population of Unity Catalog tables
 
 datasets:
-  - table: 
-      schema: *retail_schema
-      name: products
-    ddl: ../data/hardware_store/products.sql
-    data: ../data/hardware_store/products.snappy.parquet
-    format: parquet
-  - table: 
-      schema: *retail_schema
-      name: inventory
-    ddl: ../data/hardware_store/inventory.sql
-    data: ../data/hardware_store/inventory.snappy.parquet
-    format: parquet
+- table:
+    schema: *retail_schema
+    name: products
+  ddl: ../data/hardware_store/products.sql
+  data: ../data/hardware_store/products.snappy.parquet
+  format: parquet
+- table:
+    schema: *retail_schema
+    name: inventory
+  ddl: ../data/hardware_store/inventory.sql
+  data: ../data/hardware_store/inventory.snappy.parquet
+  format: parquet

--- a/config/examples/12_middleware/combined_middleware.yaml
+++ b/config/examples/12_middleware/combined_middleware.yaml
@@ -23,7 +23,7 @@ schemas:
     schema_name: ${var.schema}
 
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
@@ -48,13 +48,13 @@ middleware:
     name: dao_ai.middleware.create_custom_field_validation_middleware
     args:
       fields:
-        - name: store_num
-          description: "Store number for context"
-          example_value: "12345"
-        - name: user_id
-          description: "User identifier"
-          required: false
-          example_value: "user_abc"
+      - name: store_num
+        description: "Store number for context"
+        example_value: "12345"
+      - name: user_id
+        description: "User identifier"
+        required: false
+        example_value: "user_abc"
 
   # Step 2: Log the request
   request_logging: &request_logging
@@ -113,22 +113,23 @@ agents:
     description: "Production-ready agent with comprehensive middleware"
     model: *default_llm
     tools:
-      - *genie_tool
+    - *genie_tool
     middleware:
       # Middleware executes in order:
-      - *input_validation                   # 1. Validate required fields
-      - *request_logging                    # 2. Log incoming request
-      - *rate_limiting                      # 3. Check rate limits
-      - *performance_tracking               # 4. Monitor execution time
-      - *audit_logging                      # 5. Create audit trail
+    - *input_validation
+    - *request_logging
+    - *rate_limiting
+    - *performance_tracking
+    - *audit_logging
+                                            # 5. Create audit trail
     prompt: |
       ### Store Context
       - **Store Number**: {store_num}
       - **User ID**: {user_id}
-      
+
       You are a production-ready store assistant with comprehensive
       middleware for validation, logging, rate limiting, and auditing.
-      
+
       Your responses are monitored for quality and performance.
     handoff_prompt: |
       Store-related questions that require validated context and
@@ -143,9 +144,10 @@ agents:
     description: "Development agent with minimal middleware"
     model: *default_llm
     tools:
-      - *genie_tool
+    - *genie_tool
     middleware:
-      - *request_logging                    # Only logging for debugging
+    - *request_logging
+                                            # Only logging for debugging
     prompt: |
       You are a development assistant with minimal middleware.
       This configuration is suitable for testing and debugging.
@@ -159,15 +161,15 @@ app:
     name: combined_middleware_dao
   endpoint_name: combined_middleware_demo_dao
   agents:
-    - *production_agent
-    - *dev_agent
+  - *production_agent
+  - *dev_agent
   orchestration:
     supervisor:
       model: *default_llm
   input_example:
     messages:
-      - role: user
-        content: What products are available in my store?
+    - role: user
+      content: What products are available in my store?
     custom_inputs:
       configurable:
         store_num: "12345"

--- a/config/examples/12_middleware/context_management.yaml
+++ b/config/examples/12_middleware/context_management.yaml
@@ -36,7 +36,7 @@ schemas:
 # RESOURCES
 # =============================================================================
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
@@ -116,7 +116,7 @@ middleware:
   # CONSERVATIVE CONTEXT EDITING
   # ---------------------------------------------------------------------------
   # For agents that need more history preserved
-  conservative_context_editor: &conservative_context_editor
+  conservative_context_editor:
     name: dao_ai.middleware.create_context_editing_middleware
     args:
       trigger: 150000             # Higher threshold - wait longer to clear
@@ -139,21 +139,22 @@ middleware:
   # CONTEXT EDITING WITH EXCLUDED TOOLS
   # ---------------------------------------------------------------------------
   # Exclude certain tools from clearing (using YAML alias)
-  selective_context_editor: &selective_context_editor
+  selective_context_editor:
     name: dao_ai.middleware.create_context_editing_middleware
     args:
       trigger: 80000
       keep: 3
       exclude_tools:
-        - *time_tool              # Never clear time tool outputs
-        - current_time            # Can also use string name
+      - *time_tool
+                                  # Never clear time tool outputs
+      - current_time              # Can also use string name
       placeholder: "[cleared]"
 
   # ---------------------------------------------------------------------------
   # MODEL-BASED TOKEN COUNTING
   # ---------------------------------------------------------------------------
   # Uses model's tokenizer for accurate counting (slower but precise)
-  precise_context_editor: &precise_context_editor
+  precise_context_editor:
     name: dao_ai.middleware.create_context_editing_middleware
     args:
       trigger: 90000
@@ -174,22 +175,23 @@ agents:
     description: "Data analyst agent with context management for long sessions"
     model: *default_llm
     tools:
-      - *genie_tool
-      - *search_tool
-      - *time_tool
+    - *genie_tool
+    - *search_tool
+    - *time_tool
     middleware:
-      - *basic_context_editor     # Manage context for long conversations
+    - *basic_context_editor
+                                  # Manage context for long conversations
     prompt: |
       You are a data analyst assistant that helps users explore retail data.
-      
+
       You may make many queries during a session. The system automatically
       manages conversation context by clearing older tool outputs while
       keeping recent ones available.
-      
+
       If you see "[cleared]" in previous tool outputs, those results have been
       summarized for context management. You can re-run queries if you need
       the original data again.
-      
+
       Your capabilities:
       - Query retail data using the genie tool
       - Search the web for additional context
@@ -205,20 +207,20 @@ agents:
     description: "Research agent with aggressive context management"
     model: *default_llm
     tools:
-      - *search_tool
-      - *time_tool
+    - *search_tool
+    - *time_tool
     middleware:
-      - *aggressive_context_editor
+    - *aggressive_context_editor
     prompt: |
       You are a research assistant that performs extensive web searches.
-      
+
       Web search results can be verbose. The system aggressively manages
       context to keep conversations within token limits.
-      
+
       When you see "[output cleared for context management]", previous search
       results have been cleared. If you need that information again, perform
       a new search.
-      
+
       Tips:
       - Summarize key findings before moving to new searches
       - Reference specific facts rather than expecting full outputs to persist
@@ -233,17 +235,18 @@ agents:
     description: "Agent for extended sessions with full context clearing"
     model: *default_llm
     tools:
-      - *genie_tool
-      - *search_tool
+    - *genie_tool
+    - *search_tool
     middleware:
-      - *full_context_editor      # Clear both inputs and outputs
+    - *full_context_editor
+                                  # Clear both inputs and outputs
     prompt: |
       You are an assistant designed for extended analysis sessions.
-      
+
       To maximize the length of our conversation, the system clears both
       tool inputs AND outputs from older messages. This means previous
       queries and their results are summarized as "[cleared]".
-      
+
       Best practices:
       - Keep a mental summary of key findings
       - Re-query when you need specific data points
@@ -263,17 +266,16 @@ app:
     name: context_management_dao
   endpoint_name: context_management_demo_dao
   agents:
-    - *data_analyst_agent
-    - *research_agent
-    - *long_running_agent
+  - *data_analyst_agent
+  - *research_agent
+  - *long_running_agent
   orchestration:
     supervisor:
       model: *default_llm
-  
   input_example:
     messages:
-      - role: user
-        content: Analyze our top 10 products and compare them to industry trends.
+    - role: user
+      content: Analyze our top 10 products and compare them to industry trends.
     custom_inputs:
       configurable:
         thread_id: "long-session-123"

--- a/config/examples/12_middleware/custom_field_validation.yaml
+++ b/config/examples/12_middleware/custom_field_validation.yaml
@@ -30,7 +30,7 @@ schemas:
 # RESOURCES
 # =============================================================================
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
@@ -60,15 +60,15 @@ middleware:
     args:
       fields:
         # Required field - must be provided (no 'required: false')
-        - name: store_num
-          description: "Your store number for inventory lookups"
-          example_value: "12345"
-        
+      - name: store_num
+        description: "Your store number for inventory lookups"
+        example_value: "12345"
+
         # Optional field - shown in error message if missing, but not required
-        - name: user_id
-          description: "Your unique user identifier"
-          required: false
-          example_value: "user_abc123"
+      - name: user_id
+        description: "Your unique user identifier"
+        required: false
+        example_value: "user_abc123"
 
   # ---------------------------------------------------------------------------
   # API Key Validation
@@ -79,14 +79,13 @@ middleware:
     name: dao_ai.middleware.create_custom_field_validation_middleware
     args:
       fields:
-        - name: external_api_key
-          description: "API key for external service integration"
-          example_value: "sk-proj-xxxxxxxxxxxxx"
-        
-        - name: api_region
-          description: "API region (us-east, us-west, eu-west)"
-          required: false
-          example_value: "us-east"
+      - name: external_api_key
+        description: "API key for external service integration"
+        example_value: "sk-proj-xxxxxxxxxxxxx"
+      - name: api_region
+        description: "API region (us-east, us-west, eu-west)"
+        required: false
+        example_value: "us-east"
 
   # ---------------------------------------------------------------------------
   # Multi-Tenant Validation
@@ -97,19 +96,17 @@ middleware:
     name: dao_ai.middleware.create_custom_field_validation_middleware
     args:
       fields:
-        - name: tenant_id
-          description: "Your organization's tenant identifier"
-          example_value: "org_2a8d9c3b"
-        
-        - name: workspace_id
-          description: "Workspace ID within the tenant"
-          required: false
-          example_value: "ws_abc123"
-        
-        - name: user_role
-          description: "User's role (admin, manager, user)"
-          required: false
-          example_value: "manager"
+      - name: tenant_id
+        description: "Your organization's tenant identifier"
+        example_value: "org_2a8d9c3b"
+      - name: workspace_id
+        description: "Workspace ID within the tenant"
+        required: false
+        example_value: "ws_abc123"
+      - name: user_role
+        description: "User's role (admin, manager, user)"
+        required: false
+        example_value: "manager"
 
 # =============================================================================
 # TOOLS
@@ -137,17 +134,18 @@ agents:
     description: "Retail store assistant that requires store context"
     model: *default_llm
     tools:
-      - *genie_tool
+    - *genie_tool
     middleware:
-      - *store_validation                           # Validates store_num before execution
+    - *store_validation
+                                                    # Validates store_num before execution
     prompt: |
       ### Store Context
       - **Store Number**: {store_num}
       - **User ID**: {user_id}
-      
+
       You are a helpful store assistant. You have access to store-specific data
       and can answer questions about inventory, products, and store operations.
-      
+
       Always use the store_num context when querying data to ensure accurate,
       location-specific information.
     handoff_prompt: |
@@ -162,17 +160,18 @@ agents:
     description: "Agent that integrates with external APIs"
     model: *default_llm
     tools:
-      - *genie_tool
+    - *genie_tool
     middleware:
-      - *api_key_validation                        # Validates API credentials
+    - *api_key_validation
+                                                   # Validates API credentials
     prompt: |
       ### API Configuration
       - **API Key**: (provided securely)
       - **Region**: {api_region}
-      
+
       You are an integration specialist that can connect to external services.
       Use the provided API credentials to fetch data from third-party systems.
-      
+
       Always ensure API calls are secure and properly authenticated.
     handoff_prompt: |
       Questions that require data from external APIs or third-party integrations.
@@ -185,19 +184,20 @@ agents:
     description: "Multi-tenant agent with organization context"
     model: *default_llm
     tools:
-      - *genie_tool
+    - *genie_tool
     middleware:
-      - *tenant_validation                         # Validates tenant context
+    - *tenant_validation
+                                                   # Validates tenant context
     prompt: |
       ### Tenant Context
       - **Tenant ID**: {tenant_id}
       - **Workspace**: {workspace_id}
       - **User Role**: {user_role}
-      
+
       You are an enterprise assistant serving multiple organizations.
       Always scope your responses and data access to the current tenant context
       to ensure proper data isolation and security.
-      
+
       Respect user roles and permissions when providing information.
     handoff_prompt: |
       Enterprise-level questions that require tenant-specific context.
@@ -214,31 +214,28 @@ app:
     name: field_validation_middleware_dao
   endpoint_name: field_validation_middleware_demo_dao
   agents:
-    - *store_agent
-    - *api_agent
-    - *tenant_agent
+  - *store_agent
+  - *api_agent
+  - *tenant_agent
   orchestration:
     supervisor:
       model: *default_llm
-  
   # ---------------------------------------------------------------------------
   # Input Examples
   # ---------------------------------------------------------------------------
   # These show the correct format for providing validated fields
   input_example:
     messages:
-      - role: user
-        content: What products do we have in stock?
+    - role: user
+      content: What products do we have in stock?
     custom_inputs:
       configurable:
         # Store Agent requires these fields:
         store_num: "12345"              # Required by store_validation
         user_id: "user_abc123"          # Optional but recommended
-        
         # API Agent requires these fields:
         # external_api_key: "sk-xxxxx"  # Required by api_key_validation
         # api_region: "us-east"         # Optional
-        
         # Tenant Agent requires these fields:
         # tenant_id: "org_2a8d9c3b"     # Required by tenant_validation
         # workspace_id: "ws_abc123"     # Optional

--- a/config/examples/12_middleware/deepagents_middleware.yaml
+++ b/config/examples/12_middleware/deepagents_middleware.yaml
@@ -31,13 +31,13 @@ schemas:
     schema_name: ${var.schema}
 
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
       max_tokens: 4096
 
-    summarization_llm: &summarization_llm
+    summarization_llm:
       name: databricks-claude-sonnet-4
       temperature: 0.0
       max_tokens: 2048
@@ -108,7 +108,7 @@ middleware:
   # Example with "volume" backend (Databricks Unity Catalog Volumes):
   # Agent reads and writes files in /Volumes/my_catalog/my_schema/agent_workspace.
   # All file paths the agent sees are relative to this root.
-  filesystem_volume: &filesystem_volume
+  filesystem_volume:
     name: dao_ai.middleware.filesystem.create_filesystem_middleware
     args:
       backend_type: volume
@@ -149,20 +149,20 @@ middleware:
     args:
       subagents:
         # String model -- passed through to deepagents
-        - name: researcher
-          description: "Research agent for gathering information"
-          system_prompt: "You are a research specialist. Find and summarize information."
-          model: "openai:gpt-4o-mini"
-          tools: []
+      - name: researcher
+        description: "Research agent for gathering information"
+        system_prompt: "You are a research specialist. Find and summarize information."
+        model: "openai:gpt-4o-mini"
+        tools: []
         # Dict model -- converted to ChatDatabricks via LLMModel.as_chat_model()
-        - name: analyst
-          description: "Data analysis agent using a Databricks serving endpoint"
-          system_prompt: "You are a data analyst. Analyze data and provide insights."
-          model:
-            name: "databricks-meta-llama-3-3-70b-instruct"
-            temperature: 0.1
-            max_tokens: 4096
-          tools: []
+      - name: analyst
+        description: "Data analysis agent using a Databricks serving endpoint"
+        system_prompt: "You are a data analyst. Analyze data and provide insights."
+        model:
+          name: "databricks-meta-llama-3-3-70b-instruct"
+          temperature: 0.1
+          max_tokens: 4096
+        tools: []
 
   # ---------------------------------------------------------------------------
   # 4. Skill Discovery (SkillsMiddleware)
@@ -170,24 +170,24 @@ middleware:
   # Discovers SKILL.md files and injects a skill listing into the system
   # prompt with progressive disclosure. Agents can read full skill content
   # on demand.
-  skills: &skills
+  skills:
     name: dao_ai.middleware.skills.create_skills_middleware
     args:
       sources:
-        - /skills/base/
-        - /skills/user/
+      - /skills/base/
+      - /skills/user/
 
   # ---------------------------------------------------------------------------
   # 5. AGENTS.md Memory (MemoryMiddleware)
   # ---------------------------------------------------------------------------
   # Loads context from AGENTS.md files at startup and injects it into the
   # system prompt. Encourages the agent to update memory files as it learns.
-  memory: &memory
+  memory:
     name: dao_ai.middleware.memory_agents.create_agents_memory_middleware
     args:
       sources:
-        - ~/.deepagents/AGENTS.md
-        - ./.deepagents/AGENTS.md
+      - ~/.deepagents/AGENTS.md
+      - ./.deepagents/AGENTS.md
 
   # ---------------------------------------------------------------------------
   # 6. Enhanced Summarization (Deep Agents SummarizationMiddleware)
@@ -225,12 +225,12 @@ agents:
     description: "An agent with Deep Agents middleware for task planning and file operations"
     model: *default_llm
     tools:
-      - *time_tool
+    - *time_tool
     middleware:
-      - *todo                  # Task planning via write_todos tool
-      - *filesystem            # File operations (ephemeral state backend)
-      # - *filesystem_volume   # Swap above for Databricks Volume backend
-      - *summarization         # Context management via enhanced summarization
+    - *todo
+    - *filesystem
+    - *summarization
+                               # Context management via enhanced summarization
     prompt: |
       You are a helpful coding assistant with file operation capabilities.
 
@@ -246,10 +246,11 @@ agents:
     description: "A supervisor agent that can delegate to specialized subagents"
     model: *default_llm
     tools:
-      - *time_tool
+    - *time_tool
     middleware:
-      - *todo                  # Task planning
-      - *subagent              # Spawn isolated subagents via task tool
+    - *todo
+    - *subagent
+                               # Spawn isolated subagents via task tool
     prompt: |
       You are a supervisor agent. Break complex tasks into subtasks and
       delegate them to specialized subagents using the task tool.
@@ -267,15 +268,15 @@ app:
     name: deepagents_middleware_dao
   endpoint_name: deepagents_middleware_demo_dao
   agents:
-    - *coding_agent
-    - *supervisor_agent
+  - *coding_agent
+  - *supervisor_agent
   orchestration:
     supervisor:
       model: *default_llm
   input_example:
     messages:
-      - role: user
-        content: Create a todo list for building a REST API
+    - role: user
+      content: Create a todo list for building a REST API
     custom_inputs:
       configurable: {}
       session: {}

--- a/config/examples/12_middleware/limit_middleware.yaml
+++ b/config/examples/12_middleware/limit_middleware.yaml
@@ -35,7 +35,7 @@ schemas:
 # RESOURCES
 # =============================================================================
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
@@ -127,7 +127,8 @@ middleware:
   search_limit: &search_limit
     name: dao_ai.middleware.create_tool_call_limit_middleware
     args:
-      tool: *search_tool          # Can reference the tool model directly
+      tool: *search_tool
+                                  # Can reference the tool model directly
       thread_limit: 8             # Max 8 searches per conversation
       run_limit: 4                # Max 4 searches per message
       exit_behavior: continue
@@ -178,24 +179,25 @@ agents:
     description: "Research agent with tool call limits for cost control"
     model: *default_llm
     tools:
-      - *genie_tool
-      - *search_tool
-      - *time_tool
+    - *genie_tool
+    - *search_tool
+    - *time_tool
     middleware:
       # Multiple ToolCallLimitMiddleware instances work because each has a unique name
-      - *global_tool_limit        # Name: ToolCallLimitMiddleware (global safety net)
-      - *genie_limit              # Name: ToolCallLimitMiddleware[genie]
-      - *search_limit             # Name: ToolCallLimitMiddleware[search_web]
-      - *model_call_limit         # LLM cost control
+    - *global_tool_limit
+    - *genie_limit
+    - *search_limit
+    - *model_call_limit
+                                  # LLM cost control
     prompt: |
       You are a research assistant that can:
       - Query retail data using the genie tool
       - Search the web for additional information
       - Check the current time
-      
+
       Be efficient with your tool usage. If you hit a limit, try a different
       approach or provide the best answer with available information.
-      
+
       When you receive a limit error, acknowledge it and provide a partial
       answer based on what you've already learned.
     handoff_prompt: |
@@ -209,20 +211,21 @@ agents:
     description: "Agent with strict limits for high-cost environments"
     model: *default_llm
     tools:
-      - *genie_tool
-      - *time_tool
+    - *genie_tool
+    - *time_tool
     middleware:
-      - *strict_genie_limit       # ONE ToolCallLimitMiddleware (strict)
-      - *strict_model_limit       # ONE ModelCallLimitMiddleware (strict)
+    - *strict_genie_limit
+    - *strict_model_limit
+                                  # ONE ModelCallLimitMiddleware (strict)
     prompt: |
       You are a budget-conscious assistant. You have very limited
       API calls available, so be strategic with your queries.
-      
+
       Before making a query:
       1. Plan what information you actually need
       2. Combine multiple questions into one query when possible
       3. Use cached or previous information when available
-      
+
       If a limit is reached, execution will stop immediately.
     handoff_prompt: |
       Questions that require minimal, strategic tool usage.
@@ -235,10 +238,10 @@ agents:
     description: "Simple agent with basic global limits"
     model: *default_llm
     tools:
-      - *time_tool
+    - *time_tool
     middleware:
-      - *global_tool_limit
-      - *model_call_limit
+    - *global_tool_limit
+    - *model_call_limit
     prompt: |
       You are a simple assistant. Answer user questions helpfully.
     handoff_prompt: |
@@ -256,17 +259,16 @@ app:
     name: limit_middleware_dao
   endpoint_name: limit_middleware_demo_dao
   agents:
-    - *research_agent
-    - *budget_agent
-    - *simple_agent
+  - *research_agent
+  - *budget_agent
+  - *simple_agent
   orchestration:
     supervisor:
       model: *default_llm
-  
   input_example:
     messages:
-      - role: user
-        content: What products are low on stock?
+    - role: user
+      content: What products are low on stock?
     custom_inputs:
       configurable:
         thread_id: "example-thread-123"

--- a/config/examples/12_middleware/logging_middleware.yaml
+++ b/config/examples/12_middleware/logging_middleware.yaml
@@ -23,7 +23,7 @@ schemas:
     schema_name: ${var.schema}
 
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
@@ -108,10 +108,11 @@ agents:
     description: "Agent with request logging enabled"
     model: *default_llm
     tools:
-      - *genie_tool
-      - *current_time
+    - *genie_tool
+    - *current_time
     middleware:
-      - *request_logger                     # Logs all requests
+    - *request_logger
+                                            # Logs all requests
     prompt: |
       You are a helpful assistant with request logging enabled.
       All interactions are logged for quality assurance.
@@ -124,9 +125,10 @@ agents:
     description: "Agent with performance monitoring"
     model: *default_llm
     tools:
-      - *genie_tool
+    - *genie_tool
     middleware:
-      - *performance_monitor                # Tracks execution time
+    - *performance_monitor
+                                            # Tracks execution time
     prompt: |
       You are a helpful assistant with performance monitoring.
       Slow operations will be flagged for optimization.
@@ -139,10 +141,11 @@ agents:
     description: "Agent with comprehensive audit logging"
     model: *default_llm
     tools:
-      - *genie_tool
-      - *current_time
+    - *genie_tool
+    - *current_time
     middleware:
-      - *audit_trail                        # Full audit logs
+    - *audit_trail
+                                            # Full audit logs
     prompt: |
       You are a helpful assistant with comprehensive audit logging.
       All actions are tracked for compliance and security purposes.
@@ -156,16 +159,16 @@ app:
     name: logging_middleware_dao
   endpoint_name: logging_middleware_demo_dao
   agents:
-    - *logged_agent
-    - *monitored_agent
-    - *audited_agent
+  - *logged_agent
+  - *monitored_agent
+  - *audited_agent
   orchestration:
     supervisor:
       model: *default_llm
   input_example:
     messages:
-      - role: user
-        content: What time is it?
+    - role: user
+      content: What time is it?
     custom_inputs:
       configurable:
         user_id: "test_user_123"

--- a/config/examples/12_middleware/pii_middleware.yaml
+++ b/config/examples/12_middleware/pii_middleware.yaml
@@ -36,7 +36,7 @@ schemas:
 # RESOURCES
 # =============================================================================
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
@@ -155,7 +155,7 @@ middleware:
   # INPUT-ONLY PROTECTION
   # ---------------------------------------------------------------------------
   # Only check user inputs, not agent outputs
-  input_email_check: &input_email_check
+  input_email_check:
     name: dao_ai.middleware.create_pii_middleware
     args:
       pii_type: email
@@ -203,31 +203,32 @@ agents:
     description: "Customer service agent with comprehensive PII protection"
     model: *default_llm
     tools:
-      - *genie_tool
-      - *time_tool
+    - *genie_tool
+    - *time_tool
     middleware:
       # Apply multiple PII protections
-      - *email_redact             # Redact email addresses
-      - *phone_mask               # Mask phone numbers
-      - *ssn_block                # Block SSN entirely
-      - *credit_card_hash         # Hash credit card numbers
+    - *email_redact
+    - *phone_mask
+    - *ssn_block
+    - *credit_card_hash
+                                  # Hash credit card numbers
     prompt: |
       You are a customer service assistant for a retail company.
-      
+
       IMPORTANT: For privacy compliance, the system automatically:
       - Redacts email addresses as [REDACTED]
       - Masks phone numbers partially
       - Blocks messages containing Social Security Numbers
       - Hashes credit card numbers
-      
+
       If a customer shares sensitive information, acknowledge that it has
       been protected and assure them their privacy is maintained.
-      
+
       You can help with:
       - Order status inquiries
       - Product questions
       - General customer support
-      
+
       Never ask customers for sensitive personal information. Use account
       lookup tools instead of asking for SSN or credit card numbers.
     handoff_prompt: |
@@ -241,27 +242,27 @@ agents:
     description: "Healthcare assistant with strict PII protection for compliance"
     model: *default_llm
     tools:
-      - *time_tool
+    - *time_tool
     middleware:
       # Strict protection for healthcare
-      - *email_redact
-      - *phone_mask
-      - *ssn_block
-      - *address_redact
+    - *email_redact
+    - *phone_mask
+    - *ssn_block
+    - *address_redact
     prompt: |
       You are a healthcare information assistant.
-      
+
       PRIVACY NOTICE: For HIPAA compliance, this system automatically:
       - Redacts email addresses
       - Masks phone numbers
       - Blocks Social Security Numbers
       - Redacts physical addresses
-      
+
       You can provide general health information, but you cannot:
       - Access or discuss specific patient records
       - Store or transmit protected health information
       - Provide medical diagnoses or treatment recommendations
-      
+
       For specific medical concerns, please consult a healthcare provider.
     handoff_prompt: |
       General health questions (not specific patient information).
@@ -274,21 +275,22 @@ agents:
     description: "Data analyst with PII protection on query results"
     model: *default_llm
     tools:
-      - *genie_tool
+    - *genie_tool
     middleware:
-      - *tool_pii_check           # Protect PII in database query results
-      - *output_phone_check       # Mask phone numbers in outputs
+    - *tool_pii_check
+    - *output_phone_check
+                                  # Mask phone numbers in outputs
     prompt: |
       You are a data analyst assistant that queries retail databases.
-      
+
       The system automatically masks or redacts personally identifiable
       information in query results to protect customer privacy.
-      
+
       When analyzing customer data:
       - Focus on aggregated metrics and trends
       - Don't attempt to identify individual customers
       - Report on patterns rather than specific personal details
-      
+
       If query results show masked data like "j***@email.com", this is
       intentional privacy protection.
     handoff_prompt: |
@@ -306,17 +308,16 @@ app:
     name: pii_middleware_dao
   endpoint_name: pii_middleware_demo_dao
   agents:
-    - *customer_service_agent
-    - *healthcare_agent
-    - *data_analysis_agent
+  - *customer_service_agent
+  - *healthcare_agent
+  - *data_analysis_agent
   orchestration:
     supervisor:
       model: *default_llm
-  
   input_example:
     messages:
-      - role: user
-        content: I need help with my order. My email is john@example.com
+    - role: user
+      content: I need help with my order. My email is john@example.com
     custom_inputs:
       configurable:
         thread_id: "privacy-example-123"

--- a/config/examples/12_middleware/retry_middleware.yaml
+++ b/config/examples/12_middleware/retry_middleware.yaml
@@ -35,7 +35,7 @@ schemas:
 # RESOURCES
 # =============================================================================
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
@@ -174,23 +174,24 @@ agents:
     description: "Production-ready agent with comprehensive retry logic"
     model: *default_llm
     tools:
-      - *genie_tool
-      - *search_tool
-      - *time_tool
+    - *genie_tool
+    - *search_tool
+    - *time_tool
     middleware:
-      - *tools_retry              # Tool retry logic for all tools
-      - *model_retry              # LLM retry logic
+    - *tools_retry
+    - *model_retry
+                                  # LLM retry logic
     prompt: |
       You are a resilient research assistant designed for production use.
-      
+
       If a tool call fails, the system will automatically retry with
       exponential backoff. You don't need to manually handle transient errors.
-      
+
       Your capabilities:
       - Query retail data using the genie tool
       - Search the web for additional information
       - Check the current time
-      
+
       Focus on providing accurate, helpful responses. The retry middleware
       handles temporary failures automatically.
     handoff_prompt: |
@@ -204,17 +205,18 @@ agents:
     description: "Agent with aggressive retry for maximum reliability"
     model: *default_llm
     tools:
-      - *genie_tool
+    - *genie_tool
     middleware:
-      - *critical_retry           # Aggressive tool retry
-      - *aggressive_model_retry   # Aggressive LLM retry
+    - *critical_retry
+    - *aggressive_model_retry
+                                  # Aggressive LLM retry
     prompt: |
       You are a high-availability assistant. Your tools have aggressive
       retry logic to ensure maximum reliability.
-      
+
       If failures persist after many retries, the system will raise an
       error to indicate a genuine service outage.
-      
+
       Focus on providing accurate answers from the retail database.
     handoff_prompt: |
       Critical queries that must succeed.
@@ -227,10 +229,11 @@ agents:
     description: "Simple agent with basic retry for common failures"
     model: *default_llm
     tools:
-      - *time_tool
+    - *time_tool
     middleware:
-      - *basic_tool_retry         # Basic retry for all tools
-      - *model_retry              # Basic LLM retry
+    - *basic_tool_retry
+    - *model_retry
+                                  # Basic LLM retry
     prompt: |
       You are a simple assistant. Answer user questions helpfully.
       The system handles temporary failures automatically.
@@ -249,17 +252,16 @@ app:
     name: retry_middleware_dao
   endpoint_name: retry_middleware_demo_dao
   agents:
-    - *resilient_agent
-    - *high_availability_agent
-    - *simple_agent
+  - *resilient_agent
+  - *high_availability_agent
+  - *simple_agent
   orchestration:
     supervisor:
       model: *default_llm
-  
   input_example:
     messages:
-      - role: user
-        content: What products are trending this week?
+    - role: user
+      content: What products are trending this week?
     custom_inputs:
       configurable:
         thread_id: "example-thread-123"

--- a/config/examples/12_middleware/tool_selector_middleware.yaml
+++ b/config/examples/12_middleware/tool_selector_middleware.yaml
@@ -34,7 +34,7 @@ parameters:
 # DATABRICKS SCHEMAS
 # =============================================================================
 schemas:
-  retail_schema: &retail_schema
+  retail_schema:
     catalog_name: ${var.catalog}
     schema_name: ${var.schema}
 
@@ -42,7 +42,7 @@ schemas:
 # RESOURCES
 # =============================================================================
 resources:
-  llms:
+  models:
     # Main agent model - more expensive, more capable
     main_llm: &main_llm
       name: databricks-claude-sonnet-4
@@ -188,10 +188,12 @@ middleware:
   basic_selector: &basic_selector
     name: dao_ai.middleware.create_llm_tool_selector_middleware
     args:
-      model: *selector_llm          # Fast, cheap model for filtering
+      model: *selector_llm
+                                    # Fast, cheap model for filtering
       max_tools: 3                   # Select top 3 most relevant tools
       always_include:                # Tools to always keep available
-        - *search_tool               # Web search often useful
+      - *search_tool
+                                     # Web search often useful
 
   # ---------------------------------------------------------------------------
   # RESEARCH-FOCUSED SELECTOR
@@ -203,8 +205,9 @@ middleware:
       model: *selector_llm
       max_tools: 5                   # Allow more tools for research
       always_include:
-        - *search_tool               # Web search
-        - *wikipedia_tool            # Wikipedia
+      - *search_tool
+      - *wikipedia_tool
+                                     # Wikipedia
 
   # ---------------------------------------------------------------------------
   # DATA-FOCUSED SELECTOR
@@ -216,8 +219,9 @@ middleware:
       model: *selector_llm
       max_tools: 4
       always_include:
-        - *genie_tool                # Always include Genie for data queries
-        - *sql_query_tool            # Direct SQL access
+      - *genie_tool
+      - *sql_query_tool
+                                     # Direct SQL access
 
   # ---------------------------------------------------------------------------
   # AGGRESSIVE SELECTOR (Cost Optimization)
@@ -230,7 +234,7 @@ middleware:
       model: *selector_llm
       max_tools: 2                   # Very selective
       always_include:
-        - search_web                 # Use tool name string instead of alias
+      - search_web                   # Use tool name string instead of alias
 
 # =============================================================================
 # AGENT DEFINITIONS
@@ -249,20 +253,21 @@ agents:
     llm: *main_llm
     tools:
       # Register ALL tools - selector will filter at runtime
-      - *genie_tool
-      - *sql_query_tool
-      - *search_tool
-      - *wikipedia_tool
-      - *email_tool
-      - *slack_tool
-      - *read_file_tool
-      - *write_file_tool
-      - *time_tool
-      - *calculator_tool
-      - *weather_tool
-      - *calendar_tool
+    - *genie_tool
+    - *sql_query_tool
+    - *search_tool
+    - *wikipedia_tool
+    - *email_tool
+    - *slack_tool
+    - *read_file_tool
+    - *write_file_tool
+    - *time_tool
+    - *calculator_tool
+    - *weather_tool
+    - *calendar_tool
     middleware:
-      - *basic_selector              # Dynamically select 3 most relevant
+    - *basic_selector
+                                     # Dynamically select 3 most relevant
 
   # ---------------------------------------------------------------------------
   # DATA ANALYST AGENT
@@ -275,15 +280,16 @@ agents:
       Prioritizes data query tools but can access others as needed.
     llm: *main_llm
     tools:
-      - *genie_tool
-      - *sql_query_tool
-      - *search_tool
-      - *calculator_tool
-      - *time_tool
-      - *read_file_tool
-      - *write_file_tool
+    - *genie_tool
+    - *sql_query_tool
+    - *search_tool
+    - *calculator_tool
+    - *time_tool
+    - *read_file_tool
+    - *write_file_tool
     middleware:
-      - *data_selector               # Always includes Genie + SQL
+    - *data_selector
+                                     # Always includes Genie + SQL
 
   # ---------------------------------------------------------------------------
   # RESEARCH AGENT
@@ -296,15 +302,16 @@ agents:
       Always has access to search tools, selects others as needed.
     llm: *main_llm
     tools:
-      - *search_tool
-      - *wikipedia_tool
-      - *genie_tool                  # For internal data research
-      - *read_file_tool
-      - *write_file_tool
-      - *calculator_tool
-      - *time_tool
+    - *search_tool
+    - *wikipedia_tool
+    - *genie_tool
+    - *read_file_tool
+    - *write_file_tool
+    - *calculator_tool
+    - *time_tool
     middleware:
-      - *research_selector           # Always includes search + wikipedia
+    - *research_selector
+                                     # Always includes search + wikipedia
 
   # ---------------------------------------------------------------------------
   # COST-OPTIMIZED AGENT
@@ -317,14 +324,15 @@ agents:
       Only 2 tools selected per turn to minimize token usage.
     llm: *main_llm
     tools:
-      - *search_tool
-      - *genie_tool
-      - *calculator_tool
-      - *time_tool
-      - *weather_tool
-      - *calendar_tool
+    - *search_tool
+    - *genie_tool
+    - *calculator_tool
+    - *time_tool
+    - *weather_tool
+    - *calendar_tool
     middleware:
-      - *cost_optimized_selector     # Very selective: only 2 tools
+    - *cost_optimized_selector
+                                     # Very selective: only 2 tools
 
 # =============================================================================
 # CONFIGURATION

--- a/config/examples/13_orchestration/deep_agent_pattern.yaml
+++ b/config/examples/13_orchestration/deep_agent_pattern.yaml
@@ -18,7 +18,7 @@
 # RESOURCES
 # =============================================================================
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
@@ -59,7 +59,7 @@ app:
     name: deep_agent_minimal
 
   agents:
-    - *main_agent
+  - *main_agent
 
   # ---------------------------------------------------------------------------
   # ORCHESTRATION
@@ -73,7 +73,7 @@ app:
       # Tools merge with deepagents' built-in suite:
       # write_todos, ls, read_file, write_file, edit_file, glob, grep, execute, task
       tools:
-        - *current_time
+      - *current_time
 
       # Inline system prompt. PromptModel references also work.
       system_prompt: |
@@ -83,5 +83,5 @@ app:
 
   input_example:
     messages:
-      - role: user
-        content: "Plan a research task about cordless drills under $200, then summarize."
+    - role: user
+      content: "Plan a research task about cordless drills under $200, then summarize."

--- a/config/examples/13_orchestration/deep_agent_with_skills.yaml
+++ b/config/examples/13_orchestration/deep_agent_with_skills.yaml
@@ -35,7 +35,7 @@ schemas:
 # RESOURCES
 # =============================================================================
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
@@ -82,7 +82,8 @@ agents:
     description: "Sporting goods research specialist"
     model: *default_llm
     skills:
-      - *research_skill         # R1: skill on agent → middleware
+    - *research_skill
+                                # R1: skill on agent → middleware
     prompt: |
       You investigate products thoroughly using the loaded research skill.
       For comparison questions, surface trade-offs honestly. Always cite
@@ -103,7 +104,8 @@ app:
     name: deep_agent_skills
 
   agents:
-    - *research_specialist      # R2: implicit sub-agent (no need to re-list under subagents)
+  - *research_specialist
+                                # R2: implicit sub-agent (no need to re-list under subagents)
 
   orchestration:
     deep_agent:
@@ -116,15 +118,15 @@ app:
         than two steps.
 
       tools:
-        - *current_time
+      - *current_time
 
       # Top-level skills (passed natively to create_deep_agent(skills=...)).
       skills:
-        - *governed_lookup_skill
+      - *governed_lookup_skill
 
       # AGENTS.md instruction files loaded into the system prompt at startup.
       instruction_files:
-        - skills/sporting_goods_store/research/AGENTS.md
+      - skills/sporting_goods_store/research/AGENTS.md
 
       # R2: Dict-form subagents for extras not already in app.agents.
       # The dict key becomes the sub-agent's name.
@@ -137,15 +139,15 @@ app:
 
       # Filesystem permissions — read everywhere, write only under /workspace.
       permissions:
-        - paths: ["/workspace/**"]
-          mode: allow
-          operations: [read, write]
-        - paths: ["/**"]
-          mode: allow
-          operations: [read]
-        - paths: ["/**"]
-          mode: deny
-          operations: [write]
+      - paths: ["/workspace/**"]
+        mode: allow
+        operations: [read, write]
+      - paths: ["/**"]
+        mode: allow
+        operations: [read]
+      - paths: ["/**"]
+        mode: deny
+        operations: [write]
 
       # Human-in-the-loop on potentially destructive ops.
       interrupt_on:
@@ -153,5 +155,5 @@ app:
 
   input_example:
     messages:
-      - role: user
-        content: "Use your research skill to recommend a softball bat under $200 for a 12-year-old."
+    - role: user
+      content: "Use your research skill to recommend a softball bat under $200 for a 12-year-old."

--- a/config/examples/13_orchestration/deep_agent_with_subagents.yaml
+++ b/config/examples/13_orchestration/deep_agent_with_subagents.yaml
@@ -19,7 +19,7 @@
 # RESOURCES
 # =============================================================================
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
@@ -56,7 +56,7 @@ agents:
     description: "Product information specialist for sporting goods"
     model: *default_llm
     tools:
-      - *current_time
+    - *current_time
     prompt: |
       You answer detailed product questions: specifications, features, pricing,
       use cases. When a question is about availability or stock counts, defer
@@ -68,7 +68,7 @@ agents:
     description: "Inventory and availability specialist"
     model: *fast_llm
     tools:
-      - *current_time
+    - *current_time
     prompt: |
       You answer questions about stock counts, store availability, and
       restocking ETAs.
@@ -85,9 +85,9 @@ app:
     name: deep_agent_subagents
 
   agents:
-    - *main_agent
-    - *product_specialist
-    - *inventory_specialist
+  - *main_agent
+  - *product_specialist
+  - *inventory_specialist
 
   orchestration:
     deep_agent:
@@ -100,22 +100,22 @@ app:
 
       subagents:
         # Form 1: AgentModel anchor — full carry-over.
-        - *product_specialist
+      - *product_specialist
 
         # Form 2: string reference — looked up in app.agents by name.
-        - inventory_specialist
+      - inventory_specialist
 
         # Form 3: inline SubAgentModel — declarative dict.
-        - name: math_helper
-          description: >-
-            Quick math helper. Use for unit conversions, percentage discounts,
-            and arithmetic on prices.
-          system_prompt: |
-            You are a precise calculator. Show your work briefly before
-            stating the final number.
-          model: *fast_llm
+      - name: math_helper
+        description: >-
+          Quick math helper. Use for unit conversions, percentage discounts,
+          and arithmetic on prices.
+        system_prompt: |
+          You are a precise calculator. Show your work briefly before
+          stating the final number.
+        model: *fast_llm
 
   input_example:
     messages:
-      - role: user
-        content: "I need a softball bat under $200. Find me one and tell me if it's in stock."
+    - role: user
+      content: "I need a softball bat under $200. Find me one and tell me if it's in stock."

--- a/config/examples/13_orchestration/deterministic_handoff_pattern.yaml
+++ b/config/examples/13_orchestration/deterministic_handoff_pattern.yaml
@@ -21,7 +21,7 @@
 # RESOURCES
 # =============================================================================
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
@@ -103,10 +103,10 @@ app:
     name: deterministic_handoff_dao
 
   agents:
-    - *triage_agent
-    - *resolution_agent
-    - *summary_agent
-    - *escalation_agent
+  - *triage_agent
+  - *resolution_agent
+  - *summary_agent
+  - *escalation_agent
 
   orchestration:
     swarm:
@@ -121,14 +121,14 @@ app:
       # escalation_agent: no handoffs (terminal node)
       handoffs:
         triage_agent:
-          - agent: resolution_agent
-            is_deterministic: true
+        - agent: resolution_agent
+          is_deterministic: true
         resolution_agent:
-          - agent: summary_agent
-            is_deterministic: true
-          - escalation_agent           # agentic: LLM can choose to escalate
+        - agent: summary_agent
+          is_deterministic: true
+        - escalation_agent             # agentic: LLM can choose to escalate
 
   input_example:
     messages:
-      - role: user
-        content: "I've been charged twice for my subscription this month. Can you help?"
+    - role: user
+      content: "I've been charged twice for my subscription this month. Can you help?"

--- a/config/examples/13_orchestration/supervisor_pattern.yaml
+++ b/config/examples/13_orchestration/supervisor_pattern.yaml
@@ -21,7 +21,7 @@ variables:
 # RESOURCES
 # =============================================================================
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
@@ -63,7 +63,7 @@ agents:
     description: "Specialist for product details, specifications, and features"
     model: *default_llm
     tools:
-      - *search_products
+    - *search_products
     prompt: |
       You are a product information specialist. Your role is to provide detailed,
       accurate information about products including:
@@ -71,7 +71,7 @@ agents:
       - Pricing information
       - Product comparisons
       - Use cases and applications
-      
+
       Always use your search tools to find current, accurate product information.
       Be thorough and provide helpful details to customers.
 
@@ -81,15 +81,15 @@ agents:
     description: "Specialist for stock levels, availability, and inventory information"
     model: *default_llm
     tools:
-      - *check_inventory
-      - *search_products
+    - *check_inventory
+    - *search_products
     prompt: |
       You are an inventory management specialist. Your role is to provide:
       - Current stock levels and availability
       - Store location information
       - Restocking timelines
       - Alternative product suggestions if items are out of stock
-      
+
       Use your inventory tools first, then search for alternatives if needed.
       Always provide accurate, real-time inventory information.
 
@@ -110,16 +110,15 @@ app:
   name: supervisor_pattern_dao
   description: "Supervisor orchestration pattern example with specialized agents"
   log_level: INFO
-  
+
   registered_model:
     name: supervisor_pattern_dao
-  
+
   # List all worker agents that the supervisor can route to
   agents:
-    - *product_agent
-    - *inventory_agent
-    - *general_agent
-  
+  - *product_agent
+  - *inventory_agent
+  - *general_agent
   # Supervisor configuration
   orchestration:
     supervisor:
@@ -127,20 +126,20 @@ app:
       prompt: |
         You are a routing coordinator for a customer service system. Analyze incoming
         customer requests and route them to the most appropriate specialist agent:
-        
+
         - product_agent: For questions about product details, features, specifications,
           pricing, or comparisons
         - inventory_agent: For questions about stock availability, inventory levels,
           or product location in store
         - general_agent: For general questions about store policies, hours, services,
           or other non-product inquiries
-        
+
         Route the request to the single most appropriate agent based on the primary
         intent of the customer's question.
 
   # Example input demonstrating the pattern
   input_example:
     messages:
-      - role: user
-        content: "Do you have the Dewalt cordless drill in stock?"
+    - role: user
+      content: "Do you have the Dewalt cordless drill in stock?"
 

--- a/config/examples/13_orchestration/swarm_pattern.yaml
+++ b/config/examples/13_orchestration/swarm_pattern.yaml
@@ -20,7 +20,7 @@ variables:
 # RESOURCES
 # =============================================================================
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
@@ -87,21 +87,21 @@ agents:
     description: "Product information specialist"
     model: *default_llm
     tools:
-      - *search_products
-      - *transfer_to_inventory
-      - *transfer_to_comparison
+    - *search_products
+    - *transfer_to_inventory
+    - *transfer_to_comparison
     prompt: |
       You are a product information specialist providing details about products.
-      
+
       Your expertise:
       - Product specifications and features
       - Pricing and product details
       - General product information
-      
+
       When to hand off:
       - If customer asks about STOCK or AVAILABILITY → use transfer_to_inventory
       - If customer wants to COMPARE multiple products → use transfer_to_comparison
-      
+
       Use your search tool to find accurate product information, and hand off when
       the conversation moves beyond product details into other specialties.
     handoff_prompt: |
@@ -114,22 +114,22 @@ agents:
     description: "Inventory and availability specialist"
     model: *default_llm
     tools:
-      - *check_inventory
-      - *search_products
-      - *transfer_to_product
-      - *transfer_to_comparison
+    - *check_inventory
+    - *search_products
+    - *transfer_to_product
+    - *transfer_to_comparison
     prompt: |
       You are an inventory management specialist checking stock and availability.
-      
+
       Your expertise:
       - Stock levels and availability
       - Store inventory information
       - Product location in store
-      
+
       When to hand off:
       - If customer asks for DETAILED product specs → use transfer_to_product
       - If customer wants to COMPARE options → use transfer_to_comparison
-      
+
       Check inventory first, provide alternatives if out of stock, and hand off
       when the conversation needs different expertise.
     handoff_prompt: |
@@ -142,21 +142,21 @@ agents:
     description: "Product comparison specialist"
     model: *default_llm
     tools:
-      - *search_products
-      - *transfer_to_product
-      - *transfer_to_inventory
+    - *search_products
+    - *transfer_to_product
+    - *transfer_to_inventory
     prompt: |
       You are a product comparison specialist helping customers compare options.
-      
+
       Your expertise:
       - Side-by-side product comparisons
       - Feature and price analysis
       - Pros and cons evaluation
-      
+
       When to hand off:
       - If customer wants DETAILED specs on one product → use transfer_to_product
       - If customer asks about STOCK of compared items → use transfer_to_inventory
-      
+
       Compare products objectively, highlight key differences, and hand off when
       the conversation focuses on a single product or availability.
     handoff_prompt: |
@@ -170,19 +170,19 @@ app:
   name: swarm_pattern_dao
   description: "Swarm orchestration pattern with peer-to-peer agent handoffs"
   log_level: INFO
-  
+
   registered_model:
     name: swarm_pattern_dao
-  
+
   # List all agents in the swarm (no hierarchy - they're peers)
   agents:
-    - *product_agent
-    - *inventory_agent
-    - *comparison_agent
+  - *product_agent
+  - *inventory_agent
+  - *comparison_agent
 
   # Example input demonstrating the pattern
   input_example:
     messages:
-      - role: user
-        content: "Tell me about the Dewalt cordless drill and check if you have it in stock"
+    - role: user
+      content: "Tell me about the Dewalt cordless drill and check if you have it in stock"
 

--- a/config/examples/14_basic_tools/rest_api_tool.yaml
+++ b/config/examples/14_basic_tools/rest_api_tool.yaml
@@ -25,7 +25,7 @@ schemas:
     schema_name: ${var.schema}
 
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
@@ -33,7 +33,7 @@ resources:
 
   # UC Connection for the external API (used in Mode 1)
   connections:
-    external_api_connection: &external_api_connection
+    external_api_connection:
       name: my_external_api                         # UC Connection name
       on_behalf_of_user: true                       # Use calling user's identity
 
@@ -76,7 +76,7 @@ agents:
     description: "Agent that interacts with an external REST API"
     model: *default_llm
     tools:
-      - *call_api
+    - *call_api
     prompt: |
       You are a helpful assistant that can interact with an external REST API.
 
@@ -94,7 +94,7 @@ app:
     schema: *default_schema
     name: rest_api_tool_example_dao
   agents:
-    - *api_agent
+  - *api_agent
   orchestration:
     swarm:
       default_agent: *api_agent

--- a/config/examples/14_basic_tools/slack_integration.yaml
+++ b/config/examples/14_basic_tools/slack_integration.yaml
@@ -13,12 +13,13 @@ parameters:
     default: default
 
 schemas:
-  default_schema: &default_schema                   # Unity Catalog schema configuration
+  default_schema: &default_schema
+                                                    # Unity Catalog schema configuration
     catalog_name: ${var.catalog}                              # Unity Catalog name
     schema_name: ${var.schema}                            # Schema within the catalog
 
 resources:
-  llms:
+  models:
     # Primary LLM for Slack agent
     default_llm: &default_llm
       name: databricks-claude-sonnet-4  # Databricks serving endpoint name
@@ -40,7 +41,8 @@ tools:
       type: factory                                 # Tool type: factory function
       name: dao_ai.tools.create_send_slack_message_tool  # Factory function path
       args:                                         # Arguments passed to factory
-        connection: *slack_connection               # Reference to Slack UC connection
+        connection: *slack_connection
+                                                    # Reference to Slack UC connection
         channel_name: "general"                     # Slack channel name (can also use channel_id)
         name: send_slack_message
         description: Send a message to the #general Slack channel
@@ -50,9 +52,10 @@ agents:
   slack_agent: &slack_agent
     name: slack_agent                               # Agent identifier
     description: "Agent that can send notifications to Slack"
-    model: *default_llm                             # Reference to LLM configuration
+    model: *default_llm
+                                                    # Reference to LLM configuration
     tools:                                          # Tools available to this agent
-      - *slack_tool
+    - *slack_tool
     prompt: |                                       # System prompt defining agent behavior
       You are a helpful assistant that can send notifications to Slack.
       When asked to notify someone or send a message, use the send_slack_message tool
@@ -63,19 +66,22 @@ app:
   description: "Agent system that can send notifications to Slack"
   log_level: INFO                                   # Logging level for the application
   registered_model:                                 # MLflow registered model configuration
-    schema: *default_schema                         # Schema where model will be registered
+    schema: *default_schema
+                                                    # Schema where model will be registered
     name: slack_notification_agent_dao              # Model name in MLflow registry
   endpoint_name: slack_notification_agent_dao       # Model serving endpoint name
   tags:                                             # Tags for resource organization
     integration: slack                              # Integration type
     notification: true                              # Indicates notification capabilities
   permissions:                                      # Model serving permissions
-    - principals: [users]                           # Grant access to all users
-      entitlements:
-        - CAN_QUERY                                 # Query permissions
+  - principals: [users]                             # Grant access to all users
+    entitlements:
+    - CAN_QUERY                                     # Query permissions
   agents:                                           # List of agents included in the system
-    - *slack_agent                                  # Slack notification agent
+  - *slack_agent
+                                                    # Slack notification agent
   orchestration:                                    # Agent orchestration configuration
     swarm:                                          # Swarm orchestration pattern
-      default_agent: *slack_agent                   # Default agent for routing
+      default_agent: *slack_agent
+                                                    # Default agent for routing
 

--- a/config/examples/14_basic_tools/sql_tool_example.yaml
+++ b/config/examples/14_basic_tools/sql_tool_example.yaml
@@ -29,7 +29,7 @@ resources:
         env: DATABRICKS_WAREHOUSE_ID
 
   # Define the LLM for the agent
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4  # Databricks serving endpoint name
 
@@ -121,13 +121,13 @@ agents:
     name: inventory_analyst
     model: *default_llm
     tools:
-      - *get_product_count
-      - *get_products_by_department
-      - *check_low_inventory
-      - *get_popular_products
+    - *get_product_count
+    - *get_products_by_department
+    - *check_low_inventory
+    - *get_popular_products
     prompt: |
       You are a helpful inventory analyst assistant for a hardware store.
-      
+
       You have access to SQL tools that can query the product catalog and inventory database.
       Use these tools to help answer questions about:
       - Product counts and availability
@@ -135,12 +135,12 @@ agents:
       - Department-level statistics
       - Popular products and pricing
       - Low stock alerts
-      
+
       When presenting data:
       - Format numbers clearly (use commas for thousands)
       - Highlight important findings
       - Provide actionable insights when relevant
-      
+
       Be concise but informative in your responses.
 
 app:
@@ -150,4 +150,4 @@ app:
     schema: *hardware_store_schema
     name: sql_tool_example_agent_dao
   agents:
-    - *inventory_analyst
+  - *inventory_analyst

--- a/config/examples/14_basic_tools/teams_integration.yaml
+++ b/config/examples/14_basic_tools/teams_integration.yaml
@@ -13,12 +13,13 @@ parameters:
     default: default
 
 schemas:
-  default_schema: &default_schema                   # Unity Catalog schema configuration
+  default_schema: &default_schema
+                                                    # Unity Catalog schema configuration
     catalog_name: ${var.catalog}                              # Unity Catalog name
     schema_name: ${var.schema}                            # Schema within the catalog
 
 resources:
-  llms:
+  models:
     # Primary LLM for Teams agent
     default_llm: &default_llm
       name: databricks-claude-sonnet-4  # Databricks serving endpoint name
@@ -40,7 +41,8 @@ tools:
       type: factory                                 # Tool type: factory function
       name: dao_ai.tools.create_send_teams_message_tool  # Factory function path
       args:                                         # Arguments passed to factory
-        connection: *teams_connection               # Reference to Teams UC connection
+        connection: *teams_connection
+                                                    # Reference to Teams UC connection
         team_id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"  # Microsoft Teams team ID (GUID)
         channel_name: "General"                     # Teams channel name (can also use channel_id)
         name: send_teams_message
@@ -51,9 +53,10 @@ agents:
   teams_agent: &teams_agent
     name: teams_agent                               # Agent identifier
     description: "Agent that can send notifications to Microsoft Teams"
-    model: *default_llm                             # Reference to LLM configuration
+    model: *default_llm
+                                                    # Reference to LLM configuration
     tools:                                          # Tools available to this agent
-      - *teams_tool
+    - *teams_tool
     prompt: |                                       # System prompt defining agent behavior
       You are a helpful assistant that can send notifications to Microsoft Teams.
       When asked to notify someone or send a message, use the send_teams_message tool
@@ -64,18 +67,21 @@ app:
   description: "Agent system that can send notifications to Microsoft Teams"
   log_level: INFO                                   # Logging level for the application
   registered_model:                                 # MLflow registered model configuration
-    schema: *default_schema                         # Schema where model will be registered
+    schema: *default_schema
+                                                    # Schema where model will be registered
     name: teams_notification_agent_dao              # Model name in MLflow registry
   endpoint_name: teams_notification_agent_dao       # Model serving endpoint name
   tags:                                             # Tags for resource organization
     integration: teams                              # Integration type
     notification: true                              # Indicates notification capabilities
   permissions:                                      # Model serving permissions
-    - principals: [users]                           # Grant access to all users
-      entitlements:
-        - CAN_QUERY                                 # Query permissions
+  - principals: [users]                             # Grant access to all users
+    entitlements:
+    - CAN_QUERY                                     # Query permissions
   agents:                                           # List of agents included in the system
-    - *teams_agent                                  # Teams notification agent
+  - *teams_agent
+                                                    # Teams notification agent
   orchestration:                                    # Agent orchestration configuration
     swarm:                                          # Swarm orchestration pattern
-      default_agent: *teams_agent                   # Default agent for routing
+      default_agent: *teams_agent
+                                                    # Default agent for routing

--- a/config/examples/15_complete_applications/README.md
+++ b/config/examples/15_complete_applications/README.md
@@ -401,8 +401,8 @@ schemas:
   retail_schema: &retail_schema           # Unity Catalog location
 
 resources:
-  llms:
-    default_llm: &default_llm             # Primary LLM
+  models:
+    default_llm: &default_llm             # Primary LLM (chat)
     judge_llm: &judge_llm                 # Guardrail evaluator
   vector_stores:
     products_store: &products_store       # Semantic search

--- a/config/examples/15_complete_applications/brick_store.yaml
+++ b/config/examples/15_complete_applications/brick_store.yaml
@@ -40,18 +40,18 @@ parameters:
 variables:
   client_id: &client_id
     options:
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_CLIENT_ID
-      - env: RETAIL_AI_DATABRICKS_CLIENT_ID
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_ID
+    - env: RETAIL_AI_DATABRICKS_CLIENT_ID
 
   client_secret: &client_secret
     options:
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
-      - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+    - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET
 
 service_principals:
-  retail_consumer_goods_sp: &retail_consumer_goods_sp
+  retail_consumer_goods_sp:
     name: retail_consumer_goods_sp
     client_id: *client_id
     client_secret: *client_secret
@@ -64,12 +64,12 @@ schemas:
     catalog_name: ${var.catalog}
     schema_name: ${var.schema}
     permissions:
-      - principals: [users]
-        privileges:
-          - USE_CATALOG
-          - USE_SCHEMA
-          - SELECT
-          - EXECUTE
+    - principals: [users]
+      privileges:
+      - USE_CATALOG
+      - USE_SCHEMA
+      - SELECT
+      - EXECUTE
 
 # =============================================================================
 # RESOURCES
@@ -78,7 +78,7 @@ resources:
   # ---------------------------------------------------------------------------
   # LANGUAGE MODELS
   # ---------------------------------------------------------------------------
-  llms:
+  models:
     fast_llm: &fast_llm
       name: databricks-gpt-5-4-mini
       temperature: 0.1
@@ -97,7 +97,7 @@ resources:
       max_tokens: 4096
       on_behalf_of_user: true
       fallbacks:
-        - databricks-claude-sonnet-4-6
+      - databricks-claude-sonnet-4-6
 
     judge_llm: &judge_llm
       name: databricks-claude-3-7-sonnet
@@ -132,21 +132,21 @@ resources:
         schema: *brickstore_schema
         name: products
       primary_key: product_id
-      doc_uri: ~
+      doc_uri:
       embedding_source_column: long_description
       columns:
-        - product_id
-        - sku
-        - upc
-        - brand_name
-        - product_name
-        - merchandise_class
-        - department_name
-        - category_name
-        - color
-        - size
-        - base_price
-        - long_description
+      - product_id
+      - sku
+      - upc
+      - brand_name
+      - product_name
+      - merchandise_class
+      - department_name
+      - category_name
+      - color
+      - size
+      - base_price
+      - long_description
 
     stores_vector_store: &stores_vector_store
       embedding_model: *embedding_model
@@ -161,15 +161,15 @@ resources:
         schema: *brickstore_schema
         name: dim_stores
       primary_key: store_id
-      doc_uri: ~
+      doc_uri:
       embedding_source_column: store_details_text
       columns:
-        - store_id
-        - store_name
-        - store_address
-        - store_city
-        - store_state
-        - store_details_text
+      - store_id
+      - store_name
+      - store_address
+      - store_city
+      - store_state
+      - store_details_text
 
   # ---------------------------------------------------------------------------
   # WAREHOUSES
@@ -200,52 +200,52 @@ resources:
       parent_path: "${var.genie_parent_path}"
       warehouse: *brickstore_warehouse
       table_sources:
-        - table:
-            schema: *brickstore_schema
-            name: products
-            on_behalf_of_user: true
-          description: "Product catalog with SKU, UPC, brand, department, category, price."
-        - table:
-            schema: *brickstore_schema
-            name: inventory
-            on_behalf_of_user: true
-          description: "Per-store inventory with on-hand quantity, warehouse backstock, retail amount, popularity, aisle location."
-        - table:
-            schema: *brickstore_schema
-            name: dim_stores
-            on_behalf_of_user: true
-          description: "Store directory: id, name, address, city/state, manager id, hours, type, latitude/longitude, departments offered."
-        - table:
-            schema: *brickstore_schema
-            name: customers
-            on_behalf_of_user: true
-          description: "Customer profiles: tier, preferences (style/size/color/brand), lifetime spend, satisfaction, upcoming appointments, alerts."
-        - table:
-            schema: *brickstore_schema
-            name: employee_performance
-            on_behalf_of_user: true
-          description: "Monthly employee performance: sales achievement, task completion, customer satisfaction, attendance, by department."
-        - table:
-            schema: *brickstore_schema
-            name: employee_tasks
-            on_behalf_of_user: true
-          description: "Per-task assignments: store, employee, type, priority, status, due time, customer/order linkage."
-        - table:
-            schema: *brickstore_schema
-            name: managers
-            on_behalf_of_user: true
-          description: "Manager directory: contact info, department, communication preferences, work schedule."
-        - table:
-            schema: *brickstore_schema
-            name: appointments
-            on_behalf_of_user: true
-          description: "Customer appointment scheduling: type, date/time, store, stylist, status."
+      - table:
+          schema: *brickstore_schema
+          name: products
+          on_behalf_of_user: true
+        description: "Product catalog with SKU, UPC, brand, department, category, price."
+      - table:
+          schema: *brickstore_schema
+          name: inventory
+          on_behalf_of_user: true
+        description: "Per-store inventory with on-hand quantity, warehouse backstock, retail amount, popularity, aisle location."
+      - table:
+          schema: *brickstore_schema
+          name: dim_stores
+          on_behalf_of_user: true
+        description: "Store directory: id, name, address, city/state, manager id, hours, type, latitude/longitude, departments offered."
+      - table:
+          schema: *brickstore_schema
+          name: customers
+          on_behalf_of_user: true
+        description: "Customer profiles: tier, preferences (style/size/color/brand), lifetime spend, satisfaction, upcoming appointments, alerts."
+      - table:
+          schema: *brickstore_schema
+          name: employee_performance
+          on_behalf_of_user: true
+        description: "Monthly employee performance: sales achievement, task completion, customer satisfaction, attendance, by department."
+      - table:
+          schema: *brickstore_schema
+          name: employee_tasks
+          on_behalf_of_user: true
+        description: "Per-task assignments: store, employee, type, priority, status, due time, customer/order linkage."
+      - table:
+          schema: *brickstore_schema
+          name: managers
+          on_behalf_of_user: true
+        description: "Manager directory: contact info, department, communication preferences, work schedule."
+      - table:
+          schema: *brickstore_schema
+          name: appointments
+          on_behalf_of_user: true
+        description: "Customer appointment scheduling: type, date/time, store, stylist, status."
       sample_questions:
-        - "How many BOPIS-style task assignments are open at store 101 right now?"
-        - "Which departments have the highest task completion rate this month?"
-        - "What's the average customer satisfaction score by store?"
-        - "Which products in Womens Fashion have the highest current inventory?"
-        - "How many upcoming appointments are scheduled at each store this week?"
+      - "How many BOPIS-style task assignments are open at store 101 right now?"
+      - "Which departments have the highest task completion rate this month?"
+      - "What's the average customer satisfaction score by store?"
+      - "Which products in Womens Fashion have the highest current inventory?"
+      - "How many upcoming appointments are scheduled at each store this week?"
 
   # ---------------------------------------------------------------------------
   # FUNCTIONS
@@ -342,80 +342,80 @@ retrievers:
   products_retriever: &products_retriever
     vector_store: *products_vector_store
     columns:
-      - product_id
-      - sku
-      - upc
-      - brand_name
-      - product_name
-      - merchandise_class
-      - department_name
-      - category_name
-      - color
-      - size
-      - base_price
-      - long_description
+    - product_id
+    - sku
+    - upc
+    - brand_name
+    - product_name
+    - merchandise_class
+    - department_name
+    - category_name
+    - color
+    - size
+    - base_price
+    - long_description
     search_parameters:
       num_results: 50
       filters: {}
       query_type: HYBRID
     instructed:
       columns:
-        - name: product_id
-          type: number
-          description: "Unique product identifier"
-        - name: sku
-          type: string
-          description: "Stock keeping unit - internal product code"
-        - name: upc
-          type: string
-          description: "Universal Product Code - barcode number"
-        - name: brand_name
-          type: string
-          description: "Brand or manufacturer (Adidas, Nike, Lululemon, etc.)"
-        - name: product_name
-          type: string
-          description: "Product display name"
-        - name: merchandise_class
-          type: string
-          description: "Broad category (Apparel, Footwear, Electronics, Home Goods, Accessories)"
-        - name: department_name
-          type: string
-          description: "Department (Womens Fashion, Mens Fashion, Electronics, Home Goods, Accessories)"
-        - name: category_name
-          type: string
-          description: "Category within department"
-        - name: color
-          type: string
-          description: "Primary color"
-        - name: size
-          type: string
-          description: "Size specification"
-        - name: base_price
-          type: number
-          description: "Base retail price in USD"
-        - name: long_description
-          type: string
-          description: "Detailed product description"
+      - name: product_id
+        type: number
+        description: "Unique product identifier"
+      - name: sku
+        type: string
+        description: "Stock keeping unit - internal product code"
+      - name: upc
+        type: string
+        description: "Universal Product Code - barcode number"
+      - name: brand_name
+        type: string
+        description: "Brand or manufacturer (Adidas, Nike, Lululemon, etc.)"
+      - name: product_name
+        type: string
+        description: "Product display name"
+      - name: merchandise_class
+        type: string
+        description: "Broad category (Apparel, Footwear, Electronics, Home Goods, Accessories)"
+      - name: department_name
+        type: string
+        description: "Department (Womens Fashion, Mens Fashion, Electronics, Home Goods, Accessories)"
+      - name: category_name
+        type: string
+        description: "Category within department"
+      - name: color
+        type: string
+        description: "Primary color"
+      - name: size
+        type: string
+        description: "Size specification"
+      - name: base_price
+        type: number
+        description: "Base retail price in USD"
+      - name: long_description
+        type: string
+        description: "Detailed product description"
       constraints:
-        - "Use brand_name for brand filtering"
-        - "Use merchandise_class for product type filtering"
-        - "Use department_name for department-level queries"
-        - "Use color or size for fit filtering"
-        - "Only use columns listed above"
+      - "Use brand_name for brand filtering"
+      - "Use merchandise_class for product type filtering"
+      - "Use department_name for department-level queries"
+      - "Use color or size for fit filtering"
+      - "Only use columns listed above"
       decomposition:
         model: *decomposition_llm
         max_subqueries: 3
         rrf_k: 60
         normalize_filter_case: uppercase
         examples:
-          - query: "black Adidas Gazelle size 10"
-            filters: {"brand_name": "ADIDAS", "merchandise_class": "FOOTWEAR", "color": "BLACK", "size": "10"}
-          - query: "designer black handbag under $300"
-            filters: {"merchandise_class": "ACCESSORIES", "color": "BLACK"}
-          - query: "women's professional dresses"
-            filters: {"department_name": "WOMENS FASHION", "merchandise_class": "APPAREL"}
-          - query: "Nike running shoes excluding Pegasus"
-            filters: {"brand_name": "NIKE", "merchandise_class": "FOOTWEAR"}
+        - query: "black Adidas Gazelle size 10"
+          filters: {"brand_name": "ADIDAS", "merchandise_class": "FOOTWEAR", "color": "BLACK", "size": "10"}
+        - query: "designer black handbag under $300"
+          filters: {"merchandise_class": "ACCESSORIES", "color": "BLACK"}
+        - query: "women's professional dresses"
+          filters: {"department_name": "WOMENS FASHION", "merchandise_class": "APPAREL"}
+        - query: "Nike running shoes excluding Pegasus"
+          filters: {"brand_name": "NIKE", "merchandise_class": "FOOTWEAR"}
       rerank:
         model: *decomposition_llm
         instructions: |
@@ -429,20 +429,20 @@ retrievers:
       model: ms-marco-MiniLM-L-12-v2
       top_n: 20
       columns:
-        - brand_name
-        - product_name
-        - merchandise_class
-        - department_name
+      - brand_name
+      - product_name
+      - merchandise_class
+      - department_name
 
   stores_retriever: &stores_retriever
     vector_store: *stores_vector_store
     columns:
-      - store_id
-      - store_name
-      - store_address
-      - store_city
-      - store_state
-      - store_details_text
+    - store_id
+    - store_name
+    - store_address
+    - store_city
+    - store_state
+    - store_details_text
     search_parameters:
       num_results: 10
       filters: {}
@@ -650,27 +650,27 @@ tools:
           nearby-store checks, customer appointment preparation, BOPIS
           orders, employee performance, and personal styling support.
         agents:
-          - name: product
-            description: "Product details, SKU/UPC lookup, comparisons, recommendations"
-          - name: inventory
-            description: "Stock levels, store availability, nearby stores, hold guidance"
-          - name: orders
-            description: "BOPIS pickups, order tracking, delivery scheduling"
-          - name: customer
-            description: "Customer profiles, upcoming appointments, prep summaries"
-          - name: stylist
-            description: "Personal styling sessions and outfit preselection"
-          - name: employee
-            description: "Top performers, task assignments, manager lookup"
-          - name: general
-            description: "Store info, hours, services, and other inquiries"
+        - name: product
+          description: "Product details, SKU/UPC lookup, comparisons, recommendations"
+        - name: inventory
+          description: "Stock levels, store availability, nearby stores, hold guidance"
+        - name: orders
+          description: "BOPIS pickups, order tracking, delivery scheduling"
+        - name: customer
+          description: "Customer profiles, upcoming appointments, prep summaries"
+        - name: stylist
+          description: "Personal styling sessions and outfit preselection"
+        - name: employee
+          description: "Top performers, task assignments, manager lookup"
+        - name: general
+          description: "Store info, hours, services, and other inquiries"
         sample_prompts:
-          - "Do you have Adidas Gazelle size 10 black at store 101?"
-          - "Who has appointments today at store 101 that I should prep for?"
-          - "Tell me about Victoria Sterling - she just walked in"
-          - "Find a personal shopper for a 2pm walk-in at store 101"
-          - "Who are the top performers in Womens Fashion this month?"
-          - "Where is the Marina Market store?"
+        - "Do you have Adidas Gazelle size 10 black at store 101?"
+        - "Who has appointments today at store 101 that I should prep for?"
+        - "Tell me about Victoria Sterling - she just walked in"
+        - "Find a personal shopper for a 2pm walk-in at store 101"
+        - "Who are the top performers in Womens Fashion this month?"
+        - "Where is the Marina Market store?"
 
 # =============================================================================
 # PROMPTS (MLflow Prompt Registry)
@@ -1002,9 +1002,9 @@ memory: &memory
 
   extraction:
     schemas:
-      - user_profile
-      - preference
-      - episode
+    - user_profile
+    - preference
+    - episode
     instructions: |
       Extract the user's role (associate, manager, stylist, pickup-desk),
       their `store_num`, their typical workflow (in-aisle assist, BOPIS pickup,
@@ -1026,13 +1026,13 @@ middleware:
     name: dao_ai.middleware.create_custom_field_validation_middleware
     args:
       fields:
-        - name: store_num
-          description: "Your store number for inventory, customer, and task lookups"
-          example_value: "101"
-        - name: user_id
-          description: "Your unique user identifier"
-          required: false
-          example_value: "associate_01"
+      - name: store_num
+        description: "Your store number for inventory, customer, and task lookups"
+        example_value: "101"
+      - name: user_id
+        description: "Your unique user identifier"
+        required: false
+        example_value: "associate_01"
 
 # =============================================================================
 # AGENTS
@@ -1043,12 +1043,12 @@ agents:
     description: "General store associate for store info, store search, and quick customer/appointment context"
     model: *tool_calling_llm
     tools:
-      - *current_time_tool
-      - *find_store_details_by_location_tool
-      - *find_store_by_number_tool
-      - *find_upcoming_customer_appointments_tool
-      - *get_customer_details_tool
-      - *store_ops_analytics_tool
+    - *current_time_tool
+    - *find_store_details_by_location_tool
+    - *find_store_by_number_tool
+    - *find_upcoming_customer_appointments_tool
+    - *get_customer_details_tool
+    - *store_ops_analytics_tool
     guardrails: []
     prompt: *general_prompt
     handoff_prompt: "Store info, hours, location, services, quick customer lookups, or any inquiry that doesn't clearly belong to a specialist."
@@ -1058,9 +1058,9 @@ agents:
     description: "BOPIS and order fulfillment specialist for pickup, staging, and order tracking"
     model: *tool_calling_llm
     tools:
-      - *current_time_tool
-      - *get_customer_details_tool
-      - *store_ops_analytics_tool
+    - *current_time_tool
+    - *get_customer_details_tool
+    - *store_ops_analytics_tool
     guardrails: []
     prompt: *orders_prompt
     handoff_prompt: "BOPIS pickups, online order status, in-store order tracking, delivery scheduling, or hold confirmations (narrative)."
@@ -1070,10 +1070,10 @@ agents:
     description: "Product specialist covering catalog lookup, comparisons, and recommendations"
     model: *tool_calling_llm
     tools:
-      - *product_vector_search_tool
-      - *find_product_by_sku_tool
-      - *find_product_by_upc_tool
-      - *store_ops_analytics_tool
+    - *product_vector_search_tool
+    - *find_product_by_sku_tool
+    - *find_product_by_upc_tool
+    - *store_ops_analytics_tool
     guardrails: []
     prompt: *product_prompt
     handoff_prompt: "Product details, SKU/UPC lookups, side-by-side comparisons, or 'what's similar to X' recommendations."
@@ -1083,12 +1083,12 @@ agents:
     description: "Inventory specialist for stock checks at the home store and nearby stores"
     model: *tool_calling_llm
     tools:
-      - *find_inventory_by_sku_tool
-      - *find_inventory_by_upc_tool
-      - *find_store_inventory_by_sku_tool
-      - *find_store_inventory_by_upc_tool
-      - *find_nearby_stores_inventory_tool
-      - *product_vector_search_tool
+    - *find_inventory_by_sku_tool
+    - *find_inventory_by_upc_tool
+    - *find_store_inventory_by_sku_tool
+    - *find_store_inventory_by_upc_tool
+    - *find_nearby_stores_inventory_tool
+    - *product_vector_search_tool
     guardrails: []
     prompt: *inventory_prompt
     handoff_prompt: "Stock levels at this store, nearby-store availability, out-of-stock alternatives, or hold guidance."
@@ -1098,11 +1098,11 @@ agents:
     description: "Customer service specialist for upcoming-visit prep and customer profile context"
     model: *tool_calling_llm
     tools:
-      - *find_upcoming_customer_appointments_tool
-      - *get_customer_details_tool
-      - *get_customer_preparation_summary_tool
-      - *product_vector_search_tool
-      - *find_inventory_by_sku_tool
+    - *find_upcoming_customer_appointments_tool
+    - *get_customer_details_tool
+    - *get_customer_preparation_summary_tool
+    - *product_vector_search_tool
+    - *find_inventory_by_sku_tool
     guardrails: []
     prompt: *customer_prompt
     handoff_prompt: "Upcoming customer appointments, pre-visit preparation, customer profile lookups, or 'who's coming in today'."
@@ -1112,11 +1112,11 @@ agents:
     description: "Personal stylist for active styling sessions, outfit selection, and inventory preselection"
     model: *tool_calling_llm
     tools:
-      - *get_customer_details_tool
-      - *get_customer_preparation_summary_tool
-      - *product_vector_search_tool
-      - *find_store_inventory_by_sku_tool
-      - *find_personal_shopping_associates_tool
+    - *get_customer_details_tool
+    - *get_customer_preparation_summary_tool
+    - *product_vector_search_tool
+    - *find_store_inventory_by_sku_tool
+    - *find_personal_shopping_associates_tool
     guardrails: []
     prompt: *stylist_prompt
     handoff_prompt: "Personal styling sessions, outfit building, inventory preselection by customer preference, or finding an available stylist."
@@ -1126,11 +1126,11 @@ agents:
     description: "Manager-on-duty specialist for top performers, task assignments, and manager lookups"
     model: *tool_calling_llm
     tools:
-      - *find_top_employees_by_department_tool
-      - *find_personal_shopping_associates_tool
-      - *find_employee_manager_tool
-      - *find_task_assignments_tool
-      - *employee_insights_tool
+    - *find_top_employees_by_department_tool
+    - *find_personal_shopping_associates_tool
+    - *find_employee_manager_tool
+    - *find_task_assignments_tool
+    - *employee_insights_tool
     guardrails: []
     prompt: *employee_prompt
     handoff_prompt: "Top performers, employee performance, task assignments, overdue tasks, or 'who's <employee>'s manager'."
@@ -1153,30 +1153,30 @@ app:
   monitoring:
     sample_rate: 1.0
     scorers:
-      - safety
-      - completeness
-      - relevance_to_query
-      - tool_call_efficiency
+    - safety
+    - completeness
+    - relevance_to_query
+    - tool_call_efficiency
     guidelines_sample_rate: 0.5
     guidelines:
-      - name: customer_service_accuracy
-        guidelines:
-          - Inventory counts and stock levels must come from tool results, never fabricated
-          - Customer profile data, appointment details, and preparation summaries must be sourced from UC function results
-          - Hold IDs are narrative-only ("HOLD-<store_id>-<yyyymmddhhmm>") - never claim a hold row was inserted
-          - Stylist notifications are narrative-only - draft the message text and tell the user to send it
-      - name: tool_usage_quality
-        guidelines:
-          - SKU and UPC lookups must use the corresponding `find_*_by_sku_uc` / `find_*_by_upc_uc` tool, not Genie
-          - Genie analytics tools should be used for trends and aggregates, not single-record lookups
-          - Vector search should be used when the user describes a product rather than naming a SKU
-          - When stock is zero at the home store, the agent must call `find_nearby_stores_inventory_uc` before suggesting alternatives
-      - name: response_professionalism
-        guidelines:
-          - Responses use floor-friendly language - associates are usually mid-task
-          - Currency values use USD formatting with a `$` prefix
-          - When the customer profile has `requires_manager_greeting=true`, that flag must be surfaced
-          - Privacy-sensitive customer fields (alerts, dietary, accessibility) are only used to prepare service, not casually mentioned
+    - name: customer_service_accuracy
+      guidelines:
+      - Inventory counts and stock levels must come from tool results, never fabricated
+      - Customer profile data, appointment details, and preparation summaries must be sourced from UC function results
+      - Hold IDs are narrative-only ("HOLD-<store_id>-<yyyymmddhhmm>") - never claim a hold row was inserted
+      - Stylist notifications are narrative-only - draft the message text and tell the user to send it
+    - name: tool_usage_quality
+      guidelines:
+      - SKU and UPC lookups must use the corresponding `find_*_by_sku_uc` / `find_*_by_upc_uc` tool, not Genie
+      - Genie analytics tools should be used for trends and aggregates, not single-record lookups
+      - Vector search should be used when the user describes a product rather than naming a SKU
+      - When stock is zero at the home store, the agent must call `find_nearby_stores_inventory_uc` before suggesting alternatives
+    - name: response_professionalism
+      guidelines:
+      - Responses use floor-friendly language - associates are usually mid-task
+      - Currency values use USD formatting with a `$` prefix
+      - When the customer profile has `requires_manager_greeting=true`, that flag must be surfaced
+      - Privacy-sensitive customer fields (alerts, dietary, accessibility) are only used to prepare service, not casually mentioned
   environment_vars:
     RETAIL_AI_DATABRICKS_CLIENT_ID: "{{secrets/retail_consumer_goods/RETAIL_AI_DATABRICKS_CLIENT_ID}}"
     RETAIL_AI_DATABRICKS_CLIENT_SECRET: "{{secrets/retail_consumer_goods/RETAIL_AI_DATABRICKS_CLIENT_SECRET}}"
@@ -1188,23 +1188,23 @@ app:
   enable_chat_proxy: true
 
   permissions:
-    - principals: [users]
-      entitlements:
-        - CAN_QUERY
+  - principals: [users]
+    entitlements:
+    - CAN_QUERY
   agents:
-    - *general
-    - *orders
-    - *product
-    - *inventory
-    - *customer
-    - *stylist
-    - *employee
+  - *general
+  - *orders
+  - *product
+  - *inventory
+  - *customer
+  - *stylist
+  - *employee
   orchestration:
     memory: *memory
     supervisor:
       model: *supervisor_llm
       tools:
-        - *app_info_tool
+      - *app_info_tool
       prompt: |
         You are a routing coordinator for an in-store associate companion. You do
         NOT answer questions yourself. Your only job is to read the request and
@@ -1215,11 +1215,11 @@ app:
         request to one of: general, orders, product, inventory, customer, stylist,
         employee. Never attempt to answer a substantive question yourself.
       middleware:
-        - *store_validation
+      - *store_validation
   input_example:
     messages:
-      - role: user
-        content: "Do you have Adidas Gazelle size 10 in black at store 101?"
+    - role: user
+      content: "Do you have Adidas Gazelle size 10 in black at store 101?"
     custom_inputs:
       configurable:
         user_id: associate_01
@@ -1231,103 +1231,103 @@ app:
 # =============================================================================
 unity_catalog_functions:
   # Product / inventory primitives (existing SQL files)
-  - function: *find_product_by_sku
-    ddl: ../functions/brickstore/find_product_by_sku.sql
-    test:
-      parameters:
-        sku: ["STB-KCP-001"]
+- function: *find_product_by_sku
+  ddl: ../functions/brickstore/find_product_by_sku.sql
+  test:
+    parameters:
+      sku: ["STB-KCP-001"]
 
-  - function: *find_product_by_upc
-    ddl: ../functions/brickstore/find_product_by_upc.sql
-    test:
-      parameters:
-        upc: ["012345678901"]
+- function: *find_product_by_upc
+  ddl: ../functions/brickstore/find_product_by_upc.sql
+  test:
+    parameters:
+      upc: ["012345678901"]
 
-  - function: *find_inventory_by_sku
-    ddl: ../functions/brickstore/find_inventory_by_sku.sql
-    test:
-      parameters:
-        sku: ["PET-KCP-001"]
+- function: *find_inventory_by_sku
+  ddl: ../functions/brickstore/find_inventory_by_sku.sql
+  test:
+    parameters:
+      sku: ["PET-KCP-001"]
 
-  - function: *find_inventory_by_upc
-    ddl: ../functions/brickstore/find_inventory_by_upc.sql
-    test:
-      parameters:
-        upc: ["123456789012"]
+- function: *find_inventory_by_upc
+  ddl: ../functions/brickstore/find_inventory_by_upc.sql
+  test:
+    parameters:
+      upc: ["123456789012"]
 
-  - function: *find_store_inventory_by_sku
-    ddl: ../functions/brickstore/find_store_inventory_by_sku.sql
-    test:
-      parameters:
-        store_id: 101
-        sku: ["DUN-KCP-001"]
+- function: *find_store_inventory_by_sku
+  ddl: ../functions/brickstore/find_store_inventory_by_sku.sql
+  test:
+    parameters:
+      store_id: 101
+      sku: ["DUN-KCP-001"]
 
-  - function: *find_store_inventory_by_upc
-    ddl: ../functions/brickstore/find_store_inventory_by_upc.sql
-    test:
-      parameters:
-        store_id: 101
-        upc: ["234567890123"]
+- function: *find_store_inventory_by_upc
+  ddl: ../functions/brickstore/find_store_inventory_by_upc.sql
+  test:
+    parameters:
+      store_id: 101
+      upc: ["234567890123"]
 
-  - function: *find_store_by_number
-    ddl: ../functions/brickstore/find_store_by_number.sql
-    test:
-      parameters:
-        store_ids: [1, 2]
+- function: *find_store_by_number
+  ddl: ../functions/brickstore/find_store_by_number.sql
+  test:
+    parameters:
+      store_ids: [1, 2]
 
   # New brick_store SQL functions
-  - function: *find_nearby_stores_inventory
-    ddl: ../functions/brickstore/find_nearby_stores_inventory.sql
-    test:
-      parameters:
-        reference_store_id: 101
-        sku: ["PET-KCP-001"]
-        max_results: 3
+- function: *find_nearby_stores_inventory
+  ddl: ../functions/brickstore/find_nearby_stores_inventory.sql
+  test:
+    parameters:
+      reference_store_id: 101
+      sku: ["PET-KCP-001"]
+      max_results: 3
 
-  - function: *find_top_employees_by_department
-    ddl: ../functions/brickstore/find_top_employees_by_department.sql
-    test:
-      parameters:
-        department_name: "Womens Fashion"
-        limit_count: 5
+- function: *find_top_employees_by_department
+  ddl: ../functions/brickstore/find_top_employees_by_department.sql
+  test:
+    parameters:
+      department_name: "Womens Fashion"
+      limit_count: 5
 
-  - function: *find_personal_shopping_associates
-    ddl: ../functions/brickstore/find_personal_shopping_associates.sql
-    test:
-      parameters:
-        limit_count: 5
+- function: *find_personal_shopping_associates
+  ddl: ../functions/brickstore/find_personal_shopping_associates.sql
+  test:
+    parameters:
+      limit_count: 5
 
-  - function: *find_employee_manager
-    ddl: ../functions/brickstore/find_employee_manager.sql
-    test:
-      parameters:
-        employee_id: ["EMP-016"]
+- function: *find_employee_manager
+  ddl: ../functions/brickstore/find_employee_manager.sql
+  test:
+    parameters:
+      employee_id: ["EMP-016"]
 
-  - function: *find_task_assignments
-    ddl: ../functions/brickstore/find_task_assignments.sql
-    test:
-      parameters:
-        store_id: []
-        task_status_filter: ""
+- function: *find_task_assignments
+  ddl: ../functions/brickstore/find_task_assignments.sql
+  test:
+    parameters:
+      store_id: []
+      task_status_filter: ""
 
-  - function: *find_upcoming_customer_appointments
-    ddl: ../functions/brickstore/find_upcoming_customer_appointments.sql
-    test:
-      parameters:
-        store_id: []
-        days_ahead: 30
+- function: *find_upcoming_customer_appointments
+  ddl: ../functions/brickstore/find_upcoming_customer_appointments.sql
+  test:
+    parameters:
+      store_id: []
+      days_ahead: 30
 
-  - function: *get_customer_details
-    ddl: ../functions/brickstore/get_customer_details.sql
-    test:
-      parameters:
-        customer_lookup: "CUST-005"
+- function: *get_customer_details
+  ddl: ../functions/brickstore/get_customer_details.sql
+  test:
+    parameters:
+      customer_lookup: "CUST-005"
 
-  - function: *get_customer_preparation_summary
-    ddl: ../functions/brickstore/get_customer_preparation_summary.sql
-    test:
-      parameters:
-        customer_id: ["CUST-005"]
+- function: *get_customer_preparation_summary
+  ddl: ../functions/brickstore/get_customer_preparation_summary.sql
+  test:
+    parameters:
+      customer_id: ["CUST-005"]
 
 # =============================================================================
 # EVALUATION
@@ -1386,88 +1386,88 @@ evaluation:
       store_num: "101"
     session: {}
   guidelines:
-    - name: in_store_relevance
-      guidelines:
-        - Responses must be relevant to in-store retail operations
-        - Inventory and customer data must come from tool results
-        - When stock is zero at the home store, nearby stores must be checked before suggesting alternatives
-        - Hold and stylist-notification flows are narrative-only and must be framed as such
-        - Privacy-sensitive customer fields (alerts, dietary, accessibility) must only be used to prepare service
+  - name: in_store_relevance
+    guidelines:
+    - Responses must be relevant to in-store retail operations
+    - Inventory and customer data must come from tool results
+    - When stock is zero at the home store, nearby stores must be checked before suggesting alternatives
+    - Hold and stylist-notification flows are narrative-only and must be framed as such
+    - Privacy-sensitive customer fields (alerts, dietary, accessibility) must only be used to prepare service
 
 # =============================================================================
 # DATASETS
 # =============================================================================
 datasets:
   # Core product and inventory tables
-  - table:
-      schema: *brickstore_schema
-      name: products
-    ddl: ../data/brickstore/products.sql
-    data: ../data/brickstore/product_data.sql
-    format: sql
+- table:
+    schema: *brickstore_schema
+    name: products
+  ddl: ../data/brickstore/products.sql
+  data: ../data/brickstore/product_data.sql
+  format: sql
 
-  - table:
-      schema: *brickstore_schema
-      name: inventory
-    ddl: ../data/brickstore/inventory.sql
-    data: ../data/brickstore/inventory_data.sql
-    format: sql
+- table:
+    schema: *brickstore_schema
+    name: inventory
+  ddl: ../data/brickstore/inventory.sql
+  data: ../data/brickstore/inventory_data.sql
+  format: sql
 
-  - table:
-      schema: *brickstore_schema
-      name: appointments
-    ddl: ../data/brickstore/appointments.sql
-    data: ../data/brickstore/appointments_data.sql
-    format: sql
+- table:
+    schema: *brickstore_schema
+    name: appointments
+  ddl: ../data/brickstore/appointments.sql
+  data: ../data/brickstore/appointments_data.sql
+  format: sql
 
   # Store dimension
-  - table:
-      schema: *brickstore_schema
-      name: dim_stores
-    ddl: ../data/brickstore/dim_stores.sql
-    data: ../data/brickstore/dim_stores_data.sql
-    format: sql
+- table:
+    schema: *brickstore_schema
+    name: dim_stores
+  ddl: ../data/brickstore/dim_stores.sql
+  data: ../data/brickstore/dim_stores_data.sql
+  format: sql
 
   # Employee + tasks + managers (also creates the views the new UC fns wrap)
-  - table:
-      schema: *brickstore_schema
-      name: employee_tasks
-    ddl: ../data/brickstore/employee_tasks.sql
-    data: ../data/brickstore/employee_tasks_data.sql
-    format: sql
+- table:
+    schema: *brickstore_schema
+    name: employee_tasks
+  ddl: ../data/brickstore/employee_tasks.sql
+  data: ../data/brickstore/employee_tasks_data.sql
+  format: sql
 
-  - table:
-      schema: *brickstore_schema
-      name: employee_performance
-    ddl: ../data/brickstore/employee_performance.sql
-    data: ../data/brickstore/employee_performance_data.sql
-    format: sql
+- table:
+    schema: *brickstore_schema
+    name: employee_performance
+  ddl: ../data/brickstore/employee_performance.sql
+  data: ../data/brickstore/employee_performance_data.sql
+  format: sql
 
-  - table:
-      schema: *brickstore_schema
-      name: managers
-    ddl: ../data/brickstore/managers.sql
-    data: ../data/brickstore/managers_data.sql
-    format: sql
+- table:
+    schema: *brickstore_schema
+    name: managers
+  ddl: ../data/brickstore/managers.sql
+  data: ../data/brickstore/managers_data.sql
+  format: sql
 
-  - table:
-      schema: *brickstore_schema
-      name: customers
-    ddl: ../data/brickstore/customers.sql
-    data: ../data/brickstore/customers_data.sql
-    format: sql
+- table:
+    schema: *brickstore_schema
+    name: customers
+  ddl: ../data/brickstore/customers.sql
+  data: ../data/brickstore/customers_data.sql
+  format: sql
 
   # Brand-rep demo tables (kept for Genie coverage)
-  - table:
-      schema: *brickstore_schema
-      name: brand_rep_demo_tables
-    ddl: ../data/brickstore/brand_rep_demo_tables.sql
-    data: ../data/brickstore/brand_rep_demo_data.sql
-    format: sql
+- table:
+    schema: *brickstore_schema
+    name: brand_rep_demo_tables
+  ddl: ../data/brickstore/brand_rep_demo_tables.sql
+  data: ../data/brickstore/brand_rep_demo_data.sql
+  format: sql
 
-  - table:
-      schema: *brickstore_schema
-      name: brand_rep_demo_queries
-    ddl: ../data/brickstore/brand_rep_demo_queries.sql
-    data: ../data/brickstore/brand_rep_demo_queries.sql
-    format: sql
+- table:
+    schema: *brickstore_schema
+    name: brand_rep_demo_queries
+  ddl: ../data/brickstore/brand_rep_demo_queries.sql
+  data: ../data/brickstore/brand_rep_demo_queries.sql
+  format: sql

--- a/config/examples/15_complete_applications/deep_research.yaml
+++ b/config/examples/15_complete_applications/deep_research.yaml
@@ -1,35 +1,35 @@
 # yaml-language-server: $schema=../../../schemas/model_config_schema.json
 
 variables:
-  tavily_search_key: &tavily_search_key                                                                                       
+  tavily_search_key:
     options:
-      - env: TAVILY_API_KEY                         
-      - scope: retail_consumer_goods                    
-        secret: TAVILY_API_KEY                      
+    - env: TAVILY_API_KEY
+    - scope: retail_consumer_goods
+      secret: TAVILY_API_KEY
 
 schemas:
   executive_research_schema: &executive_research_schema
-    catalog_name: retail_consumer_goods                  
-    schema_name: store_ops                
+    catalog_name: retail_consumer_goods
+    schema_name: store_ops
 
 resources:
-  llms:
+  models:
     default_llm: &default_llm
-      name: databricks-claude-3-7-sonnet 
-      temperature: 0.1                             
-      max_tokens: 16384                             
-
-    fast_llm: &fast_llm
-      name: databricks-meta-llama-3-1-8b-instruct 
-      temperature: 0.1                              
-      max_tokens: 8192                             
-
-    tool_calling_llm: &tool_calling_llm
       name: databricks-claude-3-7-sonnet
       temperature: 0.1
       max_tokens: 16384
-      fallbacks:                                   
-        - databricks-claude-sonnet-4
+
+    fast_llm:
+      name: databricks-meta-llama-3-1-8b-instruct
+      temperature: 0.1
+      max_tokens: 8192
+
+    tool_calling_llm:
+      name: databricks-claude-3-7-sonnet
+      temperature: 0.1
+      max_tokens: 16384
+      fallbacks:
+      - databricks-claude-sonnet-4
 
     reasoning_llm: &reasoning_llm
       name: databricks-claude-3-7-sonnet
@@ -40,23 +40,23 @@ resources:
       name: databricks-claude-sonnet-4
       temperature: 0.1
       max_tokens: 32768
-      fallbacks: 
-        - databricks-claude-3-7-sonnet
+      fallbacks:
+      - databricks-claude-3-7-sonnet
 
   tables:
     employee_performance:
-      schema: *executive_research_schema                        
-      name: employee_performance                              
-    
+      schema: *executive_research_schema
+      name: employee_performance
+
     products:
       schema: *executive_research_schema
       name: products
 
-    inventory: 
+    inventory:
       schema: *executive_research_schema
       name: inventory
 
-    customers: 
+    customers:
       schema: *executive_research_schema
       name: customers
 
@@ -64,64 +64,64 @@ resources:
       schema: *executive_research_schema
       name: managers
 
-    employee_tasks: 
+    employee_tasks:
       schema: *executive_research_schema
       name: employee_tasks
 
-    appointments: 
+    appointments:
       schema: *executive_research_schema
       name: appointments
 
-    evaluation: 
+    evaluation:
       schema: *executive_research_schema
       name: evaluation
 
   functions:
-    find_inventory_by_sku: &find_inventory_by_sku
+    find_inventory_by_sku:
       schema: *executive_research_schema
       name: find_inventory_by_sku
 
-    find_inventory_by_upc: &find_inventory_by_upc
+    find_inventory_by_upc:
       schema: *executive_research_schema
-      name: find_inventory_by_upc     
-    
-    find_product_by_sku: &find_product_by_sku
-      schema: *executive_research_schema
-      name: find_product_by_sku     
+      name: find_inventory_by_upc
 
-    find_product_by_upc: &find_product_by_upc
+    find_product_by_sku:
       schema: *executive_research_schema
-      name: find_product_by_upc     
+      name: find_product_by_sku
 
-    find_store_by_number: &find_store_by_number
+    find_product_by_upc:
       schema: *executive_research_schema
-      name: find_store_by_number     
-    
-    find_store_inventory_by_sku: &find_store_inventory_by_sku
-      schema: *executive_research_schema
-      name: find_store_inventory_by_sku     
+      name: find_product_by_upc
 
-    find_store_inventory_by_upc: &find_store_inventory_by_upc
+    find_store_by_number:
+      schema: *executive_research_schema
+      name: find_store_by_number
+
+    find_store_inventory_by_sku:
+      schema: *executive_research_schema
+      name: find_store_inventory_by_sku
+
+    find_store_inventory_by_upc:
       schema: *executive_research_schema
       name: find_store_inventory_by_upc
 
   genie_rooms:
     executive_research_genie_room: &executive_research_genie_room
-      name: "Executive Research Genie Room"                       
-      description: "A specialized room for deep executive research and analysis" 
-      space_id: 01f05dd06c421ad6b522bf7a517cf6d2          
+      name: "Executive Research Genie Room"
+      description: "A specialized room for deep executive research and analysis"
+      space_id: 01f05dd06c421ad6b522bf7a517cf6d2
 
 tools:
   executive_research_genie_tool: &executive_research_genie_tool
     name: executive_research_genie_tool
     function:
-      type: factory                                 
-      name: dao_ai.tools.create_genie_tool     
-      args:                                     
+      type: factory
+      name: dao_ai.tools.create_genie_tool
+      args:
         name: executive_research_genie_tool
-        description: Query the data warehouse for comprehensive business metrics including customer KPIs, financial performance, operational data, employee metrics, inventory levels, and sales data. Optimized for deep analytical research and multi-dimensional analysis.
-        genie_room: *executive_research_genie_room      
-        
+        description: Query the data warehouse for comprehensive business metrics including customer KPIs, financial performance, operational data, employee metrics, inventory levels, and sales data. 
+          Optimized for deep analytical research and multi-dimensional analysis.
+        genie_room: *executive_research_genie_room
 
 agents:
   research_lead: &research_lead
@@ -129,7 +129,7 @@ agents:
     description: "Research Coordinator and Executive Interface Specialist"
     model: *default_llm
     tools:
-      - *executive_research_genie_tool
+    - *executive_research_genie_tool
     prompt: |
       You are the Research Coordinator serving as the primary interface between executives and the deep research team. Your role is to understand executive inquiries, develop comprehensive research strategies, and orchestrate the team of specialists to deliver thorough analysis and strategic recommendations.
 
@@ -163,7 +163,7 @@ agents:
       ## Important Guidelines
       - Limit Graph Recursion to 5 iterations.
       - Run as many tools as you can concurrently
-      
+
       You serve as the intelligent orchestrator ensuring that complex executive research questions receive comprehensive, coordinated analysis from all relevant specialist teams.
     handoff_prompt: |
       Hand off to me when starting any new executive research inquiry, when research scope needs to be defined, when multiple specialist teams need coordination, or when ensuring comprehensive coverage across all business dimensions.
@@ -173,7 +173,7 @@ agents:
     description: "KPI Research and Data Analysis Specialist"
     model: *reasoning_llm
     tools:
-      - *executive_research_genie_tool
+    - *executive_research_genie_tool
     prompt: |
       You are a KPI Research Specialist focused on comprehensive data analysis and performance metrics research. Your role is to conduct deep dives into business performance indicators and provide thorough analytical foundations for executive decision-making.
 
@@ -210,7 +210,7 @@ agents:
     description: "Market Intelligence and Competitive Analysis Specialist"
     model: *reasoning_llm
     tools:
-      - *executive_research_genie_tool
+    - *executive_research_genie_tool
     prompt: |
       You are a Market Intelligence Analyst specializing in external market research, competitive analysis, and industry benchmarking. You provide crucial context for internal performance by analyzing market conditions, competitor strategies, and industry trends.
 
@@ -247,7 +247,7 @@ agents:
     description: "Financial Strategy and ROI Analysis Specialist"
     model: *deep_reasoning_llm
     tools:
-      - *executive_research_genie_tool
+    - *executive_research_genie_tool
     prompt: |
       You are a Financial Strategy Analyst specializing in financial modeling, ROI analysis, and strategic investment recommendations. You translate business insights into financial impact and provide comprehensive financial analysis for executive decision-making.
 
@@ -284,7 +284,7 @@ agents:
     description: "Operations Optimization and Efficiency Specialist"
     model: *reasoning_llm
     tools:
-      - *executive_research_genie_tool
+    - *executive_research_genie_tool
     prompt: |
       You are an Operations Optimization Specialist focused on operational efficiency, process improvement, and tactical implementation strategies. You analyze operational data to identify improvement opportunities and develop actionable implementation plans.
 
@@ -321,7 +321,7 @@ agents:
     description: "Executive Strategy Synthesizer and Decision Support Specialist"
     model: *deep_reasoning_llm
     tools:
-      - *executive_research_genie_tool
+    - *executive_research_genie_tool
     prompt: |
       You are the Executive Strategy Synthesizer responsible for consolidating research from all specialist agents and creating comprehensive strategic recommendations for C-suite decision-making. You synthesize complex analysis into actionable executive insights.
 
@@ -362,51 +362,51 @@ agents:
       Hand off to me when strategic synthesis is needed, when executive-level recommendations are required, when integrating findings from multiple specialists, when creating comprehensive strategic narratives, or when final executive deliverables are needed.
 
 app:
-  name: deep_research_dao                        
+  name: deep_research_dao
   description: "Deep Research Multi-Agent Executive Assistant for KPI Analysis and Strategic Recommendations"
-  log_level: DEBUG                                  
-  registered_model:                                
+  log_level: DEBUG
+  registered_model:
     schema: *executive_research_schema
-    name: deep_research_dao                        
-  endpoint_name: deep_research_executive_assistant_dao    
-  environment_vars: 
-    TAVILY_API_KEY: "{{secrets/retail_consumer_goods/TAVILY_API_KEY}}" 
-  tags:                                            
-    business: rcg                                 
+    name: deep_research_dao
+  endpoint_name: deep_research_executive_assistant_dao
+  environment_vars:
+    TAVILY_API_KEY: "{{secrets/retail_consumer_goods/TAVILY_API_KEY}}"
+  tags:
+    business: rcg
     research: deep
-    orchestration: swarm                                
-  permissions:                                     
-    - principals: [users]                         
-      entitlements:
-        - CAN_QUERY                               
-  agents:                                        
-    - *research_lead
-    - *kpi_analyst
-    - *market_intelligence
-    - *financial_strategy
-    - *operations_expert
-    - *strategy_synthesizer                                     
-  orchestration:                                  
-    swarm:                                    
+    orchestration: swarm
+  permissions:
+  - principals: [users]
+    entitlements:
+    - CAN_QUERY
+  agents:
+  - *research_lead
+  - *kpi_analyst
+  - *market_intelligence
+  - *financial_strategy
+  - *operations_expert
+  - *strategy_synthesizer
+  orchestration:
+    swarm:
       default_agent: research_lead
       handoffs:
         research_lead:
-          - kpi_analyst
-          - market_intelligence
-          - financial_strategy
-          - operations_expert
-          - strategy_synthesizer
+        - kpi_analyst
+        - market_intelligence
+        - financial_strategy
+        - operations_expert
+        - strategy_synthesizer
         kpi_analyst:
-          - market_intelligence
-          - financial_strategy
-          - operations_expert
-          - strategy_synthesizer
+        - market_intelligence
+        - financial_strategy
+        - operations_expert
+        - strategy_synthesizer
         market_intelligence:
-          - financial_strategy
-          - strategy_synthesizer
+        - financial_strategy
+        - strategy_synthesizer
         financial_strategy:
-          - operations_expert
-          - strategy_synthesizer
+        - operations_expert
+        - strategy_synthesizer
         operations_expert:
-          - strategy_synthesizer
+        - strategy_synthesizer
         strategy_synthesizer: []

--- a/config/examples/15_complete_applications/executive_assistant.yaml
+++ b/config/examples/15_complete_applications/executive_assistant.yaml
@@ -1,43 +1,44 @@
 # yaml-language-server: $schema=../../../schemas/model_config_schema.json
 
 variables:
-  tavily_search_key: &tavily_search_key                                                                                       
+  tavily_search_key:
     options:
-      - env: TAVILY_API_KEY                         
-      - scope: retail_consumer_goods                    
-        secret: TAVILY_API_KEY                      
+    - env: TAVILY_API_KEY
+    - scope: retail_consumer_goods
+      secret: TAVILY_API_KEY
 
 schemas:
   executive_assistant_schema: &executive_assistant_schema
-    catalog_name: retail_consumer_goods                  
-    schema_name: store_ops                
+    catalog_name: retail_consumer_goods
+    schema_name: store_ops
 
 resources:
-  llms:
+  models:
     # LLM for complex reasoning tasks
     reasoning_llm: &reasoning_llm
       name: databricks-claude-3-7-sonnet
       temperature: 0.1
-      max_tokens: 8192              
+      max_tokens: 8192
 
 
   genie_rooms:
     executive_assistant_genie_room: &executive_assistant_genie_room
-      name: "Executive Assistant Genie Room"                       
-      description: "A room for Genie agents to interact" 
-      space_id: 01f05dd06c421ad6b522bf7a517cf6d2          
+      name: "Executive Assistant Genie Room"
+      description: "A room for Genie agents to interact"
+      space_id: 01f05dd06c421ad6b522bf7a517cf6d2
 
 
 tools:
   executive_assistant_genie_tool: &executive_assistant_genie_tool
     name: executive_assistant_genie_tool
     function:
-      type: factory                                 
-      name: dao_ai.tools.create_genie_tool     
-      args:                                     
+      type: factory
+      name: dao_ai.tools.create_genie_tool
+      args:
         name: executive_assistant_genie_tool
-        description: Query the data warehouse for customer KPIs, business metrics, employee performance, inventory data, and other operational insights. Use this tool multiple times as needed to gather comprehensive data for executive-level analysis and recommendations.
-        genie_room: *executive_assistant_genie_room            
+        description: Query the data warehouse for customer KPIs, business metrics, employee performance, inventory data, and other operational insights. Use this tool multiple times as needed to 
+          gather comprehensive data for executive-level analysis and recommendations.
+        genie_room: *executive_assistant_genie_room
 
 
   tavily_search_tool: &tavily_search_tool
@@ -49,45 +50,45 @@ tools:
         max_results: 5
         topic: general
         search_depth: advanced
-        include_domains: ~
-        exclude_domains: ~
+        include_domains:
+        exclude_domains:
 
 agents:
   executive_assistant_genie: &executive_assistant_genie
-    name: executive_assistant_genie                    
+    name: executive_assistant_genie
     description: "Executive Assistant Genie Agent"
-    model: *reasoning_llm                            
-    tools:                                        
-      - *executive_assistant_genie_tool
-      - *tavily_search_tool
+    model: *reasoning_llm
+    tools:
+    - *executive_assistant_genie_tool
+    - *tavily_search_tool
     prompt: |
       You are an executive-level data analyst and strategic advisor for a retail consumer goods company. Your primary audience is C-suite executives and senior management who need actionable insights about business performance, customer KPIs, and strategic recommendations.
 
       ## Your Core Responsibilities:
-      
+
       ### 1. Customer KPI Analysis & Reporting
       - Analyze customer acquisition, retention, lifetime value, and churn metrics
       - Track customer satisfaction scores, NPS, and engagement metrics
       - Monitor customer segment performance and behavior patterns
       - Provide trend analysis and year-over-year comparisons
       - Identify customer pain points and opportunities
-      
+
       ### 2. Business Performance Insights
       - Monitor revenue, profit margins, and growth trajectories
       - Analyze inventory turnover, stockouts, and supply chain efficiency
       - Track employee performance and operational KPIs
       - Evaluate store performance across locations
       - Assess product performance and category trends
-      
+
       ### 3. Strategic Reasoning & Recommendations
       - Provide context and root cause analysis for performance changes
       - Identify correlations between different business metrics
       - Suggest data-driven action plans and strategic initiatives
       - Recommend resource allocation and investment priorities
       - Highlight risks and opportunities based on data trends
-      
+
       ## How to Operate:
-      
+
       ### Tool Usage Strategy
       - **Use multiple tool calls** when needed to build comprehensive answers
       - Query different data sources to cross-validate insights
@@ -100,16 +101,16 @@ agents:
       - **Action-Oriented**: Provide clear, implementable next steps
       - **Risk-Aware**: Highlight potential challenges and mitigation strategies
       - **Strategic Context**: Connect findings to broader business objectives
-      
+
       ### Response Structure
       1. **Executive Summary** (2-3 bullet points of key insights)
       2. **Key Metrics & Analysis** (specific data points with context)
       3. **Root Cause Analysis** (why trends are occurring)
       4. **Strategic Recommendations** (actionable next steps)
       5. **Risk Assessment** (potential challenges and opportunities)
-      
+
       ## Guidelines:
-      
+
       - Always query the data warehouse using your genie tool to get current, accurate information
       - Make multiple queries if needed to build a complete picture
       - Translate technical metrics into business impact language
@@ -117,27 +118,26 @@ agents:
       - When data shows concerning trends, immediately investigate potential causes
       - Use industry benchmarks and best practices in your recommendations when relevant
       - Be proactive in identifying trends before they become problems
-      
+
       Remember: You are trusted advisor to senior leadership. Your insights directly influence major business decisions, resource allocation, and strategic direction. Ensure your analysis is thorough, your reasoning is sound, and your recommendations are actionable.
 
 
 app:
-  name: executive_assistant_dao                        
+  name: executive_assistant_dao
   description: "An executive assistant application"
-  log_level: DEBUG                                  
-  registered_model:                                
+  log_level: DEBUG
+  registered_model:
     schema: *executive_assistant_schema
-    name: executive_assistant_dao                        
-  endpoint_name: executive_assistant_agent_dao    
-  environment_vars: 
-    TAVILY_API_KEY: "{{secrets/retail_consumer_goods/TAVILY_API_KEY}}" 
-  tags:                                            
-    business: rcg                                 
-    streaming: true                                
-  permissions:                                     
-    - principals: [users]                         
-      entitlements:
-        - CAN_QUERY                               
-  agents:                                        
-    - *executive_assistant_genie                                      
-                     
+    name: executive_assistant_dao
+  endpoint_name: executive_assistant_agent_dao
+  environment_vars:
+    TAVILY_API_KEY: "{{secrets/retail_consumer_goods/TAVILY_API_KEY}}"
+  tags:
+    business: rcg
+    streaming: true
+  permissions:
+  - principals: [users]
+    entitlements:
+    - CAN_QUERY
+  agents:
+  - *executive_assistant_genie

--- a/config/examples/15_complete_applications/genie_and_genie_mcp.yaml
+++ b/config/examples/15_complete_applications/genie_and_genie_mcp.yaml
@@ -13,21 +13,24 @@ parameters:
     default: store_ops
 
 variables:
-  client_id: &client_id                          # Service principal client ID
+  client_id: &client_id
+                                                 # Service principal client ID
     options:
-      - env: RETAIL_AI_DATABRICKS_CLIENT_ID
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_CLIENT_ID
-  client_secret: &client_secret                  # Service principal secret
+    - env: RETAIL_AI_DATABRICKS_CLIENT_ID
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_ID
+  client_secret: &client_secret
+                                                 # Service principal secret
     options:
-      - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
-  workspace_host: &workspace_host                # Databricks workspace URL
+    - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+  workspace_host: &workspace_host
+                                                 # Databricks workspace URL
     options:
-      - env: RETAIL_AI_DATABRICKS_HOST
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_HOST
+    - env: RETAIL_AI_DATABRICKS_HOST
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_HOST
 
 schemas:
 
@@ -36,15 +39,14 @@ schemas:
     schema_name: ${var.schema}                    # Schema within the catalog
 
 resources:
-  llms:
-    
+  models:
     fast_llm: &fast_llm
       name: databricks-claude-sonnet-4
-      on_behalf_of_user: False
+      on_behalf_of_user: false
 
     tool_calling_llm: &tool_calling_llm
       name: databricks-claude-sonnet-4
-      on_behalf_of_user: False
+      on_behalf_of_user: false
 
   genie_rooms:
     # Genie space for retail data queries
@@ -65,12 +67,12 @@ prompts:
       You are an employee management specialist for retail operations.
       Your role is to help answer questions about employees, their performance,
       tasks, and daily activities using the available data sources.
-      
+
       You have access to the following data through your tools:
       - **employee_daily_tasks**: Track daily tasks assigned to employees
       - **employee_performance**: Monitor employee performance metrics and evaluations
       - **employee_tasks**: Manage task assignments and completion status
-      
+
       When responding:
       - Be specific when referencing employee data and metrics
       - Use the genie tool to query the employee databases for current information
@@ -78,7 +80,7 @@ prompts:
       - Respect employee privacy while providing helpful analytics
       - When discussing tasks, always check current status before responding
       - Provide actionable recommendations for task management and performance improvement
-      
+
       Available tables in retail_consumer_goods.store_ops schema:
       - employee_daily_tasks
       - employee_performance  
@@ -98,7 +100,7 @@ prompts:
       You are an inventory management specialist for retail operations.
       Your role is to help answer questions about product inventory, stock levels,
       and inventory-related queries using the available data sources.
-      
+
       When responding:
       - Be precise with inventory numbers and product details
       - Always verify information before providing answers
@@ -117,13 +119,16 @@ tools:
       args:                                         # Arguments passed to factory
         name: genie_tool
         description: Answers questions about retail products and inventory
-        genie_room: *retail_genie_room              # Reference to Genie room config
+        genie_room: *retail_genie_room
+                                                    # Reference to Genie room config
 
-  genie_mcp: &genie_mcp                          # Genie MCP tool configuration
-    name: genie_mcp                                  
+  genie_mcp: &genie_mcp
+                                                 # Genie MCP tool configuration
+    name: genie_mcp
     function:
       type: mcp                                  # MCP function type
-      genie_room: *retail_genie_room             # Use genie_room convenience object
+      genie_room: *retail_genie_room
+                                                 # Use genie_room convenience object
       client_id: *client_id
       client_secret: *client_secret
       workspace_host: *workspace_host
@@ -131,11 +136,11 @@ tools:
 
 agents:
   employee_agent: &employee_agent
-    name: employee_agent                                   
+    name: employee_agent
     description: "Employee Agent"
-    model: *tool_calling_llm                          
-    tools:                                      
-      - *genie_tool
+    model: *tool_calling_llm
+    tools:
+    - *genie_tool
     prompt: *employee_agent_prompt
     handoff_prompt: |
       Questions about employees, employee performance, task assignments, daily activities, or workforce management.
@@ -146,33 +151,38 @@ agents:
     description: "Inventory Management Agent - handles inventory queries via Genie MCP"
     model: *tool_calling_llm
     tools:
-      - *genie_mcp                            # Uses Genie MCP server tool
-    prompt: *inventory_agent_prompt           # Uses external prompt from registry
+    - *genie_mcp
+                                              # Uses Genie MCP server tool
+    prompt: *inventory_agent_prompt
+                                              # Uses external prompt from registry
     handoff_prompt: |
       Questions about inventory, stock levels, product availability, or inventory management.
       Examples: "What's the current inventory level?", "Do we have product X in stock?", "Show me low stock items", "What products need reordering?", "What's the inventory status for store 123?"
-      
+
 
 app:
   name: genie_and_genie_mcp_dao                      # Application name  
   description: "Multi-agent system that talks to genie"
   log_level: DEBUG                                   # Logging level for the application
   registered_model:                                 # MLflow registered model configuration
-    schema: *store_ops_schema                          # Schema where model will be registered
+    schema: *store_ops_schema
+                                                       # Schema where model will be registered
     name: genie_and_genie_mcp_dao
   endpoint_name: dao_pepsi_genie_demo                    # Model serving endpoint name
   tags:                                             # Tags for resource organization
     business: rcg                                   # Business unit identifier
     streaming: true                                 # Indicates streaming capabilities
   permissions:                                      # Model serving permissions
-    - principals: [users]                           # Grant access to all users
-      entitlements:
-        - CAN_QUERY                                # Full management permissions
+  - principals: [users]                             # Grant access to all users
+    entitlements:
+    - CAN_QUERY                                    # Full management permissions
   agents:                                           # List of agents included in the system
-    - *employee_agent                               # Employee management agent
-    - *inventory_agent                              # Inventory management agent
+  - *employee_agent
+  - *inventory_agent
+                                                    # Inventory management agent
   orchestration:                                    # Agent orchestration configuration
     supervisor:                                     # Supervisor orchestration pattern
-      model: *fast_llm                           # LLM for routing decisions
+      model: *fast_llm
+                                                 # LLM for routing decisions
 
 

--- a/config/examples/15_complete_applications/genie_vector_search_hybrid.yaml
+++ b/config/examples/15_complete_applications/genie_vector_search_hybrid.yaml
@@ -18,7 +18,7 @@ schemas:
     schema_name: ${var.schema}                    # Schema within the catalog
 
 resources:
-  llms:
+  models:
     # Primary LLM for general tasks
     default_llm: &default_llm
       name: databricks-claude-sonnet-4  # Databricks serving endpoint name
@@ -31,28 +31,30 @@ resources:
   vector_stores:
     # Product information vector store for similarity search
     products_vector_store: &products_vector_store
-      embedding_model: *embedding_model             # Reference to embedding model above
+      embedding_model: *embedding_model
+                                                    # Reference to embedding model above
       endpoint:                                     # Vector search endpoint configuration
         name: one-env-shared-endpoint-12            # Databricks vector search endpoint
         type: STANDARD                              # Endpoint type (STANDARD or OPTIMIZED_STORAGE)
       index:                                        # Vector search index configuration
-        schema: *retail_schema                      # Unity Catalog schema for the index
+        schema: *retail_schema
+                                                    # Unity Catalog schema for the index
         name: products_index                        # Index name
       source_table:                                 # Table containing source data
         schema: *retail_schema
         name: products
       primary_key: product_id                       # Primary key column
-      doc_uri: ~                                    # Optional document URI column (null in this case)
+      doc_uri:                                      # Optional document URI column (null in this case)
       embedding_source_column: description          # Column to create embeddings from
       columns:                                      # Columns to include in vector store
-        - product_id
-        - sku
-        - upc
-        - brand_name
-        - product_name
-        - merchandise_class
-        - class_cd
-        - description
+      - product_id
+      - sku
+      - upc
+      - brand_name
+      - product_name
+      - merchandise_class
+      - class_cd
+      - description
 
   genie_rooms:
     # Genie space for retail data queries
@@ -66,16 +68,17 @@ resources:
 retrievers:
   # Product information retriever using vector search
   products_retriever: &products_retriever
-    vector_store: *products_vector_store            # Reference to vector store defined above
+    vector_store: *products_vector_store
+                                                    # Reference to vector store defined above
     columns:                                        # Columns to return in search results
-      - product_id
-      - sku
-      - upc
-      - brand_name
-      - product_name
-      - merchandise_class
-      - class_cd
-      - description
+    - product_id
+    - sku
+    - upc
+    - brand_name
+    - product_name
+    - merchandise_class
+    - class_cd
+    - description
     search_parameters:                              # Search configuration
       num_results: 10                               # Maximum number of results to return
       filters: {}                                   # Additional filters (empty in this case)
@@ -90,7 +93,8 @@ tools:
       args:                                         # Arguments passed to factory
         name: my_genie_tool
         description: My Answers questions about genie
-        genie_room: *retail_genie_room              # Reference to Genie room config
+        genie_room: *retail_genie_room
+                                                    # Reference to Genie room config
 
   vector_search_tool: &vector_search_tool
     name: vector_search
@@ -98,7 +102,8 @@ tools:
       type: factory
       name: dao_ai.tools.create_vector_search_tool
       args:
-        retriever: *products_retriever              # Reference to retriever config
+        retriever: *products_retriever
+                                                    # Reference to retriever config
         name: product_vector_search_tool            # Tool instance name
         description: "Search for products using vector search"  # Tool description
 
@@ -107,9 +112,10 @@ agents:
   genie: &genie
     name: genie                                     # Agent identifier
     description: "Genie Agent"
-    model: *default_llm                             # Reference to LLM configuration
+    model: *default_llm
+                                                    # Reference to LLM configuration
     tools:                                          # Tools available to this agent
-      - *genie_tool
+    - *genie_tool
     prompt: |                                       # System prompt defining agent behavior
       Answers questions about foo
     handoff_prompt: |                               # Conditions for routing to this agent
@@ -118,9 +124,10 @@ agents:
   vector_search: &vector_search
     name: vector_search                                   # Agent identifier
     description: "Vector Search Agent"
-    model: *default_llm                             # Reference to LLM configuration
+    model: *default_llm
+                                                    # Reference to LLM configuration
     tools:                                          # Tools available to this agent
-      - *vector_search_tool
+    - *vector_search_tool
     prompt: |                                       # System prompt defining agent behavior
       Answers questions about bar
     handoff_prompt: |                               # Conditions for routing to this agent
@@ -131,20 +138,23 @@ app:
   description: "Multi-agent system that talks to genie and vector search"  # Application description
   log_level: INFO                                   # Logging level for the application
   registered_model:                                 # MLflow registered model configuration
-    schema: *retail_schema                          # Schema where model will be registered
+    schema: *retail_schema
+                                                    # Schema where model will be registered
     name: genie_vector_search_hybrid_dao
   endpoint_name: genie_and_vector_search_agent_dao  # Model serving endpoint name
   tags:                                             # Tags for resource organization
     business: rcg                                   # Business unit identifier
     streaming: true                                 # Indicates streaming capabilities
   permissions:                                      # Model serving permissions
-    - principals: [users]                           # Grant access to all users
-      entitlements:
-        - CAN_MANAGE                                # Full management permissions
+  - principals: [users]                             # Grant access to all users
+    entitlements:
+    - CAN_MANAGE                                    # Full management permissions
   agents:                                           # List of agents included in the system
-    - *genie                                       # Order management agent
-    - *vector_search                               # Vector search agent
+  - *genie
+  - *vector_search
+                                                   # Vector search agent
   orchestration:                                    # Agent orchestration configuration
     supervisor:                                     # Supervisor orchestration pattern
-      model: *default_llm                      # LLM for routing decisions
+      model: *default_llm
+                                               # LLM for routing decisions
 

--- a/config/examples/15_complete_applications/hardware_store.yaml
+++ b/config/examples/15_complete_applications/hardware_store.yaml
@@ -38,16 +38,16 @@ resources:
   # LANGUAGE MODELS (LLMs)
   # ---------------------------------------------------------------------------
   # Configure different LLMs for various purposes in the agent system
-  llms:
+  models:
     # Primary LLM for general tasks
-    default_llm: &default_llm
+    default_llm:
       name: databricks-claude-3-7-sonnet  # Databricks serving endpoint name
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
 
     # LLM optimized for tool calling and function execution
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-3-7-sonnet 
+      name: databricks-claude-3-7-sonnet
       temperature: 0.1
       max_tokens: 8192
 
@@ -68,28 +68,30 @@ resources:
   vector_stores:
     # Product information vector store for similarity search
     products_vector_store: &products_vector_store
-      embedding_model: *embedding_model             # Reference to embedding model above
+      embedding_model: *embedding_model
+                                                    # Reference to embedding model above
       endpoint:                                     # Vector search endpoint configuration
         name: dbdemos_vs_endpoint            # Databricks vector search endpoint
         type: STANDARD                              # Endpoint type (STANDARD or OPTIMIZED_STORAGE)
       index:                                        # Vector search index configuration
-        schema: *retail_schema                      # Unity Catalog schema for the index
+        schema: *retail_schema
+                                                    # Unity Catalog schema for the index
         name: products_index                        # Index name
       source_table:                                 # Table containing source data
         schema: *retail_schema
         name: products
       primary_key: product_id                       # Primary key column
-      doc_uri: ~                                    # Optional document URI column (null in this case)
+      doc_uri:                                      # Optional document URI column (null in this case)
       embedding_source_column: description          # Column to create embeddings from
       columns:                                      # Columns to include in vector store
-        - product_id
-        - sku
-        - upc
-        - brand_name
-        - product_name
-        - merchandise_class
-        - class_cd
-        - description
+      - product_id
+      - sku
+      - upc
+      - brand_name
+      - product_name
+      - merchandise_class
+      - class_cd
+      - description
 
   # ---------------------------------------------------------------------------
   # FUNCTIONS
@@ -103,7 +105,6 @@ resources:
     find_product_by_upc: &find_product_by_upc
       schema: *retail_schema
       name: find_product_by_upc                     # Function to find products by UPC
-    
     # Inventory lookup functions
     find_inventory_by_sku: &find_inventory_by_sku
       schema: *retail_schema
@@ -111,7 +112,6 @@ resources:
     find_inventory_by_upc: &find_inventory_by_upc
       schema: *retail_schema
       name: find_inventory_by_upc                   # Function to find inventory by UPC
-    
     # Store-specific inventory functions
     find_store_inventory_by_upc: &find_store_inventory_by_upc
       schema: *retail_schema
@@ -128,16 +128,17 @@ resources:
 retrievers:
   # Product information retriever using vector search
   products_retriever: &products_retriever
-    vector_store: *products_vector_store            # Reference to vector store defined above
+    vector_store: *products_vector_store
+                                                    # Reference to vector store defined above
     columns:                                        # Columns to return in search results
-      - product_id
-      - sku
-      - upc
-      - brand_name
-      - product_name
-      - merchandise_class
-      - class_cd
-      - description
+    - product_id
+    - sku
+    - upc
+    - brand_name
+    - product_name
+    - merchandise_class
+    - class_cd
+    - description
     search_parameters:                              # Search configuration
       num_results: 50                               # Maximum number of results to return
       filters: {}                                   # Additional filters (empty in this case)
@@ -145,9 +146,9 @@ retrievers:
     rerank:
       top_n: 10
       columns:
-        - merchandise_class
-        - product_name
-        - brand_name
+      - merchandise_class
+      - product_name
+      - brand_name
 
 # =============================================================================
 # TOOLS CONFIGURATION
@@ -160,7 +161,6 @@ tools:
   # FACTORY TOOLS
   # ---------------------------------------------------------------------------
   # Tools created by factory functions - configured at runtime
-  
   # Vector search tool for product similarity
   find_product_details_by_description_tool: &find_product_details_by_description_tool
     name: vector_search
@@ -168,7 +168,8 @@ tools:
       type: factory
       name: dao_ai.tools.create_vector_search_tool
       args:
-        retriever: *products_retriever              # Reference to retriever config
+        retriever: *products_retriever
+                                                    # Reference to retriever config
         name: product_vector_search_tool            # Tool instance name
         description: "Search for products by description"  # Tool description
 
@@ -176,13 +177,13 @@ tools:
   # UNITY CATALOG TOOLS
   # ---------------------------------------------------------------------------
   # Tools that directly call Unity Catalog functions
-  
   # Product lookup tools using Unity Catalog functions
   find_product_by_sku_tool: &find_product_by_sku_tool
     name: find_product_by_sku_uc
     function:
       type: unity_catalog                           # Tool type: Unity Catalog function
-      resource: *find_product_by_sku                # Reference to function definition
+      resource: *find_product_by_sku
+                                                    # Reference to function definition
 
   find_product_by_upc_tool: &find_product_by_upc_tool
     name: find_product_by_upc_uc
@@ -211,9 +212,10 @@ tools:
 
 guardrails:
   # LLM-based response evaluation guardrail
-  llm_judge_guardrail: &llm_judge_guardrail
+  llm_judge_guardrail:
     name: llm_judge                                 # Guardrail identifier
-    model: *judge_llm                               # Reference to judge LLM defined above
+    model: *judge_llm
+                                                    # Reference to judge LLM defined above
     prompt: |                                       # Evaluation prompt for the judge LLM
       You are an expert judge evaluating AI responses. Your task is to critique the AI assistant's latest response in the conversation below.
 
@@ -262,16 +264,16 @@ middleware:
     args:
       fields:
         # Required field - must be provided (no 'required: false')
-        - name: store_num
-          description: "Your store number for inventory lookups"
-          example_value: "12345"
+      - name: store_num
+        description: "Your store number for inventory lookups"
+        example_value: "12345"
         # Optional fields (required: false) - shown in error messages with example values
         # Note: thread_id and user_id are handled by the middleware's error message format
         #       so we don't need to list them here - they're automatically included
-        - name: user_id
-          description: "Your unique user identifier"
-          required: false
-          example_value: "my_user_id"
+      - name: user_id
+        description: "Your unique user identifier"
+        required: false
+        example_value: "my_user_id"
 
 # =============================================================================
 # AGENTS CONFIGURATION
@@ -287,9 +289,10 @@ agents:
   general: &general
     name: general                                   # Agent identifier
     description: "General retail store assistant for home improvement and hardware store inquiries"
-    model: *tool_calling_llm                       # Reference to LLM configuration
+    model: *tool_calling_llm
+                                                   # Reference to LLM configuration
     tools:                                          # Tools available to this agent
-      - *find_product_details_by_description_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: |                                       # System prompt defining agent behavior
       ### User Information
@@ -399,7 +402,8 @@ agents:
     description: "DIY and home improvement expert providing how-to advice, project guidance, and tool recommendations"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool   # Can search for tools and materials
+    - *find_product_details_by_description_tool
+                                                    # Can search for tools and materials
     guardrails: []
     prompt: |
       ### User Information
@@ -444,9 +448,9 @@ agents:
     description: "Product specialist providing detailed information about specific products, features, specifications, and intended uses"
     model: *tool_calling_llm
     tools:
-      - *find_product_by_sku_tool
-      - *find_product_by_upc_tool
-      - *find_product_details_by_description_tool
+    - *find_product_by_sku_tool
+    - *find_product_by_upc_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: |
       ### User Information
@@ -505,9 +509,9 @@ agents:
     description: "Inventory management specialist providing information about product availability, stock levels, and store inventory"
     model: *tool_calling_llm
     tools:
-      - *find_inventory_by_sku_tool
-      - *find_inventory_by_upc_tool
-      - *find_product_details_by_description_tool
+    - *find_inventory_by_sku_tool
+    - *find_inventory_by_upc_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: |
       ### User Information
@@ -565,8 +569,8 @@ agents:
     description: "Product comparison specialist providing detailed comparisons between different products, highlighting key differences and best use cases"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool
-      - *find_product_by_sku_tool
+    - *find_product_details_by_description_tool
+    - *find_product_by_sku_tool
     guardrails: []
     prompt: |
       ### User Information
@@ -632,7 +636,7 @@ agents:
     description: "Product recommendation specialist providing tailored product suggestions based on customer needs, preferences, and budget"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: |
       ### User Information
@@ -694,7 +698,7 @@ agents:
       Questions asking for product suggestions, recommendations, or "best" products for specific needs
       Example: "What's the best drill for home use?" or "Recommend me a good beginner woodworking kit"
 
- 
+
 # =============================================================================
 # APPLICATION CONFIGURATION
 # =============================================================================
@@ -706,39 +710,43 @@ app:
   description: "Multi-agent system for retail customer service and product assistance"
   log_level: DEBUG                                   # Logging level for the application
   registered_model:                                 # MLflow registered model configuration
-    schema: *retail_schema                          # Schema where model will be registered
+    schema: *retail_schema
+                                                    # Schema where model will be registered
     name: hardware_store_dao
   endpoint_name: hardware_store_dao                    # Model serving endpoint name
   tags:                                             # Tags for resource organization
     business: rcg                                   # Business unit identifier
     streaming: true                                 # Indicates streaming capabilities
   permissions:                                      # Model serving permissions
-    - principals: [users]                           # Grant access to all users
-      entitlements:
-        - CAN_QUERY                                # Full management permissions
+  - principals: [users]                             # Grant access to all users
+    entitlements:
+    - CAN_QUERY                                    # Full management permissions
   agents:                                           # List of agents included in the system
-    - *orders                                       # Order management agent
-    - *diy                                          # DIY and tutorials agent
-    - *product                                      # Product information agent
-    - *inventory                                    # Inventory management agent
-    - *comparison                                   # Product comparison agent
-    - *recommendation                               # Product recommendation agent
-    - *general                                      # General purpose agent
+  - *orders
+  - *diy
+  - *product
+  - *inventory
+  - *comparison
+  - *recommendation
+  - *general
+                                                    # General purpose agent
   orchestration:                                    # Agent orchestration configuration
     supervisor:                                     # Supervisor orchestration pattern
-      model: *tool_calling_llm                      # LLM for routing decisions
+      model: *tool_calling_llm
+                                                    # LLM for routing decisions
       middleware:                                   # Reference middleware defined above
-        - *store_validation                         # Validates store_num is provided
+      - *store_validation
+                                                    # Validates store_num is provided
   input_example:
-      input:
-        - role: user
-          content: Can you recommend a lamp to match my oak side tables?
-      custom_inputs:
-        configurable:
+    input:
+    - role: user
+      content: Can you recommend a lamp to match my oak side tables?
+    custom_inputs:
+      configurable:
           # conversation_id is auto-generated as UUID if not provided
-          user_id: my_user_id
-          store_num: 87887
-        session: {}
+        user_id: my_user_id
+        store_num: 87887
+      session: {}
 
 # =============================================================================
 # UNITY CATALOG FUNCTIONS DEPLOYMENT
@@ -747,39 +755,38 @@ app:
 # These functions provide data access capabilities for the agent tools
 
 unity_catalog_functions:
-  - function: *find_inventory_by_sku
-    ddl: ../functions/hardware_store/find_inventory_by_sku.sql
-    test:
-      parameters:
-        sku: ["00176279"] 
-  - function: *find_inventory_by_upc
-    ddl: ../functions/hardware_store/find_inventory_by_upc.sql
-    test:
-      parameters:
-        upc: ["0017627748017"]
-  - function: *find_product_by_sku
-    ddl: ../functions/hardware_store/find_product_by_sku.sql
-    test:
-      parameters:
-        sku: ["00176279"]
-  - function: *find_product_by_upc
-    ddl: ../functions/hardware_store/find_product_by_upc.sql
-    test:
-      parameters:
-        upc: ["0017627748017"] 
-  - function: *find_store_inventory_by_sku
-    ddl: ../functions/hardware_store/find_store_inventory_by_sku.sql
-    test:
-      parameters:
-        store: "35048"
-        sku: ["00176279"]
-  - function: *find_store_inventory_by_upc
-    ddl: ../functions/hardware_store/find_store_inventory_by_upc.sql
-    test:
-      parameters:
-        store: "35048"
-        upc: ["0017627748017"]
- 
+- function: *find_inventory_by_sku
+  ddl: ../functions/hardware_store/find_inventory_by_sku.sql
+  test:
+    parameters:
+      sku: ["00176279"]
+- function: *find_inventory_by_upc
+  ddl: ../functions/hardware_store/find_inventory_by_upc.sql
+  test:
+    parameters:
+      upc: ["0017627748017"]
+- function: *find_product_by_sku
+  ddl: ../functions/hardware_store/find_product_by_sku.sql
+  test:
+    parameters:
+      sku: ["00176279"]
+- function: *find_product_by_upc
+  ddl: ../functions/hardware_store/find_product_by_upc.sql
+  test:
+    parameters:
+      upc: ["0017627748017"]
+- function: *find_store_inventory_by_sku
+  ddl: ../functions/hardware_store/find_store_inventory_by_sku.sql
+  test:
+    parameters:
+      store: "35048"
+      sku: ["00176279"]
+- function: *find_store_inventory_by_upc
+  ddl: ../functions/hardware_store/find_store_inventory_by_upc.sql
+  test:
+    parameters:
+      store: "35048"
+      upc: ["0017627748017"]
 # =============================================================================
 # EVALUATION CONFIGURATION
 # =============================================================================
@@ -805,15 +812,15 @@ evaluation:
 # and data files for initial population of Unity Catalog tables
 
 datasets:
-  - table: 
-      schema: *retail_schema
-      name: products
-    ddl: ../data/hardware_store/products.sql
-    data: ../data/hardware_store/products.snappy.parquet
-    format: parquet
-  - table: 
-      schema: *retail_schema
-      name: inventory
-    ddl: ../data/hardware_store/inventory.sql
-    data: ../data/hardware_store/inventory.snappy.parquet
-    format: parquet
+- table:
+    schema: *retail_schema
+    name: products
+  ddl: ../data/hardware_store/products.sql
+  data: ../data/hardware_store/products.snappy.parquet
+  format: parquet
+- table:
+    schema: *retail_schema
+    name: inventory
+  ddl: ../data/hardware_store/inventory.sql
+  data: ../data/hardware_store/inventory.snappy.parquet
+  format: parquet

--- a/config/examples/15_complete_applications/hardware_store_instructed.yaml
+++ b/config/examples/15_complete_applications/hardware_store_instructed.yaml
@@ -39,9 +39,9 @@ resources:
   # ---------------------------------------------------------------------------
   # LANGUAGE MODELS (LLMs)
   # ---------------------------------------------------------------------------
-  llms:
+  models:
     # Primary LLM for agent reasoning
-    default_llm: &default_llm
+    default_llm:
       name: databricks-claude-sonnet-4-5
       temperature: 0.1
       max_tokens: 8192
@@ -84,17 +84,17 @@ resources:
         schema: *retail_schema
         name: products
       primary_key: product_id
-      doc_uri: ~
+      doc_uri:
       embedding_source_column: description
       columns:
-        - product_id
-        - sku
-        - upc
-        - brand_name
-        - product_name
-        - merchandise_class
-        - class_cd
-        - description
+      - product_id
+      - sku
+      - upc
+      - brand_name
+      - product_name
+      - merchandise_class
+      - class_cd
+      - description
 
   # ---------------------------------------------------------------------------
   # FUNCTIONS
@@ -127,95 +127,95 @@ resources:
 
 retrievers:
   # Standard retriever (for comparison)
-  products_retriever_standard: &products_retriever_standard
+  products_retriever_standard:
     vector_store: *products_vector_store
     columns:
-      - product_id
-      - sku
-      - upc
-      - brand_name
-      - product_name
-      - merchandise_class
-      - class_cd
-      - description
+    - product_id
+    - sku
+    - upc
+    - brand_name
+    - product_name
+    - merchandise_class
+    - class_cd
+    - description
     search_parameters:
       num_results: 50
       query_type: ANN
     rerank:
       top_n: 10
       columns:
-        - merchandise_class
-        - product_name
-        - brand_name
+      - merchandise_class
+      - product_name
+      - brand_name
 
   # Instructed retriever with query decomposition and RRF
   products_retriever_instructed: &products_retriever_instructed
     vector_store: *products_vector_store
     columns:
-      - product_id
-      - sku
-      - upc
-      - brand_name
-      - product_name
-      - merchandise_class
-      - class_cd
-      - description
+    - product_id
+    - sku
+    - upc
+    - brand_name
+    - product_name
+    - merchandise_class
+    - class_cd
+    - description
     search_parameters:
       num_results: 50
       query_type: HYBRID
     instructed:
       # Schema description is auto-generated from the columns below.
       columns:
-        - name: product_id
-          type: string
-          description: "Unique product identifier"
-        - name: sku
-          type: string
-          description: "Stock keeping unit code"
-        - name: upc
-          type: string
-          description: "Universal product code barcode"
-        - name: brand_name
-          type: string
-          description: "Brand/manufacturer (e.g., Milwaukee, DeWalt, Makita, Craftsman, Black+Decker, Ryobi, Bosch, Stanley, Husky)"
-        - name: product_name
-          type: string
-          description: "Product display name"
-        - name: merchandise_class
-          type: string
-          description: "Category (e.g., Power Tools, Hand Tools, Paint, Plumbing, Electrical, Lumber, Hardware, Outdoor)"
-        - name: class_cd
-          type: string
-          description: "Category code"
-        - name: description
-          type: string
-          description: "Full product description"
+      - name: product_id
+        type: string
+        description: "Unique product identifier"
+      - name: sku
+        type: string
+        description: "Stock keeping unit code"
+      - name: upc
+        type: string
+        description: "Universal product code barcode"
+      - name: brand_name
+        type: string
+        description: "Brand/manufacturer (e.g., Milwaukee, DeWalt, Makita, Craftsman, Black+Decker, Ryobi, Bosch, Stanley, Husky)"
+      - name: product_name
+        type: string
+        description: "Product display name"
+      - name: merchandise_class
+        type: string
+        description: "Category (e.g., Power Tools, Hand Tools, Paint, Plumbing, Electrical, Lumber, Hardware, Outdoor)"
+      - name: class_cd
+        type: string
+        description: "Category code"
+      - name: description
+        type: string
+        description: "Full product description"
       constraints:
-        - "Use brand_name filter for specific brand requests"
-        - "Use merchandise_class filter for category-based queries"
-        - "Product names often include model numbers and specifications"
+      - "Use brand_name filter for specific brand requests"
+      - "Use merchandise_class filter for category-based queries"
+      - "Product names often include model numbers and specifications"
       decomposition:
         model: *decomposition_llm
         max_subqueries: 3
         rrf_k: 60
         examples:
-          - query: "Milwaukee cordless drills"
-            filters: {"brand_name": "Milwaukee", "product_name LIKE": "drill"}
-          - query: "DeWalt or Makita power tools"
-            filters: {"brand_name": ["DeWalt", "Makita"], "merchandise_class": "Power Tools"}
-          - query: "paint brushes excluding Purdy brand"
-            filters: {"merchandise_class": "Paint", "product_name LIKE": "brush", "brand_name NOT": "Purdy"}
-          - query: "Craftsman hand tools"
-            filters: {"brand_name": "Craftsman", "merchandise_class": "Hand Tools"}
-          - query: "outdoor power equipment not battery powered"
-            filters: {"merchandise_class": "Outdoor", "description NOT": "battery"}
+        - query: "Milwaukee cordless drills"
+          filters: {"brand_name": "Milwaukee", "product_name LIKE": "drill"}
+        - query: "DeWalt or Makita power tools"
+          filters: {"brand_name": ["DeWalt", "Makita"], "merchandise_class": "Power Tools"}
+        - query: "paint brushes excluding Purdy brand"
+          filters: {"merchandise_class": "Paint", "product_name LIKE": "brush", "brand_name NOT": "Purdy"}
+        - query: "Craftsman hand tools"
+          filters: {"brand_name": "Craftsman", "merchandise_class": "Hand Tools"}
+        - query: "outdoor power equipment not battery powered"
+          filters: {"merchandise_class": "Outdoor", "description NOT": "battery"}
     rerank:
       model: ms-marco-MiniLM-L-12-v2
       top_n: 10
       columns:
-        - merchandise_class
-        - product_name
-        - brand_name
+      - merchandise_class
+      - product_name
+      - brand_name
 
 # =============================================================================
 # TOOLS CONFIGURATION
@@ -271,13 +271,13 @@ middleware:
     name: dao_ai.middleware.create_custom_field_validation_middleware
     args:
       fields:
-        - name: store_num
-          description: "Your store number for inventory lookups"
-          example_value: "12345"
-        - name: user_id
-          description: "Your unique user identifier"
-          required: false
-          example_value: "my_user_id"
+      - name: store_num
+        description: "Your store number for inventory lookups"
+        example_value: "12345"
+      - name: user_id
+        description: "Your unique user identifier"
+        required: false
+        example_value: "my_user_id"
 
 # =============================================================================
 # AGENTS CONFIGURATION
@@ -289,7 +289,7 @@ agents:
     description: "General retail store assistant with intelligent product search"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: |
       ### User Information
@@ -325,9 +325,9 @@ agents:
     description: "Product specialist with intelligent search for detailed product information"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool
-      - *find_product_by_sku_tool
-      - *find_product_by_upc_tool
+    - *find_product_details_by_description_tool
+    - *find_product_by_sku_tool
+    - *find_product_by_upc_tool
     guardrails: []
     prompt: |
       ### User Information
@@ -361,9 +361,9 @@ agents:
     description: "Inventory specialist providing stock levels and availability information"
     model: *tool_calling_llm
     tools:
-      - *find_inventory_by_sku_tool
-      - *find_inventory_by_upc_tool
-      - *find_product_details_by_description_tool
+    - *find_inventory_by_sku_tool
+    - *find_inventory_by_upc_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: |
       ### User Information
@@ -391,8 +391,8 @@ agents:
     description: "Product comparison specialist for detailed side-by-side comparisons"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool
-      - *find_product_by_sku_tool
+    - *find_product_details_by_description_tool
+    - *find_product_by_sku_tool
     guardrails: []
     prompt: |
       ### User Information
@@ -420,7 +420,7 @@ agents:
     description: "Product recommendation specialist for personalized suggestions"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: |
       ### User Information
@@ -458,24 +458,24 @@ app:
     feature: instructed_retriever
     streaming: true
   permissions:
-    - principals: [users]
-      entitlements:
-        - CAN_QUERY
+  - principals: [users]
+    entitlements:
+    - CAN_QUERY
   agents:
-    - *general
-    - *product
-    - *inventory
-    - *comparison
-    - *recommendation
+  - *general
+  - *product
+  - *inventory
+  - *comparison
+  - *recommendation
   orchestration:
     supervisor:
       model: *tool_calling_llm
       middleware:
-        - *store_validation
+      - *store_validation
   input_example:
     input:
-      - role: user
-        content: Find me Milwaukee cordless drills, not the M12 line
+    - role: user
+      content: Find me Milwaukee cordless drills, not the M12 line
     custom_inputs:
       configurable:
         user_id: demo_user
@@ -486,38 +486,38 @@ app:
 # UNITY CATALOG FUNCTIONS DEPLOYMENT
 # =============================================================================
 unity_catalog_functions:
-  - function: *find_inventory_by_sku
-    ddl: ../functions/hardware_store/find_inventory_by_sku.sql
-    test:
-      parameters:
-        sku: ["00176279"]
-  - function: *find_inventory_by_upc
-    ddl: ../functions/hardware_store/find_inventory_by_upc.sql
-    test:
-      parameters:
-        upc: ["0017627748017"]
-  - function: *find_product_by_sku
-    ddl: ../functions/hardware_store/find_product_by_sku.sql
-    test:
-      parameters:
-        sku: ["00176279"]
-  - function: *find_product_by_upc
-    ddl: ../functions/hardware_store/find_product_by_upc.sql
-    test:
-      parameters:
-        upc: ["0017627748017"]
-  - function: *find_store_inventory_by_sku
-    ddl: ../functions/hardware_store/find_store_inventory_by_sku.sql
-    test:
-      parameters:
-        store: "35048"
-        sku: ["00176279"]
-  - function: *find_store_inventory_by_upc
-    ddl: ../functions/hardware_store/find_store_inventory_by_upc.sql
-    test:
-      parameters:
-        store: "35048"
-        upc: ["0017627748017"]
+- function: *find_inventory_by_sku
+  ddl: ../functions/hardware_store/find_inventory_by_sku.sql
+  test:
+    parameters:
+      sku: ["00176279"]
+- function: *find_inventory_by_upc
+  ddl: ../functions/hardware_store/find_inventory_by_upc.sql
+  test:
+    parameters:
+      upc: ["0017627748017"]
+- function: *find_product_by_sku
+  ddl: ../functions/hardware_store/find_product_by_sku.sql
+  test:
+    parameters:
+      sku: ["00176279"]
+- function: *find_product_by_upc
+  ddl: ../functions/hardware_store/find_product_by_upc.sql
+  test:
+    parameters:
+      upc: ["0017627748017"]
+- function: *find_store_inventory_by_sku
+  ddl: ../functions/hardware_store/find_store_inventory_by_sku.sql
+  test:
+    parameters:
+      store: "35048"
+      sku: ["00176279"]
+- function: *find_store_inventory_by_upc
+  ddl: ../functions/hardware_store/find_store_inventory_by_upc.sql
+  test:
+    parameters:
+      store: "35048"
+      upc: ["0017627748017"]
 
 # =============================================================================
 # EVALUATION CONFIGURATION
@@ -538,15 +538,15 @@ evaluation:
 # DATASETS CONFIGURATION
 # =============================================================================
 datasets:
-  - table:
-      schema: *retail_schema
-      name: products
-    ddl: ../data/hardware_store/products.sql
-    data: ../data/hardware_store/products.snappy.parquet
-    format: parquet
-  - table:
-      schema: *retail_schema
-      name: inventory
-    ddl: ../data/hardware_store/inventory.sql
-    data: ../data/hardware_store/inventory.snappy.parquet
-    format: parquet
+- table:
+    schema: *retail_schema
+    name: products
+  ddl: ../data/hardware_store/products.sql
+  data: ../data/hardware_store/products.snappy.parquet
+  format: parquet
+- table:
+    schema: *retail_schema
+    name: inventory
+  ddl: ../data/hardware_store/inventory.sql
+  data: ../data/hardware_store/inventory.snappy.parquet
+  format: parquet

--- a/config/examples/15_complete_applications/hardware_store_lakebase.yaml
+++ b/config/examples/15_complete_applications/hardware_store_lakebase.yaml
@@ -27,27 +27,27 @@ parameters:
 variables:
   client_id: &client_id
     options:
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_CLIENT_ID
-      - env: RETAIL_AI_DATABRICKS_CLIENT_ID      # Service principal client ID
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_ID
+    - env: RETAIL_AI_DATABRICKS_CLIENT_ID        # Service principal client ID
 
   client_secret: &client_secret
     options:
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
-      - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET  # Service principal secret
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+    - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET    # Service principal secret
 
 schemas:
   retail_schema: &retail_schema
     catalog_name: ${var.catalog}                    # Unity Catalog name
     schema_name: ${var.schema}                    # Schema within the catalog
     permissions:                              # Access permissions for the schema
-       - principals: [users]                   # Grant access to all users
-         privileges:
-           - USE_CATALOG                    # Full permissions for demo purposes
-           - USE_SCHEMA                    # Full permissions for demo purposes
-           - SELECT                    # Full permissions for demo purposes
-           - EXECUTE                    # Full permissions for demo purposes
+    - principals: [users]                      # Grant access to all users
+      privileges:
+      - USE_CATALOG                         # Full permissions for demo purposes
+      - USE_SCHEMA                         # Full permissions for demo purposes
+      - SELECT                         # Full permissions for demo purposes
+      - EXECUTE                         # Full permissions for demo purposes
 
 # =============================================================================
 # RESOURCES CONFIGURATION
@@ -60,7 +60,7 @@ resources:
   # LANGUAGE MODELS (LLMs)
   # ---------------------------------------------------------------------------
   # Configure different LLMs for various purposes in the agent system
-  llms:
+  models:
 
 
     fast_llm: &fast_llm
@@ -74,7 +74,7 @@ resources:
       temperature: 0.1
       max_tokens: 8192
       fallbacks:
-        - databricks-claude-sonnet-4-5
+      - databricks-claude-sonnet-4-5
 
 
 
@@ -88,7 +88,7 @@ resources:
     # Embedding model for vector search and semantic similarity
     embedding_model: &embedding_model
       name: databricks-gte-large-en                 # Text embedding model
-      on_behalf_of_user: False
+      on_behalf_of_user: false
 
   # ---------------------------------------------------------------------------
   # VECTOR STORES
@@ -97,29 +97,31 @@ resources:
   vector_stores:
     # Product information vector store for similarity search
     products_vector_store: &products_vector_store
-      embedding_model: *embedding_model             # Reference to embedding model above
+      embedding_model: *embedding_model
+                                                    # Reference to embedding model above
       endpoint:                                     # Vector search endpoint configuration
         name: dbdemos_vs_endpoint            # Databricks vector search endpoint
         type: STANDARD                              # Endpoint type (STANDARD or OPTIMIZED_STORAGE)
       index:                                        # Vector search index configuration
-        schema: *retail_schema                      # Unity Catalog schema for the index
+        schema: *retail_schema
+                                                    # Unity Catalog schema for the index
         name: products_index                        # Index name
       source_table:                                 # Table containing source data
         schema: *retail_schema
         name: products
       primary_key: product_id                       # Primary key column
-      doc_uri: ~                                    # Optional document URI column (null in this case)
+      doc_uri:                                      # Optional document URI column (null in this case)
       embedding_source_column: description          # Column to create embeddings from
       columns:                                      # Columns to include in vector store
-        - product_id
-        - sku
-        - upc
-        - brand_name
-        - product_name
-        - merchandise_class
-        - class_cd
-        - description
-      on_behalf_of_user: False
+      - product_id
+      - sku
+      - upc
+      - brand_name
+      - product_name
+      - merchandise_class
+      - class_cd
+      - description
+      on_behalf_of_user: false
 
   # ---------------------------------------------------------------------------
   # FUNCTIONS
@@ -133,7 +135,6 @@ resources:
     find_product_by_upc: &find_product_by_upc
       schema: *retail_schema
       name: find_product_by_upc                     # Function to find products by UPC
-    
     # Inventory lookup functions
     find_inventory_by_sku: &find_inventory_by_sku
       schema: *retail_schema
@@ -141,7 +142,6 @@ resources:
     find_inventory_by_upc: &find_inventory_by_upc
       schema: *retail_schema
       name: find_inventory_by_upc                   # Function to find inventory by UPC
-    
     # Store-specific inventory functions
     find_store_inventory_by_upc: &find_store_inventory_by_upc
       schema: *retail_schema
@@ -162,8 +162,7 @@ resources:
     retail_database: &retail_database
       name: "Retail and Consumer Goods Database"
       project: "retail-consumer-goods"  # Autoscaling Lakebase project name
-      description: "Database for agent memory and checkpoints" 
-   
+      description: "Database for agent memory and checkpoints"
       client_id: *client_id
       client_secret: *client_secret
       on_behalf_of_user: false
@@ -176,16 +175,17 @@ resources:
 retrievers:
   # Product information retriever using vector search
   products_retriever: &products_retriever
-    vector_store: *products_vector_store            # Reference to vector store defined above
+    vector_store: *products_vector_store
+                                                    # Reference to vector store defined above
     columns:                                        # Columns to return in search results
-      - product_id
-      - sku
-      - upc
-      - brand_name
-      - product_name
-      - merchandise_class
-      - class_cd
-      - description
+    - product_id
+    - sku
+    - upc
+    - brand_name
+    - product_name
+    - merchandise_class
+    - class_cd
+    - description
     search_parameters:                              # Search configuration
       num_results: 10                               # Maximum number of results to return
       filters: {}                                   # Additional filters (empty in this case)
@@ -202,7 +202,6 @@ tools:
   # FACTORY TOOLS
   # ---------------------------------------------------------------------------
   # Tools created by factory functions - configured at runtime
-  
   # Vector search tool for product similarity
   find_product_details_by_description_tool: &find_product_details_by_description_tool
     name: vector_search
@@ -210,7 +209,8 @@ tools:
       type: factory
       name: dao_ai.tools.create_vector_search_tool
       args:
-        retriever: *products_retriever              # Reference to retriever config
+        retriever: *products_retriever
+                                                    # Reference to retriever config
         name: product_vector_search_tool            # Tool instance name
         description: "Search for products by description"  # Tool description
 
@@ -218,13 +218,13 @@ tools:
   # UNITY CATALOG TOOLS
   # ---------------------------------------------------------------------------
   # Tools that directly call Unity Catalog functions
-  
   # Product lookup tools using Unity Catalog functions
   find_product_by_sku_tool: &find_product_by_sku_tool
     name: find_product_by_sku_uc
     function:
       type: unity_catalog                           # Tool type: Unity Catalog function
-      resource: *find_product_by_sku                      # Merge function configuration
+      resource: *find_product_by_sku
+                                                          # Merge function configuration
 
   find_product_by_upc_tool: &find_product_by_upc_tool
     name: find_product_by_upc_uc
@@ -254,22 +254,24 @@ tools:
 
 memory: &memory
   # Conversation checkpointing for state persistence
-  checkpointer: 
+  checkpointer:
     name: default_checkpointer                      # Checkpointer identifier
-    database: *retail_database                      # Reference to database configuration (type inferred from presence)
+    database: *retail_database
+                                                    # Reference to database configuration (type inferred from presence)
 
   # Long-term memory store for agent context
-  store: 
+  store:
     name: default_store                             # Store identifier
-    database: *retail_database                      # Database for persistence (type inferred from presence)
+    database: *retail_database
+                                                    # Database for persistence (type inferred from presence)
     namespace: "{user_id}"
 
   # Memory extraction and injection
   extraction:
     schemas:                                        # Structured memory types
-      - user_profile                                # Singleton profile per user (name, preferences, etc.)
-      - preference                                  # Collection of user preferences
-      - episode                                     # Notable interaction patterns
+    - user_profile                                  # Singleton profile per user (name, preferences, etc.)
+    - preference                                    # Collection of user preferences
+    - episode                                       # Notable interaction patterns
     instructions: |
       Extract the user's name, role, shopping preferences, product interests,
       and any notable interaction patterns. Update the user profile with new
@@ -278,8 +280,10 @@ memory: &memory
     auto_inject: true                               # Inject relevant memories into prompts
     auto_inject_limit: 5                            # Max memories to inject per turn
     background_extraction: true                     # Extract memories in background thread
-    extraction_model: *tool_calling_llm             # Use tool-calling LLM for extraction
-    query_model: *fast_llm                          # Use fast LLM for search query optimization
+    extraction_model: *tool_calling_llm
+                                                    # Use tool-calling LLM for extraction
+    query_model: *fast_llm
+                                                    # Use fast LLM for search query optimization
 
 # =============================================================================
 # AGENTS CONFIGURATION
@@ -295,9 +299,10 @@ agents:
   general: &general
     name: general                                   # Agent identifier
     description: "General retail store assistant for home improvement and hardware store inquiries"
-    model: *tool_calling_llm                       # Reference to LLM configuration
+    model: *tool_calling_llm
+                                                   # Reference to LLM configuration
     tools:                                          # Tools available to this agent
-      - *find_product_details_by_description_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: |                                       # System prompt defining agent behavior
       ### User Information
@@ -407,7 +412,8 @@ agents:
     description: "DIY and home improvement expert providing how-to advice, project guidance, and tool recommendations"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool   # Can search for tools and materials
+    - *find_product_details_by_description_tool
+                                                    # Can search for tools and materials
     guardrails: []
     prompt: |
       ### User Information
@@ -452,9 +458,9 @@ agents:
     description: "Product specialist providing detailed information about specific products, features, specifications, and intended uses"
     model: *tool_calling_llm
     tools:
-      - *find_product_by_sku_tool
-      - *find_product_by_upc_tool
-      - *find_product_details_by_description_tool
+    - *find_product_by_sku_tool
+    - *find_product_by_upc_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: |
       ### User Information
@@ -513,9 +519,9 @@ agents:
     description: "Inventory management specialist providing information about product availability, stock levels, and store inventory"
     model: *tool_calling_llm
     tools:
-      - *find_inventory_by_sku_tool
-      - *find_inventory_by_upc_tool
-      - *find_product_details_by_description_tool
+    - *find_inventory_by_sku_tool
+    - *find_inventory_by_upc_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: |
       ### User Information
@@ -573,8 +579,8 @@ agents:
     description: "Product comparison specialist providing detailed comparisons between different products, highlighting key differences and best use cases"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool
-      - *find_product_by_sku_tool
+    - *find_product_details_by_description_tool
+    - *find_product_by_sku_tool
     guardrails: []
     prompt: |
       ### User Information
@@ -640,7 +646,7 @@ agents:
     description: "Product recommendation specialist providing tailored product suggestions based on customer needs, preferences, and budget"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: |
       ### User Information
@@ -714,16 +720,16 @@ middleware:
     args:
       fields:
         # Required field - must be provided (no 'required: false')
-        - name: store_num
-          description: "Your store number for inventory lookups"
-          example_value: "12345"
+      - name: store_num
+        description: "Your store number for inventory lookups"
+        example_value: "12345"
         # Optional fields (required: false) - shown in error messages with example values
         # Note: thread_id and user_id are handled by the middleware's error message format
         #       so we don't need to list them here - they're automatically included
-        - name: user_id
-          description: "Your unique user identifier"
-          required: false
-          example_value: "my_user_id"
+      - name: user_id
+        description: "Your unique user identifier"
+        required: false
+        example_value: "my_user_id"
 
 # =============================================================================
 # APPLICATION CONFIGURATION
@@ -736,7 +742,8 @@ app:
   description: "Multi-agent system for retail customer service and product assistance"
   log_level: DEBUG                                   # Logging level for the application
   registered_model:                                 # MLflow registered model configuration
-    schema: *retail_schema                          # Schema where model will be registered
+    schema: *retail_schema
+                                                    # Schema where model will be registered
     name: hardware_store_lakebase_dao
   endpoint_name: hardware_store_lakebase_dao           # Model serving endpoint name
   environment_vars:
@@ -744,37 +751,41 @@ app:
     RETAIL_AI_DATABRICKS_CLIENT_SECRET: "{{secrets/retail_consumer_goods/RETAIL_AI_DATABRICKS_CLIENT_SECRET}}"
   tags:                                             # Tags for resource organization
     business: rcg                                   # Business unit identifier
-    streaming: True                                 # Indicates streaming capabilities
+    streaming: true                                 # Indicates streaming capabilities
   permissions:                                      # Model serving permissions
-    - principals: [users]                           # Grant access to all users
-      entitlements:
-        - CAN_QUERY                                # Full management permissions
+  - principals: [users]                             # Grant access to all users
+    entitlements:
+    - CAN_QUERY                                    # Full management permissions
   agents:                                           # List of agents included in the system
-    - *orders                                       # Order management agent
-    - *diy                                          # DIY and tutorials agent
-    - *product                                      # Product information agent
-    - *inventory                                    # Inventory management agent
-    - *comparison                                   # Product comparison agent
-    - *recommendation                               # Product recommendation agent
-    - *general                                      # General purpose agent
+  - *orders
+  - *diy
+  - *product
+  - *inventory
+  - *comparison
+  - *recommendation
+  - *general
+                                                    # General purpose agent
 
   orchestration:                                    # Agent orchestration configuration
-    memory: *memory                            # Memory store for conversation context
+    memory: *memory
+                                               # Memory store for conversation context
     supervisor:                                     # Supervisor orchestration pattern
-      model: *fast_llm                      # LLM for routing decisions
+      model: *fast_llm
+                                            # LLM for routing decisions
       middleware:                                       # Middleware for input validation
-        - *store_validation                             # Validate required custom fields
+      - *store_validation
+                                                        # Validate required custom fields
 
   input_example:
-      messages:
-        - role: user
-          content: Can you recommend a lamp to match my oak side tables?
-      custom_inputs:
-        configurable:
+    messages:
+    - role: user
+      content: Can you recommend a lamp to match my oak side tables?
+    custom_inputs:
+      configurable:
           # conversation_id is auto-generated as UUID if not provided
-          user_id: my_user_id
-          store_num: 87887
-        session: {}
+        user_id: my_user_id
+        store_num: 87887
+      session: {}
 
 # =============================================================================
 # UNITY CATALOG FUNCTIONS DEPLOYMENT
@@ -783,39 +794,44 @@ app:
 # These functions provide data access capabilities for the agent tools
 
 unity_catalog_functions:
-  - function: *find_inventory_by_sku                    # Reference to function definition
-    ddl: ../functions/hardware_store/find_inventory_by_sku.sql
-    test:
-      parameters:
-        sku: ["00176279"] 
-  - function: *find_inventory_by_upc                    # Reference to function definition
-    ddl: ../functions/hardware_store/find_inventory_by_upc.sql
-    test:
-      parameters:
-        upc: ["0017627748017"]
-  - function: *find_product_by_sku                      # Reference to function definition
-    ddl: ../functions/hardware_store/find_product_by_sku.sql
-    test:
-      parameters:
-        sku: ["00176279"]
-  - function: *find_product_by_upc                      # Reference to function definition
-    ddl: ../functions/hardware_store/find_product_by_upc.sql
-    test:
-      parameters:
-        upc: ["0017627748017"] 
-  - function: *find_store_inventory_by_sku              # Reference to function definition
-    ddl: ../functions/hardware_store/find_store_inventory_by_sku.sql
-    test:
-      parameters:
-        store: "35048"
-        sku: ["00176279"]
-  - function: *find_store_inventory_by_upc              # Reference to function definition
-    ddl: ../functions/hardware_store/find_store_inventory_by_upc.sql
-    test:
-      parameters:
-        store: "35048"
-        upc: ["0017627748017"]
- 
+- function: *find_inventory_by_sku
+                                                        # Reference to function definition
+  ddl: ../functions/hardware_store/find_inventory_by_sku.sql
+  test:
+    parameters:
+      sku: ["00176279"]
+- function: *find_inventory_by_upc
+                                                        # Reference to function definition
+  ddl: ../functions/hardware_store/find_inventory_by_upc.sql
+  test:
+    parameters:
+      upc: ["0017627748017"]
+- function: *find_product_by_sku
+                                                        # Reference to function definition
+  ddl: ../functions/hardware_store/find_product_by_sku.sql
+  test:
+    parameters:
+      sku: ["00176279"]
+- function: *find_product_by_upc
+                                                        # Reference to function definition
+  ddl: ../functions/hardware_store/find_product_by_upc.sql
+  test:
+    parameters:
+      upc: ["0017627748017"]
+- function: *find_store_inventory_by_sku
+                                                        # Reference to function definition
+  ddl: ../functions/hardware_store/find_store_inventory_by_sku.sql
+  test:
+    parameters:
+      store: "35048"
+      sku: ["00176279"]
+- function: *find_store_inventory_by_upc
+                                                        # Reference to function definition
+  ddl: ../functions/hardware_store/find_store_inventory_by_upc.sql
+  test:
+    parameters:
+      store: "35048"
+      upc: ["0017627748017"]
 # =============================================================================
 # EVALUATION CONFIGURATION
 # =============================================================================
@@ -835,11 +851,11 @@ evaluation:
       store_num: 87887
     session: {}
   guidelines:
-    - name: my_relevance_guideline
-      guidelines:
-        - Ensure responses are relevant to the user's query
-        - Prioritize information from the user's context
-        - Avoid unnecessary jargon or technical details
+  - name: my_relevance_guideline
+    guidelines:
+    - Ensure responses are relevant to the user's query
+    - Prioritize information from the user's context
+    - Avoid unnecessary jargon or technical details
 
 # =============================================================================
 # DATASETS CONFIGURATION
@@ -848,15 +864,15 @@ evaluation:
 # and data files for initial population of Unity Catalog tables
 
 datasets:
-  - table: 
-      schema: *retail_schema
-      name: products
-    ddl: ../data/hardware_store/products.sql
-    data: ../data/hardware_store/products.snappy.parquet
-    format: parquet
-  - table: 
-      schema: *retail_schema
-      name: inventory
-    ddl: ../data/hardware_store/inventory.sql
-    data: ../data/hardware_store/inventory.snappy.parquet
-    format: parquet
+- table:
+    schema: *retail_schema
+    name: products
+  ddl: ../data/hardware_store/products.sql
+  data: ../data/hardware_store/products.snappy.parquet
+  format: parquet
+- table:
+    schema: *retail_schema
+    name: inventory
+  ddl: ../data/hardware_store/inventory.sql
+  data: ../data/hardware_store/inventory.snappy.parquet
+  format: parquet

--- a/config/examples/15_complete_applications/hardware_store_swarm.yaml
+++ b/config/examples/15_complete_applications/hardware_store_swarm.yaml
@@ -38,9 +38,9 @@ resources:
   # LANGUAGE MODELS (LLMs)
   # ---------------------------------------------------------------------------
   # Configure different LLMs for various purposes in the agent system
-  llms:
+  models:
     # Primary LLM for general tasks
-    default_llm: &default_llm
+    default_llm:
       name: databricks-claude-3-7-sonnet  # Databricks serving endpoint name
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
@@ -68,29 +68,31 @@ resources:
   vector_stores:
     # Product information vector store for similarity search
     products_vector_store: &products_vector_store
-      embedding_model: *embedding_model             # Reference to embedding model above
+      embedding_model: *embedding_model
+                                                    # Reference to embedding model above
       endpoint:                                     # Vector search endpoint configuration
         name: dbdemos_vs_endpoint            # Databricks vector search endpoint
         type: STANDARD                              # Endpoint type (STANDARD or OPTIMIZED_STORAGE)
       index:                                        # Vector search index configuration
-        schema: *retail_schema                      # Unity Catalog schema for the index
+        schema: *retail_schema
+                                                    # Unity Catalog schema for the index
         name: products_index                        # Index name
       source_table:                                 # Table containing source data
         schema: *retail_schema
         name: products
       primary_key: product_id                       # Primary key column
-      doc_uri: ~                                    # Optional document URI column (null in this case)
+      doc_uri:                                      # Optional document URI column (null in this case)
       embedding_source_column: description          # Column to create embeddings from
       columns:                                      # Columns to include in vector store
-        - product_id
-        - sku
-        - upc
-        - brand_name
-        - product_name
-        - merchandise_class
-        - class_cd
-        - description
-      on_behalf_of_user: False
+      - product_id
+      - sku
+      - upc
+      - brand_name
+      - product_name
+      - merchandise_class
+      - class_cd
+      - description
+      on_behalf_of_user: false
 
   # ---------------------------------------------------------------------------
   # FUNCTIONS
@@ -104,7 +106,6 @@ resources:
     find_product_by_upc: &find_product_by_upc
       schema: *retail_schema
       name: find_product_by_upc                     # Function to find products by UPC
-    
     # Inventory lookup functions
     find_inventory_by_sku: &find_inventory_by_sku
       schema: *retail_schema
@@ -112,7 +113,6 @@ resources:
     find_inventory_by_upc: &find_inventory_by_upc
       schema: *retail_schema
       name: find_inventory_by_upc                   # Function to find inventory by UPC
-    
     # Store-specific inventory functions
     find_store_inventory_by_upc: &find_store_inventory_by_upc
       schema: *retail_schema
@@ -129,16 +129,17 @@ resources:
 retrievers:
   # Product information retriever using vector search
   products_retriever: &products_retriever
-    vector_store: *products_vector_store            # Reference to vector store defined above
+    vector_store: *products_vector_store
+                                                    # Reference to vector store defined above
     columns:                                        # Columns to return in search results
-      - product_id
-      - sku
-      - upc
-      - brand_name
-      - product_name
-      - merchandise_class
-      - class_cd
-      - description
+    - product_id
+    - sku
+    - upc
+    - brand_name
+    - product_name
+    - merchandise_class
+    - class_cd
+    - description
     search_parameters:                              # Search configuration
       num_results: 10                               # Maximum number of results to return
       filters: {}                                   # Additional filters (empty in this case)
@@ -155,16 +156,15 @@ tools:
   # FACTORY TOOLS
   # ---------------------------------------------------------------------------
   # Tools created by factory functions - configured at runtime
-  
   # Vector search tool for product similarity
-  find_product_details_by_description_tool:
-    &find_product_details_by_description_tool
+  find_product_details_by_description_tool: &find_product_details_by_description_tool
     name: find_product_details_by_description
     function:
       type: factory
       name: dao_ai.tools.create_vector_search_tool
       args:
-        retriever: *products_retriever              # Reference to retriever config
+        retriever: *products_retriever
+                                                    # Reference to retriever config
         name: product_vector_search_tool            # Tool instance name
         description: "Search for products using vector search"  # Tool description
 
@@ -172,13 +172,13 @@ tools:
   # UNITY CATALOG TOOLS
   # ---------------------------------------------------------------------------
   # Tools that directly call Unity Catalog functions
-  
   # Product lookup tools using Unity Catalog functions
   find_product_by_sku_tool: &find_product_by_sku_tool
     name: find_product_by_sku_uc
     function:
       type: unity_catalog                           # Tool type: Unity Catalog function
-      resource: *find_product_by_sku                # Reference to function definition
+      resource: *find_product_by_sku
+                                                    # Reference to function definition
 
   find_product_by_upc_tool: &find_product_by_upc_tool
     name: find_product_by_upc_uc
@@ -208,13 +208,14 @@ tools:
 
 memory: &memory
   # Conversation checkpointing for state persistence
-  checkpointer: 
+  checkpointer:
     name: default_checkpointer                      # Checkpointer identifier (type inferred as memory - no database)
 
   # Long-term memory store for agent context
-  store: 
+  store:
     name: default_store                             # Store identifier (type inferred as memory - no database)
-    embedding_model: *embedding_model               # Model for semantic memory
+    embedding_model: *embedding_model
+                                                    # Model for semantic memory
     # dims: 1536                                    # Auto-detected from embedding model if omitted
     namespace: "{user_id}"
 
@@ -230,16 +231,16 @@ middleware:
     args:
       fields:
         # Required field - must be provided (no 'required: false')
-        - name: store_num
-          description: "Your store number for inventory lookups"
-          example_value: "12345"
+      - name: store_num
+        description: "Your store number for inventory lookups"
+        example_value: "12345"
         # Optional fields (required: false) - shown in error messages with example values
         # Note: thread_id and user_id are handled by the middleware's error message format
         #       so we don't need to list them here - they're automatically included
-        - name: user_id
-          description: "Your unique user identifier"
-          required: false
-          example_value: "my_user_id"
+      - name: user_id
+        description: "Your unique user identifier"
+        required: false
+        example_value: "my_user_id"
 
 # =============================================================================
 # AGENTS CONFIGURATION
@@ -255,7 +256,8 @@ agents:
   general: &general
     name: general                                   # Agent identifier
     description: "General retail store assistant for home improvement and hardware store inquiries"
-    model: *tool_calling_llm                       # Reference to LLM configuration
+    model: *tool_calling_llm
+                                                   # Reference to LLM configuration
     tools: []                                      # Tools available to this agent
     guardrails: []
     prompt: |                                       # System prompt defining agent behavior
@@ -366,7 +368,8 @@ agents:
     description: "DIY and home improvement expert providing how-to advice, project guidance, and tool recommendations"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool   # Can search for tools and materials
+    - *find_product_details_by_description_tool
+                                                    # Can search for tools and materials
     guardrails: []
     prompt: |
       ### User Information
@@ -411,9 +414,9 @@ agents:
     description: "Product specialist providing detailed information about specific products, features, specifications, and intended uses"
     model: *tool_calling_llm
     tools:
-      - *find_product_by_sku_tool
-      - *find_product_by_upc_tool
-      - *find_product_details_by_description_tool
+    - *find_product_by_sku_tool
+    - *find_product_by_upc_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: |
       ### User Information
@@ -472,9 +475,9 @@ agents:
     description: "Inventory management specialist providing information about product availability, stock levels, and store inventory"
     model: *tool_calling_llm
     tools:
-      - *find_inventory_by_sku_tool
-      - *find_inventory_by_upc_tool
-      - *find_product_details_by_description_tool
+    - *find_inventory_by_sku_tool
+    - *find_inventory_by_upc_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: |
       ### User Information
@@ -532,8 +535,8 @@ agents:
     description: "Product comparison specialist providing detailed comparisons between different products, highlighting key differences and best use cases"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool
-      - *find_product_by_sku_tool
+    - *find_product_details_by_description_tool
+    - *find_product_by_sku_tool
     guardrails: []
     prompt: |
       ### User Information
@@ -599,7 +602,7 @@ agents:
     description: "Product recommendation specialist providing tailored product suggestions based on customer needs, preferences, and budget"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: |
       ### User Information
@@ -672,36 +675,39 @@ app:
   description: "Multi-agent system for retail customer service and product assistance"
   log_level: TRACE                                   # Logging level for the application
   registered_model:                                 # MLflow registered model configuration
-    schema: *retail_schema                          # Schema where model will be registered
+    schema: *retail_schema
+                                                    # Schema where model will be registered
     name: hardware_store_swarm_dao
   endpoint_name: hardware_store_swarm_dao                    # Model serving endpoint name
   tags:                                             # Tags for resource organization
     business: rcg                                   # Business unit identifier
     streaming: true                                 # Indicates streaming capabilities
   permissions:                                      # Model serving permissions
-    - principals: [users]                           # Grant access to all users
-      entitlements:
-        - CAN_QUERY                                # Full management permissions
+  - principals: [users]                             # Grant access to all users
+    entitlements:
+    - CAN_QUERY                                    # Full management permissions
   agents:                                           # List of agents included in the system
-    - *orders                                       # Order management agent
-    - *diy                                          # DIY and tutorials agent
-    - *product                                      # Product information agent
-    - *inventory                                    # Inventory management agent
-    - *comparison                                   # Product comparison agent
-    - *recommendation                               # Product recommendation agent
-    - *general                                      # General purpose agent
+  - *orders
+  - *diy
+  - *product
+  - *inventory
+  - *comparison
+  - *recommendation
+  - *general
+                                                    # General purpose agent
   input_example:
-      messages:
-        - role: user
-          content: Can you recommend a lamp to match my oak side tables?
-      custom_inputs:
-        configurable:
+    messages:
+    - role: user
+      content: Can you recommend a lamp to match my oak side tables?
+    custom_inputs:
+      configurable:
           # conversation_id is auto-generated as UUID if not provided
-          user_id: my_user_id
-          store_num: 87887
-        session: {}
+        user_id: my_user_id
+        store_num: 87887
+      session: {}
   orchestration:                                    # Agent orchestration configuration
-    memory: *memory                     # Reference to memory configuration for state persistence
+    memory: *memory
+                                        # Reference to memory configuration for state persistence
     # SWARM ORCHESTRATION PATTERN
     # ========================================================================
     # Swarm orchestration enables agents to collaborate directly through 
@@ -724,12 +730,11 @@ app:
       # Starting agent for new conversations - acts as the entry point
       # Users initially interact with this agent before potential handoffs
       default_agent: *general
-      
       # Swarm-level middleware applied to ALL agents
       # This ensures consistent validation across the entire swarm
       middleware:
-        - *store_validation                           # Validate required custom fields for all agents
-      
+      - *store_validation
+                                                      # Validate required custom fields for all agents
       # Handoff configuration: defines which agents can transfer to which other agents
       # Structure: {agent_name: [list_of_target_agents_or_null]}
       # 
@@ -746,15 +751,15 @@ app:
       handoffs:
         # General agent can hand off to any agent (~ means null/any)
         # This makes general agent the universal router for initial triage
-        general: ~ 
-        
+        general:
+
         # DIY agent can hand off to specific product and recommendation agents
         # This creates a focused workflow: DIY -> Product Info -> Inventory -> Recommendations
-        diy: 
-          - "product"      # String reference to product agent
-          - *inventory     # YAML anchor reference to inventory agent  
-          - *recommendation # YAML anchor reference to recommendation agent
-        
+        diy:
+        - "product"        # String reference to product agent
+        - *inventory
+        - *recommendation
+                            # YAML anchor reference to recommendation agent
         # Inventory agent has no outbound handoffs (empty list)
         # This makes inventory a "terminal" agent that completes conversations
         # Users would need to start new conversations or other agents hand off elsewhere
@@ -767,39 +772,38 @@ app:
 # These functions provide data access capabilities for the agent tools
 
 unity_catalog_functions:
-  - function: *find_inventory_by_sku
-    ddl: ../functions/hardware_store/find_inventory_by_sku.sql
-    test:
-      parameters:
-        sku: ["00176279"] 
-  - function: *find_inventory_by_upc
-    ddl: ../functions/hardware_store/find_inventory_by_upc.sql
-    test:
-      parameters:
-        upc: ["0017627748017"]
-  - function: *find_product_by_sku
-    ddl: ../functions/hardware_store/find_product_by_sku.sql
-    test:
-      parameters:
-        sku: ["00176279"]
-  - function: *find_product_by_upc
-    ddl: ../functions/hardware_store/find_product_by_upc.sql
-    test:
-      parameters:
-        upc: ["0017627748017"] 
-  - function: *find_store_inventory_by_sku
-    ddl: ../functions/hardware_store/find_store_inventory_by_sku.sql
-    test:
-      parameters:
-        store: "35048"
-        sku: ["00176279"]
-  - function: *find_store_inventory_by_upc
-    ddl: ../functions/hardware_store/find_store_inventory_by_upc.sql
-    test:
-      parameters:
-        store: "35048"
-        upc: ["0017627748017"]
- 
+- function: *find_inventory_by_sku
+  ddl: ../functions/hardware_store/find_inventory_by_sku.sql
+  test:
+    parameters:
+      sku: ["00176279"]
+- function: *find_inventory_by_upc
+  ddl: ../functions/hardware_store/find_inventory_by_upc.sql
+  test:
+    parameters:
+      upc: ["0017627748017"]
+- function: *find_product_by_sku
+  ddl: ../functions/hardware_store/find_product_by_sku.sql
+  test:
+    parameters:
+      sku: ["00176279"]
+- function: *find_product_by_upc
+  ddl: ../functions/hardware_store/find_product_by_upc.sql
+  test:
+    parameters:
+      upc: ["0017627748017"]
+- function: *find_store_inventory_by_sku
+  ddl: ../functions/hardware_store/find_store_inventory_by_sku.sql
+  test:
+    parameters:
+      store: "35048"
+      sku: ["00176279"]
+- function: *find_store_inventory_by_upc
+  ddl: ../functions/hardware_store/find_store_inventory_by_upc.sql
+  test:
+    parameters:
+      store: "35048"
+      upc: ["0017627748017"]
 # =============================================================================
 # EVALUATION CONFIGURATION
 # =============================================================================
@@ -825,15 +829,15 @@ evaluation:
 # and data files for initial population of Unity Catalog tables
 
 datasets:
-  - table: 
-      schema: *retail_schema
-      name: products
-    ddl: ../data/hardware_store/products.sql
-    data: ../data/hardware_store/products.snappy.parquet
-    format: parquet
-  - table: 
-      schema: *retail_schema
-      name: inventory
-    ddl: ../data/hardware_store/inventory.sql
-    data: ../data/hardware_store/inventory.snappy.parquet
-    format: parquet
+- table:
+    schema: *retail_schema
+    name: products
+  ddl: ../data/hardware_store/products.sql
+  data: ../data/hardware_store/products.snappy.parquet
+  format: parquet
+- table:
+    schema: *retail_schema
+    name: inventory
+  ddl: ../data/hardware_store/inventory.sql
+  data: ../data/hardware_store/inventory.snappy.parquet
+  format: parquet

--- a/config/examples/15_complete_applications/quick_serve_restaurant.yaml
+++ b/config/examples/15_complete_applications/quick_serve_restaurant.yaml
@@ -19,39 +19,39 @@ parameters:
 # including schemas, resources, tools, agents, and orchestration patterns.
 
 variables:
-  database_host_var: &database_host_var                                              
-    default_value: localhost                                             
+  database_host_var:
+    default_value: localhost
     options:
-      - env: PGHOST                              # Environment variable
-      - scope: retail_consumer_goods                         # Databricks secret scope
-        secret: PGHOST                           # Secret name
-  port_var: &port_var
+    - env: PGHOST                                # Environment variable
+    - scope: retail_consumer_goods                           # Databricks secret scope
+      secret: PGHOST                             # Secret name
+  port_var:
     default_value: 5432
     options:
-    - env: PGPORT 
+    - env: PGPORT
     - scope: retail_consumer_goods
       secret: PGPORT
-  database_var: &database_var
+  database_var:
     default_value: databricks_postgres           # Default database name
     options:
-    - env: PGDATABASE 
+    - env: PGDATABASE
     - scope: retail_consumer_goods
       secret: PGDATABASE
   client_id_var: &client_id_var
     options:
-      - env: RETAIL_AI_DATABRICKS_CLIENT_ID      # Service principal client ID
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_CLIENT_ID
+    - env: RETAIL_AI_DATABRICKS_CLIENT_ID        # Service principal client ID
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_ID
   client_secret_var: &client_secret_var
     options:
-      - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET  # Service principal secret
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+    - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET    # Service principal secret
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
   workspace_host_var: &workspace_host_var
     options:
-      - env: RETAIL_AI_DATABRICKS_HOST           # Databricks workspace URL
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_HOST
+    - env: RETAIL_AI_DATABRICKS_HOST             # Databricks workspace URL
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_HOST
 
 
 # =============================================================================
@@ -74,7 +74,7 @@ resources:
   # LANGUAGE MODELS (LLMs)
   # ---------------------------------------------------------------------------
   # Configure different LLMs for various purposes in the agent system
-  llms:
+  models:
 
     # LLM optimized for tool calling and function execution
     tool_calling_llm: &tool_calling_llm
@@ -82,10 +82,10 @@ resources:
       temperature: 0.1
       max_tokens: 8192
       fallbacks:                                     # Fallback models if primary fails
-        - databricks-claude-sonnet-4
+      - databricks-claude-sonnet-4
 
     # LLM for complex reasoning tasks
-    reasoning_llm: &reasoning_llm
+    reasoning_llm:
       name: databricks-claude-3-7-sonnet
       temperature: 0.1
       max_tokens: 8192
@@ -107,22 +107,24 @@ resources:
   vector_stores:
     # Product information vector store for similarity search
     items_description_vector_store: &items_description_vector_store
-      embedding_model: *embedding_model             # Reference to embedding model above
+      embedding_model: *embedding_model
+                                                    # Reference to embedding model above
       endpoint:                                     # Vector search endpoint configuration
         name: dbdemos_vs_endpoint            # Databricks vector search endpoint
         type: STANDARD                              # Endpoint type (STANDARD or OPTIMIZED_STORAGE)
       index:                                        # Vector search index configuration
-        schema: *qsr_schema                      # Unity Catalog schema for the index
+        schema: *qsr_schema
+                                                 # Unity Catalog schema for the index
         name: items_description_vs_index                        # Index name
       source_table:                                 # Table containing source data
         schema: *qsr_schema
         name: items_description
       primary_key: item_name                       # Primary key column
-      doc_uri: ~                                    # Optional document URI column (null in this case)
+      doc_uri:                                      # Optional document URI column (null in this case)
       embedding_source_column: item_review          # Column to create embeddings from
       columns:                                      # Columns to include in vector store
-        - item_name
-        - item_review
+      - item_name
+      - item_review
 
 
 
@@ -133,16 +135,16 @@ resources:
   functions:
     insert_coffee_order: &insert_coffee_order
       schema: *qsr_schema
-      name: insert_coffee_order             
+      name: insert_coffee_order
     match_item_by_description_and_price: &match_item_by_description_and_price
       schema: *qsr_schema
-      name: match_item_by_description_and_price                  
+      name: match_item_by_description_and_price
     match_historical_item_order_by_date: &match_historical_item_order_by_date
       schema: *qsr_schema
-      name: match_historical_item_order_by_date                    
+      name: match_historical_item_order_by_date
     lookup_items_by_descriptions: &lookup_items_by_descriptions
       schema: *qsr_schema
-      name: lookup_items_by_descriptions                   
+      name: lookup_items_by_descriptions
 
 
   # ---------------------------------------------------------------------------
@@ -151,7 +153,7 @@ resources:
   # Define SQL warehouses for query execution
   warehouses:
     # Shared warehouse for general query execution
-    shared_endpoint_warehouse: &shared_endpoint_warehouse
+    shared_endpoint_warehouse:
       name: "Shared Endpoint Warehouse"             # Human-readable name
       description: "A warehouse for shared endpoints"  # Description
       warehouse_id: 148ccb90800933a1                # Databricks warehouse ID
@@ -165,11 +167,12 @@ resources:
 
 retrievers:
   # Product information retriever using vector search
-  items_description_retriever: &items_description_retriever
-    vector_store: *items_description_vector_store            # Reference to vector store defined above
+  items_description_retriever:
+    vector_store: *items_description_vector_store
+                                                             # Reference to vector store defined above
     columns:                                        # Columns to return in search results
-      - item_name
-      - item_review
+    - item_name
+    - item_review
     search_parameters:                              # Search configuration
       num_results: 10                               # Maximum number of results to return
       filters: {}                                   # Additional filters (empty in this case)
@@ -246,7 +249,7 @@ prompts:
       ### User Information
       - **User Id**: {user_id}
       - **Session ID**: {thread_id}
-      
+
       You are an expert barista at a specialty coffee shop with comprehensive knowledge of our menu, prices, and customer preferences. Your primary role is to help customers discover menu items, make recommendations, process orders, and provide information about past orders.
 
       ## Your Capabilities & When to Use Tools:
@@ -300,13 +303,14 @@ prompts:
 
 memory: &memory
   # Conversation checkpointing for state persistence
-  checkpointer: 
+  checkpointer:
     name: default_checkpointer                      # Checkpointer identifier (type inferred as memory - no database)
 
   # Long-term memory store for agent context
-  store: 
+  store:
     name: default_store                             # Store identifier (type inferred as memory - no database)
-    embedding_model: *embedding_model               # Model for semantic memory
+    embedding_model: *embedding_model
+                                                    # Model for semantic memory
     # dims: 1536                                    # Auto-detected from embedding model if omitted
     namespace: "{user_id}"
 
@@ -324,16 +328,19 @@ agents:
   # This example shows how to use a prompt reference from the prompts section
   barista: &barista
     name: barista                                   # Agent identifier
-    description: "Expert coffee shop barista specializing in menu recommendations, coffee ordering, price inquiries, item descriptions, and order history. Can find products by description, match items within price ranges, process coffee orders, and retrieve historical order data."
-    model: *tool_calling_llm                       # Reference to LLM configuration
-    tools: 
-      - *insert_coffee_order_tool
-      - *match_item_by_description_and_price_tool
-      - *match_historical_item_order_by_date_tool
-      - *lookup_items_by_descriptions_tool
-      - *current_time_tool
-    prompt: *barista_prompt                        # Reference to prompt (instead of inline)
-    handoff_prompt: |                              
+    description: "Expert coffee shop barista specializing in menu recommendations, coffee ordering, price inquiries, item descriptions, and order history. Can find products by description, match items within
+      price ranges, process coffee orders, and retrieve historical order data."
+    model: *tool_calling_llm
+                                                   # Reference to LLM configuration
+    tools:
+    - *insert_coffee_order_tool
+    - *match_item_by_description_and_price_tool
+    - *match_historical_item_order_by_date_tool
+    - *lookup_items_by_descriptions_tool
+    - *current_time_tool
+    prompt: *barista_prompt
+                                                   # Reference to prompt (instead of inline)
+    handoff_prompt: |
       Coffee shop inquiries including menu questions, item recommendations, price checks, coffee ordering, taste descriptions, and order history.
       Examples: "What coffee drinks do you have?", "I'd like a medium latte", "What's good for under $4?", "What did I order yesterday?", "Tell me about your cold brew", "Can you recommend something sweet?"
 
@@ -348,10 +355,11 @@ app:
   description: "Multi-agent system for coffee shop order management and customer service"
   log_level: TRACE                                   # Logging level for the application
   registered_model:                                 # MLflow registered model configuration
-    schema: *qsr_schema                          # Schema where model will be registered
+    schema: *qsr_schema
+                                                 # Schema where model will be registered
     name: quick_serve_restaurant_dao
   endpoint_name: coffee_shop_agent_dao                    # Model serving endpoint name
-  environment_vars: 
+  environment_vars:
     # PGHOST: "{{secrets/retail_consumer_goods/PGHOST}}"  # Databricks host URL
     RETAIL_AI_DATABRICKS_CLIENT_ID: "{{secrets/retail_consumer_goods/RETAIL_AI_DATABRICKS_CLIENT_ID}}"
     RETAIL_AI_DATABRICKS_CLIENT_SECRET: "{{secrets/retail_consumer_goods/RETAIL_AI_DATABRICKS_CLIENT_SECRET}}"
@@ -360,24 +368,26 @@ app:
     business: rcg                                   # Business unit identifier
     streaming: true                                 # Indicates streaming capabilities
   permissions:                                      # Model serving permissions
-    - principals: [users]                           # Grant access to all users
-      entitlements:
-        - CAN_QUERY                                # Full management permissions
+  - principals: [users]                             # Grant access to all users
+    entitlements:
+    - CAN_QUERY                                    # Full management permissions
   agents:                                           # List of agents included in the system
-    - *barista  
+  - *barista
   orchestration:                                    # Agent orchestration configuration
     swarm:                                     # Supervisor orchestration pattern
-      default_agent: *barista                       # Default agent for routing
-    memory: *memory                            # Memory store for conversation context
+      default_agent: *barista
+                                                    # Default agent for routing
+    memory: *memory
+                                               # Memory store for conversation context
   input_example:
-      messages:
-        - role: user
-          content: How much is a green tea?
-      custom_inputs:
-        configurable:
+    messages:
+    - role: user
+      content: How much is a green tea?
+    custom_inputs:
+      configurable:
           # conversation_id is auto-generated as UUID if not provided
-          user_id: my_user_id
-        session: {}
+        user_id: my_user_id
+      session: {}
 
 # =============================================================================
 # UNITY CATALOG FUNCTIONS DEPLOYMENT
@@ -386,14 +396,14 @@ app:
 # These functions provide data access capabilities for the agent tools
 
 unity_catalog_functions:
-  - function: *lookup_items_by_descriptions
-    ddl: ../functions/quick_serve_restaurant/lookup_items_by_descriptions.sql
-  - function: *match_historical_item_order_by_date
-    ddl: ../functions/quick_serve_restaurant/match_historical_item_order_by_date.sql
-  - function: *match_item_by_description_and_price
-    ddl: ../functions/quick_serve_restaurant/match_item_by_description_and_price.sql
-  - function: *insert_coffee_order
-    ddl: ../functions/quick_serve_restaurant/insert_coffee_order.sql
+- function: *lookup_items_by_descriptions
+  ddl: ../functions/quick_serve_restaurant/lookup_items_by_descriptions.sql
+- function: *match_historical_item_order_by_date
+  ddl: ../functions/quick_serve_restaurant/match_historical_item_order_by_date.sql
+- function: *match_item_by_description_and_price
+  ddl: ../functions/quick_serve_restaurant/match_item_by_description_and_price.sql
+- function: *insert_coffee_order
+  ddl: ../functions/quick_serve_restaurant/insert_coffee_order.sql
 
 # =============================================================================
 # EVALUATION CONFIGURATION
@@ -419,45 +429,45 @@ evaluation:
 # and data files for initial population of Unity Catalog tables
 
 datasets:
-  - table: 
-      schema: *qsr_schema
-      name: orders_raw
-    ddl: ../data/quick_serve_restaurant/orders_raw.sql
-    data: ../data/quick_serve_restaurant/orders_raw.csv
-    format: csv
-    read_options:
-      header: True
-  - table: 
-      schema: *qsr_schema
-      name: items_raw
-    ddl: ../data/quick_serve_restaurant/items_raw.sql
-    data: ../data/quick_serve_restaurant/items_raw.csv
-    format: csv
-    read_options:
-      header: True
-    table_schema: |
-      item_id STRING
-      ,sku STRING
-      ,item_name STRING
-      ,item_cat STRING
-      ,item_size STRING
-      ,item_price DECIMAL(10,2)
-  - table: 
-      schema: *qsr_schema
-      name: items_description
-    ddl: ../data/quick_serve_restaurant/items_description.sql
-    data: ../data/quick_serve_restaurant/items_description.csv
-    read_options:
-      header: True
-      escape: "\""
-      multiLine: True
-    format: csv
-  - table: 
-      schema: *qsr_schema
-      name: fulfil_item_orders
-    ddl: ../data/quick_serve_restaurant/fulfil_item_orders.sql
+- table:
+    schema: *qsr_schema
+    name: orders_raw
+  ddl: ../data/quick_serve_restaurant/orders_raw.sql
+  data: ../data/quick_serve_restaurant/orders_raw.csv
+  format: csv
+  read_options:
+    header: true
+- table:
+    schema: *qsr_schema
+    name: items_raw
+  ddl: ../data/quick_serve_restaurant/items_raw.sql
+  data: ../data/quick_serve_restaurant/items_raw.csv
+  format: csv
+  read_options:
+    header: true
+  table_schema: |
+    item_id STRING
+    ,sku STRING
+    ,item_name STRING
+    ,item_cat STRING
+    ,item_size STRING
+    ,item_price DECIMAL(10,2)
+- table:
+    schema: *qsr_schema
+    name: items_description
+  ddl: ../data/quick_serve_restaurant/items_description.sql
+  data: ../data/quick_serve_restaurant/items_description.csv
+  read_options:
+    header: true
+    escape: "\""
+    multiLine: true
+  format: csv
+- table:
+    schema: *qsr_schema
+    name: fulfil_item_orders
+  ddl: ../data/quick_serve_restaurant/fulfil_item_orders.sql
 
 
 
 
-    
+

--- a/config/examples/15_complete_applications/reservations_system.yaml
+++ b/config/examples/15_complete_applications/reservations_system.yaml
@@ -17,20 +17,19 @@ schemas:
     catalog_name: ${var.catalog}                    # Unity Catalog name
     schema_name: ${var.schema}                    # Schema within the catalog
     permissions:                              # Access permissions for the schema
-      - principals: [users]                   # Grant access to all users
-        privileges:
-          - ALL_PRIVILEGES                    # Full permissions for demo purposes
+    - principals: [users]                     # Grant access to all users
+      privileges:
+      - ALL_PRIVILEGES                        # Full permissions for demo purposes
 
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4  # Databricks serving endpoint name
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
-        
 memory: &memory
   # Conversation checkpointing for state persistence
-  checkpointer: 
+  checkpointer:
     name: default_checkpointer                      # Checkpointer identifier (type inferred as memory - no database)
 
 
@@ -43,16 +42,17 @@ tools:
       human_in_the_loop:
         review_prompt: |
           Would you like to reserver your reservation?
-          
+
 
 agents:
   reservation: &reservation
     name: reservation                                     # Agent identifier
     description: "Reservation Agent"
-    model: *default_llm                             # Reference to LLM configuration
+    model: *default_llm
+                                                    # Reference to LLM configuration
     tools:                                          # Tools available to this agent
-      - *reservation_tool
-    prompt: |                                      
+    - *reservation_tool
+    prompt: |
       You are a reservation agent that can book, cancel, and check availability for reservations.
     handoff_prompt: |                               # Conditions for routing to this agent
       When asked about reservations, book, or cancel reservations, or check availability
@@ -62,24 +62,27 @@ app:
   description: "Multi-agent system that talks to reservation agent"
   log_level: TRACE                                   # Logging level for the application
   registered_model:                                 # MLflow registered model configuration
-    schema: *retail_schema                          # Schema where model will be registered
+    schema: *retail_schema
+                                                    # Schema where model will be registered
     name: reservations_system_dao
   endpoint_name: reservation_agent_dao               # Model serving endpoint name
   agents:                                           # List of agents included in the system
-    - *reservation                                        # Order management agent
+  - *reservation
+                                                          # Order management agent
   orchestration:                                    # Agent orchestration configuration
     supervisor:                                     # Supervisor orchestration pattern
-      model: *default_llm                           # LLM for routing decisions
-    memory: *memory                             # Memory for state persistence
+      model: *default_llm
+                                                    # LLM for routing decisions
+    memory: *memory
+                                                # Memory for state persistence
   input_example:
-      messages:
-        - role: user
-          content: Can create a reservation for me?
-      custom_inputs:
-        configurable:
+    messages:
+    - role: user
+      content: Can create a reservation for me?
+    custom_inputs:
+      configurable:
           # conversation_id is auto-generated as UUID if not provided
-          user_id: john.smith@databricks.com
-        session: {}
-        
+        user_id: john.smith@databricks.com
+      session: {}
 
 

--- a/config/examples/15_complete_applications/sporting_goods_store.yaml
+++ b/config/examples/15_complete_applications/sporting_goods_store.yaml
@@ -30,18 +30,18 @@ parameters:
 variables:
   client_id: &client_id
     options:
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_CLIENT_ID
-      - env: RETAIL_AI_DATABRICKS_CLIENT_ID
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_ID
+    - env: RETAIL_AI_DATABRICKS_CLIENT_ID
 
   client_secret: &client_secret
     options:
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
-      - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+    - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET
 
 service_principals:
-  retail_consumer_goods_sp: &retail_consumer_goods_sp
+  retail_consumer_goods_sp:
     name: retail_consumer_goods_sp
     client_id: *client_id
     client_secret: *client_secret
@@ -54,12 +54,12 @@ schemas:
     catalog_name: ${var.catalog}
     schema_name: ${var.schema}
     permissions:
-      - principals: [users]
-        privileges:
-          - USE_CATALOG
-          - USE_SCHEMA
-          - SELECT
-          - EXECUTE
+    - principals: [users]
+      privileges:
+      - USE_CATALOG
+      - USE_SCHEMA
+      - SELECT
+      - EXECUTE
 
 # =============================================================================
 # RESOURCES
@@ -68,7 +68,7 @@ resources:
   # ---------------------------------------------------------------------------
   # LANGUAGE MODELS
   # ---------------------------------------------------------------------------
-  llms:
+  models:
     fast_llm: &fast_llm
       name: databricks-gpt-5-4-mini
       temperature: 0.1
@@ -87,7 +87,7 @@ resources:
       max_tokens: 4096
       on_behalf_of_user: true
       fallbacks:
-        - databricks-claude-sonnet-4-6
+      - databricks-claude-sonnet-4-6
 
     judge_llm: &judge_llm
       name: databricks-claude-sonnet-4-5
@@ -126,19 +126,19 @@ resources:
         schema: *sporting_goods_schema
         name: products
       primary_key: product_id
-      doc_uri: ~
+      doc_uri:
       embedding_source_column: long_description
       columns:
-        - product_id
-        - sku
-        - upc
-        - brand_name
-        - product_name
-        - merchandise_class
-        - department_name
-        - sport_category
-        - base_price
-        - long_description
+      - product_id
+      - sku
+      - upc
+      - brand_name
+      - product_name
+      - merchandise_class
+      - department_name
+      - sport_category
+      - base_price
+      - long_description
 
   # ---------------------------------------------------------------------------
   # WAREHOUSES
@@ -214,74 +214,75 @@ retrievers:
   products_retriever: &products_retriever
     vector_store: *products_vector_store
     columns:
-      - product_id
-      - sku
-      - upc
-      - brand_name
-      - product_name
-      - merchandise_class
-      - department_name
-      - sport_category
-      - base_price
-      - long_description
+    - product_id
+    - sku
+    - upc
+    - brand_name
+    - product_name
+    - merchandise_class
+    - department_name
+    - sport_category
+    - base_price
+    - long_description
     search_parameters:
       num_results: 50
       filters: {}
       query_type: HYBRID
     instructed:
       columns:
-        - name: product_id
-          type: number
-          description: "Unique product identifier"
-        - name: sku
-          type: string
-          description: "Stock keeping unit - internal product code (e.g., NKE-RUN-001)"
-        - name: upc
-          type: string
-          description: "Universal Product Code - barcode number"
-        - name: brand_name
-          type: string
-          description: "Brand/manufacturer (Nike, Adidas, Under Armour, New Balance, Patagonia, The North Face, Columbia, Wilson, Spalding, Coleman, YETI, Osprey, Trek, Giro, Oakley, Garmin, Hydro Flask, Callaway, Lululemon, Bowflex, Rogue Fitness)"
-        - name: product_name
-          type: string
-          description: "Product display name"
-        - name: merchandise_class
-          type: string
-          description: "Product category (Footwear, Apparel, Equipment, Accessories, etc.)"
-        - name: department_name
-          type: string
-          description: "Department (Athletic Footwear, Athletic Apparel, Team Sports, Fitness Equipment, Outdoor & Camping, Cycling, Accessories, Golf)"
-        - name: sport_category
-          type: string
-          description: "Sport or activity (Running, Basketball, Football, Soccer, Golf, Training, Outdoor, Camping, Hiking, Cycling, Yoga, Fitness, Lifestyle, General)"
-        - name: base_price
-          type: number
-          description: "Base retail price in USD"
-        - name: long_description
-          type: string
-          description: "Detailed product description with features and specifications"
+      - name: product_id
+        type: number
+        description: "Unique product identifier"
+      - name: sku
+        type: string
+        description: "Stock keeping unit - internal product code (e.g., NKE-RUN-001)"
+      - name: upc
+        type: string
+        description: "Universal Product Code - barcode number"
+      - name: brand_name
+        type: string
+        description: "Brand/manufacturer (Nike, Adidas, Under Armour, New Balance, Patagonia, The North Face, Columbia, Wilson, Spalding, Coleman, YETI, Osprey, Trek, Giro, Oakley, Garmin, Hydro Flask,
+          Callaway, Lululemon, Bowflex, Rogue Fitness)"
+      - name: product_name
+        type: string
+        description: "Product display name"
+      - name: merchandise_class
+        type: string
+        description: "Product category (Footwear, Apparel, Equipment, Accessories, etc.)"
+      - name: department_name
+        type: string
+        description: "Department (Athletic Footwear, Athletic Apparel, Team Sports, Fitness Equipment, Outdoor & Camping, Cycling, Accessories, Golf)"
+      - name: sport_category
+        type: string
+        description: "Sport or activity (Running, Basketball, Football, Soccer, Golf, Training, Outdoor, Camping, Hiking, Cycling, Yoga, Fitness, Lifestyle, General)"
+      - name: base_price
+        type: number
+        description: "Base retail price in USD"
+      - name: long_description
+        type: string
+        description: "Detailed product description with features and specifications"
       constraints:
-        - "Use brand_name for brand filtering"
-        - "Use sport_category for sport-based queries"
-        - "Use merchandise_class for product type filtering"
-        - "Use department_name for department-level queries"
-        - "Only use columns listed above"
+      - "Use brand_name for brand filtering"
+      - "Use sport_category for sport-based queries"
+      - "Use merchandise_class for product type filtering"
+      - "Use department_name for department-level queries"
+      - "Only use columns listed above"
       decomposition:
         model: *decomposition_llm
         max_subqueries: 3
         rrf_k: 60
         normalize_filter_case: uppercase
         examples:
-          - query: "Nike running shoes"
-            filters: {"brand_name": "NIKE", "sport_category": "RUNNING", "merchandise_class": "FOOTWEAR"}
-          - query: "Patagonia or North Face outdoor jackets"
-            filters: {"brand_name": ["PATAGONIA", "THE NORTH FACE"], "merchandise_class": "APPAREL", "sport_category": "OUTDOOR"}
-          - query: "basketball equipment excluding Spalding"
-            filters: {"sport_category": "BASKETBALL", "merchandise_class": "EQUIPMENT", "brand_name NOT": "SPALDING"}
-          - query: "Under Armour training apparel"
-            filters: {"brand_name": "UNDER ARMOUR", "merchandise_class": "APPAREL", "sport_category": "TRAINING"}
-          - query: "golf clubs and equipment"
-            filters: {"sport_category": "GOLF", "merchandise_class": "EQUIPMENT"}
+        - query: "Nike running shoes"
+          filters: {"brand_name": "NIKE", "sport_category": "RUNNING", "merchandise_class": "FOOTWEAR"}
+        - query: "Patagonia or North Face outdoor jackets"
+          filters: {"brand_name": ["PATAGONIA", "THE NORTH FACE"], "merchandise_class": "APPAREL", "sport_category": "OUTDOOR"}
+        - query: "basketball equipment excluding Spalding"
+          filters: {"sport_category": "BASKETBALL", "merchandise_class": "EQUIPMENT", "brand_name NOT": "SPALDING"}
+        - query: "Under Armour training apparel"
+          filters: {"brand_name": "UNDER ARMOUR", "merchandise_class": "APPAREL", "sport_category": "TRAINING"}
+        - query: "golf clubs and equipment"
+          filters: {"sport_category": "GOLF", "merchandise_class": "EQUIPMENT"}
       rerank:
         model: *decomposition_llm
         instructions: |
@@ -299,10 +300,10 @@ retrievers:
       model: ms-marco-MiniLM-L-12-v2
       top_n: 20
       columns:
-        - brand_name
-        - product_name
-        - sport_category
-        - merchandise_class
+      - brand_name
+      - product_name
+      - sport_category
+      - merchandise_class
 
 # =============================================================================
 # TOOLS
@@ -422,27 +423,27 @@ tools:
           covering assortment planning, forecasting, buying, pricing,
           sales analytics, and inventory across all sporting goods categories.
         agents:
-          - name: assortment_planning
-            description: "Assortment planning and planogram strategy"
-          - name: forecasting
-            description: "Demand forecasting and trend analysis"
-          - name: purchase_order
-            description: "Purchase orders and vendor management"
-          - name: pricing
-            description: "Pricing strategy, markdowns, and promotions"
-          - name: sales
-            description: "Sales performance and revenue analytics"
-          - name: inventory
-            description: "Stock levels, replenishment, and availability"
-          - name: general
-            description: "Product info and general store inquiries"
+        - name: assortment_planning
+          description: "Assortment planning and planogram strategy"
+        - name: forecasting
+          description: "Demand forecasting and trend analysis"
+        - name: purchase_order
+          description: "Purchase orders and vendor management"
+        - name: pricing
+          description: "Pricing strategy, markdowns, and promotions"
+        - name: sales
+          description: "Sales performance and revenue analytics"
+        - name: inventory
+          description: "Stock levels, replenishment, and availability"
+        - name: general
+          description: "Product info and general store inquiries"
         sample_prompts:
-          - "What Nike running shoes do we carry?"
-          - "What's the demand forecast for running shoes next quarter?"
-          - "Show me open purchase orders from Nike"
-          - "What are our margin targets for footwear?"
-          - "How are trail running shoes performing this month?"
-          - "What's the stock level on SKU NKE-RUN-001?"
+        - "What Nike running shoes do we carry?"
+        - "What's the demand forecast for running shoes next quarter?"
+        - "Show me open purchase orders from Nike"
+        - "What are our margin targets for footwear?"
+        - "How are trail running shoes performing this month?"
+        - "What's the stock level on SKU NKE-RUN-001?"
 
 
 # =============================================================================
@@ -809,9 +810,9 @@ memory: &memory
 
   extraction:
     schemas:
-      - user_profile
-      - preference
-      - episode
+    - user_profile
+    - preference
+    - episode
     instructions: |
       Extract the user's name, role, and merchandising focus areas. Track their
       preferred product categories, brands of interest, stores they manage, and
@@ -832,13 +833,13 @@ middleware:
     name: dao_ai.middleware.create_custom_field_validation_middleware
     args:
       fields:
-        - name: store_num
-          description: "Your store number for inventory and sales lookups"
-          example_value: "DEN-FLAG"
-        - name: user_id
-          description: "Your unique user identifier"
-          required: false
-          example_value: "merchandiser_01"
+      - name: store_num
+        description: "Your store number for inventory and sales lookups"
+        example_value: "DEN-FLAG"
+      - name: user_id
+        description: "Your unique user identifier"
+        required: false
+        example_value: "merchandiser_01"
 
 # =============================================================================
 # AGENTS
@@ -849,8 +850,8 @@ agents:
     description: "Assortment planning specialist managing category mix, planogram strategy, seasonal transitions, and product lifecycle for sporting goods"
     model: *tool_calling_llm
     tools:
-      - *merchandising_analytics_tool
-      - *find_product_details_by_description_tool
+    - *merchandising_analytics_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: *assortment_planning_prompt
     handoff_prompt: "Assortment strategy, category mix, planogram planning, seasonal transitions, new product introductions, or SKU rationalization."
@@ -860,8 +861,8 @@ agents:
     description: "Demand forecasting analyst providing predictions, trend analysis, seasonal projections, and stockout risk assessment for sporting goods"
     model: *tool_calling_llm
     tools:
-      - *merchandising_analytics_tool
-      - *current_time_tool
+    - *merchandising_analytics_tool
+    - *current_time_tool
     guardrails: []
     prompt: *forecasting_prompt
     handoff_prompt: "Demand forecasting, sales predictions, trend analysis, seasonal demand patterns, or stockout risk assessment."
@@ -871,8 +872,8 @@ agents:
     description: "Purchase order and buying specialist managing PO lifecycle, vendor relationships, buying decisions, and receiving for sporting goods"
     model: *tool_calling_llm
     tools:
-      - *merchandising_analytics_tool
-      - *find_inventory_by_sku_tool
+    - *merchandising_analytics_tool
+    - *find_inventory_by_sku_tool
     guardrails: []
     prompt: *purchase_order_prompt
     handoff_prompt: "Purchase orders, buying decisions, vendor management, reorder quantities, PO tracking, receiving, or supplier performance."
@@ -882,9 +883,9 @@ agents:
     description: "Pricing strategy specialist managing initial pricing, markdowns, promotions, competitive pricing, and clearance for sporting goods"
     model: *tool_calling_llm
     tools:
-      - *sales_pricing_analytics_tool
-      - *find_product_by_sku_tool
-      - *find_product_by_upc_tool
+    - *sales_pricing_analytics_tool
+    - *find_product_by_sku_tool
+    - *find_product_by_upc_tool
     guardrails: []
     prompt: *pricing_prompt
     handoff_prompt: "Pricing strategy, markdowns, promotional pricing, competitive pricing, margin analysis, or clearance pricing."
@@ -894,9 +895,9 @@ agents:
     description: "Sales analytics specialist providing performance analysis, revenue tracking, store comparisons, and return analysis for sporting goods"
     model: *tool_calling_llm
     tools:
-      - *sales_pricing_analytics_tool
-      - *find_inventory_by_sku_tool
-      - *find_product_details_by_description_tool
+    - *sales_pricing_analytics_tool
+    - *find_inventory_by_sku_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: *sales_prompt
     recursion_limit: 12
@@ -907,11 +908,11 @@ agents:
     description: "Inventory management specialist providing stock levels, replenishment, allocation, and product availability for sporting goods"
     model: *tool_calling_llm
     tools:
-      - *find_inventory_by_sku_tool
-      - *find_inventory_by_upc_tool
-      - *find_store_inventory_by_sku_tool
-      - *find_store_inventory_by_upc_tool
-      - *find_product_details_by_description_tool
+    - *find_inventory_by_sku_tool
+    - *find_inventory_by_upc_tool
+    - *find_store_inventory_by_sku_tool
+    - *find_store_inventory_by_upc_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: *inventory_prompt
     handoff_prompt: "Stock levels, product availability, replenishment, store transfers, warehouse stock, or out-of-stock situations."
@@ -921,7 +922,7 @@ agents:
     description: "General merchandising assistant for product information, store inquiries, and questions not handled by specialist agents"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: *general_prompt
     handoff_prompt: "General product info, store inquiries, policies, or questions not handled by other specialist agents."
@@ -943,30 +944,30 @@ app:
   monitoring:
     sample_rate: 1.0
     scorers:
-      - safety
-      - completeness
-      - relevance_to_query
-      - tool_call_efficiency
+    - safety
+    - completeness
+    - relevance_to_query
+    - tool_call_efficiency
     guidelines_sample_rate: 0.5
     guidelines:
-      - name: merchandising_accuracy
-        guidelines:
-          - Inventory counts and stock levels must come from tool results, not fabricated
-          - Pricing recommendations must reference actual product data from the catalog
-          - Purchase order statuses and vendor information must be sourced from analytics tools
-          - Demand forecasts must clearly state the data sources and confidence level
-      - name: tool_usage_quality
-        guidelines:
-          - The agent must call the appropriate tool before answering product, inventory, or pricing questions
-          - Genie analytics tools should be used for trend analysis and aggregate metrics, not UC functions
-          - UC function tools should be used for specific SKU or UPC lookups, not analytics queries
-          - Vector search should be used when the user describes products by attributes rather than by SKU or UPC
-      - name: response_professionalism
-        guidelines:
-          - Responses should use merchandising terminology appropriate for retail professionals
-          - Financial figures (margin, revenue, cost) should be formatted consistently with currency symbols
-          - Recommendations should include actionable next steps with specific SKUs or categories
-          - Seasonal context and timing should be considered in all planning recommendations
+    - name: merchandising_accuracy
+      guidelines:
+      - Inventory counts and stock levels must come from tool results, not fabricated
+      - Pricing recommendations must reference actual product data from the catalog
+      - Purchase order statuses and vendor information must be sourced from analytics tools
+      - Demand forecasts must clearly state the data sources and confidence level
+    - name: tool_usage_quality
+      guidelines:
+      - The agent must call the appropriate tool before answering product, inventory, or pricing questions
+      - Genie analytics tools should be used for trend analysis and aggregate metrics, not UC functions
+      - UC function tools should be used for specific SKU or UPC lookups, not analytics queries
+      - Vector search should be used when the user describes products by attributes rather than by SKU or UPC
+    - name: response_professionalism
+      guidelines:
+      - Responses should use merchandising terminology appropriate for retail professionals
+      - Financial figures (margin, revenue, cost) should be formatted consistently with currency symbols
+      - Recommendations should include actionable next steps with specific SKUs or categories
+      - Seasonal context and timing should be considered in all planning recommendations
  # service_principal: *retail_consumer_goods_sp
   environment_vars:
     RETAIL_AI_DATABRICKS_CLIENT_ID: "{{secrets/retail_consumer_goods/RETAIL_AI_DATABRICKS_CLIENT_ID}}"
@@ -979,33 +980,33 @@ app:
   enable_chat_proxy: true
 
   permissions:
-    - principals: [users]
-      entitlements:
-        - CAN_QUERY
+  - principals: [users]
+    entitlements:
+    - CAN_QUERY
   agents:
-    - *assortment_planning
-    - *forecasting
-    - *purchase_order
-    - *pricing
-    - *sales
-    - *inventory
-    - *general
+  - *assortment_planning
+  - *forecasting
+  - *purchase_order
+  - *pricing
+  - *sales
+  - *inventory
+  - *general
   orchestration:
     memory: *memory
     supervisor:
       model: *supervisor_llm
       tools:
-        - *app_info_tool
+      - *app_info_tool
       prompt: |
         You are a routing coordinator for a sporting goods merchandising system. You do NOT answer questions yourself. Your ONLY job is to analyze incoming requests and hand off to the most appropriate specialist agent using the handoff tools.
 
         IMPORTANT: You do NOT have access to product data, inventory systems, sales data, or any merchandising tools. You MUST hand off every request to an agent. Never attempt to answer a merchandising question yourself. Always hand off. Never answer directly.
       middleware:
-        - *store_validation
+      - *store_validation
   input_example:
     messages:
-      - role: user
-        content: What Nike running shoes do we carry?
+    - role: user
+      content: What Nike running shoes do we carry?
     custom_inputs:
       configurable:
         user_id: merchandiser_01
@@ -1016,38 +1017,38 @@ app:
 # UNITY CATALOG FUNCTIONS
 # =============================================================================
 unity_catalog_functions:
-  - function: *find_product_by_sku
-    ddl: ../functions/sporting_goods_store/find_product_by_sku.sql
-    test:
-      parameters:
-        sku: ["NKE-RUN-001"]
-  - function: *find_product_by_upc
-    ddl: ../functions/sporting_goods_store/find_product_by_upc.sql
-    test:
-      parameters:
-        upc: ["194501234567"]
-  - function: *find_inventory_by_sku
-    ddl: ../functions/sporting_goods_store/find_inventory_by_sku.sql
-    test:
-      parameters:
-        sku: ["NKE-RUN-001"]
-  - function: *find_inventory_by_upc
-    ddl: ../functions/sporting_goods_store/find_inventory_by_upc.sql
-    test:
-      parameters:
-        upc: ["194501234567"]
-  - function: *find_store_inventory_by_sku
-    ddl: ../functions/sporting_goods_store/find_store_inventory_by_sku.sql
-    test:
-      parameters:
-        store: "DEN-FLAG"
-        sku: ["NKE-RUN-001"]
-  - function: *find_store_inventory_by_upc
-    ddl: ../functions/sporting_goods_store/find_store_inventory_by_upc.sql
-    test:
-      parameters:
-        store: "DEN-FLAG"
-        upc: ["194501234567"]
+- function: *find_product_by_sku
+  ddl: ../functions/sporting_goods_store/find_product_by_sku.sql
+  test:
+    parameters:
+      sku: ["NKE-RUN-001"]
+- function: *find_product_by_upc
+  ddl: ../functions/sporting_goods_store/find_product_by_upc.sql
+  test:
+    parameters:
+      upc: ["194501234567"]
+- function: *find_inventory_by_sku
+  ddl: ../functions/sporting_goods_store/find_inventory_by_sku.sql
+  test:
+    parameters:
+      sku: ["NKE-RUN-001"]
+- function: *find_inventory_by_upc
+  ddl: ../functions/sporting_goods_store/find_inventory_by_upc.sql
+  test:
+    parameters:
+      upc: ["194501234567"]
+- function: *find_store_inventory_by_sku
+  ddl: ../functions/sporting_goods_store/find_store_inventory_by_sku.sql
+  test:
+    parameters:
+      store: "DEN-FLAG"
+      sku: ["NKE-RUN-001"]
+- function: *find_store_inventory_by_upc
+  ddl: ../functions/sporting_goods_store/find_store_inventory_by_upc.sql
+  test:
+    parameters:
+      store: "DEN-FLAG"
+      upc: ["194501234567"]
 
 # =============================================================================
 # EVALUATION
@@ -1104,55 +1105,55 @@ evaluation:
       store_num: DEN-FLAG
     session: {}
   guidelines:
-    - name: merchandising_relevance
-      guidelines:
-        - Responses should be relevant to sporting goods merchandising operations
-        - Recommendations should reference specific products, brands, or categories from the catalog
-        - Pricing and inventory data should be accurate and sourced from tool results
-        - Seasonal context should be considered in all merchandising recommendations
+  - name: merchandising_relevance
+    guidelines:
+    - Responses should be relevant to sporting goods merchandising operations
+    - Recommendations should reference specific products, brands, or categories from the catalog
+    - Pricing and inventory data should be accurate and sourced from tool results
+    - Seasonal context should be considered in all merchandising recommendations
 
 # =============================================================================
 # DATASETS
 # =============================================================================
 datasets:
-  - table:
-      schema: *sporting_goods_schema
-      name: products
-    ddl: ../data/sporting_goods_store/products.sql
-    data: ../data/sporting_goods_store/product_data.sql
-    format: sql
+- table:
+    schema: *sporting_goods_schema
+    name: products
+  ddl: ../data/sporting_goods_store/products.sql
+  data: ../data/sporting_goods_store/product_data.sql
+  format: sql
 
-  - table:
-      schema: *sporting_goods_schema
-      name: inventory
-    ddl: ../data/sporting_goods_store/inventory.sql
-    data: ../data/sporting_goods_store/inventory_data.sql
-    format: sql
+- table:
+    schema: *sporting_goods_schema
+    name: inventory
+  ddl: ../data/sporting_goods_store/inventory.sql
+  data: ../data/sporting_goods_store/inventory_data.sql
+  format: sql
 
-  - table:
-      schema: *sporting_goods_schema
-      name: dim_stores
-    ddl: ../data/sporting_goods_store/dim_stores.sql
-    data: ../data/sporting_goods_store/dim_stores_data.sql
-    format: sql
+- table:
+    schema: *sporting_goods_schema
+    name: dim_stores
+  ddl: ../data/sporting_goods_store/dim_stores.sql
+  data: ../data/sporting_goods_store/dim_stores_data.sql
+  format: sql
 
-  - table:
-      schema: *sporting_goods_schema
-      name: sales_orders
-    ddl: ../data/sporting_goods_store/sales_orders.sql
-    data: ../data/sporting_goods_store/sales_orders_data.sql
-    format: sql
+- table:
+    schema: *sporting_goods_schema
+    name: sales_orders
+  ddl: ../data/sporting_goods_store/sales_orders.sql
+  data: ../data/sporting_goods_store/sales_orders_data.sql
+  format: sql
 
-  - table:
-      schema: *sporting_goods_schema
-      name: purchase_orders
-    ddl: ../data/sporting_goods_store/purchase_orders.sql
-    data: ../data/sporting_goods_store/purchase_orders_data.sql
-    format: sql
+- table:
+    schema: *sporting_goods_schema
+    name: purchase_orders
+  ddl: ../data/sporting_goods_store/purchase_orders.sql
+  data: ../data/sporting_goods_store/purchase_orders_data.sql
+  format: sql
 
-  - table:
-      schema: *sporting_goods_schema
-      name: pricing_history
-    ddl: ../data/sporting_goods_store/pricing_history.sql
-    data: ../data/sporting_goods_store/pricing_history_data.sql
-    format: sql
+- table:
+    schema: *sporting_goods_schema
+    name: pricing_history
+  ddl: ../data/sporting_goods_store/pricing_history.sql
+  data: ../data/sporting_goods_store/pricing_history_data.sql
+  format: sql

--- a/config/examples/15_complete_applications/sporting_goods_store_slim.yaml
+++ b/config/examples/15_complete_applications/sporting_goods_store_slim.yaml
@@ -30,15 +30,15 @@ parameters:
 variables:
   client_id: &client_id
     options:
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_CLIENT_ID
-      - env: RETAIL_AI_DATABRICKS_CLIENT_ID
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_ID
+    - env: RETAIL_AI_DATABRICKS_CLIENT_ID
 
   client_secret: &client_secret
     options:
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
-      - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+    - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET
 
 service_principals:
   retail_consumer_goods_sp:
@@ -54,12 +54,12 @@ schemas:
     catalog_name: ${var.catalog}
     schema_name: ${var.schema}
     permissions:
-      - principals: [users]
-        privileges:
-          - USE_CATALOG
-          - USE_SCHEMA
-          - SELECT
-          - EXECUTE
+    - principals: [users]
+      privileges:
+      - USE_CATALOG
+      - USE_SCHEMA
+      - SELECT
+      - EXECUTE
 
 # =============================================================================
 # RESOURCES
@@ -68,7 +68,7 @@ resources:
   # ---------------------------------------------------------------------------
   # LANGUAGE MODELS
   # ---------------------------------------------------------------------------
-  llms:
+  models:
     fast_llm: &fast_llm
       name: databricks-gpt-5-4-mini
       temperature: 0.1
@@ -87,7 +87,7 @@ resources:
       max_tokens: 4096
       on_behalf_of_user: true
       fallbacks:
-        - databricks-claude-sonnet-4-6
+      - databricks-claude-sonnet-4-6
 
     judge_llm: &judge_llm
       name: databricks-claude-sonnet-4-5
@@ -127,16 +127,16 @@ resources:
       doc_uri:
       embedding_source_column: long_description
       columns:
-        - product_id
-        - sku
-        - upc
-        - brand_name
-        - product_name
-        - merchandise_class
-        - department_name
-        - sport_category
-        - base_price
-        - long_description
+      - product_id
+      - sku
+      - upc
+      - brand_name
+      - product_name
+      - merchandise_class
+      - department_name
+      - sport_category
+      - base_price
+      - long_description
 
   # ---------------------------------------------------------------------------
   # WAREHOUSES
@@ -196,74 +196,75 @@ retrievers:
   products_retriever: &products_retriever
     vector_store: *products_vector_store
     columns:
-      - product_id
-      - sku
-      - upc
-      - brand_name
-      - product_name
-      - merchandise_class
-      - department_name
-      - sport_category
-      - base_price
-      - long_description
+    - product_id
+    - sku
+    - upc
+    - brand_name
+    - product_name
+    - merchandise_class
+    - department_name
+    - sport_category
+    - base_price
+    - long_description
     search_parameters:
       num_results: 50
       filters: {}
       query_type: HYBRID
     instructed:
       columns:
-        - name: product_id
-          type: number
-          description: "Unique product identifier"
-        - name: sku
-          type: string
-          description: "Stock keeping unit - internal product code (e.g., NKE-RUN-001)"
-        - name: upc
-          type: string
-          description: "Universal Product Code - barcode number"
-        - name: brand_name
-          type: string
-          description: "Brand/manufacturer (Nike, Adidas, Under Armour, New Balance, Patagonia, The North Face, Columbia, Wilson, Spalding, Coleman, YETI, Osprey, Trek, Giro, Oakley, Garmin, Hydro Flask, Callaway, Lululemon, Bowflex, Rogue Fitness)"
-        - name: product_name
-          type: string
-          description: "Product display name"
-        - name: merchandise_class
-          type: string
-          description: "Product category (Footwear, Apparel, Equipment, Accessories, etc.)"
-        - name: department_name
-          type: string
-          description: "Department (Athletic Footwear, Athletic Apparel, Team Sports, Fitness Equipment, Outdoor & Camping, Cycling, Accessories, Golf)"
-        - name: sport_category
-          type: string
-          description: "Sport or activity (Running, Basketball, Football, Soccer, Golf, Training, Outdoor, Camping, Hiking, Cycling, Yoga, Fitness, Lifestyle, General)"
-        - name: base_price
-          type: number
-          description: "Base retail price in USD"
-        - name: long_description
-          type: string
-          description: "Detailed product description with features and specifications"
+      - name: product_id
+        type: number
+        description: "Unique product identifier"
+      - name: sku
+        type: string
+        description: "Stock keeping unit - internal product code (e.g., NKE-RUN-001)"
+      - name: upc
+        type: string
+        description: "Universal Product Code - barcode number"
+      - name: brand_name
+        type: string
+        description: "Brand/manufacturer (Nike, Adidas, Under Armour, New Balance, Patagonia, The North Face, Columbia, Wilson, Spalding, Coleman, YETI, Osprey, Trek, Giro, Oakley, Garmin, Hydro Flask,
+          Callaway, Lululemon, Bowflex, Rogue Fitness)"
+      - name: product_name
+        type: string
+        description: "Product display name"
+      - name: merchandise_class
+        type: string
+        description: "Product category (Footwear, Apparel, Equipment, Accessories, etc.)"
+      - name: department_name
+        type: string
+        description: "Department (Athletic Footwear, Athletic Apparel, Team Sports, Fitness Equipment, Outdoor & Camping, Cycling, Accessories, Golf)"
+      - name: sport_category
+        type: string
+        description: "Sport or activity (Running, Basketball, Football, Soccer, Golf, Training, Outdoor, Camping, Hiking, Cycling, Yoga, Fitness, Lifestyle, General)"
+      - name: base_price
+        type: number
+        description: "Base retail price in USD"
+      - name: long_description
+        type: string
+        description: "Detailed product description with features and specifications"
       constraints:
-        - "Use brand_name for brand filtering"
-        - "Use sport_category for sport-based queries"
-        - "Use merchandise_class for product type filtering"
-        - "Use department_name for department-level queries"
-        - "Only use columns listed above"
+      - "Use brand_name for brand filtering"
+      - "Use sport_category for sport-based queries"
+      - "Use merchandise_class for product type filtering"
+      - "Use department_name for department-level queries"
+      - "Only use columns listed above"
       decomposition:
         model: *decomposition_llm
         max_subqueries: 3
         rrf_k: 60
         normalize_filter_case: uppercase
         examples:
-          - query: "Nike running shoes"
-            filters: {"brand_name": "NIKE", "sport_category": "RUNNING", "merchandise_class": "FOOTWEAR"}
-          - query: "Patagonia or North Face outdoor jackets"
-            filters: {"brand_name": ["PATAGONIA", "THE NORTH FACE"], "merchandise_class": "APPAREL", "sport_category": "OUTDOOR"}
-          - query: "basketball equipment excluding Spalding"
-            filters: {"sport_category": "BASKETBALL", "merchandise_class": "EQUIPMENT", "brand_name NOT": "SPALDING"}
-          - query: "Under Armour training apparel"
-            filters: {"brand_name": "UNDER ARMOUR", "merchandise_class": "APPAREL", "sport_category": "TRAINING"}
-          - query: "golf clubs and equipment"
-            filters: {"sport_category": "GOLF", "merchandise_class": "EQUIPMENT"}
+        - query: "Nike running shoes"
+          filters: {"brand_name": "NIKE", "sport_category": "RUNNING", "merchandise_class": "FOOTWEAR"}
+        - query: "Patagonia or North Face outdoor jackets"
+          filters: {"brand_name": ["PATAGONIA", "THE NORTH FACE"], "merchandise_class": "APPAREL", "sport_category": "OUTDOOR"}
+        - query: "basketball equipment excluding Spalding"
+          filters: {"sport_category": "BASKETBALL", "merchandise_class": "EQUIPMENT", "brand_name NOT": "SPALDING"}
+        - query: "Under Armour training apparel"
+          filters: {"brand_name": "UNDER ARMOUR", "merchandise_class": "APPAREL", "sport_category": "TRAINING"}
+        - query: "golf clubs and equipment"
+          filters: {"sport_category": "GOLF", "merchandise_class": "EQUIPMENT"}
       rerank:
         model: *decomposition_llm
         instructions: |
@@ -277,10 +278,10 @@ retrievers:
       model: ms-marco-MiniLM-L-12-v2
       top_n: 20
       columns:
-        - brand_name
-        - product_name
-        - sport_category
-        - merchandise_class
+      - brand_name
+      - product_name
+      - sport_category
+      - merchandise_class
 
 # =============================================================================
 # TOOLS
@@ -382,27 +383,27 @@ tools:
           covering assortment planning, forecasting, buying, pricing,
           sales analytics, and inventory across all sporting goods categories.
         agents:
-          - name: assortment_planning
-            description: "Assortment planning and planogram strategy"
-          - name: forecasting
-            description: "Demand forecasting and trend analysis"
-          - name: purchase_order
-            description: "Purchase orders and vendor management"
-          - name: pricing
-            description: "Pricing strategy, markdowns, and promotions"
-          - name: sales
-            description: "Sales performance and revenue analytics"
-          - name: inventory
-            description: "Stock levels, replenishment, and availability"
-          - name: general
-            description: "Product info and general store inquiries"
+        - name: assortment_planning
+          description: "Assortment planning and planogram strategy"
+        - name: forecasting
+          description: "Demand forecasting and trend analysis"
+        - name: purchase_order
+          description: "Purchase orders and vendor management"
+        - name: pricing
+          description: "Pricing strategy, markdowns, and promotions"
+        - name: sales
+          description: "Sales performance and revenue analytics"
+        - name: inventory
+          description: "Stock levels, replenishment, and availability"
+        - name: general
+          description: "Product info and general store inquiries"
         sample_prompts:
-          - "What Nike running shoes do we carry?"
-          - "What's the demand forecast for running shoes next quarter?"
-          - "Show me open purchase orders from Nike"
-          - "What are our margin targets for footwear?"
-          - "How are trail running shoes performing this month?"
-          - "What's the stock level on SKU NKE-RUN-001?"
+        - "What Nike running shoes do we carry?"
+        - "What's the demand forecast for running shoes next quarter?"
+        - "Show me open purchase orders from Nike"
+        - "What are our margin targets for footwear?"
+        - "How are trail running shoes performing this month?"
+        - "What's the stock level on SKU NKE-RUN-001?"
 
 
 # =============================================================================
@@ -769,9 +770,9 @@ memory: &memory
 
   extraction:
     schemas:
-      - user_profile
-      - preference
-      - episode
+    - user_profile
+    - preference
+    - episode
     instructions: |
       Extract the user's name, role, and merchandising focus areas. Track their
       preferred product categories, brands of interest, stores they manage, and
@@ -792,13 +793,13 @@ middleware:
     name: dao_ai.middleware.create_custom_field_validation_middleware
     args:
       fields:
-        - name: store_num
-          description: "Your store number for inventory and sales lookups"
-          example_value: "DEN-FLAG"
-        - name: user_id
-          description: "Your unique user identifier"
-          required: false
-          example_value: "merchandiser_01"
+      - name: store_num
+        description: "Your store number for inventory and sales lookups"
+        example_value: "DEN-FLAG"
+      - name: user_id
+        description: "Your unique user identifier"
+        required: false
+        example_value: "merchandiser_01"
 
 # =============================================================================
 # AGENTS
@@ -809,8 +810,8 @@ agents:
     description: "Assortment planning specialist managing category mix, planogram strategy, seasonal transitions, and product lifecycle for sporting goods"
     model: *tool_calling_llm
     tools:
-      - *merchandising_analytics_tool
-      - *find_product_details_by_description_tool
+    - *merchandising_analytics_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: *assortment_planning_prompt
     handoff_prompt: "Assortment strategy, category mix, planogram planning, seasonal transitions, new product introductions, or SKU rationalization."
@@ -820,8 +821,8 @@ agents:
     description: "Demand forecasting analyst providing predictions, trend analysis, seasonal projections, and stockout risk assessment for sporting goods"
     model: *tool_calling_llm
     tools:
-      - *merchandising_analytics_tool
-      - *current_time_tool
+    - *merchandising_analytics_tool
+    - *current_time_tool
     guardrails: []
     prompt: *forecasting_prompt
     handoff_prompt: "Demand forecasting, sales predictions, trend analysis, seasonal demand patterns, or stockout risk assessment."
@@ -831,8 +832,8 @@ agents:
     description: "Purchase order and buying specialist managing PO lifecycle, vendor relationships, buying decisions, and receiving for sporting goods"
     model: *tool_calling_llm
     tools:
-      - *merchandising_analytics_tool
-      - *find_inventory_by_sku_tool
+    - *merchandising_analytics_tool
+    - *find_inventory_by_sku_tool
     guardrails: []
     prompt: *purchase_order_prompt
     handoff_prompt: "Purchase orders, buying decisions, vendor management, reorder quantities, PO tracking, receiving, or supplier performance."
@@ -842,8 +843,8 @@ agents:
     description: "Pricing strategy specialist managing initial pricing, markdowns, promotions, competitive pricing, and clearance for sporting goods"
     model: *tool_calling_llm
     tools:
-      - *sales_pricing_analytics_tool
-      - *find_product_by_sku_tool
+    - *sales_pricing_analytics_tool
+    - *find_product_by_sku_tool
     guardrails: []
     prompt: *pricing_prompt
     handoff_prompt: "Pricing strategy, markdowns, promotional pricing, competitive pricing, margin analysis, or clearance pricing."
@@ -853,9 +854,9 @@ agents:
     description: "Sales analytics specialist providing performance analysis, revenue tracking, store comparisons, and return analysis for sporting goods"
     model: *tool_calling_llm
     tools:
-      - *sales_pricing_analytics_tool
-      - *find_inventory_by_sku_tool
-      - *find_product_details_by_description_tool
+    - *sales_pricing_analytics_tool
+    - *find_inventory_by_sku_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: *sales_prompt
     recursion_limit: 12
@@ -866,9 +867,9 @@ agents:
     description: "Inventory management specialist providing stock levels, replenishment, allocation, and product availability for sporting goods"
     model: *tool_calling_llm
     tools:
-      - *find_inventory_by_sku_tool
-      - *find_store_inventory_by_sku_tool
-      - *find_product_details_by_description_tool
+    - *find_inventory_by_sku_tool
+    - *find_store_inventory_by_sku_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: *inventory_prompt
     handoff_prompt: "Stock levels, product availability, replenishment, store transfers, warehouse stock, or out-of-stock situations."
@@ -878,7 +879,7 @@ agents:
     description: "General merchandising assistant for product information, store inquiries, and questions not handled by specialist agents"
     model: *tool_calling_llm
     tools:
-      - *find_product_details_by_description_tool
+    - *find_product_details_by_description_tool
     guardrails: []
     prompt: *general_prompt
     handoff_prompt: "General product info, store inquiries, policies, or questions not handled by other specialist agents."
@@ -900,30 +901,30 @@ app:
   monitoring:
     sample_rate: 1.0
     scorers:
-      - safety
-      - completeness
-      - relevance_to_query
-      - tool_call_efficiency
+    - safety
+    - completeness
+    - relevance_to_query
+    - tool_call_efficiency
     guidelines_sample_rate: 0.5
     guidelines:
-      - name: merchandising_accuracy
-        guidelines:
-          - Inventory counts and stock levels must come from tool results, not fabricated
-          - Pricing recommendations must reference actual product data from the catalog
-          - Purchase order statuses and vendor information must be sourced from analytics tools
-          - Demand forecasts must clearly state the data sources and confidence level
-      - name: tool_usage_quality
-        guidelines:
-          - The agent must call the appropriate tool before answering product, inventory, or pricing questions
-          - Genie analytics tools should be used for trend analysis and aggregate metrics, not UC functions
-          - UC function tools should be used for specific SKU or UPC lookups, not analytics queries
-          - Vector search should be used when the user describes products by attributes rather than by SKU or UPC
-      - name: response_professionalism
-        guidelines:
-          - Responses should use merchandising terminology appropriate for retail professionals
-          - Financial figures (margin, revenue, cost) should be formatted consistently with currency symbols
-          - Recommendations should include actionable next steps with specific SKUs or categories
-          - Seasonal context and timing should be considered in all planning recommendations
+    - name: merchandising_accuracy
+      guidelines:
+      - Inventory counts and stock levels must come from tool results, not fabricated
+      - Pricing recommendations must reference actual product data from the catalog
+      - Purchase order statuses and vendor information must be sourced from analytics tools
+      - Demand forecasts must clearly state the data sources and confidence level
+    - name: tool_usage_quality
+      guidelines:
+      - The agent must call the appropriate tool before answering product, inventory, or pricing questions
+      - Genie analytics tools should be used for trend analysis and aggregate metrics, not UC functions
+      - UC function tools should be used for specific SKU or UPC lookups, not analytics queries
+      - Vector search should be used when the user describes products by attributes rather than by SKU or UPC
+    - name: response_professionalism
+      guidelines:
+      - Responses should use merchandising terminology appropriate for retail professionals
+      - Financial figures (margin, revenue, cost) should be formatted consistently with currency symbols
+      - Recommendations should include actionable next steps with specific SKUs or categories
+      - Seasonal context and timing should be considered in all planning recommendations
  # service_principal: *retail_consumer_goods_sp
   environment_vars:
     RETAIL_AI_DATABRICKS_CLIENT_ID: "{{secrets/retail_consumer_goods/RETAIL_AI_DATABRICKS_CLIENT_ID}}"
@@ -936,33 +937,33 @@ app:
   enable_chat_proxy: true
 
   permissions:
-    - principals: [users]
-      entitlements:
-        - CAN_QUERY
+  - principals: [users]
+    entitlements:
+    - CAN_QUERY
   agents:
-    - *assortment_planning
-    - *forecasting
-    - *purchase_order
-    - *pricing
-    - *sales
-    - *inventory
-    - *general
+  - *assortment_planning
+  - *forecasting
+  - *purchase_order
+  - *pricing
+  - *sales
+  - *inventory
+  - *general
   orchestration:
     memory: *memory
     supervisor:
       model: *supervisor_llm
       tools:
-        - *app_info_tool
+      - *app_info_tool
       prompt: |
         You are a routing coordinator for a sporting goods merchandising system. You do NOT answer questions yourself. Your ONLY job is to analyze incoming requests and hand off to the most appropriate specialist agent using the handoff tools.
 
         IMPORTANT: You do NOT have access to product data, inventory systems, sales data, or any merchandising tools. You MUST hand off every request to an agent. Never attempt to answer a merchandising question yourself. Always hand off. Never answer directly.
       middleware:
-        - *store_validation
+      - *store_validation
   input_example:
     messages:
-      - role: user
-        content: What Nike running shoes do we carry?
+    - role: user
+      content: What Nike running shoes do we carry?
     custom_inputs:
       configurable:
         user_id: merchandiser_01
@@ -973,22 +974,22 @@ app:
 # UNITY CATALOG FUNCTIONS
 # =============================================================================
 unity_catalog_functions:
-  - function: *find_product_by_sku
-    ddl: ../functions/sporting_goods_store/find_product_by_sku.sql
-    test:
-      parameters:
-        sku: ["NKE-RUN-001"]
-  - function: *find_inventory_by_sku
-    ddl: ../functions/sporting_goods_store/find_inventory_by_sku.sql
-    test:
-      parameters:
-        sku: ["NKE-RUN-001"]
-  - function: *find_store_inventory_by_sku
-    ddl: ../functions/sporting_goods_store/find_store_inventory_by_sku.sql
-    test:
-      parameters:
-        store: "DEN-FLAG"
-        sku: ["NKE-RUN-001"]
+- function: *find_product_by_sku
+  ddl: ../functions/sporting_goods_store/find_product_by_sku.sql
+  test:
+    parameters:
+      sku: ["NKE-RUN-001"]
+- function: *find_inventory_by_sku
+  ddl: ../functions/sporting_goods_store/find_inventory_by_sku.sql
+  test:
+    parameters:
+      sku: ["NKE-RUN-001"]
+- function: *find_store_inventory_by_sku
+  ddl: ../functions/sporting_goods_store/find_store_inventory_by_sku.sql
+  test:
+    parameters:
+      store: "DEN-FLAG"
+      sku: ["NKE-RUN-001"]
 
 # =============================================================================
 # EVALUATION
@@ -1045,55 +1046,55 @@ evaluation:
       store_num: DEN-FLAG
     session: {}
   guidelines:
-    - name: merchandising_relevance
-      guidelines:
-        - Responses should be relevant to sporting goods merchandising operations
-        - Recommendations should reference specific products, brands, or categories from the catalog
-        - Pricing and inventory data should be accurate and sourced from tool results
-        - Seasonal context should be considered in all merchandising recommendations
+  - name: merchandising_relevance
+    guidelines:
+    - Responses should be relevant to sporting goods merchandising operations
+    - Recommendations should reference specific products, brands, or categories from the catalog
+    - Pricing and inventory data should be accurate and sourced from tool results
+    - Seasonal context should be considered in all merchandising recommendations
 
 # =============================================================================
 # DATASETS
 # =============================================================================
 datasets:
-  - table:
-      schema: *sporting_goods_schema
-      name: products
-    ddl: ../data/sporting_goods_store/products.sql
-    data: ../data/sporting_goods_store/product_data.sql
-    format: sql
+- table:
+    schema: *sporting_goods_schema
+    name: products
+  ddl: ../data/sporting_goods_store/products.sql
+  data: ../data/sporting_goods_store/product_data.sql
+  format: sql
 
-  - table:
-      schema: *sporting_goods_schema
-      name: inventory
-    ddl: ../data/sporting_goods_store/inventory.sql
-    data: ../data/sporting_goods_store/inventory_data.sql
-    format: sql
+- table:
+    schema: *sporting_goods_schema
+    name: inventory
+  ddl: ../data/sporting_goods_store/inventory.sql
+  data: ../data/sporting_goods_store/inventory_data.sql
+  format: sql
 
-  - table:
-      schema: *sporting_goods_schema
-      name: dim_stores
-    ddl: ../data/sporting_goods_store/dim_stores.sql
-    data: ../data/sporting_goods_store/dim_stores_data.sql
-    format: sql
+- table:
+    schema: *sporting_goods_schema
+    name: dim_stores
+  ddl: ../data/sporting_goods_store/dim_stores.sql
+  data: ../data/sporting_goods_store/dim_stores_data.sql
+  format: sql
 
-  - table:
-      schema: *sporting_goods_schema
-      name: sales_orders
-    ddl: ../data/sporting_goods_store/sales_orders.sql
-    data: ../data/sporting_goods_store/sales_orders_data.sql
-    format: sql
+- table:
+    schema: *sporting_goods_schema
+    name: sales_orders
+  ddl: ../data/sporting_goods_store/sales_orders.sql
+  data: ../data/sporting_goods_store/sales_orders_data.sql
+  format: sql
 
-  - table:
-      schema: *sporting_goods_schema
-      name: purchase_orders
-    ddl: ../data/sporting_goods_store/purchase_orders.sql
-    data: ../data/sporting_goods_store/purchase_orders_data.sql
-    format: sql
+- table:
+    schema: *sporting_goods_schema
+    name: purchase_orders
+  ddl: ../data/sporting_goods_store/purchase_orders.sql
+  data: ../data/sporting_goods_store/purchase_orders_data.sql
+  format: sql
 
-  - table:
-      schema: *sporting_goods_schema
-      name: pricing_history
-    ddl: ../data/sporting_goods_store/pricing_history.sql
-    data: ../data/sporting_goods_store/pricing_history_data.sql
-    format: sql
+- table:
+    schema: *sporting_goods_schema
+    name: pricing_history
+  ddl: ../data/sporting_goods_store/pricing_history.sql
+  data: ../data/sporting_goods_store/pricing_history_data.sql
+  format: sql

--- a/config/examples/16_instructed_retriever/full_pipeline.yaml
+++ b/config/examples/16_instructed_retriever/full_pipeline.yaml
@@ -30,7 +30,7 @@ schemas:
     schema_name: ${var.schema}
 
 resources:
-  llms:
+  models:
     # Primary LLM for agent reasoning
     default_llm: &default_llm
       name: databricks-claude-sonnet-4-5
@@ -61,23 +61,9 @@ resources:
         schema: *retail_schema
         name: products
       primary_key: product_id
-      doc_uri: ~
+      doc_uri:
       embedding_source_column: description
       columns:
-        - product_id
-        - sku
-        - upc
-        - brand_name
-        - product_name
-        - merchandise_class
-        - class_cd
-        - description
-
-retrievers:
-  # Full pipeline retriever with all components
-  full_pipeline_retriever: &full_pipeline_retriever
-    vector_store: *products_vector_store
-    columns:
       - product_id
       - sku
       - upc
@@ -86,6 +72,20 @@ retrievers:
       - merchandise_class
       - class_cd
       - description
+
+retrievers:
+  # Full pipeline retriever with all components
+  full_pipeline_retriever: &full_pipeline_retriever
+    vector_store: *products_vector_store
+    columns:
+    - product_id
+    - sku
+    - upc
+    - brand_name
+    - product_name
+    - merchandise_class
+    - class_cd
+    - description
     search_parameters:
       num_results: 50
       query_type: HYBRID
@@ -94,34 +94,34 @@ retrievers:
     # Schema description is auto-generated from the columns below.
     instructed:
       columns:
-        - name: product_id
-          type: number
-          description: "Unique product identifier"
-        - name: sku
-          type: string
-          description: "Stock keeping unit - internal product code"
-        - name: upc
-          type: string
-          description: "Universal Product Code - barcode number"
-        - name: brand_name
-          type: string
-          description: "Brand/manufacturer (MILWAUKEE, DEWALT, MAKITA, etc.)"
-        - name: product_name
-          type: string
-          description: "Product display name"
-        - name: merchandise_class
-          type: string
-          description: "Product category (POWER TOOLS, HAND TOOLS, PAINT, etc.)"
-        - name: class_cd
-          type: string
-          description: "Category code"
-        - name: description
-          type: string
-          description: "Detailed product description"
+      - name: product_id
+        type: number
+        description: "Unique product identifier"
+      - name: sku
+        type: string
+        description: "Stock keeping unit - internal product code"
+      - name: upc
+        type: string
+        description: "Universal Product Code - barcode number"
+      - name: brand_name
+        type: string
+        description: "Brand/manufacturer (MILWAUKEE, DEWALT, MAKITA, etc.)"
+      - name: product_name
+        type: string
+        description: "Product display name"
+      - name: merchandise_class
+        type: string
+        description: "Product category (POWER TOOLS, HAND TOOLS, PAINT, etc.)"
+      - name: class_cd
+        type: string
+        description: "Category code"
+      - name: description
+        type: string
+        description: "Detailed product description"
       constraints:
-        - "Use merchandise_class for category filtering"
-        - "Use brand_name for brand filtering"
-        - "Only use columns listed above"
+      - "Use merchandise_class for category filtering"
+      - "Use brand_name for brand filtering"
+      - "Only use columns listed above"
 
       # Query decomposition and RRF merging
       decomposition:
@@ -130,14 +130,14 @@ retrievers:
         max_subqueries: 3
         rrf_k: 60
         examples:
-          - query: "Milwaukee drills"
-            filters: {"brand_name": "MILWAUKEE"}
-          - query: "cordless power tools excluding DeWalt"
-            filters: {"product_name LIKE": "cordless", "brand_name NOT": "DEWALT"}
-          - query: "paint products"
-            filters: {"merchandise_class": "PAINT"}
-          - query: "Milwaukee or DeWalt tools"
-            filters: {"brand_name": ["MILWAUKEE", "DEWALT"]}
+        - query: "Milwaukee drills"
+          filters: {"brand_name": "MILWAUKEE"}
+        - query: "cordless power tools excluding DeWalt"
+          filters: {"product_name LIKE": "cordless", "brand_name NOT": "DEWALT"}
+        - query: "paint products"
+          filters: {"merchandise_class": "PAINT"}
+        - query: "Milwaukee or DeWalt tools"
+          filters: {"brand_name": ["MILWAUKEE", "DEWALT"]}
 
       # Instruction-Aware LLM reranking (uses schema context above)
       rerank:
@@ -165,9 +165,9 @@ retrievers:
     # Using columns instead of FlashRank model due to ONNX bug: https://github.com/huggingface/optimum/issues/1500
     rerank:
       columns:                            # Databricks server-side reranking
-        - merchandise_class
-        - product_name
-        - brand_name
+      - merchandise_class
+      - product_name
+      - brand_name
       top_n: 20                           # Databricks reranker outputs 20 candidates
 
 tools:
@@ -191,7 +191,7 @@ agents:
     description: "Product search with intelligent query routing and verification"
     model: *default_llm
     tools:
-      - *full_pipeline_search_tool
+    - *full_pipeline_search_tool
     prompt: |
       You are an intelligent product search assistant.
 
@@ -218,18 +218,18 @@ app:
     demo: full_pipeline
     feature: instructed_retriever
   permissions:
-    - principals: [users]
-      entitlements:
-        - CAN_QUERY
+  - principals: [users]
+    entitlements:
+    - CAN_QUERY
   agents:
-    - *intelligent_search_agent
+  - *intelligent_search_agent
   orchestration:
     supervisor:
       model: *default_llm
   input_example:
     input:
-      - role: user
-        content: Find me Milwaukee power drills
+    - role: user
+      content: Find me Milwaukee power drills
     custom_inputs:
       configurable:
         user_id: demo_user
@@ -241,18 +241,18 @@ app:
 # Source data for provisioning tables and vector search indexes
 
 datasets:
-  - table:
-      schema: *retail_schema
-      name: products
-    ddl: ../data/hardware_store/products.sql
-    data: ../data/hardware_store/products.snappy.parquet
-    format: parquet
-  - table:
-      schema: *retail_schema
-      name: inventory
-    ddl: ../data/hardware_store/inventory.sql
-    data: ../data/hardware_store/inventory.snappy.parquet
-    format: parquet
+- table:
+    schema: *retail_schema
+    name: products
+  ddl: ../data/hardware_store/products.sql
+  data: ../data/hardware_store/products.snappy.parquet
+  format: parquet
+- table:
+    schema: *retail_schema
+    name: inventory
+  ddl: ../data/hardware_store/inventory.sql
+  data: ../data/hardware_store/inventory.snappy.parquet
+  format: parquet
 
 # ==============================================================================
 # PIPELINE BEHAVIOR

--- a/config/examples/16_instructed_retriever/instructed_retriever.yaml
+++ b/config/examples/16_instructed_retriever/instructed_retriever.yaml
@@ -18,7 +18,7 @@ schemas:
     schema_name: ${var.schema}
 
 resources:
-  llms:
+  models:
     # Primary LLM for agent reasoning
     default_llm: &default_llm
       name: databricks-claude-sonnet-4-5
@@ -47,23 +47,9 @@ resources:
         schema: *retail_schema
         name: products
       primary_key: product_id
-      doc_uri: ~
+      doc_uri:
       embedding_source_column: description
       columns:
-        - product_id
-        - sku
-        - upc
-        - brand_name
-        - product_name
-        - merchandise_class
-        - class_cd
-        - description
-
-retrievers:
-  # Standard retriever (no instructed retrieval)
-  standard_retriever: &standard_retriever
-    vector_store: *products_vector_store
-    columns:
       - product_id
       - sku
       - upc
@@ -72,6 +58,20 @@ retrievers:
       - merchandise_class
       - class_cd
       - description
+
+retrievers:
+  # Standard retriever (no instructed retrieval)
+  standard_retriever: &standard_retriever
+    vector_store: *products_vector_store
+    columns:
+    - product_id
+    - sku
+    - upc
+    - brand_name
+    - product_name
+    - merchandise_class
+    - class_cd
+    - description
     search_parameters:
       num_results: 10
       query_type: ANN
@@ -80,14 +80,14 @@ retrievers:
   instructed_retriever: &instructed_retriever
     vector_store: *products_vector_store
     columns:
-      - product_id
-      - sku
-      - upc
-      - brand_name
-      - product_name
-      - merchandise_class
-      - class_cd
-      - description
+    - product_id
+    - sku
+    - upc
+    - brand_name
+    - product_name
+    - merchandise_class
+    - class_cd
+    - description
     search_parameters:
       num_results: 50
       query_type: HYBRID
@@ -95,48 +95,48 @@ retrievers:
       # Column metadata is the single source of truth for schema context.
       # Each pipeline component generates the context it needs from this data.
       columns:
-        - name: product_id
-          type: number
-          description: "Unique product identifier"
-        - name: sku
-          type: string
-          description: "Stock keeping unit - internal product code"
-        - name: upc
-          type: string
-          description: "Universal Product Code - barcode number"
-        - name: brand_name
-          type: string
-          description: "Brand/manufacturer (MILWAUKEE, DEWALT, MAKITA, etc.)"
-        - name: product_name
-          type: string
-          description: "Product display name"
-        - name: merchandise_class
-          type: string
-          description: "Product category (POWER TOOLS, HAND TOOLS, PAINT, etc.)"
-        - name: class_cd
-          type: string
-          description: "Category code"
-        - name: description
-          type: string
-          description: "Detailed product description"
+      - name: product_id
+        type: number
+        description: "Unique product identifier"
+      - name: sku
+        type: string
+        description: "Stock keeping unit - internal product code"
+      - name: upc
+        type: string
+        description: "Universal Product Code - barcode number"
+      - name: brand_name
+        type: string
+        description: "Brand/manufacturer (MILWAUKEE, DEWALT, MAKITA, etc.)"
+      - name: product_name
+        type: string
+        description: "Product display name"
+      - name: merchandise_class
+        type: string
+        description: "Product category (POWER TOOLS, HAND TOOLS, PAINT, etc.)"
+      - name: class_cd
+        type: string
+        description: "Category code"
+      - name: description
+        type: string
+        description: "Detailed product description"
       constraints:
-        - "Use merchandise_class for category filtering"
-        - "Use brand_name for brand filtering"
-        - "Only use columns listed above"
+      - "Use merchandise_class for category filtering"
+      - "Use brand_name for brand filtering"
+      - "Only use columns listed above"
       decomposition:
         model: *decomposition_llm
         normalize_filter_case: uppercase
         max_subqueries: 3
         rrf_k: 60
         examples:
-          - query: "Milwaukee drills"
-            filters: {"brand_name": "MILWAUKEE"}
-          - query: "cordless power tools excluding DeWalt"
-            filters: {"product_name LIKE": "cordless", "brand_name NOT": "DEWALT"}
-          - query: "paint products"
-            filters: {"merchandise_class": "PAINT"}
-          - query: "Milwaukee or DeWalt tools"
-            filters: {"brand_name": ["MILWAUKEE", "DEWALT"]}
+        - query: "Milwaukee drills"
+          filters: {"brand_name": "MILWAUKEE"}
+        - query: "cordless power tools excluding DeWalt"
+          filters: {"product_name LIKE": "cordless", "brand_name NOT": "DEWALT"}
+        - query: "paint products"
+          filters: {"merchandise_class": "PAINT"}
+        - query: "Milwaukee or DeWalt tools"
+          filters: {"brand_name": ["MILWAUKEE", "DEWALT"]}
       # Instruction-Aware LLM reranking (uses schema context above)
       rerank:
         model: *decomposition_llm
@@ -149,9 +149,9 @@ retrievers:
     # Reranking: Databricks columns (pure reranking, no LLM)
     rerank:
       columns:                            # Databricks server-side reranking
-        - merchandise_class
-        - product_name
-        - brand_name
+      - merchandise_class
+      - product_name
+      - brand_name
       top_n: 20                           # Databricks reranker outputs 20 candidates
 
 tools:
@@ -192,7 +192,7 @@ agents:
     description: "Product search using standard vector similarity"
     model: *default_llm
     tools:
-      - *standard_search_tool
+    - *standard_search_tool
     prompt: |
       You are a product search assistant. Use the standard_product_search tool
       to find products based on customer queries.
@@ -207,10 +207,10 @@ agents:
     description: "Product search with intelligent query decomposition"
     model: *default_llm
     tools:
-      - *instructed_search_tool
+    - *instructed_search_tool
     prompt: |
       You are an intelligent product search assistant with advanced search capabilities.
-      
+
       Use the instructed_product_search tool for queries that include:
       - Brand preferences (e.g., "Milwaukee", "not DeWalt")
       - Category filters (e.g., "power tools", "paint")
@@ -233,19 +233,19 @@ app:
     demo: instructed_retriever
     feature: query_decomposition
   permissions:
-    - principals: [users]
-      entitlements:
-        - CAN_QUERY
+  - principals: [users]
+    entitlements:
+    - CAN_QUERY
   agents:
-    - *standard_search_agent
-    - *instructed_search_agent
+  - *standard_search_agent
+  - *instructed_search_agent
   orchestration:
     supervisor:
       model: *default_llm
   input_example:
     input:
-      - role: user
-        content: Find me Milwaukee power drills
+    - role: user
+      content: Find me Milwaukee power drills
     custom_inputs:
       configurable:
         user_id: demo_user
@@ -257,15 +257,15 @@ app:
 # Source data for provisioning tables and vector search indexes
 
 datasets:
-  - table:
-      schema: *retail_schema
-      name: products
-    ddl: ../data/hardware_store/products.sql
-    data: ../data/hardware_store/products.snappy.parquet
-    format: parquet
-  - table:
-      schema: *retail_schema
-      name: inventory
-    ddl: ../data/hardware_store/inventory.sql
-    data: ../data/hardware_store/inventory.snappy.parquet
-    format: parquet
+- table:
+    schema: *retail_schema
+    name: products
+  ddl: ../data/hardware_store/products.sql
+  data: ../data/hardware_store/products.snappy.parquet
+  format: parquet
+- table:
+    schema: *retail_schema
+    name: inventory
+  ddl: ../data/hardware_store/inventory.sql
+  data: ../data/hardware_store/inventory.snappy.parquet
+  format: parquet

--- a/config/examples/17_parallel_tools/parallel_tool_calls.yaml
+++ b/config/examples/17_parallel_tools/parallel_tool_calls.yaml
@@ -21,7 +21,7 @@ parameters:
 #   - "Roll three dice for me"
 
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
@@ -151,17 +151,17 @@ agents:
     name: parallel_test_agent
     model: *default_llm
     tools:
-      - *calculator_tool
-      - *get_time_tool
-      - *random_number_tool
-      - *lookup_tool
+    - *calculator_tool
+    - *get_time_tool
+    - *random_number_tool
+    - *lookup_tool
     middleware:
       # Add observability middleware to track parallel vs sequential calls
-      - name: dao_ai.middleware.tool_call_observability.create_tool_call_observability_middleware
-        args:
-          log_level: INFO
-          include_args: true
-          track_timing: true
+    - name: dao_ai.middleware.tool_call_observability.create_tool_call_observability_middleware
+      args:
+        log_level: INFO
+        include_args: true
+        track_timing: true
     prompt: |
       You are a helpful assistant with access to various tools.
 
@@ -190,4 +190,4 @@ app:
       schema_name: ${var.schema}
     name: parallel_tool_test_dao
   agents:
-    - *parallel_test_agent
+  - *parallel_test_agent

--- a/config/examples/18_visualization/vega_lite_visualization.yaml
+++ b/config/examples/18_visualization/vega_lite_visualization.yaml
@@ -23,7 +23,7 @@ schemas:
 
 resources:
   # Define the LLM for the agent
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4  # Databricks serving endpoint name
 
@@ -37,10 +37,10 @@ resources:
       on_behalf_of_user: true                        # Execute SQL as the calling user
 
   tables:
-    products: 
+    products:
       schema: *hardware_store_schema
       name: products
-    inventory: 
+    inventory:
       schema: *hardware_store_schema
       name: inventory
 
@@ -88,8 +88,8 @@ agents:
     name: analyst_with_charts
     model: *default_llm
     tools:
-      - *chart_tool
-      - *get_department_sales
+    - *chart_tool
+    - *get_department_sales
     prompt: |
       You are a data analyst assistant that can query data and create
       visualizations. When the user asks for a chart or plot:
@@ -112,4 +112,4 @@ app:
     schema: *hardware_store_schema
     name: viz_dept_sales_dao
   agents:
-    - *analyst_with_charts
+  - *analyst_with_charts

--- a/config/examples/19_long_running_agents/deep_research.yaml
+++ b/config/examples/19_long_running_agents/deep_research.yaml
@@ -23,15 +23,15 @@ parameters:
 variables:
   client_id: &client_id
     options:
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_CLIENT_ID
-      - env: RETAIL_AI_DATABRICKS_CLIENT_ID
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_ID
+    - env: RETAIL_AI_DATABRICKS_CLIENT_ID
 
   client_secret: &client_secret
     options:
-      - scope: retail_consumer_goods
-        secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
-      - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+    - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET
 
 # =============================================================================
 # SCHEMAS
@@ -41,18 +41,18 @@ schemas:
     catalog_name: ${var.catalog}
     schema_name: ${var.schema}
     permissions:
-      - principals: [users]
-        privileges:
-          - USE_CATALOG
-          - USE_SCHEMA
-          - SELECT
-          - EXECUTE
+    - principals: [users]
+      privileges:
+      - USE_CATALOG
+      - USE_SCHEMA
+      - SELECT
+      - EXECUTE
 
 # =============================================================================
 # RESOURCES
 # =============================================================================
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.3
@@ -112,12 +112,12 @@ app:
     feature: long_running_agents
 
   permissions:
-    - principals: [users]
-      entitlements:
-        - CAN_QUERY
+  - principals: [users]
+    entitlements:
+    - CAN_QUERY
 
   agents:
-    - *researcher
+  - *researcher
 
   long_running:
     database: *retail_database
@@ -127,8 +127,8 @@ app:
 
   input_example:
     messages:
-      - role: user
-        content: "What is Databricks Lakebase?"
+    - role: user
+      content: "What is Databricks Lakebase?"
     custom_inputs:
       configurable:
         thread_id: "deep_research_demo_1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dao-ai"
-version = "0.1.74"
+version = "0.1.75"
 description = "DAO AI: A modular, multi-agent orchestration framework for complex AI workflows. Supports agent handoff, tool integration, and dynamic configuration via YAML."
 readme = "README.md"
 license = { text = "MIT" }

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -1,3 +1,5 @@
+Resolved 302 packages in 8ms
+Checked 271 packages in 17ms
 {
   "$defs": {
     "AgentModel": {
@@ -23,7 +25,7 @@
           "title": "Description"
         },
         "model": {
-          "$ref": "#/$defs/LLMModel",
+          "$ref": "#/$defs/InferenceEndpointModel",
           "description": "LLM model configuration (serving endpoint name, temperature, etc.)."
         },
         "tools": {
@@ -598,7 +600,7 @@
     },
     "BestOfNConfig": {
       "additionalProperties": false,
-      "description": "Opt-in best-of-N + LLM-as-judge wrapper around an LLMModel.\n\nWhen attached to an LLMModel, every model invocation fans out N parallel\ncandidate generations at elevated temperature, then asks a judge model to\nscore the candidates. The wrapper returns the highest-scoring candidate\nverbatim (no synthesis).\n\nCost: roughly N+1 LLM calls per protected step. Generator calls run in\nparallel so wall-clock latency is approximately one generator call plus\none judge call. Token cost is ~N x baseline plus the judge.\n\nDiversity is non-negotiable: with low generator temperature, the N\ncandidates collapse to near-identical outputs and best-of-N degenerates\ninto best-of-1 with extra cost. The wrapper enforces an effective\ngenerator temperature of max(LLMModel.temperature, 0.7) unless\n`temperature_override` is set.",
+      "description": "Opt-in best-of-N + LLM-as-judge wrapper around an InferenceEndpointModel.\n\nWhen attached to an InferenceEndpointModel, every model invocation fans out N parallel\ncandidate generations at elevated temperature, then asks a judge model to\nscore the candidates. The wrapper returns the highest-scoring candidate\nverbatim (no synthesis).\n\nCost: roughly N+1 LLM calls per protected step. Generator calls run in\nparallel so wall-clock latency is approximately one generator call plus\none judge call. Token cost is ~N x baseline plus the judge.\n\nDiversity is non-negotiable: with low generator temperature, the N\ncandidates collapse to near-identical outputs and best-of-N degenerates\ninto best-of-1 with extra cost. The wrapper enforces an effective\ngenerator temperature of max(InferenceEndpointModel.temperature, 0.7) unless\n`temperature_override` is set.",
       "properties": {
         "n": {
           "default": 8,
@@ -612,10 +614,10 @@
               "type": "string"
             },
             {
-              "$ref": "#/$defs/LLMModel"
+              "$ref": "#/$defs/InferenceEndpointModel"
             }
           ],
-          "description": "Judge model: a serving endpoint name (string) or a full LLMModel config.",
+          "description": "Judge model: a serving endpoint name (string) or a full InferenceEndpointModel config.",
           "title": "Judge"
         },
         "temperature_override": {
@@ -628,7 +630,7 @@
             }
           ],
           "default": null,
-          "description": "If set, the parallel candidate calls use this temperature regardless of the generator's configured temperature. If unset, the wrapper uses max(LLMModel.temperature, 0.7) so candidates have meaningful diversity.",
+          "description": "If set, the parallel candidate calls use this temperature regardless of the generator's configured temperature. If unset, the wrapper uses max(InferenceEndpointModel.temperature, 0.7) so candidates have meaningful diversity.",
           "title": "Temperature Override"
         }
       },
@@ -643,7 +645,7 @@
       "description": "Configuration for chat history summarization.\n\nAttributes:\n    model: The LLM to use for generating summaries.\n    max_tokens: Maximum tokens to keep after summarization (the \"keep\" threshold).\n        After summarization, recent messages totaling up to this many tokens are preserved.\n    max_tokens_before_summary: Token threshold that triggers summarization.\n        When conversation exceeds this, summarization runs. Mutually exclusive with\n        max_messages_before_summary. If neither is set, defaults to max_tokens * 10.\n    max_messages_before_summary: Message count threshold that triggers summarization.\n        When conversation exceeds this many messages, summarization runs.\n        Mutually exclusive with max_tokens_before_summary.",
       "properties": {
         "model": {
-          "$ref": "#/$defs/LLMModel",
+          "$ref": "#/$defs/InferenceEndpointModel",
           "description": "LLM used to generate conversation summaries."
         },
         "max_tokens": {
@@ -1194,7 +1196,7 @@
               "type": "string"
             },
             {
-              "$ref": "#/$defs/LLMModel"
+              "$ref": "#/$defs/InferenceEndpointModel"
             },
             {
               "type": "null"
@@ -2032,7 +2034,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LLMModel"
+              "$ref": "#/$defs/InferenceEndpointModel"
             },
             {
               "type": "null"
@@ -2101,14 +2103,14 @@
               "type": "string"
             },
             {
-              "$ref": "#/$defs/LLMModel"
+              "$ref": "#/$defs/InferenceEndpointModel"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Primary LLM. ``LLMModel`` is resolved via ``as_chat_model()``; strings pass through to ``init_chat_model`` (e.g. ``'openai:gpt-4o'``). Defaults to deepagents' default (``claude-sonnet-4-6``) when omitted.",
+          "description": "Primary LLM. ``InferenceEndpointModel`` is resolved via ``as_chat_model()``; strings pass through to ``init_chat_model`` (e.g. ``'openai:gpt-4o'``). Defaults to deepagents' default (``claude-sonnet-4-6``) when omitted.",
           "title": "Model"
         },
         "tools": {
@@ -2401,7 +2403,7 @@
       "additionalProperties": false,
       "description": "An MLflow evaluation dataset containing input/expectation pairs.",
       "properties": {
-        "schema": {
+        "schema_model": {
           "anyOf": [
             {
               "$ref": "#/$defs/SchemaModel"
@@ -2458,7 +2460,7 @@
       "description": "Configuration for MLflow GenAI offline evaluation.\n\nAttributes:\n    model: LLM model used as the judge for LLM-based scorers (e.g., Guidelines, Safety).\n           This model evaluates agent responses during evaluation.\n    table: Table to store evaluation results.\n    num_evals: Number of evaluation samples to generate.\n    replace: If True, drop and recreate the evaluation table and dataset.\n        If False, reuse existing resources. Defaults to False.\n    agent_description: Description of the agent for evaluation data generation.\n    question_guidelines: Guidelines for generating evaluation questions.\n    custom_inputs: Custom inputs to pass to the agent during evaluation.\n    guidelines: List of guideline configurations for Guidelines scorers.",
       "properties": {
         "model": {
-          "$ref": "#/$defs/LLMModel",
+          "$ref": "#/$defs/InferenceEndpointModel",
           "description": "LLM model used as the judge for LLM-based evaluation scorers."
         },
         "table": {
@@ -2787,7 +2789,7 @@
           "description": "Personal access token for PAT-based authentication.",
           "title": "Pat"
         },
-        "schema": {
+        "schema_model": {
           "anyOf": [
             {
               "$ref": "#/$defs/SchemaModel"
@@ -2962,7 +2964,7 @@
               "type": "string"
             },
             {
-              "$ref": "#/$defs/LLMModel"
+              "$ref": "#/$defs/InferenceEndpointModel"
             }
           ],
           "default": "databricks-gte-large-en",
@@ -3912,7 +3914,7 @@
     },
     "GuardrailModel": {
       "additionalProperties": false,
-      "description": "Configuration for a guardrail.\n\nGuardrails evaluate agent responses against quality or safety criteria.\nTwo configuration modes are supported:\n\n1. **Custom (LLM-judge)** -- provide *model* and *prompt*.  A\n   ``JudgeScorer`` is created using ``mlflow.genai.judges.make_judge``.\n2. **Scorer-based** -- provide *scorer* (and optionally *scorer_args*).\n   Any ``mlflow.genai.scorers.base.Scorer`` class can be used,\n   including built-in ``GuardrailsScorer`` validators such as\n   ``ToxicLanguage`` and ``DetectPII``.\n\nThe two modes are mutually exclusive.\n\nAttributes:\n    name: Name identifying this guardrail.\n    model: LLM model for the judge.  Accepts a string (model name) or\n        ``LLMModel``.  Required when using the custom judge mode.\n    prompt: Evaluation instructions using ``{{ inputs }}`` and\n        ``{{ outputs }}`` template variables.  Required when using\n        the custom judge mode.\n    scorer: Fully qualified name of an MLflow ``Scorer`` class\n        (e.g. ``\"mlflow.genai.scorers.guardrails.DetectPII\"``).\n        Required when using the scorer-based mode.\n    scorer_args: Keyword arguments forwarded to the scorer constructor\n        (e.g. ``{\"pii_entities\": [\"CREDIT_CARD\", \"SSN\"]}``).\n    hub: Optional guardrails-ai hub URI for the scorer validator\n        (e.g. ``\"hub://guardrails/toxic_language\"``).  When set,\n        the validator is auto-installed at startup if the\n        ``GUARDRAILSAI_API_KEY`` environment variable is present.\n        Only valid when *scorer* is also set.\n    num_retries: Maximum retry attempts when evaluation fails (default: 3).\n    fail_on_error: If True, block responses when the evaluation call\n        itself errors (e.g. scorer exception, network timeout).\n        If False (default), let responses through on evaluation\n        errors.\n    max_context_length: Max character length for extracted tool context\n        (default: 8000).\n    apply_to: When to run this guardrail.  ``\"input\"`` runs before\n        the model (on user messages), ``\"output\"`` runs after the\n        model (on agent responses), ``\"both\"`` runs in both places\n        (default: ``\"both\"``).",
+      "description": "Configuration for a guardrail.\n\nGuardrails evaluate agent responses against quality or safety criteria.\nTwo configuration modes are supported:\n\n1. **Custom (LLM-judge)** -- provide *model* and *prompt*.  A\n   ``JudgeScorer`` is created using ``mlflow.genai.judges.make_judge``.\n2. **Scorer-based** -- provide *scorer* (and optionally *scorer_args*).\n   Any ``mlflow.genai.scorers.base.Scorer`` class can be used,\n   including built-in ``GuardrailsScorer`` validators such as\n   ``ToxicLanguage`` and ``DetectPII``.\n\nThe two modes are mutually exclusive.\n\nAttributes:\n    name: Name identifying this guardrail.\n    model: LLM model for the judge.  Accepts a string (model name) or\n        ``InferenceEndpointModel``.  Required when using the custom judge mode.\n    prompt: Evaluation instructions using ``{{ inputs }}`` and\n        ``{{ outputs }}`` template variables.  Required when using\n        the custom judge mode.\n    scorer: Fully qualified name of an MLflow ``Scorer`` class\n        (e.g. ``\"mlflow.genai.scorers.guardrails.DetectPII\"``).\n        Required when using the scorer-based mode.\n    scorer_args: Keyword arguments forwarded to the scorer constructor\n        (e.g. ``{\"pii_entities\": [\"CREDIT_CARD\", \"SSN\"]}``).\n    hub: Optional guardrails-ai hub URI for the scorer validator\n        (e.g. ``\"hub://guardrails/toxic_language\"``).  When set,\n        the validator is auto-installed at startup if the\n        ``GUARDRAILSAI_API_KEY`` environment variable is present.\n        Only valid when *scorer* is also set.\n    num_retries: Maximum retry attempts when evaluation fails (default: 3).\n    fail_on_error: If True, block responses when the evaluation call\n        itself errors (e.g. scorer exception, network timeout).\n        If False (default), let responses through on evaluation\n        errors.\n    max_context_length: Max character length for extracted tool context\n        (default: 8000).\n    apply_to: When to run this guardrail.  ``\"input\"`` runs before\n        the model (on user messages), ``\"output\"`` runs after the\n        model (on agent responses), ``\"both\"`` runs in both places\n        (default: ``\"both\"``).",
       "properties": {
         "name": {
           "description": "Name identifying this guardrail.",
@@ -3925,7 +3927,7 @@
               "type": "string"
             },
             {
-              "$ref": "#/$defs/LLMModel"
+              "$ref": "#/$defs/InferenceEndpointModel"
             },
             {
               "type": "null"
@@ -4294,7 +4296,7 @@
           "description": "Personal access token for PAT-based authentication.",
           "title": "Pat"
         },
-        "schema": {
+        "schema_model": {
           "anyOf": [
             {
               "$ref": "#/$defs/SchemaModel"
@@ -4318,173 +4320,9 @@
       "title": "IndexModel",
       "type": "object"
     },
-    "InlineFunctionModel": {
+    "InferenceEndpointModel": {
       "additionalProperties": false,
-      "description": "Inline function model for defining tool code directly in YAML configuration.\n\nThis allows you to define simple tools without creating separate Python files.\nThe code should define a function decorated with @tool from langchain.tools.\n\nSECURITY WARNING: This model uses exec() to execute arbitrary Python code\nfrom the YAML configuration. Only load configurations from trusted sources.\nA malicious configuration could execute arbitrary code on the host system.\n\nExample YAML:\n    tools:\n      calculator:\n        name: calculator\n        function:\n          type: inline\n          code: |\n            from langchain.tools import tool\n\n            @tool\n            def calculator(expression: str) -> str:\n                '''Evaluate a mathematical expression.'''\n                return str(eval(expression))\n\nThe code block must:\n- Import @tool from langchain.tools\n- Define exactly one function decorated with @tool\n- The function name becomes the tool name",
-      "properties": {
-        "type": {
-          "const": "inline",
-          "default": "inline",
-          "description": "Function type discriminator. Must be 'inline'.",
-          "title": "Type",
-          "type": "string"
-        },
-        "human_in_the_loop": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/HumanInTheLoopModel"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Human-in-the-loop approval configuration for this tool."
-        },
-        "code": {
-          "description": "Python code defining a tool function decorated with @tool",
-          "title": "Code",
-          "type": "string"
-        }
-      },
-      "required": [
-        "code"
-      ],
-      "title": "InlineFunctionModel",
-      "type": "object"
-    },
-    "InstructedRetrieverModel": {
-      "additionalProperties": false,
-      "description": "Configuration for instructed retrieval with query decomposition and RRF merging.\n\nGroups all schema-aware, LLM-driven features: query decomposition, instruction-aware\nreranking, query routing, and result verification. These features share schema context\n(columns, constraints) and are co-located here to enforce that dependency at the type\nlevel.\n\nColumn metadata is the single source of truth for schema context. Each pipeline\ncomponent (decomposition, routing, verification, reranking) generates the specific\ncontext it needs from the structured ``columns`` data:\n- Decomposition embeds column info into the JSON schema for ``with_structured_output``\n- Routing generates a compact column summary\n- Verification generates a context with column descriptions (no operator syntax)\n- Reranking uses column names and types for instruction generation\n\nExample:\n    ```yaml\n    retriever:\n      vector_store: *products_vector_store\n      instructed:\n        columns:\n          - name: brand_name\n            type: string\n            description: \"Brand/manufacturer (MILWAUKEE, DEWALT, etc.)\"\n          - name: price\n            type: number\n            operators: [\"\", \"<\", \"<=\", \">\", \">=\"]\n            description: \"Product price in USD\"\n        constraints:\n          - \"Prefer recent products\"\n        decomposition:\n          model: *fast_llm\n          max_subqueries: 3\n          examples:\n            - query: \"cheap drills\"\n              filters: {\"price <\": 100}\n        rerank:\n          model: *fast_llm\n          instructions: \"Prioritize by brand preferences\"\n          top_n: 10\n        router:\n          model: *fast_llm\n          default_mode: standard\n        verifier:\n          model: *fast_llm\n          on_failure: warn_and_retry\n    ```",
-      "properties": {
-        "columns": {
-          "description": "Structured column info used by all pipeline components. Column names, types, operators, and descriptions are embedded into JSON schemas and prompts for each component automatically.",
-          "items": {
-            "$ref": "#/$defs/ColumnInfo"
-          },
-          "title": "Columns",
-          "type": "array"
-        },
-        "constraints": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Default constraints to always apply",
-          "title": "Constraints"
-        },
-        "decomposition": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/DecompositionModel"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Query decomposition settings for breaking complex queries into subqueries."
-        },
-        "rerank": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InstructionAwareRerankModel"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional LLM-based instruction-aware reranking stage."
-        },
-        "router": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RouterModel"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional query router for selecting execution mode (standard vs instructed)."
-        },
-        "verifier": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/VerifierModel"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional result verification with structured feedback for retry."
-        }
-      },
-      "required": [
-        "columns"
-      ],
-      "title": "InstructedRetrieverModel",
-      "type": "object"
-    },
-    "InstructionAwareRerankModel": {
-      "additionalProperties": false,
-      "description": "LLM-based reranking considering user instructions and constraints.\n\nUse fast models (GPT-3.5, Haiku, Llama 3 8B) to minimize latency (~100ms).\nRuns AFTER FlashRank as an additional constraint-aware reranking stage.\nSkipped for 'standard' mode when auto_bypass=true in router config.\n\nExample:\n    ```yaml\n    instructed:\n      columns:\n        - name: brand_name\n          type: string\n      rerank:\n        model: *fast_llm\n        instructions: |\n          Prioritize results matching price and brand constraints.\n        top_n: 10\n    ```",
-      "properties": {
-        "model": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LLMModel"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "LLM for instruction reranking (fast model recommended)"
-        },
-        "instructions": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Custom reranking instructions for constraint prioritization",
-          "title": "Instructions"
-        },
-        "top_n": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Number of documents to return after instruction reranking",
-          "title": "Top N"
-        }
-      },
-      "title": "InstructionAwareRerankModel",
-      "type": "object"
-    },
-    "LLMModel": {
-      "additionalProperties": false,
-      "description": "Configuration for an LLM served via a Databricks Model Serving endpoint.",
+      "description": "Configuration for a Databricks Model Serving endpoint used for inference.\n\nThis is the single config type for *any* serving endpoint dao-ai calls at\nruntime \u2014 not just chat LLMs. The same class backs:\n\n- Chat LLMs declared under ``resources.models`` (e.g. claude-sonnet,\n  meta-llama-3-3-70b-instruct).\n- Embedding endpoints referenced by ``VectorStoreModel.embedding_model``\n  (e.g. databricks-gte-large-en).\n- Judge / extraction / reflection / query models inside\n  ``BestOfNConfig.judge``, ``MemoryConfig.extraction_model``,\n  ``MemoryConfig.query_model``, ``DeepAgentOrchestrationConfig.judge_model``,\n  ``DeepAgentOrchestrationConfig.reflection_model``.\n- Custom agent endpoints (any model packaged behind\n  ``/serving-endpoints/<name>/invocations``).\n\nThe previous class name ``LLMModel`` is still importable as a module-level\nalias (``LLMModel = InferenceEndpointModel``) for backward compatibility;\nthe legacy name will be removed in a future major release.",
       "properties": {
         "on_behalf_of_user": {
           "anyOf": [
@@ -4700,7 +4538,7 @@
                     "type": "string"
                   },
                   {
-                    "$ref": "#/$defs/LLMModel"
+                    "$ref": "#/$defs/InferenceEndpointModel"
                   }
                 ]
               },
@@ -4710,7 +4548,7 @@
               "type": "null"
             }
           ],
-          "description": "Ordered list of fallback model names or LLMModel configs tried on primary model failure.",
+          "description": "Ordered list of fallback endpoint names or InferenceEndpointModel configs tried on primary failure.",
           "title": "Fallbacks"
         },
         "use_responses_api": {
@@ -4748,7 +4586,171 @@
       "required": [
         "name"
       ],
-      "title": "LLMModel",
+      "title": "InferenceEndpointModel",
+      "type": "object"
+    },
+    "InlineFunctionModel": {
+      "additionalProperties": false,
+      "description": "Inline function model for defining tool code directly in YAML configuration.\n\nThis allows you to define simple tools without creating separate Python files.\nThe code should define a function decorated with @tool from langchain.tools.\n\nSECURITY WARNING: This model uses exec() to execute arbitrary Python code\nfrom the YAML configuration. Only load configurations from trusted sources.\nA malicious configuration could execute arbitrary code on the host system.\n\nExample YAML:\n    tools:\n      calculator:\n        name: calculator\n        function:\n          type: inline\n          code: |\n            from langchain.tools import tool\n\n            @tool\n            def calculator(expression: str) -> str:\n                '''Evaluate a mathematical expression.'''\n                return str(eval(expression))\n\nThe code block must:\n- Import @tool from langchain.tools\n- Define exactly one function decorated with @tool\n- The function name becomes the tool name",
+      "properties": {
+        "type": {
+          "const": "inline",
+          "default": "inline",
+          "description": "Function type discriminator. Must be 'inline'.",
+          "title": "Type",
+          "type": "string"
+        },
+        "human_in_the_loop": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HumanInTheLoopModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Human-in-the-loop approval configuration for this tool."
+        },
+        "code": {
+          "description": "Python code defining a tool function decorated with @tool",
+          "title": "Code",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code"
+      ],
+      "title": "InlineFunctionModel",
+      "type": "object"
+    },
+    "InstructedRetrieverModel": {
+      "additionalProperties": false,
+      "description": "Configuration for instructed retrieval with query decomposition and RRF merging.\n\nGroups all schema-aware, LLM-driven features: query decomposition, instruction-aware\nreranking, query routing, and result verification. These features share schema context\n(columns, constraints) and are co-located here to enforce that dependency at the type\nlevel.\n\nColumn metadata is the single source of truth for schema context. Each pipeline\ncomponent (decomposition, routing, verification, reranking) generates the specific\ncontext it needs from the structured ``columns`` data:\n- Decomposition embeds column info into the JSON schema for ``with_structured_output``\n- Routing generates a compact column summary\n- Verification generates a context with column descriptions (no operator syntax)\n- Reranking uses column names and types for instruction generation\n\nExample:\n    ```yaml\n    retriever:\n      vector_store: *products_vector_store\n      instructed:\n        columns:\n          - name: brand_name\n            type: string\n            description: \"Brand/manufacturer (MILWAUKEE, DEWALT, etc.)\"\n          - name: price\n            type: number\n            operators: [\"\", \"<\", \"<=\", \">\", \">=\"]\n            description: \"Product price in USD\"\n        constraints:\n          - \"Prefer recent products\"\n        decomposition:\n          model: *fast_llm\n          max_subqueries: 3\n          examples:\n            - query: \"cheap drills\"\n              filters: {\"price <\": 100}\n        rerank:\n          model: *fast_llm\n          instructions: \"Prioritize by brand preferences\"\n          top_n: 10\n        router:\n          model: *fast_llm\n          default_mode: standard\n        verifier:\n          model: *fast_llm\n          on_failure: warn_and_retry\n    ```",
+      "properties": {
+        "columns": {
+          "description": "Structured column info used by all pipeline components. Column names, types, operators, and descriptions are embedded into JSON schemas and prompts for each component automatically.",
+          "items": {
+            "$ref": "#/$defs/ColumnInfo"
+          },
+          "title": "Columns",
+          "type": "array"
+        },
+        "constraints": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Default constraints to always apply",
+          "title": "Constraints"
+        },
+        "decomposition": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DecompositionModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Query decomposition settings for breaking complex queries into subqueries."
+        },
+        "rerank": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InstructionAwareRerankModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional LLM-based instruction-aware reranking stage."
+        },
+        "router": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RouterModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional query router for selecting execution mode (standard vs instructed)."
+        },
+        "verifier": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerifierModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional result verification with structured feedback for retry."
+        }
+      },
+      "required": [
+        "columns"
+      ],
+      "title": "InstructedRetrieverModel",
+      "type": "object"
+    },
+    "InstructionAwareRerankModel": {
+      "additionalProperties": false,
+      "description": "LLM-based reranking considering user instructions and constraints.\n\nUse fast models (GPT-3.5, Haiku, Llama 3 8B) to minimize latency (~100ms).\nRuns AFTER FlashRank as an additional constraint-aware reranking stage.\nSkipped for 'standard' mode when auto_bypass=true in router config.\n\nExample:\n    ```yaml\n    instructed:\n      columns:\n        - name: brand_name\n          type: string\n      rerank:\n        model: *fast_llm\n        instructions: |\n          Prioritize results matching price and brand constraints.\n        top_n: 10\n    ```",
+      "properties": {
+        "model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InferenceEndpointModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "LLM for instruction reranking (fast model recommended)"
+        },
+        "instructions": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Custom reranking instructions for constraint prioritization",
+          "title": "Instructions"
+        },
+        "top_n": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Number of documents to return after instruction reranking",
+          "title": "Top N"
+        }
+      },
+      "title": "InstructionAwareRerankModel",
       "type": "object"
     },
     "LogLevel": {
@@ -5261,7 +5263,7 @@
         "extraction_model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LLMModel"
+              "$ref": "#/$defs/InferenceEndpointModel"
             },
             {
               "type": "null"
@@ -5273,7 +5275,7 @@
         "query_model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LLMModel"
+              "$ref": "#/$defs/InferenceEndpointModel"
             },
             {
               "type": "null"
@@ -5669,7 +5671,7 @@
       "additionalProperties": false,
       "description": "A prompt backed by the MLflow Prompt Registry with versioning and alias support.",
       "properties": {
-        "schema": {
+        "schema_model": {
           "anyOf": [
             {
               "$ref": "#/$defs/SchemaModel"
@@ -5799,7 +5801,7 @@
               "type": "string"
             },
             {
-              "$ref": "#/$defs/LLMModel"
+              "$ref": "#/$defs/InferenceEndpointModel"
             },
             {
               "type": "null"
@@ -5870,7 +5872,7 @@
       "additionalProperties": false,
       "description": "Unity Catalog registered model where the agent artifact is logged.",
       "properties": {
-        "schema": {
+        "schema_model": {
           "anyOf": [
             {
               "$ref": "#/$defs/SchemaModel"
@@ -5960,12 +5962,12 @@
       "additionalProperties": false,
       "description": "Databricks resource declarations used by agents and tools.\n\nEach resource type is a named dictionary so entries can be referenced\nelsewhere in the config via YAML anchors.",
       "properties": {
-        "llms": {
+        "models": {
           "additionalProperties": {
-            "$ref": "#/$defs/LLMModel"
+            "$ref": "#/$defs/InferenceEndpointModel"
           },
-          "description": "LLM serving endpoint configurations keyed by name.",
-          "title": "Llms",
+          "description": "Databricks Model Serving endpoint configurations keyed by name. Holds chat LLMs, embedding models, judge/extraction/reflection/query models, and custom agent endpoints \u2014 anything reachable via /serving-endpoints/<name>/invocations. Renamed from `llms` in dao-ai 0.1.75; the old key is still accepted via field alias and will be removed in a future major release.",
+          "title": "Models",
           "type": "object"
         },
         "vector_stores": {
@@ -6155,7 +6157,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LLMModel"
+              "$ref": "#/$defs/InferenceEndpointModel"
             },
             {
               "type": "null"
@@ -6475,7 +6477,7 @@
         "embedding_model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LLMModel"
+              "$ref": "#/$defs/InferenceEndpointModel"
             },
             {
               "type": "null"
@@ -6531,7 +6533,7 @@
     },
     "SubAgentModel": {
       "additionalProperties": false,
-      "description": "A deepagents sub-agent invoked by the main deep_agent via the ``task`` tool.\n\nMirrors ``deepagents.SubAgent`` (a ``TypedDict``) but lifted into Pydantic so\nevery field can accept dao-ai primitives:\n\n* ``model`` \u2014 string serving-endpoint name OR an ``LLMModel``\n* ``tools`` \u2014 list of strings (looked up in ``config.tools``) OR ``ToolModel`` entries\n* ``skills`` \u2014 list of skill paths OR named ``SkillModel`` references\n* ``system_prompt`` \u2014 string OR ``PromptModel`` (resolved through ``make_prompt``)\n\nRequired fields per deepagents are ``name``, ``description``, and\n``system_prompt``. Optional fields override the parent deep_agent's defaults.",
+      "description": "A deepagents sub-agent invoked by the main deep_agent via the ``task`` tool.\n\nMirrors ``deepagents.SubAgent`` (a ``TypedDict``) but lifted into Pydantic so\nevery field can accept dao-ai primitives:\n\n* ``model`` \u2014 string serving-endpoint name OR an ``InferenceEndpointModel``\n* ``tools`` \u2014 list of strings (looked up in ``config.tools``) OR ``ToolModel`` entries\n* ``skills`` \u2014 list of skill paths OR named ``SkillModel`` references\n* ``system_prompt`` \u2014 string OR ``PromptModel`` (resolved through ``make_prompt``)\n\nRequired fields per deepagents are ``name``, ``description``, and\n``system_prompt``. Optional fields override the parent deep_agent's defaults.",
       "properties": {
         "name": {
           "description": "Unique sub-agent identifier. The main agent uses this when calling the ``task`` tool.",
@@ -6576,7 +6578,7 @@
               "type": "string"
             },
             {
-              "$ref": "#/$defs/LLMModel"
+              "$ref": "#/$defs/InferenceEndpointModel"
             },
             {
               "type": "null"
@@ -6662,7 +6664,7 @@
       "description": "Configuration for the supervisor agent in a supervisor orchestration pattern.",
       "properties": {
         "model": {
-          "$ref": "#/$defs/LLMModel",
+          "$ref": "#/$defs/InferenceEndpointModel",
           "description": "LLM model used by the supervisor to route tasks to sub-agents."
         },
         "tools": {
@@ -6943,7 +6945,7 @@
           "description": "Personal access token for PAT-based authentication.",
           "title": "Pat"
         },
-        "schema": {
+        "schema_model": {
           "anyOf": [
             {
               "$ref": "#/$defs/SchemaModel"
@@ -7017,7 +7019,7 @@
       "additionalProperties": false,
       "description": "Unity Catalog location for storing MLflow traces in OTEL-format Delta tables.\n\nAccepts either a SchemaModel reference (aliased to \"schema\") or a string\nin \"catalog.schema\" format. When configured on AppModel, traces are stored\nin UC Delta tables via set_experiment_trace_location().",
       "properties": {
-        "schema": {
+        "schema_model": {
           "$ref": "#/$defs/SchemaModel",
           "description": "Unity Catalog schema (catalog.schema) where OTEL trace tables are stored."
         },
@@ -7035,7 +7037,7 @@
         }
       },
       "required": [
-        "schema",
+        "schema_model",
         "warehouse"
       ],
       "title": "TraceLocationModel",
@@ -7440,7 +7442,7 @@
         "embedding_model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LLMModel"
+              "$ref": "#/$defs/InferenceEndpointModel"
             },
             {
               "type": "null"
@@ -7537,7 +7539,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LLMModel"
+              "$ref": "#/$defs/InferenceEndpointModel"
             },
             {
               "type": "null"
@@ -7732,7 +7734,7 @@
           "description": "Personal access token for PAT-based authentication.",
           "title": "Pat"
         },
-        "schema": {
+        "schema_model": {
           "anyOf": [
             {
               "$ref": "#/$defs/SchemaModel"

--- a/src/dao_ai/apps/resources.py
+++ b/src/dao_ai/apps/resources.py
@@ -9,7 +9,7 @@ Databricks Apps resource documentation:
 https://learn.microsoft.com/en-us/azure/databricks/dev-tools/databricks-apps/resources
 
 Supported resource types and their mappings:
-- LLMModel → serving-endpoint (Model Serving Endpoint)
+- InferenceEndpointModel → serving-endpoint (Model Serving Endpoint)
 - VectorStoreModel/IndexModel → vector-search-index (via UC Securable - not yet supported)
 - WarehouseModel → sql-warehouse
 - GenieRoomModel → genie-space
@@ -62,7 +62,7 @@ from dao_ai.config import (
     FunctionModel,
     GenieRoomModel,
     IsDatabricksResource,
-    LLMModel,
+    InferenceEndpointModel,
     SecretVariableModel,
     TableModel,
     TraceLocationModel,
@@ -74,7 +74,7 @@ from dao_ai.config import (
 
 # Resource type mappings from dao-ai to Databricks Apps
 RESOURCE_TYPE_MAPPING: dict[type, str] = {
-    LLMModel: "serving-endpoint",
+    InferenceEndpointModel: "serving-endpoint",
     VectorStoreModel: "vector-search-index",
     WarehouseModel: "sql-warehouse",
     GenieRoomModel: "genie-space",
@@ -153,9 +153,9 @@ API_SCOPE_TO_USER_SCOPE: dict[str, str] = {
 
 
 def _extract_llm_resources(
-    llms: dict[str, LLMModel],
+    llms: dict[str, InferenceEndpointModel],
 ) -> list[dict[str, Any]]:
-    """Extract model serving endpoint resources from LLMModels.
+    """Extract model serving endpoint resources from InferenceEndpointModels.
 
     Skips resources where ``on_behalf_of_user=True`` -- those are served via
     the user's forwarded token and surface in ``user_api_scopes`` instead;
@@ -648,7 +648,7 @@ def generate_app_resources(config: AppConfig) -> list[dict[str, Any]]:
         return resources
 
     # Extract resources from each category
-    resources.extend(_extract_llm_resources(config.resources.llms))
+    resources.extend(_extract_llm_resources(config.resources.models))
     resources.extend(_extract_vector_search_resources(config.resources.vector_stores))
     resources.extend(_extract_warehouse_resources(config.resources.warehouses))
     resources.extend(_extract_genie_resources(config.resources.genie_rooms))
@@ -721,7 +721,7 @@ def generate_user_api_scopes(config: AppConfig) -> list[str]:
     obo_resources: list[IsDatabricksResource] = []
 
     # Check each resource category
-    for llm in config.resources.llms.values():
+    for llm in config.resources.models.values():
         if llm.on_behalf_of_user:
             obo_resources.append(llm)
 
@@ -852,7 +852,7 @@ def generate_sdk_resources(
         return resources
 
     # Extract SDK resources from each category
-    resources.extend(_extract_sdk_llm_resources(config.resources.llms))
+    resources.extend(_extract_sdk_llm_resources(config.resources.models))
     resources.extend(_extract_sdk_warehouse_resources(config.resources.warehouses))
     resources.extend(_extract_sdk_genie_resources(config.resources.genie_rooms))
     resources.extend(_extract_sdk_database_resources(config.resources.databases))
@@ -871,7 +871,7 @@ def generate_sdk_resources(
 
 
 def _extract_sdk_llm_resources(
-    llms: dict[str, LLMModel],
+    llms: dict[str, InferenceEndpointModel],
 ) -> list[AppResource]:
     """Extract SDK AppResource objects for model serving endpoints.
     Skips OBO resources — user identity handles permissions via user_api_scopes."""
@@ -1728,7 +1728,7 @@ def get_resource_env_mappings(config: AppConfig) -> list[dict[str, Any]]:
         )
 
     # Map serving endpoint names
-    for key, llm in config.resources.llms.items():
+    for key, llm in config.resources.models.items():
         env_mappings.append(
             {
                 "name": f"{key.upper()}_ENDPOINT",

--- a/src/dao_ai/best_of_n.py
+++ b/src/dao_ai/best_of_n.py
@@ -150,7 +150,7 @@ class BestOfNChatModel(BaseChatModel):
 
         The temperature is bound onto the generator via `.bind(temperature=...)`
         so each parallel call carries the elevated temperature without mutating
-        the original LLMModel state.
+        the original InferenceEndpointModel state.
         """
 
         if temperature_override is not None:

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -751,9 +751,9 @@ class TableModel(IsDatabricksResource, HasFullName):
 
 
 class BestOfNConfig(BaseModel):
-    """Opt-in best-of-N + LLM-as-judge wrapper around an LLMModel.
+    """Opt-in best-of-N + LLM-as-judge wrapper around an InferenceEndpointModel.
 
-    When attached to an LLMModel, every model invocation fans out N parallel
+    When attached to an InferenceEndpointModel, every model invocation fans out N parallel
     candidate generations at elevated temperature, then asks a judge model to
     score the candidates. The wrapper returns the highest-scoring candidate
     verbatim (no synthesis).
@@ -765,7 +765,7 @@ class BestOfNConfig(BaseModel):
     Diversity is non-negotiable: with low generator temperature, the N
     candidates collapse to near-identical outputs and best-of-N degenerates
     into best-of-1 with extra cost. The wrapper enforces an effective
-    generator temperature of max(LLMModel.temperature, 0.7) unless
+    generator temperature of max(InferenceEndpointModel.temperature, 0.7) unless
     `temperature_override` is set.
     """
 
@@ -775,15 +775,15 @@ class BestOfNConfig(BaseModel):
         default=8,
         description="Number of parallel candidate generations. Must be in [1, 16].",
     )
-    judge: Union[str, "LLMModel"] = Field(
-        description="Judge model: a serving endpoint name (string) or a full LLMModel config.",
+    judge: Union[str, "InferenceEndpointModel"] = Field(
+        description="Judge model: a serving endpoint name (string) or a full InferenceEndpointModel config.",
     )
     temperature_override: Optional[float] = Field(
         default=None,
         description=(
             "If set, the parallel candidate calls use this temperature regardless "
             "of the generator's configured temperature. If unset, the wrapper uses "
-            "max(LLMModel.temperature, 0.7) so candidates have meaningful diversity."
+            "max(InferenceEndpointModel.temperature, 0.7) so candidates have meaningful diversity."
         ),
     )
 
@@ -795,8 +795,27 @@ class BestOfNConfig(BaseModel):
         return v
 
 
-class LLMModel(IsDatabricksResource):
-    """Configuration for an LLM served via a Databricks Model Serving endpoint."""
+class InferenceEndpointModel(IsDatabricksResource):
+    """Configuration for a Databricks Model Serving endpoint used for inference.
+
+    This is the single config type for *any* serving endpoint dao-ai calls at
+    runtime — not just chat LLMs. The same class backs:
+
+    - Chat LLMs declared under ``resources.models`` (e.g. claude-sonnet,
+      meta-llama-3-3-70b-instruct).
+    - Embedding endpoints referenced by ``VectorStoreModel.embedding_model``
+      (e.g. databricks-gte-large-en).
+    - Judge / extraction / reflection / query models inside
+      ``BestOfNConfig.judge``, ``MemoryConfig.extraction_model``,
+      ``MemoryConfig.query_model``, ``DeepAgentOrchestrationConfig.judge_model``,
+      ``DeepAgentOrchestrationConfig.reflection_model``.
+    - Custom agent endpoints (any model packaged behind
+      ``/serving-endpoints/<name>/invocations``).
+
+    The previous class name ``LLMModel`` is still importable as a module-level
+    alias (``LLMModel = InferenceEndpointModel``) for backward compatibility;
+    the legacy name will be removed in a future major release.
+    """
 
     model_config = ConfigDict(use_enum_values=True, extra="forbid")
     name: str = Field(
@@ -814,9 +833,9 @@ class LLMModel(IsDatabricksResource):
         default=8192,
         description="Maximum number of tokens in the model response.",
     )
-    fallbacks: Optional[list[Union[str, "LLMModel"]]] = Field(
+    fallbacks: Optional[list[Union[str, "InferenceEndpointModel"]]] = Field(
         default_factory=list,
-        description="Ordered list of fallback model names or LLMModel configs tried on primary model failure.",
+        description="Ordered list of fallback endpoint names or InferenceEndpointModel configs tried on primary failure.",
     )
     use_responses_api: Optional[bool] = Field(
         default=False,
@@ -873,9 +892,9 @@ class LLMModel(IsDatabricksResource):
 
         fallbacks: Sequence[LanguageModelLike] = []
         for fallback in self.fallbacks:
-            fallback: str | LLMModel
+            fallback: str | InferenceEndpointModel
             if isinstance(fallback, str):
-                fallback = LLMModel(
+                fallback = InferenceEndpointModel(
                     name=fallback,
                     temperature=self.temperature,
                     max_tokens=self.max_tokens,
@@ -895,7 +914,7 @@ class LLMModel(IsDatabricksResource):
 
             judge_cfg = self.best_of_n.judge
             if isinstance(judge_cfg, str):
-                judge_cfg = LLMModel(name=judge_cfg)
+                judge_cfg = InferenceEndpointModel(name=judge_cfg)
             judge_chat_model = judge_cfg.as_chat_model()
 
             chat_client = BestOfNChatModel.from_components(
@@ -923,9 +942,18 @@ class LLMModel(IsDatabricksResource):
         return DatabricksEmbeddings(endpoint=self.name)
 
 
-# Resolve the forward reference BestOfNConfig.judge -> LLMModel now that
-# LLMModel is in scope. Without this, instantiating BestOfNConfig with a dict
-# judge config would fail with a forward-reference error.
+# Backward-compatible alias. The class was renamed from LLMModel to
+# InferenceEndpointModel to reflect its real scope (every Databricks Model
+# Serving endpoint dao-ai calls — chat LLMs, embeddings, judges, extraction /
+# reflection / query models, custom agent endpoints). Customer code importing
+# the old name (`from dao_ai.config import LLMModel`) keeps working unchanged;
+# `isinstance(x, LLMModel)` continues to return True because both names point
+# at the same class. The legacy name will be removed in a future major release.
+LLMModel = InferenceEndpointModel
+
+# Resolve the forward reference BestOfNConfig.judge -> InferenceEndpointModel
+# now that the class is in scope. Without this, instantiating BestOfNConfig
+# with a dict judge config would fail with a forward-reference error.
 BestOfNConfig.model_rebuild()
 
 
@@ -2654,7 +2682,7 @@ class VectorStoreModel(IsDatabricksResource, ManagedResource):
         default=None,
         description="Column in the source table containing text to embed. Required in provisioning mode.",
     )
-    embedding_model: Optional[LLMModel] = Field(
+    embedding_model: Optional[InferenceEndpointModel] = Field(
         default=None,
         description="Embedding model endpoint. Defaults to 'databricks-gte-large-en' in provisioning mode.",
     )
@@ -2716,7 +2744,7 @@ class VectorStoreModel(IsDatabricksResource, ManagedResource):
     def set_default_embedding_model(self) -> Self:
         # Only set default embedding model in provisioning mode
         if self.source_table is not None and not self.embedding_model:
-            self.embedding_model = LLMModel(name="databricks-gte-large-en")
+            self.embedding_model = InferenceEndpointModel(name="databricks-gte-large-en")
         return self
 
     def ensure_resolved(self) -> None:
@@ -2856,7 +2884,7 @@ class VectorStoreModel(IsDatabricksResource, ManagedResource):
                 self.embedding_source_column = first.get("name")
                 model_endpoint_name = first.get("embedding_model_endpoint_name")
                 if model_endpoint_name:
-                    self.embedding_model = LLMModel(name=model_endpoint_name)
+                    self.embedding_model = InferenceEndpointModel(name=model_endpoint_name)
 
         endpoint_name = details.get("endpoint_name")
         if endpoint_name:
@@ -3449,7 +3477,7 @@ class GenieContextAwareCacheParametersBase(BaseModel):
         default=None,
         description="Weight for context similarity in the combined score (0-1). Computed as 1 - question_weight if omitted.",
     )
-    embedding_model: str | LLMModel = Field(
+    embedding_model: str | InferenceEndpointModel = Field(
         default="databricks-gte-large-en",
         description="Embedding model endpoint for generating similarity vectors.",
     )
@@ -3669,7 +3697,7 @@ class InstructionAwareRerankModel(BaseModel):
 
     model_config = ConfigDict(use_enum_values=True, extra="forbid")
 
-    model: Optional["LLMModel"] = Field(
+    model: Optional["InferenceEndpointModel"] = Field(
         default=None,
         description="LLM for instruction reranking (fast model recommended)",
     )
@@ -3858,7 +3886,7 @@ class DecompositionModel(BaseModel):
 
     model_config = ConfigDict(use_enum_values=True, extra="forbid")
 
-    model: Optional["LLMModel"] = Field(
+    model: Optional["InferenceEndpointModel"] = Field(
         default=None,
         description="LLM for query decomposition (smaller/faster model recommended)",
     )
@@ -3988,7 +4016,7 @@ class RouterModel(BaseModel):
 
     model_config = ConfigDict(use_enum_values=True, extra="forbid")
 
-    model: Optional["LLMModel"] = Field(
+    model: Optional["InferenceEndpointModel"] = Field(
         default=None,
         description="LLM for routing decision (fast model recommended)",
     )
@@ -4060,7 +4088,7 @@ class VerifierModel(BaseModel):
 
     model_config = ConfigDict(use_enum_values=True, extra="forbid")
 
-    model: Optional["LLMModel"] = Field(
+    model: Optional["InferenceEndpointModel"] = Field(
         default=None,
         description="LLM for verification (fast model recommended)",
     )
@@ -4875,7 +4903,7 @@ class GuardrailModel(BaseModel):
     Attributes:
         name: Name identifying this guardrail.
         model: LLM model for the judge.  Accepts a string (model name) or
-            ``LLMModel``.  Required when using the custom judge mode.
+            ``InferenceEndpointModel``.  Required when using the custom judge mode.
         prompt: Evaluation instructions using ``{{ inputs }}`` and
             ``{{ outputs }}`` template variables.  Required when using
             the custom judge mode.
@@ -4906,7 +4934,7 @@ class GuardrailModel(BaseModel):
     name: str = Field(
         description="Name identifying this guardrail.",
     )
-    model: Optional[str | LLMModel] = Field(
+    model: Optional[str | InferenceEndpointModel] = Field(
         default=None,
         description="LLM model for the judge. Required for custom judge mode.",
     )
@@ -4971,7 +4999,7 @@ class GuardrailModel(BaseModel):
     @model_validator(mode="after")
     def validate_llm_model(self) -> Self:
         if self.model is not None and isinstance(self.model, str):
-            self.model = LLMModel(name=self.model)
+            self.model = InferenceEndpointModel(name=self.model)
         return self
 
     def as_scorer(self) -> Any:
@@ -5070,7 +5098,7 @@ class StoreModel(BaseModel):
     name: str = Field(
         description="Unique name for this store instance.",
     )
-    embedding_model: Optional[LLMModel] = Field(
+    embedding_model: Optional[InferenceEndpointModel] = Field(
         default=None,
         description="Embedding model for semantic memory search. Required for vector-based recall.",
     )
@@ -5152,14 +5180,14 @@ class MemoryExtractionModel(BaseModel):
             "conversation turn (no latency impact on responses)."
         ),
     )
-    extraction_model: Optional[LLMModel] = Field(
+    extraction_model: Optional[InferenceEndpointModel] = Field(
         default=None,
         description=(
             "Separate LLM for memory extraction. Can be a smaller, "
             "cheaper model. When None, uses the agent's primary model."
         ),
     )
-    query_model: Optional[LLMModel] = Field(
+    query_model: Optional[InferenceEndpointModel] = Field(
         default=None,
         description=(
             "Separate LLM for optimizing memory search queries. "
@@ -5349,7 +5377,7 @@ class AgentModel(BaseModel):
         default=None,
         description="Human-readable description shown when the LLM selects handoff targets.",
     )
-    model: LLMModel = Field(
+    model: InferenceEndpointModel = Field(
         description="LLM model configuration (serving endpoint name, temperature, etc.).",
     )
     tools: list[ToolModel] = Field(
@@ -5469,7 +5497,7 @@ class SupervisorModel(BaseModel):
     """Configuration for the supervisor agent in a supervisor orchestration pattern."""
 
     model_config = ConfigDict(use_enum_values=True, extra="forbid")
-    model: LLMModel = Field(
+    model: InferenceEndpointModel = Field(
         description="LLM model used by the supervisor to route tasks to sub-agents.",
     )
     tools: list[ToolModel] = Field(
@@ -5713,7 +5741,7 @@ class SubAgentModel(BaseModel):
     Mirrors ``deepagents.SubAgent`` (a ``TypedDict``) but lifted into Pydantic so
     every field can accept dao-ai primitives:
 
-    * ``model`` — string serving-endpoint name OR an ``LLMModel``
+    * ``model`` — string serving-endpoint name OR an ``InferenceEndpointModel``
     * ``tools`` — list of strings (looked up in ``config.tools``) OR ``ToolModel`` entries
     * ``skills`` — list of skill paths OR named ``SkillModel`` references
     * ``system_prompt`` — string OR ``PromptModel`` (resolved through ``make_prompt``)
@@ -5736,7 +5764,7 @@ class SubAgentModel(BaseModel):
         default_factory=list,
         description="Tools available to this sub-agent. Strings are resolved against ``config.tools``.",
     )
-    model: Optional[LLMModel | str] = Field(
+    model: Optional[InferenceEndpointModel | str] = Field(
         default=None,
         description=(
             "LLM model. Inherits from the parent deep_agent if omitted. "
@@ -5787,10 +5815,10 @@ class DeepAgentModel(BaseModel):
     """
 
     model_config = ConfigDict(use_enum_values=True, extra="forbid")
-    model: Optional[LLMModel | str] = Field(
+    model: Optional[InferenceEndpointModel | str] = Field(
         default=None,
         description=(
-            "Primary LLM. ``LLMModel`` is resolved via ``as_chat_model()``; "
+            "Primary LLM. ``InferenceEndpointModel`` is resolved via ``as_chat_model()``; "
             "strings pass through to ``init_chat_model`` (e.g. ``'openai:gpt-4o'``). "
             "Defaults to deepagents' default (``claude-sonnet-4-6``) when omitted."
         ),
@@ -5898,7 +5926,7 @@ class DeepAgentModel(BaseModel):
 
         which gets normalized to the equivalent list form ``[{name: research, ...}]``
         before the regular validator runs. Mirrors the dict-keyed pattern used by
-        ``resources.llms``, ``tools``, and ``swarm.handoffs``.
+        ``resources.models``, ``tools``, and ``swarm.handoffs``.
         """
         if not isinstance(data, dict):
             return data
@@ -6174,7 +6202,7 @@ class ChatHistoryModel(BaseModel):
     """
 
     model_config = ConfigDict(use_enum_values=True, extra="forbid")
-    model: LLMModel = Field(
+    model: InferenceEndpointModel = Field(
         description="LLM used to generate conversation summaries.",
     )
     max_tokens: int = Field(
@@ -6768,7 +6796,7 @@ class EvaluationModel(BaseModel):
     """
 
     model_config = ConfigDict(use_enum_values=True, extra="forbid")
-    model: LLMModel = Field(
+    model: InferenceEndpointModel = Field(
         ..., description="LLM model used as the judge for LLM-based evaluation scorers."
     )
     table: TableModel = Field(
@@ -6949,7 +6977,7 @@ class PromptOptimizationModel(BaseModel):
     dataset: EvaluationDatasetModel = Field(
         description="Training dataset with input/expectation pairs for fitness evaluation.",
     )
-    reflection_model: Optional[LLMModel | str] = Field(
+    reflection_model: Optional[InferenceEndpointModel | str] = Field(
         default=None,
         description="LLM used for reflective mutation during GEPA optimization.",
     )
@@ -7205,7 +7233,7 @@ class ContextAwareCacheOptimizationModel(BaseModel):
     dataset: ContextAwareCacheEvalDatasetModel = Field(
         description="Evaluation dataset with question/context pairs and expected match labels.",
     )
-    judge_model: Optional[LLMModel | str] = Field(
+    judge_model: Optional[InferenceEndpointModel | str] = Field(
         default="databricks-meta-llama-3-3-70b-instruct",
         description="LLM judge for evaluating match quality when expected_match is None.",
     )
@@ -7380,10 +7408,25 @@ class ResourcesModel(BaseModel):
     elsewhere in the config via YAML anchors.
     """
 
-    model_config = ConfigDict(use_enum_values=True, extra="forbid")
-    llms: dict[str, LLMModel] = Field(
+    # populate_by_name=True so the legacy `llms:` key (declared via the
+    # field's `alias`) parses alongside the canonical `models:` key under
+    # the otherwise-strict `extra="forbid"` policy. Both keys produce the
+    # same `self.models` dict at runtime.
+    model_config = ConfigDict(
+        use_enum_values=True,
+        extra="forbid",
+        populate_by_name=True,
+    )
+    models: dict[str, InferenceEndpointModel] = Field(
         default_factory=dict,
-        description="LLM serving endpoint configurations keyed by name.",
+        alias="llms",
+        description=(
+            "Databricks Model Serving endpoint configurations keyed by name. "
+            "Holds chat LLMs, embedding models, judge/extraction/reflection/query "
+            "models, and custom agent endpoints — anything reachable via "
+            "/serving-endpoints/<name>/invocations. Renamed from `llms` in dao-ai 0.1.75; "
+            "the old key is still accepted via field alias and will be removed in a future major release."
+        ),
     )
     vector_stores: dict[str, VectorStoreModel] = Field(
         default_factory=dict,
@@ -7429,6 +7472,24 @@ class ResourcesModel(BaseModel):
             "Local skills ship via ``code_paths``; volume-backed skills are wired as deployment resources."
         ),
     )
+
+    @property
+    def llms(self) -> dict[str, InferenceEndpointModel]:
+        """Deprecated alias for :attr:`models`.
+
+        Old customer code accessing ``config.resources.llms`` keeps working
+        for now. Use :attr:`models` for new code. The alias will be removed
+        in a future major release.
+        """
+        import warnings
+
+        warnings.warn(
+            "ResourcesModel.llms is a deprecated alias for ResourcesModel.models; "
+            "use `.models` instead. The alias will be removed in a future major release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.models
 
     @model_validator(mode="after")
     def update_genie_warehouses(self) -> Self:

--- a/src/dao_ai/genie/cache/context_aware/base.py
+++ b/src/dao_ai/genie/cache/context_aware/base.py
@@ -34,7 +34,7 @@ from databricks.sdk.service.dashboards import (
 )
 from loguru import logger
 
-from dao_ai.config import LLMModel, WarehouseModel
+from dao_ai.config import InferenceEndpointModel, WarehouseModel
 from dao_ai.genie.cache.base import (
     CacheResult,
     GenieServiceBase,
@@ -533,7 +533,7 @@ class ContextAwareGenieService(GenieServiceBase):
 
     def _initialize_embeddings(
         self,
-        embedding_model: str | LLMModel,
+        embedding_model: str | InferenceEndpointModel,
         embedding_dims: int | None = None,
     ) -> None:
         """
@@ -542,12 +542,12 @@ class ContextAwareGenieService(GenieServiceBase):
         This helper method handles embedding model initialization for subclasses.
 
         Args:
-            embedding_model: The embedding model name or LLMModel instance
+            embedding_model: The embedding model name or InferenceEndpointModel instance
             embedding_dims: Optional pre-configured embedding dimensions
         """
-        # Convert embedding_model to LLMModel if it's a string
-        model: LLMModel = (
-            LLMModel(name=embedding_model)
+        # Convert embedding_model to InferenceEndpointModel if it's a string
+        model: InferenceEndpointModel = (
+            InferenceEndpointModel(name=embedding_model)
             if isinstance(embedding_model, str)
             else embedding_model
         )

--- a/src/dao_ai/genie/cache/context_aware/optimization.py
+++ b/src/dao_ai/genie/cache/context_aware/optimization.py
@@ -47,7 +47,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, Sequence
 import mlflow
 from loguru import logger
 
-from dao_ai.config import GenieContextAwareCacheParametersModel, LLMModel
+from dao_ai.config import GenieContextAwareCacheParametersModel, InferenceEndpointModel
 from dao_ai.utils import dao_ai_version
 
 # Type-only import for optuna.Trial to support type hints without runtime dependency
@@ -166,7 +166,7 @@ def semantic_match_judge(
     context1: str,
     question2: str,
     context2: str,
-    model: LLMModel | str,
+    model: InferenceEndpointModel | str,
     use_cache: bool = True,
 ) -> bool:
     """
@@ -195,8 +195,8 @@ def semantic_match_judge(
         if cache_key in _judge_cache:
             return _judge_cache[cache_key]
 
-    # Convert model to LLMModel if string
-    llm_model: LLMModel = LLMModel(name=model) if isinstance(model, str) else model
+    # Convert model to InferenceEndpointModel if string
+    llm_model: InferenceEndpointModel = InferenceEndpointModel(name=model) if isinstance(model, str) else model
 
     # Create the chat model
     chat = llm_model.as_chat_model()
@@ -284,7 +284,7 @@ def _evaluate_thresholds(
     similarity_threshold: float,
     context_similarity_threshold: float,
     question_weight: float,
-    judge_model: LLMModel | str | None = None,
+    judge_model: InferenceEndpointModel | str | None = None,
 ) -> tuple[float, float, float, dict[str, int]]:
     """
     Evaluate a set of thresholds against the dataset.
@@ -390,7 +390,7 @@ def _evaluate_thresholds(
 
 def _create_objective(
     dataset: ContextAwareCacheEvalDataset,
-    judge_model: LLMModel | str | None,
+    judge_model: InferenceEndpointModel | str | None,
     metric: Literal["f1", "precision", "recall", "fbeta"],
     beta: float = 1.0,
 ) -> Callable[["optuna.Trial"], float]:
@@ -447,7 +447,7 @@ def optimize_context_aware_cache_thresholds(
     original_thresholds: dict[str, float]
     | GenieContextAwareCacheParametersModel
     | None = None,
-    judge_model: LLMModel | str = "databricks-meta-llama-3-3-70b-instruct",
+    judge_model: InferenceEndpointModel | str = "databricks-meta-llama-3-3-70b-instruct",
     n_trials: int = 50,
     metric: Literal["f1", "precision", "recall", "fbeta"] = "f1",
     beta: float = 1.0,
@@ -720,7 +720,7 @@ def _log_optimization_to_mlflow(
     best_recall: float,
     best_f1: float,
     best_confusion: dict[str, int],
-    judge_model: LLMModel | str,
+    judge_model: InferenceEndpointModel | str,
 ) -> None:
     """Log optimization results to MLflow."""
     with mlflow.start_run(run_name=study_name):
@@ -777,10 +777,10 @@ def _log_optimization_to_mlflow(
 
 def generate_eval_dataset_from_cache(
     cache_entries: Sequence[dict[str, Any]],
-    embedding_model: LLMModel | str = "databricks-gte-large-en",
+    embedding_model: InferenceEndpointModel | str = "databricks-gte-large-en",
     num_positive_pairs: int = 50,
     num_negative_pairs: int = 50,
-    paraphrase_model: LLMModel | str | None = None,
+    paraphrase_model: InferenceEndpointModel | str | None = None,
     dataset_name: str = "generated_eval_dataset",
 ) -> ContextAwareCacheEvalDataset:
     """
@@ -820,21 +820,21 @@ def generate_eval_dataset_from_cache(
         raise ValueError("Need at least 2 cache entries to generate dataset")
 
     # Convert embedding model
-    emb_model: LLMModel = (
-        LLMModel(name=embedding_model)
+    emb_model: InferenceEndpointModel = (
+        InferenceEndpointModel(name=embedding_model)
         if isinstance(embedding_model, str)
         else embedding_model
     )
     embeddings = emb_model.as_embeddings_model()
 
     # Use paraphrase model or default to a capable LLM
-    para_model: LLMModel = (
-        LLMModel(name=paraphrase_model)
+    para_model: InferenceEndpointModel = (
+        InferenceEndpointModel(name=paraphrase_model)
         if isinstance(paraphrase_model, str)
         else (
             paraphrase_model
             if paraphrase_model
-            else LLMModel(name="databricks-meta-llama-3-3-70b-instruct")
+            else InferenceEndpointModel(name="databricks-meta-llama-3-3-70b-instruct")
         )
     )
     chat = para_model.as_chat_model()

--- a/src/dao_ai/memory/core.py
+++ b/src/dao_ai/memory/core.py
@@ -10,7 +10,7 @@ from loguru import logger
 
 from dao_ai.config import (
     CheckpointerModel,
-    LLMModel,
+    InferenceEndpointModel,
     StorageType,
     StoreModel,
 )
@@ -40,7 +40,7 @@ class InMemoryStoreManager(StoreManagerBase):
         self.store_model = store_model
 
     def store(self) -> BaseStore:
-        embedding_model: LLMModel = self.store_model.embedding_model
+        embedding_model: InferenceEndpointModel = self.store_model.embedding_model
 
         logger.debug(
             "Creating in-memory store", embeddings_enabled=embedding_model is not None

--- a/src/dao_ai/memory/extraction.py
+++ b/src/dao_ai/memory/extraction.py
@@ -63,7 +63,7 @@ def _unwrap_to_base_chat_model(model: ModelSpec) -> str | BaseChatModel:
 
     ``langmem.create_memory_store_manager`` only accepts ``str`` or
     ``BaseChatModel``.  When the caller passes a ``RunnableWithFallbacks``
-    (produced by ``LLMModel.as_chat_model()`` when fallbacks are configured),
+    (produced by ``InferenceEndpointModel.as_chat_model()`` when fallbacks are configured),
     we extract the primary runnable so langmem can use it directly.
     """
     if isinstance(model, str) or isinstance(model, BaseChatModel):

--- a/src/dao_ai/middleware/obo.py
+++ b/src/dao_ai/middleware/obo.py
@@ -26,7 +26,7 @@ from databricks_langchain import ChatDatabricks
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from loguru import logger
 
-from dao_ai.config import LLMModel
+from dao_ai.config import InferenceEndpointModel
 from dao_ai.middleware.base import AgentMiddleware
 from dao_ai.state import AgentState, Context
 from dao_ai.tools.tracing import ResourceInfo, set_resource_attributes
@@ -43,7 +43,7 @@ class OBOModelMiddleware(AgentMiddleware[AgentState, Context]):
     4. Swaps the model via ``request.override(model=...)``
     """
 
-    def __init__(self, llm_model: LLMModel) -> None:
+    def __init__(self, llm_model: InferenceEndpointModel) -> None:
         self.llm_model = llm_model
 
     def _create_obo_model(self, context: Context | None) -> ChatDatabricks:

--- a/src/dao_ai/middleware/subagent.py
+++ b/src/dao_ai/middleware/subagent.py
@@ -14,10 +14,10 @@ The ``model`` field in each subagent spec supports multiple input types:
 
 - **str**: A ``"provider:model"`` identifier (e.g., ``"openai:gpt-4o"``), passed
   directly to deepagents.
-- **dict**: An ``LLMModel``-style mapping (e.g.,
+- **dict**: An ``InferenceEndpointModel``-style mapping (e.g.,
   ``{"name": "my-endpoint", "temperature": 0.1}``), converted to a
-  ``ChatDatabricks`` instance via ``LLMModel.as_chat_model()``.
-- **LLMModel**: A DAO AI ``LLMModel`` instance, converted via
+  ``ChatDatabricks`` instance via ``InferenceEndpointModel.as_chat_model()``.
+- **InferenceEndpointModel**: A DAO AI ``InferenceEndpointModel`` instance, converted via
   ``as_chat_model()``.
 - **BaseChatModel**: A LangChain chat model instance (e.g., ``ChatDatabricks``),
   passed through directly.
@@ -37,7 +37,7 @@ Example:
         ],
     )
 
-    # Using a Databricks endpoint via LLMModel dict:
+    # Using a Databricks endpoint via InferenceEndpointModel dict:
     middleware = create_subagent_middleware(
         subagents=[
             {
@@ -82,7 +82,7 @@ from dao_ai.middleware._backends import resolve_backend
 from dao_ai.middleware._prompt_utils import resolve_prompt
 
 if TYPE_CHECKING:
-    from dao_ai.config import LLMModel, VolumePathModel
+    from dao_ai.config import InferenceEndpointModel, VolumePathModel
 
 __all__ = [
     "create_subagent_middleware",
@@ -90,7 +90,7 @@ __all__ = [
 
 
 def _resolve_subagent_model(
-    model: str | dict[str, Any] | LLMModel | BaseChatModel | None,
+    model: str | dict[str, Any] | InferenceEndpointModel | BaseChatModel | None,
 ) -> str | BaseChatModel | None:
     """Resolve a subagent model value to a type accepted by deepagents.
 
@@ -98,10 +98,10 @@ def _resolve_subagent_model(
     helper bridges DAO AI configuration types so users can provide:
 
     - ``str`` -- passed through (e.g., ``"openai:gpt-4o"``)
-    - ``dict`` -- treated as ``LLMModel`` kwargs, converted via
-      ``LLMModel(**dict).as_chat_model()`` which returns a
+    - ``dict`` -- treated as ``InferenceEndpointModel`` kwargs, converted via
+      ``InferenceEndpointModel(**dict).as_chat_model()`` which returns a
       ``ChatDatabricks`` instance.
-    - ``LLMModel`` -- converted via ``as_chat_model()``.
+    - ``InferenceEndpointModel`` -- converted via ``as_chat_model()``.
     - ``BaseChatModel`` -- passed through (e.g., ``ChatDatabricks``).
     - ``None`` -- returned as-is (deepagents uses the parent model).
 
@@ -123,19 +123,19 @@ def _resolve_subagent_model(
     if isinstance(model, BaseChatModel):
         return model
 
-    # Import LLMModel at runtime to avoid circular imports.
-    from dao_ai.config import LLMModel
+    # Import InferenceEndpointModel at runtime to avoid circular imports.
+    from dao_ai.config import InferenceEndpointModel
 
     if isinstance(model, dict):
         logger.debug(
             "Resolving subagent model from dict",
             model_name=model.get("name", "unknown"),
         )
-        return LLMModel(**model).as_chat_model()
+        return InferenceEndpointModel(**model).as_chat_model()
 
-    if isinstance(model, LLMModel):
+    if isinstance(model, InferenceEndpointModel):
         logger.debug(
-            "Resolving subagent model from LLMModel",
+            "Resolving subagent model from InferenceEndpointModel",
             model_name=model.name,
         )
         return model.as_chat_model()
@@ -189,12 +189,12 @@ def create_subagent_middleware(
 
     Optional subagent fields:
         - ``model``: Override model.  Accepts a ``str`` (e.g.,
-          ``"openai:gpt-4o"``), a ``dict`` of ``LLMModel`` kwargs (e.g.,
-          ``{"name": "my-endpoint", "temperature": 0.1}``), an ``LLMModel``
+          ``"openai:gpt-4o"``), a ``dict`` of ``InferenceEndpointModel`` kwargs (e.g.,
+          ``{"name": "my-endpoint", "temperature": 0.1}``), an ``InferenceEndpointModel``
           instance, or a ``BaseChatModel`` instance (e.g.,
-          ``ChatDatabricks``).  Dicts and ``LLMModel`` values are
+          ``ChatDatabricks``).  Dicts and ``InferenceEndpointModel`` values are
           automatically converted to ``ChatDatabricks`` via
-          ``LLMModel.as_chat_model()``.
+          ``InferenceEndpointModel.as_chat_model()``.
         - ``tools``: Tools the subagent can use
         - ``middleware``: Additional middleware for the subagent
 
@@ -233,7 +233,7 @@ def create_subagent_middleware(
             ],
         )
 
-        # LLMModel dict (converted to ChatDatabricks):
+        # InferenceEndpointModel dict (converted to ChatDatabricks):
         middleware = create_subagent_middleware(
             subagents=[
                 {

--- a/src/dao_ai/middleware/summarization.py
+++ b/src/dao_ai/middleware/summarization.py
@@ -20,10 +20,10 @@ Additionally, a Deep Agents variant is available via
 
 Example:
     from dao_ai.middleware import create_summarization_middleware
-    from dao_ai.config import ChatHistoryModel, LLMModel
+    from dao_ai.config import ChatHistoryModel, InferenceEndpointModel
 
     chat_history = ChatHistoryModel(
-        model=LLMModel(name="gpt-4o-mini"),
+        model=InferenceEndpointModel(name="gpt-4o-mini"),
         max_tokens=256,
         max_tokens_before_summary=4000,
     )
@@ -181,10 +181,10 @@ def create_summarization_middleware(
         List containing LoggingSummarizationMiddleware configured with the specified parameters
 
     Example:
-        from dao_ai.config import ChatHistoryModel, LLMModel
+        from dao_ai.config import ChatHistoryModel, InferenceEndpointModel
 
         chat_history = ChatHistoryModel(
-            model=LLMModel(name="gpt-4o-mini"),
+            model=InferenceEndpointModel(name="gpt-4o-mini"),
             max_tokens=256,
             max_tokens_before_summary=4000,
         )

--- a/src/dao_ai/optimization.py
+++ b/src/dao_ai/optimization.py
@@ -503,7 +503,7 @@ def optimize_prompt(
         OptimizationResult with optimization details
 
     Example:
-        from dao_ai.config import AgentModel, PromptModel, LLMModel
+        from dao_ai.config import AgentModel, PromptModel, InferenceEndpointModel
         from dao_ai.optimization import optimize_prompt
 
         prompt = PromptModel(
@@ -512,7 +512,7 @@ def optimize_prompt(
         )
         agent = AgentModel(
             name="my_agent",
-            model=LLMModel(name="databricks-meta-llama-3-3-70b-instruct"),
+            model=InferenceEndpointModel(name="databricks-meta-llama-3-3-70b-instruct"),
             prompt=prompt,
         )
 

--- a/src/dao_ai/orchestration/deep_agent.py
+++ b/src/dao_ai/orchestration/deep_agent.py
@@ -5,7 +5,7 @@ The deep_agent pattern wraps `langchain-ai/deepagents` so its full feature set â
 todo planning, filesystem ops, shell execution, sub-agent delegation via the
 ``task`` tool, skills (deepagents' SkillsMiddleware), AGENTS.md memory, and
 human-in-the-loop interrupts â€” is expressible declaratively in YAML and
-composable with dao-ai primitives (LLMModel, ToolModel, MiddlewareModel,
+composable with dao-ai primitives (InferenceEndpointModel, ToolModel, MiddlewareModel,
 AgentModel, PromptModel, SkillModel).
 
 Based on: https://github.com/langchain-ai/deepagents
@@ -39,7 +39,7 @@ from dao_ai.config import (
     DeepAgentModel,
     FilesystemPermissionModel,
     HumanInTheLoopModel,
-    LLMModel,
+    InferenceEndpointModel,
     MiddlewareModel,
     OrchestrationModel,
     PromptModel,
@@ -58,12 +58,12 @@ from dao_ai.tools import create_tools
 
 
 def _resolve_model(
-    spec: LLMModel | str | None,
+    spec: InferenceEndpointModel | str | None,
 ) -> BaseChatModel | str | None:
     """Resolve a deep_agent ``model`` field to what ``create_deep_agent`` expects.
 
     deepagents accepts ``str | BaseChatModel | None``. We give it:
-    * a fully initialized chat model when an ``LLMModel`` is supplied (so
+    * a fully initialized chat model when an ``InferenceEndpointModel`` is supplied (so
       dao-ai's temperature/max_tokens/fallbacks/best_of_n configuration is honored)
     * the raw string when a string is supplied (deepagents passes it to
       ``init_chat_model`` itself)
@@ -71,7 +71,7 @@ def _resolve_model(
     """
     if spec is None:
         return None
-    if isinstance(spec, LLMModel):
+    if isinstance(spec, InferenceEndpointModel):
         return spec.as_chat_model()
     return spec
 

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -61,7 +61,7 @@ from dao_ai.config import (
     HasFullName,
     IndexModel,
     IsDatabricksResource,
-    LLMModel,
+    InferenceEndpointModel,
     PromptModel,
     SchemaModel,
     TableModel,
@@ -376,7 +376,7 @@ class DatabricksProvider(ServiceProvider):
             experiment_id=experiment.experiment_id,
         )
 
-        llms: Sequence[LLMModel] = list(config.resources.llms.values())
+        llms: Sequence[InferenceEndpointModel] = list(config.resources.models.values())
         vector_indexes: Sequence[IndexModel] = list(
             config.resources.vector_stores.values()
         )

--- a/src/dao_ai/tools/agent.py
+++ b/src/dao_ai/tools/agent.py
@@ -8,13 +8,13 @@ from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 from langchain_core.tools import InjectedToolArg, StructuredTool
 from loguru import logger
 
-from dao_ai.config import LLMModel
+from dao_ai.config import InferenceEndpointModel
 from dao_ai.state import Context
 from dao_ai.tools.tracing import ResourceInfo, set_resource_attributes
 
 
 def create_agent_endpoint_tool(
-    llm: LLMModel | dict[str, Any],
+    llm: InferenceEndpointModel | dict[str, Any],
     name: Optional[str] = None,
     description: Optional[str] = None,
 ) -> Callable[..., Any]:
@@ -27,7 +27,7 @@ def create_agent_endpoint_tool(
     """)
 
     if isinstance(llm, dict):
-        llm = LLMModel(**llm)
+        llm = InferenceEndpointModel(**llm)
 
     if description is None:
         description = default_description

--- a/src/dao_ai/tools/instructed_retriever.py
+++ b/src/dao_ai/tools/instructed_retriever.py
@@ -23,7 +23,7 @@ from dao_ai.config import (
     ColumnInfo,
     DecomposedQueries,
     FilterItem,
-    LLMModel,
+    InferenceEndpointModel,
     SearchQuery,
 )
 from dao_ai.tools.tracing import (
@@ -52,7 +52,7 @@ def _load_prompt_template() -> dict[str, Any]:
 
 
 def _get_cached_llm(
-    model_config: LLMModel,
+    model_config: InferenceEndpointModel,
     context: "Context | None" = None,
 ) -> BaseChatModel:
     """
@@ -94,11 +94,11 @@ def _get_cached_llm(
         # via the OBO client for each parallel candidate call.
         if model_config.best_of_n is not None:
             from dao_ai.best_of_n import BestOfNChatModel
-            from dao_ai.config import LLMModel
+            from dao_ai.config import InferenceEndpointModel
 
             judge_cfg = model_config.best_of_n.judge
             if isinstance(judge_cfg, str):
-                judge_cfg = LLMModel(name=judge_cfg)
+                judge_cfg = InferenceEndpointModel(name=judge_cfg)
             obo_chat = BestOfNChatModel.from_components(
                 generator=obo_chat,
                 judge=judge_cfg.as_chat_model(),

--- a/tests/dao_ai/test_inference_endpoint_alias.py
+++ b/tests/dao_ai/test_inference_endpoint_alias.py
@@ -1,0 +1,156 @@
+"""Backward-compatibility tests for the InferenceEndpointModel / resources.models rename.
+
+dao-ai 0.1.75 renamed the Pydantic class ``LLMModel`` to
+``InferenceEndpointModel`` and renamed the ``ResourcesModel.llms`` field to
+``ResourcesModel.models``. Both renames carry aliases for backward
+compatibility:
+
+- Class rename: ``LLMModel = InferenceEndpointModel`` at module scope, so
+  ``from dao_ai.config import LLMModel`` keeps working and
+  ``isinstance(x, LLMModel)`` is still true.
+- Field rename: ``ResourcesModel.models`` declares ``alias="llms"`` and the
+  parent's ``model_config`` sets ``populate_by_name=True`` so both keys
+  parse under ``extra="forbid"``.
+
+This test guards against accidental regression on either alias.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from dao_ai.config import (
+    AppConfig,
+    AppModel,
+    InferenceEndpointModel,
+    LLMModel,
+    ResourcesModel,
+)
+
+
+class TestClassAlias:
+    """LLMModel must be the same class object as InferenceEndpointModel."""
+
+    def test_llmmodel_is_inference_endpoint_model(self) -> None:
+        assert LLMModel is InferenceEndpointModel
+
+    def test_isinstance_check_works_with_legacy_name(self) -> None:
+        endpoint = InferenceEndpointModel(name="databricks-claude-sonnet-4-5")
+        assert isinstance(endpoint, LLMModel)
+
+    def test_legacy_constructor_path(self) -> None:
+        # Customer code using `LLMModel(name=...)` should produce an
+        # InferenceEndpointModel instance.
+        endpoint = LLMModel(name="databricks-gte-large-en")
+        assert isinstance(endpoint, InferenceEndpointModel)
+        assert endpoint.name == "databricks-gte-large-en"
+
+
+class TestResourcesModelFieldAlias:
+    """ResourcesModel must parse both `models:` and `llms:` keys identically."""
+
+    SHARED_ENDPOINT = {
+        "name": "databricks-claude-sonnet-4-5",
+        "temperature": 0.2,
+        "max_tokens": 4096,
+    }
+
+    def test_models_key_parses(self) -> None:
+        resources = ResourcesModel(models={"primary": self.SHARED_ENDPOINT})
+        assert "primary" in resources.models
+        assert resources.models["primary"].name == "databricks-claude-sonnet-4-5"
+        assert isinstance(resources.models["primary"], InferenceEndpointModel)
+
+    def test_llms_key_still_parses_via_alias(self) -> None:
+        # Pydantic should accept the legacy key via field alias.
+        resources = ResourcesModel.model_validate({"llms": {"primary": self.SHARED_ENDPOINT}})
+        assert "primary" in resources.models
+        assert resources.models["primary"].name == "databricks-claude-sonnet-4-5"
+        assert isinstance(resources.models["primary"], InferenceEndpointModel)
+
+    def test_both_keys_produce_identical_objects(self) -> None:
+        models_based = ResourcesModel(models={"primary": self.SHARED_ENDPOINT})
+        llms_based = ResourcesModel.model_validate({"llms": {"primary": self.SHARED_ENDPOINT}})
+        assert models_based.models == llms_based.models
+
+    def test_models_attribute_access(self) -> None:
+        resources = ResourcesModel(models={"primary": self.SHARED_ENDPOINT})
+        # Canonical attribute access (new code path).
+        assert resources.models["primary"].name == "databricks-claude-sonnet-4-5"
+
+    def test_legacy_llms_attribute_emits_deprecation_warning(self) -> None:
+        # Customer Python code reading `.llms` should still work but emit
+        # a DeprecationWarning telling them to migrate to `.models`.
+        resources = ResourcesModel(models={"primary": self.SHARED_ENDPOINT})
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            value = resources.llms
+            assert any(issubclass(w.category, DeprecationWarning) for w in captured), (
+                "Reading ResourcesModel.llms should emit a DeprecationWarning."
+            )
+        assert value == resources.models
+
+
+class TestAppConfigEndToEnd:
+    """A minimal AppConfig should accept either key at the YAML / dict level."""
+
+    @pytest.fixture
+    def base_config_dict(self) -> dict:
+        return {
+            "version": "0.1.75",
+            "resources": {
+                # placeholder; tests overwrite this key
+            },
+            "agents": {
+                "tester": {
+                    "name": "tester",
+                    "description": "Smoke-test agent for the alias test.",
+                    "model": {"name": "databricks-claude-sonnet-4-5"},
+                },
+            },
+            "app": {
+                "name": "alias-test",
+                "deployment_target": "apps",
+                "agents": [
+                    {
+                        "name": "tester",
+                        "description": "Smoke-test agent for the alias test.",
+                        "model": {"name": "databricks-claude-sonnet-4-5"},
+                    },
+                ],
+                "orchestration": {
+                    "swarm": {"default_agent": "tester"},
+                },
+            },
+        }
+
+    def test_appconfig_accepts_models_key(self, base_config_dict: dict) -> None:
+        base_config_dict["resources"] = {
+            "models": {"primary": {"name": "databricks-claude-sonnet-4-5"}},
+        }
+        cfg = AppConfig(**base_config_dict)
+        assert "primary" in cfg.resources.models
+
+    def test_appconfig_accepts_llms_key_via_alias(self, base_config_dict: dict) -> None:
+        base_config_dict["resources"] = {
+            "llms": {"primary": {"name": "databricks-claude-sonnet-4-5"}},
+        }
+        cfg = AppConfig(**base_config_dict)
+        assert "primary" in cfg.resources.models
+
+    def test_models_and_llms_produce_equivalent_configs(self, base_config_dict: dict) -> None:
+        cfg_models = AppConfig(
+            **{
+                **base_config_dict,
+                "resources": {"models": {"primary": {"name": "databricks-claude-sonnet-4-5"}}},
+            }
+        )
+        cfg_llms = AppConfig(
+            **{
+                **base_config_dict,
+                "resources": {"llms": {"primary": {"name": "databricks-claude-sonnet-4-5"}}},
+            }
+        )
+        assert cfg_models.resources.models == cfg_llms.resources.models

--- a/uv.lock
+++ b/uv.lock
@@ -864,7 +864,7 @@ wheels = [
 
 [[package]]
 name = "dao-ai"
-version = "0.1.74"
+version = "0.1.75"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- Pydantic field rename: `ResourcesModel.llms` → `ResourcesModel.models` with `alias='llms'` + `populate_by_name=True`. Both keys parse under `extra='forbid'`.
- Class rename: `LLMModel` → `InferenceEndpointModel` with a module-level `LLMModel = InferenceEndpointModel` alias.
- Deprecated `.llms` property on `ResourcesModel` returns `.models` and warns.
- Schema regenerates with `models:` as the canonical key (`make schema` now uses `by_alias=False`).
- 11 new alias-coverage tests; all 1189 pre-existing tests still pass (failures in the suite are pre-existing pyspark / Genie API v2 issues unrelated to this change).
- All 66 shipped example configs migrated to the new key. 2 README inline-doc snippets updated.
- CHANGELOG entry under 0.1.75; version bumped.

The same `LLMModel`-shaped Pydantic class today backs `resources.llms`, `VectorStoreModel.embedding_model`, `MemoryConfig.extraction_model`/`query_model`, `BestOfNConfig.judge`, `DeepAgentOrchestrationConfig.judge_model`/`reflection_model`, and any custom agent endpoint — so the `llms` bucket name was actively misleading. This rename communicates the real scope: everything reachable via `/serving-endpoints/<name>/invocations`.

## Backward compatibility (non-negotiable)

| surface | guarantee |
|---|---|
| Existing YAML with `resources.llms:` | Still parses via field alias. |
| `from dao_ai.config import LLMModel` | Still works via module alias. |
| `isinstance(x, LLMModel)` | Still true (both names point at the same class). |
| `cfg.resources.llms` Python attribute | Still works; emits `DeprecationWarning` and returns `self.models`. |
| MLflow registrations / deployed endpoints | Unaffected. |
| Existing tests | Pass unchanged (alias is the regression guard). |
| IDE schema lint on legacy `llms:` | Flags as unknown after schema regen (runtime still accepts it). Lint papercut, not a runtime break. |

The legacy names will be removed in a future major release.

## Test plan
- [x] `make schema` regenerates and shows `models:` as the canonical key + `InferenceEndpointModel` in `$defs`.
- [x] `uv run pytest tests/dao_ai/test_inference_endpoint_alias.py` — 11/11 pass.
- [x] `uv run pytest -m unit` — 1189 pass + 13 pre-existing failures (pyspark stub + Genie v2 — same set as `main`).
- [x] All 66 `config/examples/**/*.yaml` files migrated via ruamel.yaml script (preserves comments + ordering).
- [ ] Sanity check from a clean checkout: `AppConfig.from_file("config/examples/15_complete_applications/brick_store.yaml")` loads and `cfg.resources.models` is populated.

## Follow-up

Once this lands on PyPI:
- Bump dao-ai-builder's `pyproject.toml` pin to `dao-ai>=0.1.75` and flip the yaml-generator `EMIT_KEY` from `'llms'` to `'models'`.
- Sweep all dao-ai-workshop lab YAMLs from `resources.llms:` to `resources.models:`.
- Update any customer docs / examples outside this repo.

This pull request and its description were written by Isaac.