### PR TITLE
Render chat UI in ephemeral mode + update example configs to claude-sonnet-4-5

### DIFF
--- a/config/examples/15_complete_applications/brick_store.yaml
+++ b/config/examples/15_complete_applications/brick_store.yaml
@@ -97,10 +97,10 @@ resources:
       max_tokens: 4096
       on_behalf_of_user: true
       fallbacks:
-      - databricks-claude-sonnet-4-6
+      - databricks-claude-sonnet-4-5
 
     judge_llm: &judge_llm
-      name: databricks-claude-3-7-sonnet
+      name: databricks-claude-sonnet-4-5
       temperature: 0.5
       max_tokens: 8192
       on_behalf_of_user: true

--- a/config/examples/15_complete_applications/deep_research.yaml
+++ b/config/examples/15_complete_applications/deep_research.yaml
@@ -15,7 +15,7 @@ schemas:
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-3-7-sonnet
+      name: databricks-claude-sonnet-4-5
       temperature: 0.1
       max_tokens: 16384
 
@@ -25,14 +25,14 @@ resources:
       max_tokens: 8192
 
     tool_calling_llm:
-      name: databricks-claude-3-7-sonnet
+      name: databricks-claude-sonnet-4-5
       temperature: 0.1
       max_tokens: 16384
       fallbacks:
       - databricks-claude-sonnet-4
 
     reasoning_llm: &reasoning_llm
-      name: databricks-claude-3-7-sonnet
+      name: databricks-claude-sonnet-4-5
       temperature: 0.2
       max_tokens: 16384
 
@@ -41,7 +41,7 @@ resources:
       temperature: 0.1
       max_tokens: 32768
       fallbacks:
-      - databricks-claude-3-7-sonnet
+      - databricks-claude-sonnet-4-5
 
   tables:
     employee_performance:

--- a/config/examples/15_complete_applications/executive_assistant.yaml
+++ b/config/examples/15_complete_applications/executive_assistant.yaml
@@ -16,7 +16,7 @@ resources:
   models:
     # LLM for complex reasoning tasks
     reasoning_llm: &reasoning_llm
-      name: databricks-claude-3-7-sonnet
+      name: databricks-claude-sonnet-4-5
       temperature: 0.1
       max_tokens: 8192
 

--- a/config/examples/15_complete_applications/hardware_store.yaml
+++ b/config/examples/15_complete_applications/hardware_store.yaml
@@ -41,19 +41,19 @@ resources:
   models:
     # Primary LLM for general tasks
     default_llm:
-      name: databricks-claude-3-7-sonnet  # Databricks serving endpoint name
+      name: databricks-claude-sonnet-4-5  # Databricks serving endpoint name
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
 
     # LLM optimized for tool calling and function execution
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-3-7-sonnet
+      name: databricks-claude-sonnet-4-5
       temperature: 0.1
       max_tokens: 8192
 
     # LLM for evaluating and judging responses (guardrails)
     judge_llm: &judge_llm
-      name: databricks-claude-3-7-sonnet
+      name: databricks-claude-sonnet-4-5
       temperature: 0.5                              # Higher temperature for diverse judgments
       max_tokens: 8192
 

--- a/config/examples/15_complete_applications/hardware_store_swarm.yaml
+++ b/config/examples/15_complete_applications/hardware_store_swarm.yaml
@@ -41,19 +41,19 @@ resources:
   models:
     # Primary LLM for general tasks
     default_llm:
-      name: databricks-claude-3-7-sonnet  # Databricks serving endpoint name
+      name: databricks-claude-sonnet-4-5  # Databricks serving endpoint name
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
 
     # LLM optimized for tool calling and function execution
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-3-7-sonnet
+      name: databricks-claude-sonnet-4-5
       temperature: 0.1
       max_tokens: 8192
 
     # LLM for evaluating and judging responses (guardrails)
     judge_llm: &judge_llm
-      name: databricks-claude-3-7-sonnet
+      name: databricks-claude-sonnet-4-5
       temperature: 0.5                              # Higher temperature for diverse judgments
       max_tokens: 8192
 

--- a/config/examples/15_complete_applications/quick_serve_restaurant.yaml
+++ b/config/examples/15_complete_applications/quick_serve_restaurant.yaml
@@ -78,7 +78,7 @@ resources:
 
     # LLM optimized for tool calling and function execution
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-3-7-sonnet
+      name: databricks-claude-sonnet-4-5
       temperature: 0.1
       max_tokens: 8192
       fallbacks:                                     # Fallback models if primary fails
@@ -86,13 +86,13 @@ resources:
 
     # LLM for complex reasoning tasks
     reasoning_llm:
-      name: databricks-claude-3-7-sonnet
+      name: databricks-claude-sonnet-4-5
       temperature: 0.1
       max_tokens: 8192
 
     # LLM for evaluating and judging responses (guardrails)
     judge_llm: &judge_llm
-      name: databricks-claude-3-7-sonnet
+      name: databricks-claude-sonnet-4-5
       temperature: 0.5                              # Higher temperature for diverse judgments
       max_tokens: 8192
 

