### PR TITLE
Add AI Gateway routing on InferenceEndpointModel

### DIFF
--- a/config/examples/01_getting_started/ai_gateway.yaml
+++ b/config/examples/01_getting_started/ai_gateway.yaml
@@ -1,0 +1,74 @@
+# yaml-language-server: $schema=../../../schemas/model_config_schema.json
+
+# =============================================================================
+# AI Gateway routing for InferenceEndpointModel
+# =============================================================================
+# Demonstrates the `ai_gateway: true` flag, which routes chat completions
+# through the Databricks AI Gateway path
+# (https://<host>/ai-gateway/mlflow/v1/chat/completions) instead of the
+# legacy /serving-endpoints/<name>/invocations path. The flag is additive
+# and OFF by default — existing configs are unaffected.
+#
+# When ai_gateway is true:
+# - dao-ai constructs a langchain_openai.ChatOpenAI with the AI Gateway
+#   base_url; the `name` field becomes the OpenAI-style model id sent in
+#   the request body.
+# - use_responses_api is rejected by the validator (AI Gateway exposes
+#   only the OpenAI-compatible /chat/completions path).
+# - on_behalf_of_user is currently permitted pending live verification;
+#   confirm against your workspace before relying on OBO with AI Gateway.
+
+parameters:
+  catalog:
+    description: Unity Catalog catalog name
+    default: retail_consumer_goods
+  schema:
+    description: Schema within the catalog
+    default: hardware_store
+
+schemas:
+  retail_schema: &retail_schema
+    catalog_name: ${var.catalog}
+    schema_name: ${var.schema}
+
+resources:
+  models:
+    # New path — Foundation Model served via AI Gateway.
+    gateway_llm: &gateway_llm
+      name: databricks-claude-opus-4-6
+      ai_gateway: true
+      temperature: 0.1
+      max_tokens: 1024
+
+    # Legacy path — same workspace, no flag, unchanged behavior.
+    legacy_llm: &legacy_llm
+      name: databricks-claude-sonnet-4
+      temperature: 0.1
+      max_tokens: 1024
+
+    # Mixed-mode fallbacks: AI Gateway primary with legacy fallback.
+    # Both ChatOpenAI and ChatDatabricks are LangChain Runnables, so
+    # with_fallbacks composes them without further configuration.
+    resilient_llm: &resilient_llm
+      name: databricks-claude-opus-4-6
+      ai_gateway: true
+      temperature: 0.1
+      max_tokens: 1024
+      fallbacks:
+      - databricks-claude-sonnet-4
+
+agents:
+  gateway_agent: &gateway_agent
+    name: gateway_agent
+    model: *gateway_llm
+    prompt: |
+      You are a helpful assistant served via the Databricks AI Gateway.
+
+app:
+  name: ai_gateway_example
+  log_level: INFO
+  registered_model:
+    schema: *retail_schema
+    name: ai_gateway_example
+  agents:
+  - *gateway_agent

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -4568,6 +4568,12 @@
           "title": "Disable Streaming",
           "type": "boolean"
         },
