### PR TITLE
hardware_store_lakebase: supervisor model -> claude-sonnet-4-5

### DIFF
--- a/config/examples/15_complete_applications/hardware_store_lakebase.yaml
+++ b/config/examples/15_complete_applications/hardware_store_lakebase.yaml
@@ -64,7 +64,12 @@ resources:
 
 
     fast_llm: &fast_llm
-      name: databricks-gpt-oss-120b                 # Databricks serving endpoint name
+      # NOTE: must support parallel tool calls in message history because
+      # worker agents (Claude-family) emit parallel tool_calls and the
+      # supervisor (this model) ingests that history on follow-up turns.
+      # `databricks-gpt-oss-120b` 400s with "Multiple tool calls are not
+      # supported" — see trace tr-fd4dfaea04c4517f43081e2c3bf0df25.
+      name: databricks-claude-sonnet-4-5            # Databricks serving endpoint name
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
 


### PR DESCRIPTION
The supervisor is bound to fast_llm via *fast_llm. Previously fast_llm pointed at databricks-gpt-oss-120b, which returns 400 "Multiple tool calls are not supported." when the conversation history contains an assistant message with parallel tool_calls.

Worker agents in this config use claude-sonnet-4-6, which routinely emits parallel tool_calls (e.g., product_vector_search_tool + search_memory in the DIY agent). On any follow-up turn after a worker emits parallel calls, the supervisor's LLM request fails. See trace tr-fd4dfaea04c4517f43081e2c3bf0df25.

Repoint fast_llm at databricks-claude-sonnet-4-5 — accepts parallel tool_calls in history, same family as workers, eliminates the inter-model compatibility footgun for this config.

The cleaner long-term fix is to pass parallel_tool_calls=False to all dao-ai chat models so this can't happen regardless of which model the supervisor uses. Tracked separately.

Co-authored-by: Isaac