--- a/src/dao_ai/apps/chat_ui.py
+++ b/src/dao_ai/apps/chat_ui.py
@@ -9,6 +9,7 @@ container (which has Node.js 20 + npm + git pre-installed), following the same
 pattern as the official Databricks agent templates.
 """
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -22,6 +23,44 @@ REPO_URL_SSH: str = "git@github.com:databricks/app-templates.git"
 _DEFAULT_BACKEND_PORT: int = 8000
 _DEFAULT_FRONTEND_PORT: int = 3000
 _DEFAULT_PROXY_TIMEOUT: int = 300
+
+# Env-var prefixes whose presence triggers the chat UI's drizzle migration at
+# npm-build time (and its runtime persistence code paths). The bundled
+# e2e-chatbot-app-next template's migrator hits a "drizzle" schema that isn't
+# auto-created, so the build fails when these are set. Stripping them forces
+# the chat UI's isDatabaseAvailable() check to return false, routing into
+# ephemeral mode for both build and runtime — the SPA renders without
+# persisting chat history.
+_DB_ENV_VAR_PREFIXES: tuple[str, ...] = (
+    "PG",
+    "POSTGRES",
+    "DATABASE_URL",
+    "DATABRICKS_LAKEBASE",
+    "DATABRICKS_DATABASE",
+)
+
+
+def sanitized_npm_env() -> dict[str, str]:
+    """Return a copy of os.environ with DB-binding env vars stripped.
+
+    Used when invoking the chat UI's npm subprocesses so the bundled
+    e2e-chatbot-app-next template skips its drizzle migration and runs in
+    ephemeral mode regardless of whether a postgres resource is bound to the
+    Databricks App.
+    """
+    stripped = sorted(
+        k for k in os.environ if k.startswith(_DB_ENV_VAR_PREFIXES)
+    )
+    if stripped:
+        logger.debug(
+            "Stripping DB-binding env vars from npm subprocess",
+            keys=stripped,
+        )
+    return {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith(_DB_ENV_VAR_PREFIXES)
+    }
 
 
 class ChatUIBuildError(Exception):
@@ -105,6 +144,7 @@ def _npm_run(chat_dir: Path, args: list[str], description: str) -> None:
         cwd=chat_dir,
         capture_output=True,
         text=True,
+        env=sanitized_npm_env(),
     )
     if result.returncode != 0:
         stderr = result.stderr or result.stdout

--- a/src/dao_ai/apps/start_app.py
+++ b/src/dao_ai/apps/start_app.py
@@ -35,6 +35,7 @@ from dao_ai.apps.chat_ui import (
     CHAT_APP_DIR,
     ChatUIBuildError,
     ensure_chat_ui_built,
+    sanitized_npm_env,
 )
 
 BACKEND_READY_PATTERNS = [
@@ -170,6 +171,7 @@ class ProcessManager:
         log_file,
         patterns: list[str],
         cwd: str | None = None,
+        env: dict[str, str] | None = None,
     ) -> subprocess.Popen:
         print(f"Starting {name}...")
         process = subprocess.Popen(
@@ -179,6 +181,7 @@ class ProcessManager:
             text=True,
             bufsize=1,
             cwd=cwd,
+            env=env,
         )
 
         thread = threading.Thread(
@@ -265,6 +268,7 @@ class ProcessManager:
                             cwd=frontend_dir,
                             capture_output=True,
                             text=True,
+                            env=sanitized_npm_env(),
                         )
                         if result.returncode != 0:
                             print(f"npm {desc} failed: {result.stderr}")
@@ -279,6 +283,7 @@ class ProcessManager:
                         self.frontend_log,
                         FRONTEND_READY_PATTERNS,
                         cwd=str(frontend_dir),
+                        env=sanitized_npm_env(),
                     )
                     print(
                         f"\nMonitoring processes "


### PR DESCRIPTION
## Summary

- **`apps/`** — Strip DB-binding env vars (`PG*`, `POSTGRES*`, `DATABASE_URL`, `DATABRICKS_LAKEBASE*`, `DATABRICKS_DATABASE*`) from every npm subprocess the chat UI runs (clone-build, runtime build, runtime `npm run start`). This forces the bundled `e2e-chatbot-app-next` template's `migrate.ts` into its `isDatabaseAvailable() == false` skip branch, so `npm run build` no longer fails on the broken `CREATE TABLE "drizzle"."__drizzle_migrations"` migration. The chat SPA renders with or without a postgres resource bound to the App. Chat history is ephemeral for now.
- **`config/examples/15_complete_applications/`** — Replace deprecated `databricks-claude-3-7-sonnet` with `databricks-claude-sonnet-4-5` in the six configs that still referenced it (`brick_store`, `deep_research`, `executive_assistant`, `hardware_store`, `hardware_store_swarm`, `quick_serve_restaurant`). The old endpoint is no longer hosted on current FMAPI workspaces and was causing `deploy-agents` to fail at `_set_app_resources` with `ResourceDoesNotExist`.

## Test plan

- [x] Smoke test on `dao_ai.apps.chat_ui:sanitized_npm_env()` confirms `PG*` / `POSTGRES*` / `DATABASE_URL` / `DATABRICKS_LAKEBASE_*` stripped while `PATH`/`HOME` preserved.
- [x] `ruff check` introduces no new errors over `main`.
- [x] End-to-end redeploy on `fevm` of `loyalty_offer_personalization.yaml` (the canonical broken-UI repro): bundle deploy + bundle run finished exit 0, app logs show `Chat UI built successfully` and `Both frontend and backend are ready!` — pre-fix the same config produced `❌ Database migration failed` + `Backend is ready! (running without UI)`.
- [ ] Negative test: redeploy a config that previously rendered the UI (e.g. `hardware_store_lakebase.yaml`) and confirm the SPA still loads — now in ephemeral mode rather than using its postgres binding for chat persistence.

## Follow-ups (out of scope)

- Upstream PR against `databricks/app-templates` to fix the `drizzle` schema bug — either pre-create the schema in `migrate.ts` or pass `migrationsSchema: schemaName` to `drizzle-orm`'s `migrate()`. Once that lands, this strip can become opt-out behind a config flag so apps with bound Lakebase regain chat-history persistence.
- Remove the redundant `npm install` + `npm run build` block in `start_app.py:257-273` (already done by `ensure_chat_ui_built`).

This pull request and its description were written by Isaac.