+        "ai_gateway": {
+          "default": false,
+          "description": "Route through the Databricks AI Gateway (/ai-gateway/mlflow/v1/chat/completions) instead of /serving-endpoints/<name>/invocations. When True, `name` is sent as the OpenAI-style model id in the request body. AI Gateway is OpenAI-compatible chat completions only \u2014 not for embeddings, Responses API, or non-chat endpoints.",
+          "title": "Ai Gateway",
+          "type": "boolean"
+        },
         "best_of_n": {
           "anyOf": [
             {

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -846,6 +846,17 @@ class InferenceEndpointModel(IsDatabricksResource):
         default=False,
         description="Disable streaming for this model. Required when the Foundation Model endpoint has output guardrails enabled.",
     )
+    ai_gateway: bool = Field(
+        default=False,
+        description=(
+            "Route through the Databricks AI Gateway "
+            "(/ai-gateway/mlflow/v1/chat/completions) instead of "
+            "/serving-endpoints/<name>/invocations. When True, `name` is "
+            "sent as the OpenAI-style model id in the request body. "
+            "AI Gateway is OpenAI-compatible chat completions only — not "
+            "for embeddings, Responses API, or non-chat endpoints."
+        ),
+    )
     best_of_n: Optional[BestOfNConfig] = Field(
         default=None,
         description=(
@@ -872,6 +883,103 @@ class InferenceEndpointModel(IsDatabricksResource):
             )
         ]
 
+    @model_validator(mode="after")
+    def _validate_ai_gateway_compatibility(self) -> Self:
+        if not self.ai_gateway:
+            return self
+        if self.use_responses_api:
+            raise ValueError(
+                "ai_gateway=True is incompatible with use_responses_api=True. "
+                "AI Gateway exposes only the OpenAI-compatible "
+                "/chat/completions path; Responses API endpoints must stay on "
+                "/serving-endpoints/<name>/invocations."
+            )
+        # NOTE: on_behalf_of_user + ai_gateway is permitted pending live
+        # verification. If a workspace returns 401/403 on AI Gateway with an
+        # OBO token, gate it here with a ValueError.
+        return self
+
+    def _ai_gateway_host(self) -> str:
+        """Return the workspace host without trailing slash."""
+        from dao_ai.utils import normalize_host
+
+        return normalize_host(self.workspace_client.config.host).rstrip("/")
+
+    def _ai_gateway_token_provider(self) -> Callable[[], str]:
+        """Return a callable that resolves a fresh bearer token per call.
+
+        ``ChatOpenAI`` / the ``openai`` SDK invoke this provider on every
+        request, so PAT, service-principal (OAuth-M2M), and OBO tokens are
+        always refreshed through the SDK's auth ladder instead of being
+        captured once at construction time.
+        """
+        wc: WorkspaceClient = self.workspace_client
+
+        def _provider() -> str:
+            headers: Mapping[str, str] = wc.config.authenticate()
+            auth: str = headers.get("Authorization", "")
+            if not auth.lower().startswith("bearer "):
+                raise RuntimeError(
+                    f"Could not extract bearer token for {self.name!r}; "
+                    f"authenticate() returned keys: {list(headers)}"
+                )
+            return auth.split(" ", 1)[1]
+
+        return _provider
+
+    def _resolve_ai_gateway_credentials(self) -> tuple[str, Callable[[], str]]:
+        """Return ``(host, token_provider)`` for AI Gateway HTTP calls."""
+        return self._ai_gateway_host(), self._ai_gateway_token_provider()
+
+    def chat_model_for_workspace_client(
+        self,
+        workspace_client: WorkspaceClient,
+        *,
+        disable_streaming: bool | None = None,
+    ) -> LanguageModelLike:
+        """Build a chat client bound to a specific ``WorkspaceClient``.
+
+        Used by OBO call sites that need to swap in a user-scoped
+        ``WorkspaceClient`` per request. Respects ``self.ai_gateway`` so OBO
+        traffic still routes through the AI Gateway path when enabled.
+        """
+        from dao_ai.utils import normalize_host
+
+        effective_disable_streaming: bool = (
+            self.disable_streaming if disable_streaming is None else disable_streaming
+        )
+
+        if self.ai_gateway:
+            host: str = normalize_host(workspace_client.config.host).rstrip("/")
+
+            def token_provider() -> str:
+                headers: Mapping[str, str] = workspace_client.config.authenticate()
+                auth: str = headers.get("Authorization", "")
+                if not auth.lower().startswith("bearer "):
+                    raise RuntimeError(
+                        f"Could not extract bearer token for {self.name!r}; "
+                        f"authenticate() returned keys: {list(headers)}"
+                    )
+                return auth.split(" ", 1)[1]
+
+            return ChatOpenAI(
+                model=self.name,
+                base_url=f"{host}/ai-gateway/mlflow/v1",
+                api_key=token_provider,
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
+                streaming=not effective_disable_streaming,
+            )
+
+        return ChatDatabricks(
+            model=self.name,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+            use_responses_api=self.use_responses_api,
+            disable_streaming=effective_disable_streaming,
+            workspace_client=workspace_client,
+        )
+
     def as_chat_model(self) -> LanguageModelLike:
         # When best_of_n is enabled, force streaming off — the wrapper has to
         # buffer the full candidate response before it can hand it to the judge.
@@ -883,13 +991,25 @@ class InferenceEndpointModel(IsDatabricksResource):
             )
             effective_disable_streaming = True
 
-        chat_client: LanguageModelLike = ChatDatabricks(
-            model=self.name,
-            temperature=self.temperature,
-            max_tokens=self.max_tokens,
-            use_responses_api=self.use_responses_api,
-            disable_streaming=effective_disable_streaming,
-        )
+        chat_client: LanguageModelLike
+        if self.ai_gateway:
+            host, token_provider = self._resolve_ai_gateway_credentials()
+            chat_client = ChatOpenAI(
+                model=self.name,
+                base_url=f"{host}/ai-gateway/mlflow/v1",
+                api_key=token_provider,
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
+                streaming=not effective_disable_streaming,
+            )
+        else:
+            chat_client = ChatDatabricks(
+                model=self.name,
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
+                use_responses_api=self.use_responses_api,
+                disable_streaming=effective_disable_streaming,
+            )
 
         fallbacks: Sequence[LanguageModelLike] = []
         for fallback in self.fallbacks:
@@ -929,13 +1049,24 @@ class InferenceEndpointModel(IsDatabricksResource):
         return chat_client
 
     def as_open_ai_client(self) -> LanguageModelLike:
-        chat_client: ChatOpenAI = (
-            self.workspace_client.serving_endpoints.get_langchain_chat_open_ai_client(
-                model=self.name
+        chat_client: ChatOpenAI
+        if self.ai_gateway:
+            host, token_provider = self._resolve_ai_gateway_credentials()
+            chat_client = ChatOpenAI(
+                model=self.name,
+                base_url=f"{host}/ai-gateway/mlflow/v1",
+                api_key=token_provider,
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
             )
-        )
-        chat_client.temperature = self.temperature
-        chat_client.max_tokens = self.max_tokens
+        else:
+            chat_client = (
+                self.workspace_client.serving_endpoints.get_langchain_chat_open_ai_client(
+                    model=self.name
+                )
+            )
+            chat_client.temperature = self.temperature
+            chat_client.max_tokens = self.max_tokens
 
         return chat_client
 

--- a/src/dao_ai/middleware/obo.py
+++ b/src/dao_ai/middleware/obo.py
@@ -22,8 +22,8 @@ Deployment targets:
 from typing import Awaitable, Callable
 
 from databricks.sdk import WorkspaceClient
-from databricks_langchain import ChatDatabricks
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain_core.language_models import LanguageModelLike
 from loguru import logger
 
 from dao_ai.config import InferenceEndpointModel
@@ -46,22 +46,17 @@ class OBOModelMiddleware(AgentMiddleware[AgentState, Context]):
     def __init__(self, llm_model: InferenceEndpointModel) -> None:
         self.llm_model = llm_model
 
-    def _create_obo_model(self, context: Context | None) -> ChatDatabricks:
+    def _create_obo_model(self, context: Context | None) -> LanguageModelLike:
         workspace_client: WorkspaceClient = self.llm_model.workspace_client_from(
             context
         )
         logger.debug(
-            "OBOModelMiddleware: created OBO ChatDatabricks",
+            "OBOModelMiddleware: created OBO chat client",
             model=self.llm_model.name,
             auth_type=workspace_client.config.auth_type,
+            ai_gateway=self.llm_model.ai_gateway,
         )
-        return ChatDatabricks(
-            model=self.llm_model.name,
-            temperature=self.llm_model.temperature,
-            max_tokens=self.llm_model.max_tokens,
-            use_responses_api=self.llm_model.use_responses_api,
-            workspace_client=workspace_client,
-        )
+        return self.llm_model.chat_model_for_workspace_client(workspace_client)
 
     # -- sync ----------------------------------------------------------
 
@@ -71,7 +66,7 @@ class OBOModelMiddleware(AgentMiddleware[AgentState, Context]):
         handler: Callable[[ModelRequest], ModelResponse],
     ) -> ModelResponse:
         context: Context | None = request.runtime.context if request.runtime else None
-        obo_model: ChatDatabricks = self._create_obo_model(context)
+        obo_model: LanguageModelLike = self._create_obo_model(context)
         set_resource_attributes(
             ResourceInfo("model_serving", True, self.llm_model.name)
         )
@@ -85,7 +80,7 @@ class OBOModelMiddleware(AgentMiddleware[AgentState, Context]):
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelResponse:
         context: Context | None = request.runtime.context if request.runtime else None
-        obo_model: ChatDatabricks = self._create_obo_model(context)
+        obo_model: LanguageModelLike = self._create_obo_model(context)
         set_resource_attributes(
             ResourceInfo("model_serving", True, self.llm_model.name)
         )

--- a/src/dao_ai/tools/agent.py
+++ b/src/dao_ai/tools/agent.py
@@ -1,7 +1,6 @@
 from textwrap import dedent
 from typing import Annotated, Any, Callable, Optional, Sequence
 
-from databricks_langchain import ChatDatabricks
 from langchain.tools import ToolRuntime
 from langchain_core.language_models import LanguageModelLike
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
@@ -57,16 +56,13 @@ def create_agent_endpoint_tool(
 
             workspace_client: WorkspaceClient = llm.workspace_client_from(context)
             logger.debug(
-                "Creating OBO ChatDatabricks for agent endpoint tool",
+                "Creating OBO chat client for agent endpoint tool",
                 model=llm.name,
                 auth_type=workspace_client.config.auth_type,
+                ai_gateway=llm.ai_gateway,
             )
-            model: LanguageModelLike = ChatDatabricks(
-                model=llm.name,
-                temperature=llm.temperature,
-                max_tokens=llm.max_tokens,
-                use_responses_api=llm.use_responses_api,
-                workspace_client=workspace_client,
+            model: LanguageModelLike = llm.chat_model_for_workspace_client(
+                workspace_client
             )
         else:
             model = llm.as_chat_model()

--- a/src/dao_ai/tools/instructed_retriever.py
+++ b/src/dao_ai/tools/instructed_retriever.py
@@ -67,13 +67,13 @@ def _get_cached_llm(
     """
     if model_config.on_behalf_of_user:
         from databricks.sdk import WorkspaceClient
-        from databricks_langchain import ChatDatabricks
 
         workspace_client: WorkspaceClient = model_config.workspace_client_from(context)
         logger.debug(
             "Created OBO LLM client for decomposition",
             model=model_config.name,
             auth_type=workspace_client.config.auth_type,
+            ai_gateway=model_config.ai_gateway,
         )
         # Force-disable streaming when best_of_n is set: the wrapper has to
         # buffer each candidate fully before judging.
@@ -82,13 +82,9 @@ def _get_cached_llm(
             if model_config.best_of_n is not None
             else model_config.disable_streaming
         )
-        obo_chat = ChatDatabricks(
-            model=model_config.name,
-            temperature=model_config.temperature,
-            max_tokens=model_config.max_tokens,
-            use_responses_api=model_config.use_responses_api,
+        obo_chat = model_config.chat_model_for_workspace_client(
+            workspace_client,
             disable_streaming=disable_streaming,
-            workspace_client=workspace_client,
         )
         # OBO and best_of_n must compose: the wrapper sees the user's tokens
         # via the OBO client for each parallel candidate call.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,6 +159,10 @@ def add_databricks_resource_attrs(mock: Any) -> Any:
     mock.client_secret = None
     mock.workspace_host = None
     mock.pat = None
+    # Inference endpoint flags read by model validators / OBO factory
+    mock.ai_gateway = False
+    mock.use_responses_api = False
+    mock.disable_streaming = False
     return mock
 
 

--- a/tests/dao_ai/test_agent_endpoint_tool.py
+++ b/tests/dao_ai/test_agent_endpoint_tool.py
@@ -82,7 +82,7 @@ def test_agent_endpoint_tool_obo_uses_workspace_client_from(
     with (
         patch.object(LLMModel, "workspace_client_from", return_value=mock_ws),
         patch(
-            "dao_ai.tools.agent.ChatDatabricks", return_value=mock_chat_model
+            "dao_ai.config.ChatDatabricks", return_value=mock_chat_model
         ) as mock_chat_cls,
     ):
         tool = create_agent_endpoint_tool(mock_llm_obo)
@@ -93,6 +93,7 @@ def test_agent_endpoint_tool_obo_uses_workspace_client_from(
         temperature=mock_llm_obo.temperature,
         max_tokens=mock_llm_obo.max_tokens,
         use_responses_api=mock_llm_obo.use_responses_api,
+        disable_streaming=mock_llm_obo.disable_streaming,
         workspace_client=mock_ws,
     )
     assert isinstance(result, AIMessage)

--- a/tests/dao_ai/test_ai_gateway_routing.py
+++ b/tests/dao_ai/test_ai_gateway_routing.py
@@ -1,0 +1,336 @@
+"""Unit tests for AI Gateway routing on InferenceEndpointModel.
+
+Covers the `ai_gateway: bool` flag introduced for the revamped Databricks
+AI Gateway (`/ai-gateway/mlflow/v1/chat/completions`). Verifies:
+
+- Pydantic validator rejects `ai_gateway` + `use_responses_api`
+- Default flag value leaves the legacy ChatDatabricks path intact
+- `ai_gateway=True` routes both `as_chat_model()` and `as_open_ai_client()`
+  through ChatOpenAI with the AI Gateway base_url
+- `_resolve_ai_gateway_credentials()` extracts bearer tokens uniformly
+  across PAT, service principal, and OBO modes via the SDK's
+  `Config.authenticate()`
+- Heterogeneous fallback lists (AI Gateway primary + legacy fallback)
+  compose without raising
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from dao_ai.config import InferenceEndpointModel
+
+
+# ---------------------------------------------------------------------------
+# Validator
+# ---------------------------------------------------------------------------
+
+
+def test_default_ai_gateway_is_false() -> None:
+    model = InferenceEndpointModel(name="databricks-meta-llama-3-3-70b-instruct")
+    assert model.ai_gateway is False
+
+
+def test_ai_gateway_true_with_responses_api_rejected() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        InferenceEndpointModel(
+            name="databricks-claude-opus-4-6",
+            ai_gateway=True,
+            use_responses_api=True,
+        )
+    assert "use_responses_api" in str(exc_info.value)
+
+
+def test_ai_gateway_true_with_obo_currently_allowed() -> None:
+    """OBO + ai_gateway is permitted in v1 pending live verification."""
+    model = InferenceEndpointModel(
+        name="databricks-claude-opus-4-6",
+        ai_gateway=True,
+        on_behalf_of_user=True,
+    )
+    assert model.ai_gateway is True
+    assert model.on_behalf_of_user is True
+
+
+# ---------------------------------------------------------------------------
+# Credential resolver
+# ---------------------------------------------------------------------------
+
+
+def _stub_workspace_client(host: str, token: str) -> MagicMock:
+    wc = MagicMock()
+    wc.config.host = host
+    wc.config.authenticate.return_value = {"Authorization": f"Bearer {token}"}
+    return wc
+
+
+def test_resolve_credentials_returns_host_and_provider() -> None:
+    model = InferenceEndpointModel(name="x", ai_gateway=True)
+    wc = _stub_workspace_client(
+        host="https://adb-984752964297111.11.azuredatabricks.net/",
+        token="dapi-test-token",
+    )
+    with patch.object(
+        type(model), "workspace_client", new_callable=lambda: property(lambda self: wc)
+    ):
+        host, provider = model._resolve_ai_gateway_credentials()
+    assert host == "https://adb-984752964297111.11.azuredatabricks.net"
+    assert callable(provider)
+    assert provider() == "dapi-test-token"
+
+
+def test_token_provider_refreshes_per_call() -> None:
+    """Token provider must call authenticate() each time so rotated/refreshed
+    OBO and OAuth-M2M tokens are picked up without re-instantiating the client."""
+    model = InferenceEndpointModel(name="x", ai_gateway=True)
+    wc = MagicMock()
+    wc.config.host = "https://example.databricks.com"
+    wc.config.authenticate.side_effect = [
+        {"Authorization": "Bearer token-v1"},
+        {"Authorization": "Bearer token-v2"},
+    ]
+    with patch.object(
+        type(model), "workspace_client", new_callable=lambda: property(lambda self: wc)
+    ):
+        provider = model._ai_gateway_token_provider()
+        assert provider() == "token-v1"
+        assert provider() == "token-v2"
+
+
+def test_resolve_credentials_raises_when_no_bearer() -> None:
+    model = InferenceEndpointModel(name="x", ai_gateway=True)
+    wc = MagicMock()
+    wc.config.host = "https://example.databricks.com"
+    wc.config.authenticate.return_value = {"X-Custom": "nope"}
+    with patch.object(
+        type(model), "workspace_client", new_callable=lambda: property(lambda self: wc)
+    ):
+        _, provider = model._resolve_ai_gateway_credentials()
+        with pytest.raises(RuntimeError, match="bearer token"):
+            provider()
+
+
+# ---------------------------------------------------------------------------
+# as_chat_model routing
+# ---------------------------------------------------------------------------
+
+
+def test_as_chat_model_default_uses_chat_databricks() -> None:
+    model = InferenceEndpointModel(
+        name="databricks-meta-llama-3-3-70b-instruct",
+        temperature=0.2,
+        max_tokens=512,
+    )
+    with patch("dao_ai.config.ChatDatabricks") as mock_chat_databricks, patch(
+        "dao_ai.config.ChatOpenAI"
+    ) as mock_chat_openai:
+        mock_chat_databricks.return_value = MagicMock(name="chat_databricks_instance")
+        result = model.as_chat_model()
+    mock_chat_databricks.assert_called_once()
+    mock_chat_openai.assert_not_called()
+    kwargs = mock_chat_databricks.call_args.kwargs
+    assert kwargs["model"] == "databricks-meta-llama-3-3-70b-instruct"
+    assert kwargs["temperature"] == 0.2
+    assert kwargs["max_tokens"] == 512
+    assert result is mock_chat_databricks.return_value
+
+
+def test_as_chat_model_ai_gateway_uses_chat_openai() -> None:
+    model = InferenceEndpointModel(
+        name="databricks-claude-opus-4-6",
+        ai_gateway=True,
+        temperature=0.1,
+        max_tokens=1024,
+    )
+    fake_provider = lambda: "dapi-test-token"  # noqa: E731
+    with patch.object(
+        InferenceEndpointModel,
+        "_resolve_ai_gateway_credentials",
+        return_value=(
+            "https://adb-984752964297111.11.azuredatabricks.net",
+            fake_provider,
+        ),
+    ), patch("dao_ai.config.ChatOpenAI") as mock_chat_openai, patch(
+        "dao_ai.config.ChatDatabricks"
+    ) as mock_chat_databricks:
+        mock_chat_openai.return_value = MagicMock(name="chat_openai_instance")
+        result = model.as_chat_model()
+    mock_chat_databricks.assert_not_called()
+    mock_chat_openai.assert_called_once()
+    kwargs = mock_chat_openai.call_args.kwargs
+    assert kwargs["model"] == "databricks-claude-opus-4-6"
+    assert (
+        kwargs["base_url"]
+        == "https://adb-984752964297111.11.azuredatabricks.net/ai-gateway/mlflow/v1"
+    )
+    # api_key must be the callable provider — captured strings can't refresh
+    # OBO / OAuth-M2M tokens. The openai SDK invokes the callable per request.
+    assert kwargs["api_key"] is fake_provider
+    assert kwargs["api_key"]() == "dapi-test-token"
+    assert kwargs["temperature"] == 0.1
+    assert kwargs["max_tokens"] == 1024
+    assert kwargs["streaming"] is True  # disable_streaming defaults False
+    assert result is mock_chat_openai.return_value
+
+
+def test_as_chat_model_ai_gateway_disables_streaming_when_requested() -> None:
+    model = InferenceEndpointModel(
+        name="databricks-claude-opus-4-6",
+        ai_gateway=True,
+        disable_streaming=True,
+    )
+    with patch.object(
+        InferenceEndpointModel,
+        "_resolve_ai_gateway_credentials",
+        return_value=("https://x", lambda: "tok"),
+    ), patch("dao_ai.config.ChatOpenAI") as mock_chat_openai:
+        model.as_chat_model()
+    assert mock_chat_openai.call_args.kwargs["streaming"] is False
+
+
+# ---------------------------------------------------------------------------
+# as_open_ai_client routing
+# ---------------------------------------------------------------------------
+
+
+def test_as_open_ai_client_ai_gateway_uses_direct_chat_openai() -> None:
+    model = InferenceEndpointModel(
+        name="databricks-claude-opus-4-6",
+        ai_gateway=True,
+        temperature=0.1,
+        max_tokens=2048,
+    )
+    fake_provider = lambda: "tok"  # noqa: E731
+    with patch.object(
+        InferenceEndpointModel,
+        "_resolve_ai_gateway_credentials",
+        return_value=("https://host", fake_provider),
+    ), patch("dao_ai.config.ChatOpenAI") as mock_chat_openai:
+        mock_chat_openai.return_value = MagicMock()
+        model.as_open_ai_client()
+    mock_chat_openai.assert_called_once_with(
+        model="databricks-claude-opus-4-6",
+        base_url="https://host/ai-gateway/mlflow/v1",
+        api_key=fake_provider,
+        temperature=0.1,
+        max_tokens=2048,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Heterogeneous fallbacks compose
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# OBO simulation
+# ---------------------------------------------------------------------------
+
+
+def test_chat_model_for_workspace_client_uses_ai_gateway_when_flag_set() -> None:
+    """OBO-style construction (per-request workspace_client) must route through
+    AI Gateway when ai_gateway=True on the config — not silently fall back to
+    ChatDatabricks. This is the bug that motivated the shared factory."""
+    model = InferenceEndpointModel(
+        name="databricks-claude-opus-4-6",
+        ai_gateway=True,
+        on_behalf_of_user=True,
+        temperature=0.0,
+        max_tokens=128,
+    )
+    obo_wc = MagicMock()
+    obo_wc.config.host = "https://obo-host.databricks.com"
+    obo_wc.config.authenticate.return_value = {"Authorization": "Bearer obo-user-token"}
+
+    with patch("dao_ai.config.ChatOpenAI") as mock_chat_openai, patch(
+        "dao_ai.config.ChatDatabricks"
+    ) as mock_chat_databricks:
+        mock_chat_openai.return_value = MagicMock()
+        model.chat_model_for_workspace_client(obo_wc)
+
+    mock_chat_databricks.assert_not_called()
+    mock_chat_openai.assert_called_once()
+    kwargs = mock_chat_openai.call_args.kwargs
+    assert kwargs["base_url"] == "https://obo-host.databricks.com/ai-gateway/mlflow/v1"
+    assert kwargs["model"] == "databricks-claude-opus-4-6"
+    # Token provider must close over the OBO workspace_client — not the
+    # config-level one — so OBO-scoped requests carry the user's token.
+    assert callable(kwargs["api_key"])
+    assert kwargs["api_key"]() == "obo-user-token"
+
+
+def test_chat_model_for_workspace_client_legacy_path_passes_workspace_client() -> None:
+    """Without ai_gateway, OBO factory falls through to ChatDatabricks bound
+    to the OBO workspace_client (unchanged legacy behavior)."""
+    model = InferenceEndpointModel(
+        name="databricks-meta-llama-3-3-70b-instruct",
+        on_behalf_of_user=True,
+        temperature=0.0,
+        max_tokens=128,
+    )
+    obo_wc = MagicMock()
+
+    with patch("dao_ai.config.ChatDatabricks") as mock_chat_databricks, patch(
+        "dao_ai.config.ChatOpenAI"
+    ) as mock_chat_openai:
+        mock_chat_databricks.return_value = MagicMock()
+        model.chat_model_for_workspace_client(obo_wc)
+
+    mock_chat_openai.assert_not_called()
+    mock_chat_databricks.assert_called_once()
+    kwargs = mock_chat_databricks.call_args.kwargs
+    assert kwargs["workspace_client"] is obo_wc
+    assert kwargs["model"] == "databricks-meta-llama-3-3-70b-instruct"
+
+
+# ---------------------------------------------------------------------------
+# Tool calling — unit-level wiring
+# ---------------------------------------------------------------------------
+
+
+def test_as_chat_model_returns_runnable_with_bind_tools() -> None:
+    """The returned client must expose bind_tools() so dao-ai agent loops
+    (which always call .bind_tools(tools)) work transparently against the
+    AI Gateway path."""
+    model = InferenceEndpointModel(name="databricks-claude-opus-4-6", ai_gateway=True)
+    with patch.object(
+        InferenceEndpointModel,
+        "_resolve_ai_gateway_credentials",
+        return_value=("https://x", lambda: "t"),
+    ):
+        client = model.as_chat_model()
+    assert hasattr(client, "bind_tools"), (
+        "as_chat_model() must return a client with bind_tools() — agent loops "
+        "depend on this. Got: " + type(client).__name__
+    )
+
+
+def test_heterogeneous_fallbacks_compose() -> None:
+    """AI Gateway primary + legacy fallback should chain via with_fallbacks."""
+    primary = InferenceEndpointModel(
+        name="databricks-claude-opus-4-6",
+        ai_gateway=True,
+        fallbacks=["databricks-meta-llama-3-3-70b-instruct"],
+    )
+
+    chat_openai_instance = MagicMock(name="ChatOpenAI-instance")
+    chat_databricks_instance = MagicMock(name="ChatDatabricks-instance")
+    chained = MagicMock(name="with_fallbacks-result")
+    chat_openai_instance.with_fallbacks.return_value = chained
+
+    with patch.object(
+        InferenceEndpointModel,
+        "_resolve_ai_gateway_credentials",
+        return_value=("https://h", lambda: "t"),
+    ), patch("dao_ai.config.ChatOpenAI", return_value=chat_openai_instance), patch(
+        "dao_ai.config.ChatDatabricks", return_value=chat_databricks_instance
+    ):
+        result = primary.as_chat_model()
+
+    chat_openai_instance.with_fallbacks.assert_called_once()
+    (fallback_list,) = chat_openai_instance.with_fallbacks.call_args.args
+    assert fallback_list == [chat_databricks_instance]
+    assert result is chained

--- a/tests/dao_ai/test_instructed_retriever.py
+++ b/tests/dao_ai/test_instructed_retriever.py
@@ -679,7 +679,7 @@ class TestLLMCaching:
 
         assert key1 != key2
 
-    @patch("databricks_langchain.ChatDatabricks")
+    @patch("dao_ai.config.ChatDatabricks")
     @patch.object(LLMModel, "workspace_client_from")
     def test_obo_bypasses_cache(
         self,
@@ -708,7 +708,7 @@ class TestLLMCaching:
         assert actual is mock_chat_model
         assert len(_llm_cache) == 0  # cache should not be populated
 
-    @patch("databricks_langchain.ChatDatabricks")
+    @patch("dao_ai.config.ChatDatabricks")
     @patch.object(LLMModel, "workspace_client_from")
     def test_obo_creates_fresh_client_per_call(
         self,

--- a/tests/dao_ai/test_resource_tracing.py
+++ b/tests/dao_ai/test_resource_tracing.py
@@ -300,10 +300,8 @@ class TestOBOMiddlewareResourceInfo:
     """Verify OBOModelMiddleware sets resource attributes on model calls."""
 
     @patch("dao_ai.middleware.obo.set_resource_attributes")
-    @patch("dao_ai.middleware.obo.ChatDatabricks")
     def test_sync_wrap_sets_attributes(
         self,
-        mock_chat: MagicMock,
         mock_set: MagicMock,
     ) -> None:
         from dao_ai.config import LLMModel
@@ -315,6 +313,8 @@ class TestOBOMiddlewareResourceInfo:
         llm_model.temperature = 0.0
         llm_model.max_tokens = None
         llm_model.use_responses_api = False
+        llm_model.ai_gateway = False
+        llm_model.chat_model_for_workspace_client.return_value = MagicMock()
 
         middleware = OBOModelMiddleware(llm_model)
 
@@ -331,10 +331,8 @@ class TestOBOMiddlewareResourceInfo:
         assert info.name == "my-obo-model"
 
     @patch("dao_ai.middleware.obo.set_resource_attributes")
-    @patch("dao_ai.middleware.obo.ChatDatabricks")
     def test_async_wrap_sets_attributes(
         self,
-        mock_chat: MagicMock,
         mock_set: MagicMock,
     ) -> None:
         import asyncio
@@ -348,6 +346,8 @@ class TestOBOMiddlewareResourceInfo:
         llm_model.temperature = 0.0
         llm_model.max_tokens = None
         llm_model.use_responses_api = False
+        llm_model.ai_gateway = False
+        llm_model.chat_model_for_workspace_client.return_value = MagicMock()
 
         middleware = OBOModelMiddleware(llm_model)
 


### PR DESCRIPTION
## Summary

- Adds `ai_gateway: bool` flag on `InferenceEndpointModel` that routes chat completions through the revamped Databricks AI Gateway path (`/ai-gateway/mlflow/v1/chat/completions`) via `ChatOpenAI`. The legacy `/serving-endpoints/<name>/invocations` path via `ChatDatabricks` remains the default. `databricks-langchain==0.19.0`'s `ChatDatabricks` has no `base_url` override, so the OpenAI-compatible client is required.
- Centralizes OBO chat-model construction in a shared `chat_model_for_workspace_client(wc)` factory on the config class. Previously three OBO sites (`middleware/obo.py`, `tools/agent.py`, `tools/instructed_retriever.py`) hardcoded `ChatDatabricks(...)`, which would have silently bypassed AI Gateway whenever `on_behalf_of_user: true` and `ai_gateway: true` were both set.
- Switches `api_key` to a callable so the openai SDK re-resolves the bearer token per request via `wc.config.authenticate()` — fixes silent staleness for short-lived OBO and OAuth-M2M tokens.

## Live validation

Workspace `adb-984752964297111.11.azuredatabricks.net`, model `databricks-claude-opus-4-6`:

- Basic chat → 200, expected completion
- Tool calling round-trip via `bind_tools()` → model emits `tool_call`, `ToolMessage` round-trip returns final answer
- Streaming (`.stream()`) — multiple chunks
- Async (`.ainvoke()`)
- Structured output (`.with_structured_output()`) — works with `disable_streaming: true` (AI Gateway constraint)
- Heterogeneous fallback chain (AI Gateway primary + Model Serving fallback)

## Constraints / known limitations

- `ai_gateway=True` is rejected by validator when combined with `use_responses_api=True` (AI Gateway exposes only OpenAI-compatible `/chat/completions`).
- Structured output requires `disable_streaming: true` on the model config — AI Gateway returns `INVALID_PARAMETER_VALUE: Structured output is not currently supported with streaming`.
- OBO live test against AI Gateway still needs a Databricks Apps runtime (local pytest can't synthesize a real forwarded user token). Validator gate is in place but commented out — uncomment if AI Gateway rejects user tokens.

## Test plan

- [x] 14 new unit tests in `tests/dao_ai/test_ai_gateway_routing.py` pass
- [x] OBO test patch sites updated (`test_agent_endpoint_tool.py`, `test_resource_tracing.py`, `test_instructed_retriever.py`)
- [x] `tests/conftest.py::add_databricks_resource_attrs` extended with new field defaults
- [x] `schemas/model_config_schema.json` regenerated (additive — single new property)
- [x] Live smoke against AI Gateway: chat, tools, streaming, async, structured output, fallbacks
- [ ] OBO live smoke from a Databricks Apps runtime (cannot be done locally)
- [ ] App deploy probe — confirm `as_resources()` emission is safe for FMAPI endpoints behind AI Gateway
- [ ] MLflow autolog trace parity smoke

## Example config

`config/examples/01_getting_started/ai_gateway.yaml` demonstrates mixed AI Gateway + legacy models and a heterogeneous fallback chain.

This pull request and its description were written by Isaac.