### PR TITLE
config: surface unresolved SP creds in DatabaseModel.workspace_client

### DIFF
--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -427,8 +427,16 @@ class IsDatabricksResource(ABC, BaseModel):
         2. Service Principal (client_id + client_secret + workspace_host)
         3. PAT (pat + workspace_host)
         4. Ambient/default authentication
+
+        Diagnostics: when client_id or client_secret are configured but
+        resolve to None (e.g. the running identity lacks read access to
+        the secret scope), a warning is logged before the silent fall-
+        through to ambient -- otherwise the SP intent disappears without
+        any signal, producing confusing "password authentication failed
+        for user '<my-email>'" errors downstream from
+        ``databricks_ai_bridge.lakebase.AsyncLakebasePool``.
         """
-        from dao_ai.utils import normalize_host
+        from dao_ai.utils import get_default_databricks_host, normalize_host
 
         # Check for OBO first (highest priority)
         if self.on_behalf_of_user:
@@ -436,6 +444,9 @@ class IsDatabricksResource(ABC, BaseModel):
             logger.debug(
                 f"Creating WorkspaceClient for {self.__class__.__name__} "
                 f"with OBO credentials strategy (Model Serving)"
+            )
+            logger.trace(
+                f"{self.__class__.__name__} auth method=obo",
             )
             return WorkspaceClient(credentials_strategy=credentials_strategy)
 
@@ -452,17 +463,36 @@ class IsDatabricksResource(ABC, BaseModel):
             else None
         )
 
+        # SP creds were configured but resolved to None -- typical cause
+        # is a missing READ grant on the secret scope. Warn loudly so the
+        # ensuing ambient fall-through is debuggable instead of silent.
+        if self.client_id and not client_id_value:
+            logger.warning(
+                f"{self.__class__.__name__}.client_id is configured but resolves "
+                f"to None -- falling through to non-SP auth. Check secret scope "
+                f"READ grant for the running identity."
+            )
+        if self.client_secret and not client_secret_value:
+            logger.warning(
+                f"{self.__class__.__name__}.client_secret is configured but "
+                f"resolves to None -- falling through to non-SP auth. Check "
+                f"secret scope READ grant for the running identity."
+            )
+
         if client_id_value and client_secret_value:
-            # If workspace_host is not provided, check DATABRICKS_HOST env var first,
-            # then fall back to WorkspaceClient().config.host
+            # If workspace_host is not provided, default to the current
+            # workspace via the same resolver dao-ai uses elsewhere
+            # (env var first, then ambient WorkspaceClient).
             if not workspace_host_value:
-                workspace_host_value = os.getenv("DATABRICKS_HOST")
-                if not workspace_host_value:
-                    workspace_host_value = WorkspaceClient().config.host
+                workspace_host_value = get_default_databricks_host()
 
             logger.debug(
                 f"Creating WorkspaceClient for {self.__class__.__name__} with service principal: "
                 f"client_id={client_id_value}, host={workspace_host_value}"
+            )
+            logger.trace(
+                f"{self.__class__.__name__} auth method=service_principal "
+                f"client_id={client_id_value} host={workspace_host_value}",
             )
             return WorkspaceClient(
                 host=workspace_host_value,
@@ -473,9 +503,18 @@ class IsDatabricksResource(ABC, BaseModel):
 
         # Check for PAT authentication
         pat_value: str | None = value_of(self.pat) if self.pat else None
+        if self.pat and not pat_value:
+            logger.warning(
+                f"{self.__class__.__name__}.pat is configured but resolves to "
+                f"None -- falling through to ambient auth. Check secret scope "
+                f"READ grant for the running identity."
+            )
         if pat_value:
             logger.debug(
                 f"Creating WorkspaceClient for {self.__class__.__name__} with PAT"
+            )
+            logger.trace(
+                f"{self.__class__.__name__} auth method=pat host={workspace_host_value}",
             )
             return WorkspaceClient(
                 host=workspace_host_value,
@@ -487,6 +526,9 @@ class IsDatabricksResource(ABC, BaseModel):
         logger.debug(
             f"Creating WorkspaceClient for {self.__class__.__name__} "
             "with default/ambient authentication"
+        )
+        logger.trace(
+            f"{self.__class__.__name__} auth method=ambient",
         )
         return WorkspaceClient()
 

--- a/tests/dao_ai/test_database_model_auth.py
+++ b/tests/dao_ai/test_database_model_auth.py
@@ -1,0 +1,231 @@
+"""Tests for :meth:`IsDatabricksResource.workspace_client` diagnostics.
+
+The property already implemented the right four-branch precedence
+(OBO -> SP -> PAT -> Ambient), but silent fall-through when SP secrets
+resolved to None left users staring at unrelated postgres errors
+(``password authentication failed for user '<my-email>'``) downstream.
+
+These tests pin the diagnostic surface:
+
+1. Configuring ``client_id`` + ``client_secret`` that resolve cleanly
+   produces a service-principal ``WorkspaceClient`` (no ambient
+   fall-through), with ``workspace_host`` defaulted from
+   ``get_default_databricks_host`` when not provided.
+2. Configuring ``client_id`` but having ``value_of`` resolve to None
+   emits a warning naming the unresolved field, then falls through to
+   ambient cleanly (no exception). The warning is the contract: when
+   the user expressed SP intent, dao-ai must not silently swallow it.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from databricks.sdk import WorkspaceClient
+
+from dao_ai.config import (
+    DatabaseModel,
+    SecretVariableModel,
+)
+
+
+@pytest.mark.unit
+def test_workspace_client_sp_branch_fires_when_credentials_resolve(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """client_id + client_secret + workspace_host -> SP WorkspaceClient."""
+    db = DatabaseModel(
+        name="testdb",
+        project="testproj",
+        client_id="11111111-2222-3333-4444-555555555555",
+        client_secret="dummy-secret",
+        workspace_host="https://test.cloud.databricks.com",
+    )
+
+    # The constructed client should carry the SP creds, not ambient.
+    constructed: dict = {}
+
+    def _fake_init(
+        self: WorkspaceClient,
+        host: str | None = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        auth_type: str | None = None,
+        token: str | None = None,
+        **_: object,
+    ) -> None:
+        constructed["host"] = host
+        constructed["client_id"] = client_id
+        constructed["client_secret"] = client_secret
+        constructed["auth_type"] = auth_type
+        constructed["token"] = token
+
+    monkeypatch.setattr(WorkspaceClient, "__init__", _fake_init)
+
+    _ = db.workspace_client
+
+    assert constructed["client_id"] == "11111111-2222-3333-4444-555555555555"
+    assert constructed["client_secret"] == "dummy-secret"
+    assert constructed["host"] == "https://test.cloud.databricks.com"
+    assert constructed["auth_type"] == "oauth-m2m"
+    assert constructed["token"] is None
+
+
+@pytest.mark.unit
+def test_workspace_client_sp_defaults_host_via_get_default_databricks_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SP credentials without workspace_host pick the host from the resolver."""
+    monkeypatch.setattr(
+        "dao_ai.config.get_default_databricks_host",
+        lambda: "https://from-resolver.cloud.databricks.com",
+        raising=False,
+    )
+    # The resolver lives on dao_ai.utils -- patch both import sites the
+    # function is referenced from.
+    monkeypatch.setattr(
+        "dao_ai.utils.get_default_databricks_host",
+        lambda: "https://from-resolver.cloud.databricks.com",
+    )
+
+    db = DatabaseModel(
+        name="testdb",
+        project="testproj",
+        client_id="11111111-2222-3333-4444-555555555555",
+        client_secret="dummy-secret",
+        # no workspace_host
+    )
+
+    constructed_host: dict = {}
+
+    def _fake_init(
+        self: WorkspaceClient,
+        host: str | None = None,
+        **_: object,
+    ) -> None:
+        constructed_host["host"] = host
+
+    monkeypatch.setattr(WorkspaceClient, "__init__", _fake_init)
+
+    _ = db.workspace_client
+    assert constructed_host["host"] == "https://from-resolver.cloud.databricks.com"
+
+
+@pytest.mark.unit
+def test_workspace_client_warns_when_sp_creds_unresolvable(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A SecretVariableModel that resolves to None must produce a warning.
+
+    Matches the lab-07-memory failure mode: the YAML sets
+    ``client_id: *client_id`` pointing at a secret scope the running
+    identity can't read; dao-ai used to fall through to ambient auth
+    silently. The warning is the diagnostic contract.
+    """
+    # Patch SecretVariableModel.as_value to simulate an unreadable scope.
+    monkeypatch.setattr(
+        SecretVariableModel,
+        "as_value",
+        lambda self: None,
+    )
+
+    db = DatabaseModel(
+        name="testdb",
+        project="testproj",
+        client_id=SecretVariableModel(scope="dao_ai_workshop", secret="client_id"),
+        client_secret=SecretVariableModel(
+            scope="dao_ai_workshop", secret="client_secret"
+        ),
+        workspace_host="https://test.cloud.databricks.com",
+    )
+
+    # Don't actually construct a WorkspaceClient.
+    monkeypatch.setattr(WorkspaceClient, "__init__", lambda self, **_: None)
+
+    # loguru -> stderr by default; reroute to caplog so pytest sees it.
+    from loguru import logger as _logger
+
+    handler_id = _logger.add(caplog.handler, level="WARNING")
+    try:
+        _ = db.workspace_client
+    finally:
+        _logger.remove(handler_id)
+
+    warnings = [
+        rec.message
+        for rec in caplog.records
+        if rec.levelno >= logging.WARNING and "resolves to None" in rec.message
+    ]
+    assert any("client_id" in w for w in warnings), (
+        f"expected warning naming client_id, saw: {warnings}"
+    )
+    assert any("client_secret" in w for w in warnings), (
+        f"expected warning naming client_secret, saw: {warnings}"
+    )
+
+
+@pytest.mark.unit
+def test_workspace_client_ambient_no_creds_no_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When neither client_id nor pat is set, the property silently uses ambient.
+
+    This is the canonical "interactive notebook = ambient" path. No
+    warning should fire because no SP intent was expressed.
+    """
+    db = DatabaseModel(
+        name="testdb",
+        project="testproj",
+        # no client_id, client_secret, pat, or on_behalf_of_user
+    )
+
+    monkeypatch.setattr(WorkspaceClient, "__init__", lambda self, **_: None)
+
+    from loguru import logger as _logger
+
+    handler_id = _logger.add(caplog.handler, level="WARNING")
+    try:
+        _ = db.workspace_client
+    finally:
+        _logger.remove(handler_id)
+
+    sp_warnings = [
+        rec.message for rec in caplog.records if "resolves to None" in rec.message
+    ]
+    assert sp_warnings == [], (
+        f"unexpected SP-resolution warnings on ambient path: {sp_warnings}"
+    )
+
+
+@pytest.mark.unit
+def test_workspace_client_pat_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pat is honored when client_id/client_secret are unset."""
+    db = DatabaseModel(
+        name="testdb",
+        project="testproj",
+        pat="dapi-fake-token-value",
+        workspace_host="https://test.cloud.databricks.com",
+    )
+
+    constructed: dict = {}
+
+    def _fake_init(
+        self: WorkspaceClient,
+        host: str | None = None,
+        token: str | None = None,
+        auth_type: str | None = None,
+        **_: object,
+    ) -> None:
+        constructed["host"] = host
+        constructed["token"] = token
+        constructed["auth_type"] = auth_type
+
+    monkeypatch.setattr(WorkspaceClient, "__init__", _fake_init)
+
+    _ = db.workspace_client
+    assert constructed["token"] == "dapi-fake-token-value"
+    assert constructed["auth_type"] == "pat"
+    assert constructed["host"] == "https://test.cloud.databricks.com"

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -1483,22 +1483,17 @@ def test_database_model_workspace_client_oauth_without_workspace_host():
     """Test that OAuth works even when workspace_host is not provided.
 
     When client_id and client_secret are provided but workspace_host is not,
-    the WorkspaceClient should check DATABRICKS_HOST env var first, then fall
-    back to WorkspaceClient().config.host if not set.
+    the WorkspaceClient defaults the host via
+    :func:`dao_ai.utils.get_default_databricks_host` (env var first, then
+    ambient WorkspaceClient).
     """
     from unittest.mock import MagicMock, patch
 
-    # Mock the WorkspaceClient
-    mock_ws_client_instance = MagicMock()
-    mock_ws_client_instance.config.host = "https://default.databricks.com"
-
     with patch("dao_ai.config.WorkspaceClient") as mock_ws_client:
-        with patch("dao_ai.config.os.getenv") as mock_getenv:
-            mock_ws_client.return_value = mock_ws_client_instance
-            # DATABRICKS_HOST is not set
-            mock_getenv.return_value = None
+        with patch("dao_ai.utils.get_default_databricks_host") as mock_resolver:
+            mock_ws_client.return_value = MagicMock()
+            mock_resolver.return_value = "https://default.databricks.com"
 
-            # Create database with OAuth credentials but NO workspace_host
             database = DatabaseModel(
                 name="test_db",
                 project="test_db",
@@ -1508,47 +1503,38 @@ def test_database_model_workspace_client_oauth_without_workspace_host():
                 # workspace_host is intentionally NOT provided
             )
 
-            # Access workspace_client property - should use OAuth with default host
             _ = database.workspace_client
 
-            # Verify DATABRICKS_HOST was checked
-            mock_getenv.assert_called_with("DATABRICKS_HOST")
+            mock_resolver.assert_called_once()
 
-            # Verify WorkspaceClient was called twice:
-            # 1. First to get the default host (WorkspaceClient().config.host)
-            # 2. Second with OAuth credentials
-            assert mock_ws_client.call_count == 2
-
-            # Get the second call (the OAuth one)
-            second_call_kwargs = mock_ws_client.call_args_list[1].kwargs
-
-            # Should have client_id/client_secret for service principal auth
-            assert second_call_kwargs.get("client_id") == "test_client_id"
-            assert second_call_kwargs.get("client_secret") == "test_client_secret"
-            assert second_call_kwargs.get("auth_type") == "oauth-m2m"
-            # host should be the default from WorkspaceClient().config.host
-            assert second_call_kwargs.get("host") == "https://default.databricks.com"
+            # WorkspaceClient is constructed once (with OAuth creds). The
+            # ambient client construction that would normally back the
+            # resolver is mocked out, so no extra call should fire here.
+            assert mock_ws_client.call_count == 1
+            call_kwargs = mock_ws_client.call_args.kwargs
+            assert call_kwargs.get("client_id") == "test_client_id"
+            assert call_kwargs.get("client_secret") == "test_client_secret"
+            assert call_kwargs.get("auth_type") == "oauth-m2m"
+            assert call_kwargs.get("host") == "https://default.databricks.com"
 
 
 @pytest.mark.unit
 def test_database_model_workspace_client_oauth_uses_databricks_host_env():
-    """Test that OAuth uses DATABRICKS_HOST env var when set.
+    """Test that OAuth host defaults via the shared resolver.
 
-    When client_id and client_secret are provided and DATABRICKS_HOST is set,
-    it should use that instead of creating a WorkspaceClient to get the host.
+    When client_id and client_secret are provided and the resolver
+    returns a value (typically because DATABRICKS_HOST is set in the
+    environment), the constructed WorkspaceClient uses that host -- no
+    ambient WorkspaceClient is constructed for host discovery here
+    because the resolver itself is mocked.
     """
     from unittest.mock import MagicMock, patch
 
-    # Mock the WorkspaceClient
-    mock_ws_client_instance = MagicMock()
-
     with patch("dao_ai.config.WorkspaceClient") as mock_ws_client:
-        with patch("dao_ai.config.os.getenv") as mock_getenv:
-            mock_ws_client.return_value = mock_ws_client_instance
-            # DATABRICKS_HOST is set
-            mock_getenv.return_value = "https://env-host.databricks.com"
+        with patch("dao_ai.utils.get_default_databricks_host") as mock_resolver:
+            mock_ws_client.return_value = MagicMock()
+            mock_resolver.return_value = "https://env-host.databricks.com"
 
-            # Create database with OAuth credentials but NO workspace_host
             database = DatabaseModel(
                 name="test_db",
                 project="test_db",
@@ -1558,24 +1544,14 @@ def test_database_model_workspace_client_oauth_uses_databricks_host_env():
                 # workspace_host is intentionally NOT provided
             )
 
-            # Access workspace_client property
             _ = database.workspace_client
 
-            # Verify DATABRICKS_HOST was checked
-            mock_getenv.assert_called_with("DATABRICKS_HOST")
-
-            # Verify WorkspaceClient was only called once (for OAuth)
-            # Should NOT be called to get default host since env var is set
+            mock_resolver.assert_called_once()
             assert mock_ws_client.call_count == 1
-
-            # Get the OAuth call
             call_kwargs = mock_ws_client.call_args.kwargs
-
-            # Should have client_id/client_secret for service principal auth
             assert call_kwargs.get("client_id") == "test_client_id"
             assert call_kwargs.get("client_secret") == "test_client_secret"
             assert call_kwargs.get("auth_type") == "oauth-m2m"
-            # host should be from DATABRICKS_HOST env var
             assert call_kwargs.get("host") == "https://env-host.databricks.com"
 
 


### PR DESCRIPTION
## Summary

`IsDatabricksResource.workspace_client` already implemented the right four-branch precedence — OBO → SP → PAT → Ambient — but two papercuts made the SP branch hard to debug when secrets resolved to None:

1. **Silent fall-through to ambient.** When `client_id` or `client_secret` are configured as `SecretVariableModel` references and the running identity can't read the secret scope, `value_of(...)` returns `None`, the SP branch's `if client_id_value and client_secret_value` check evaluates `False`, and the property silently constructs an ambient WorkspaceClient. Downstream, `databricks_ai_bridge.lakebase.AsyncLakebasePool` mints tokens for the ambient identity (the human in a notebook), producing the lovely
   ```
   password authentication failed for user '<my-email>'
   ```
   without any breadcrumb tying it back to the unresolved SP secret.

2. **No signal which branch fired.** The existing `logger.debug` lines were per-branch but didn't name the chosen auth method in a greppable format.

This PR adds diagnostics without changing the precedence:

- **`logger.warning`** when `client_id`, `client_secret`, or `pat` are configured but resolve to `None`. The warning names the unresolved field so the fix (re-check the secret scope grant) is obvious.
- **`logger.trace`** per branch announcing the chosen auth method + the resolved host. `grep "auth method" stderr.log` now diagnoses the path in one shot.
- Centralised the `workspace_host` fallback through `dao_ai.utils.get_default_databricks_host` (env var → ambient WorkspaceClient), which is the same resolver `dao_ai.apps.a2a.security._resolve_host` switched to in [#90 commit 1debd50](https://github.com/natefleming/dao-ai/commit/1debd50). Removes the open-coded duplicate.

No behaviour change for the happy paths (resolved creds work; no creds → ambient). The ambient fall-through stays in place when neither `client_id` nor `client_secret` is set — that matches the documented precedence (notebook → user; Apps → app SP; Model Serving → ms SP).

## Tests

- 5 new tests in `tests/dao_ai/test_database_model_auth.py`:
  - SP branch fires with concrete creds
  - SP host defaults via the shared resolver
  - **warning fires on SP-intent + None-resolution** (the diagnostic contract)
  - no warning on no-creds ambient path
  - PAT branch honored when client_id/client_secret unset
- 2 existing tests in `test_databricks.py` updated to mock `dao_ai.utils.get_default_databricks_host` instead of `dao_ai.config.os.getenv` (the contract under test is preserved; the patch target moved with the refactor).

## Motivating bug

User hit this running lab-07-memory cell 15 in `dao-ai-workshop`. The lab YAML pointed `client_id` / `client_secret` at a secret scope; the user's interactive identity couldn't read it; ambient auth fired silently; postgres rejected the user's email. With this change, the warning surfaces the cause at boot and the user can fix the scope grant in seconds.

## Test plan

- [ ] Reviewer: `make format && make test` clean.
- [ ] Reviewer: re-run lab-07 cell 15 against fevm. Watch the new TRACE line:
  ```
  DatabaseModel auth method=service_principal client_id=<uuid> host=https://...
  ```
- [ ] Reviewer (negative): point `client_id` at a bogus secret. Re-run. Expect:
  ```
  WARNING  DatabaseModel.client_id is configured but resolves to None ...
  ```

This pull request and its description were written by Isaac.