### PR TITLE
Fix schema regen: schema field of TableModel/etc. flipped to canonical name in 0.1.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.76]
+
+### Fixed
+- **Schema regeneration restored alias names** so existing example configs validate cleanly against the JSON schema again. 0.1.75 set `model_json_schema(by_alias=False)` to make `resources.models:` canonical, but that change cascaded to *every* field with a Pydantic alias — most importantly `TableModel.schema_model` / `VolumeModel.schema_model` / etc., which are Python-side aliased to `schema:` because `schema` collides with `BaseModel.schema()`. The result: yaml-language-server lit up every `schema:` key in every config as "additional property not allowed", even though runtime parsing was unaffected. The fix:
+  - Reverted the `Makefile` schema target to default `model_json_schema()` (`by_alias=True`), so aliased fields like `schema_model→schema` emit their alias as the canonical schema property.
+  - Switched `ResourcesModel.models` from `Field(alias="llms")` to `Field(validation_alias=AliasChoices("models", "llms"))` so the *rename* keeps `models` as canonical in the schema while still accepting `llms` as input. This is the right Pydantic tool for "rename with input-only back-compat".
+  - Removed the now-unneeded `populate_by_name=True` from `ResourcesModel.model_config` (AliasChoices handles both keys directly).
+- Schema regenerated; `config/examples/15_complete_applications/brick_store.yaml` and other in-repo examples that use `schema:` and `models:` now validate cleanly. All 11 alias regression tests still pass.
+
 ## [0.1.75]
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ distclean: clean
 	$(FIND) $(SRC_DIR) $(TEST_DIR) \( -name __pycache__ -a -type d \) -prune -exec rm -rf {} \;
 
 schema: depends
-	@$(PYTHON) -c "from dao_ai.config import AppConfig; import json; print(json.dumps(AppConfig.model_json_schema(by_alias=False), indent=2))"
+	@$(PYTHON) -c "from dao_ai.config import AppConfig; import json; print(json.dumps(AppConfig.model_json_schema(), indent=2))"
 
 test: 
 	$(PYTEST) -ra --tb=short $(TEST_DIR)

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -2401,7 +2401,7 @@
       "additionalProperties": false,
       "description": "An MLflow evaluation dataset containing input/expectation pairs.",
       "properties": {
-        "schema_model": {
+        "schema": {
           "anyOf": [
             {
               "$ref": "#/$defs/SchemaModel"
@@ -2787,7 +2787,7 @@
           "description": "Personal access token for PAT-based authentication.",
           "title": "Pat"
         },
-        "schema_model": {
+        "schema": {
           "anyOf": [
             {
               "$ref": "#/$defs/SchemaModel"
@@ -4294,7 +4294,7 @@
           "description": "Personal access token for PAT-based authentication.",
           "title": "Pat"
         },
-        "schema_model": {
+        "schema": {
           "anyOf": [
             {
               "$ref": "#/$defs/SchemaModel"
@@ -5669,7 +5669,7 @@
       "additionalProperties": false,
       "description": "A prompt backed by the MLflow Prompt Registry with versioning and alias support.",
       "properties": {
-        "schema_model": {
+        "schema": {
           "anyOf": [
             {
               "$ref": "#/$defs/SchemaModel"
@@ -5870,7 +5870,7 @@
       "additionalProperties": false,
       "description": "Unity Catalog registered model where the agent artifact is logged.",
       "properties": {
-        "schema_model": {
+        "schema": {
           "anyOf": [
             {
               "$ref": "#/$defs/SchemaModel"
@@ -5964,7 +5964,7 @@
           "additionalProperties": {
             "$ref": "#/$defs/InferenceEndpointModel"
           },
-          "description": "Databricks Model Serving endpoint configurations keyed by name. Holds chat LLMs, embedding models, judge/extraction/reflection/query models, and custom agent endpoints \u2014 anything reachable via /serving-endpoints/<name>/invocations. Renamed from `llms` in dao-ai 0.1.75; the old key is still accepted via field alias and will be removed in a future major release.",
+          "description": "Databricks Model Serving endpoint configurations keyed by name. Holds chat LLMs, embedding models, judge/extraction/reflection/query models, and custom agent endpoints \u2014 anything reachable via /serving-endpoints/<name>/invocations. Renamed from `llms` in dao-ai 0.1.75; the legacy key is still accepted via validation alias and will be removed in a future major release.",
           "title": "Models",
           "type": "object"
         },
@@ -6943,7 +6943,7 @@
           "description": "Personal access token for PAT-based authentication.",
           "title": "Pat"
         },
-        "schema_model": {
+        "schema": {
           "anyOf": [
             {
               "$ref": "#/$defs/SchemaModel"
@@ -7017,7 +7017,7 @@
       "additionalProperties": false,
       "description": "Unity Catalog location for storing MLflow traces in OTEL-format Delta tables.\n\nAccepts either a SchemaModel reference (aliased to \"schema\") or a string\nin \"catalog.schema\" format. When configured on AppModel, traces are stored\nin UC Delta tables via set_experiment_trace_location().",
       "properties": {
-        "schema_model": {
+        "schema": {
           "$ref": "#/$defs/SchemaModel",
           "description": "Unity Catalog schema (catalog.schema) where OTEL trace tables are stored."
         },
@@ -7035,7 +7035,7 @@
         }
       },
       "required": [
-        "schema_model",
+        "schema",
         "warehouse"
       ],
       "title": "TraceLocationModel",
@@ -7732,7 +7732,7 @@
           "description": "Personal access token for PAT-based authentication.",
           "title": "Pat"
         },
-        "schema_model": {
+        "schema": {
           "anyOf": [
             {
               "$ref": "#/$defs/SchemaModel"

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -82,6 +82,7 @@ from mlflow.types.responses import (
     ResponsesAgentRequest,
 )
 from pydantic import (
+    AliasChoices,
     BaseModel,
     ConfigDict,
     Field,
@@ -7408,24 +7409,25 @@ class ResourcesModel(BaseModel):
     elsewhere in the config via YAML anchors.
     """
 
-    # populate_by_name=True so the legacy `llms:` key (declared via the
-    # field's `alias`) parses alongside the canonical `models:` key under
-    # the otherwise-strict `extra="forbid"` policy. Both keys produce the
-    # same `self.models` dict at runtime.
+    # `validation_alias=AliasChoices("models", "llms")` accepts both YAML
+    # keys at parse time while keeping `models` as the canonical Python
+    # field name (and therefore the canonical JSON-schema property). This
+    # is the right tool for a *rename with back-compat* — `Field(alias=...)`
+    # would have flipped the schema's canonical name to `llms`, defeating
+    # the rename for IDE / linting purposes.
     model_config = ConfigDict(
         use_enum_values=True,
         extra="forbid",
-        populate_by_name=True,
     )
     models: dict[str, InferenceEndpointModel] = Field(
         default_factory=dict,
-        alias="llms",
+        validation_alias=AliasChoices("models", "llms"),
         description=(
             "Databricks Model Serving endpoint configurations keyed by name. "
             "Holds chat LLMs, embedding models, judge/extraction/reflection/query "
             "models, and custom agent endpoints — anything reachable via "
             "/serving-endpoints/<name>/invocations. Renamed from `llms` in dao-ai 0.1.75; "
-            "the old key is still accepted via field alias and will be removed in a future major release."
+            "the legacy key is still accepted via validation alias and will be removed in a future major release."
         ),
     )
     vector_stores: dict[str, VectorStoreModel] = Field(


### PR DESCRIPTION
## Summary

0.1.75's `model_json_schema(by_alias=False)` change had a cascading effect on **every** Pydantic field with an alias — most importantly the `schema_model` field on `TableModel`, `VolumeModel`, `FunctionModel`, and friends (Python-side named `schema_model` because `.schema` shadows `BaseModel.schema()`, but aliased as `schema:` in YAML). After 0.1.75, every YAML in the wild that uses `schema: *some_anchor` linted as **"additional property 'schema' not allowed"** in VS Code via yaml-language-server, even though runtime parsing was unaffected.

## Reproducer

```python
import json, yaml, jsonschema
schema = json.load(open('schemas/model_config_schema.json'))
data = yaml.safe_load(open('config/examples/15_complete_applications/brick_store.yaml'))
jsonschema.validate(instance=data, schema=schema)
# FAIL: Additional properties are not allowed ('schema' was unexpected)
# path: ['unity_catalog_functions', 0, 'function']
```

## Fix

- **`Makefile`**: revert `schema` target back to default `model_json_schema()` (i.e. `by_alias=True`). All aliased fields emit their alias as the canonical property again.
- **`src/dao_ai/config.py`**: change `ResourcesModel.models` from `Field(alias="llms")` → `Field(validation_alias=AliasChoices("models", "llms"))`. This is Pydantic's idiomatic tool for "input accepts multiple names; schema/output uses the field name" — exactly what the 0.1.75 rename wanted.
- Drop the now-redundant `populate_by_name=True` from `ResourcesModel.model_config`.
- Regenerate `schemas/model_config_schema.json`.

## Effects

| surface | before fix | after fix |
|---|---|---|
| `schema: *anchor` in YAML | ❌ lint error | ✅ valid |
| `resources.models:` | ✅ valid | ✅ valid |
| `resources.llms:` (legacy) | ✅ valid | ✅ valid |
| `LLMModel` import alias | ✅ works | ✅ works |

## Test plan

- [x] `brick_store.yaml` validates clean against regenerated schema (was the original report).
- [x] All 11 alias regression tests in `tests/dao_ai/test_inference_endpoint_alias.py` still pass.
- [x] Schema regenerated and committed.
- [ ] Open `config/examples/15_complete_applications/brick_store.yaml` in VS Code after this lands — confirm zero red squiggles.

The 5 remaining schema-validation hits across `config/examples/**` are pre-existing (forward YAML anchors in `filtered_mcp.yaml` / `conversation_summarization.yaml` / `human_in_the_loop.yaml`, and shape mismatches in `tool_selector_middleware.yaml` / `deep_agent_with_skills.yaml`) — unrelated to this fix.

This pull request and its description were written by Isaac.