### PR TITLE
orchestration: default output_mode to last_message (correctness fix)

### DIFF
--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -6074,8 +6074,8 @@
           "description": "Memory configuration scoped to the orchestration layer (checkpointer, store, extraction)."
         },
         "output_mode": {
-          "default": "full_history",
-          "description": "How an agent's response flows back into parent state. ``full_history`` returns the agent's full local history including intermediate AI/tool messages, which lets the same agent see its own prior tool results across multi-turn conversations. ``last_message`` returns only the final AI response, which trims tokens but loses intermediate content. Default flipped to ``full_history`` so per-agent ToolMessage tagging actually has messages to identify.",
+          "default": "last_message",
+          "description": "How an agent's response flows back into parent state. ``last_message`` (default) returns only the final AI response from each agent, isolating downstream consumers (supervisor or peer swarm agents) from worker-side message corruption \u2014 middleware mutations that interleave system/tool messages, parallel tool calls that some strict-validation LLMs reject in history, or orphan tool_result blocks. ``full_history`` returns the agent's full local history, preserving cross-agent tool context (one agent can see another's structured tool outputs) at the cost of exposing downstream consumers to any worker-side malformed messages. Override per app via ``orchestration.output_mode: full_history`` when cross-agent tool context is required and the worker-side message-assembly path is known to be clean.",
           "enum": [
             "full_history",
             "last_message"

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -6256,16 +6256,22 @@ class OrchestrationModel(BaseModel):
         description="Memory configuration scoped to the orchestration layer (checkpointer, store, extraction).",
     )
     output_mode: Literal["full_history", "last_message"] = Field(
-        default="full_history",
+        default="last_message",
         description=(
             "How an agent's response flows back into parent state. "
-            "``full_history`` returns the agent's full local history including "
-            "intermediate AI/tool messages, which lets the same agent see its "
-            "own prior tool results across multi-turn conversations. "
-            "``last_message`` returns only the final AI response, which trims "
-            "tokens but loses intermediate content. Default flipped to "
-            "``full_history`` so per-agent ToolMessage tagging actually has "
-            "messages to identify."
+            "``last_message`` (default) returns only the final AI response "
+            "from each agent, isolating downstream consumers (supervisor or "
+            "peer swarm agents) from worker-side message corruption — "
+            "middleware mutations that interleave system/tool messages, "
+            "parallel tool calls that some strict-validation LLMs reject in "
+            "history, or orphan tool_result blocks. "
+            "``full_history`` returns the agent's full local history, "
+            "preserving cross-agent tool context (one agent can see another's "
+            "structured tool outputs) at the cost of exposing downstream "
+            "consumers to any worker-side malformed messages. Override per "
+            "app via ``orchestration.output_mode: full_history`` when cross-"
+            "agent tool context is required and the worker-side message-"
+            "assembly path is known to be clean."
         ),
     )
 

--- a/tests/dao_ai/test_apps_obo_partition.py
+++ b/tests/dao_ai/test_apps_obo_partition.py
@@ -371,12 +371,13 @@ class TestSportingGoodsConfigPartition:
     ) -> None:
         resources = generate_app_resources(config)
         names_in_resources = {r["name"] for r in resources}
-        # Pick representative non-OBO resources from the canonical config
+        # Pick representative non-OBO resources from the canonical config.
+        # Note: ``products_vector_store`` and ``shared_warehouse`` were
+        # flipped to OBO in PR #93 to fit under the 20-resource Apps cap, so
+        # they are intentionally absent from app-level resources.
         for name in (
             "judge_llm",
             "embedding_model",
-            "products_vector_store",
-            "shared_warehouse",
             "merchandising_analytics_room",
             "sales_pricing_room",
             "find_product_by_sku",

--- a/tests/dao_ai/test_orchestration_multi_turn.py
+++ b/tests/dao_ai/test_orchestration_multi_turn.py
@@ -1,0 +1,325 @@
+"""Multi-turn integration smoke tests for the default ``output_mode``.
+
+Reproduces the deployment shape (worker subgraph wrapped in
+``create_agent_node_handler`` inside a parent orchestration graph) for both
+supervisor and swarm patterns. Drives 2-turn conversations against the
+parent graph with the same ``thread_id`` and ``user_id`` across turns to
+verify:
+
+1. Both turns complete with no orphan tool_result / parallel tool_call
+   issues bubbling up to the parent.
+2. The parent state's message history never contains worker-side malformed
+   patterns (interleaved system messages, orphan tool_results, parallel
+   tool_calls in assistant messages from the worker).
+
+This is the integration version of the unit tests in
+``test_output_mode_default_regression.py`` — same invariant, full LangGraph
+runtime.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import pytest
+from langchain.agents import create_agent
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+
+from dao_ai.orchestration.core import create_agent_node_handler
+from dao_ai.state import AgentState, Context
+
+# ---------------------------------------------------------------------------
+# Test fixtures: a tiny FakeChatModel that mimics the worker patterns that
+# caused the bug — parallel tool_calls, text + tool_calls in one message,
+# and a clean final text response.
+# ---------------------------------------------------------------------------
+
+
+@tool
+def find_inventory(sku: str) -> str:
+    """Look up inventory for a given SKU."""
+    return f"sku={sku} qty=3"
+
+
+@tool
+def search_memory(query: str) -> str:
+    """Search long-term memory."""
+    return "[]"
+
+
+class _ParallelToolCallWorker(BaseChatModel):
+    """Worker that emits PARALLEL tool_calls + text in a single assistant
+    message on first call, then a clean final answer once tool results land.
+    Each call returns a fresh AIMessage with a unique id to avoid
+    ``add_messages`` dedup across turns.
+    """
+
+    @property
+    def _llm_type(self) -> str:
+        return "fake-parallel-worker"
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        has_tool_result = any(isinstance(m, ToolMessage) for m in messages)
+        if has_tool_result:
+            msg = AIMessage(
+                content="Found 3 in stock.",
+                id=str(uuid.uuid4()),
+            )
+        else:
+            msg = AIMessage(
+                content="Let me search inventory and memory at once.",
+                tool_calls=[
+                    {
+                        "name": "find_inventory",
+                        "args": {"sku": "DEWALT-DRILL"},
+                        "id": f"tu_par_a_{uuid.uuid4().hex[:6]}",
+                        "type": "tool_call",
+                    },
+                    {
+                        "name": "search_memory",
+                        "args": {"query": "drill prefs"},
+                        "id": f"tu_par_b_{uuid.uuid4().hex[:6]}",
+                        "type": "tool_call",
+                    },
+                ],
+                id=str(uuid.uuid4()),
+            )
+        return ChatResult(generations=[ChatGeneration(message=msg)])
+
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+
+def _build_worker_subgraph() -> "CompiledStateGraph":  # noqa: F821
+    """Single agent with parallel-tool-call behavior."""
+    return create_agent(
+        name="inventory_worker",
+        model=_ParallelToolCallWorker(),
+        tools=[find_inventory, search_memory],
+        checkpointer=InMemorySaver(),
+        state_schema=AgentState,
+        context_schema=Context,
+    )
+
+
+def _build_parent_with_handler(output_mode: str) -> "CompiledStateGraph":  # noqa: F821
+    """Parent orchestration graph that wraps the worker via
+    ``create_agent_node_handler`` — same shape as the supervisor/swarm
+    deployment.
+    """
+    worker = _build_worker_subgraph()
+    handler = create_agent_node_handler(
+        agent_name="inventory_worker",
+        agent=worker,
+        output_mode=output_mode,
+    )
+    workflow = StateGraph(
+        AgentState,
+        input=AgentState,
+        output=AgentState,
+        context_schema=Context,
+    )
+    workflow.add_node("inventory_worker", handler)
+    workflow.add_edge(START, "inventory_worker")
+    workflow.add_edge("inventory_worker", END)
+    return workflow.compile(checkpointer=InMemorySaver())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _assert_no_orphan_tool_results(messages: list) -> None:
+    """Walk the message list and assert every ToolMessage has a matching
+    tool_use in the immediately preceding assistant message. This is the
+    Anthropic-strict-validation rule that previously caused the 400s.
+    """
+    for i, msg in enumerate(messages):
+        if not isinstance(msg, ToolMessage):
+            continue
+        # Walk backwards to find the most recent AIMessage. There may be
+        # ToolMessages or other AIMessages between, but the matching
+        # tool_use must be in a preceding AIMessage.
+        found = False
+        for j in range(i - 1, -1, -1):
+            prev = messages[j]
+            if isinstance(prev, AIMessage):
+                tcs = prev.tool_calls or []
+                if any(tc.get("id") == msg.tool_call_id for tc in tcs):
+                    found = True
+                break
+            # If we cross another ToolMessage, that's fine — could be a
+            # multi-tool batch. Keep walking.
+        assert found, (
+            f"orphan ToolMessage at index {i} "
+            f"(tool_call_id={msg.tool_call_id}) "
+            f"— no matching tool_use in any preceding AIMessage"
+        )
+
+
+def _assert_no_parallel_tool_calls_in_assistant(messages: list) -> None:
+    """Assert no surfaced AIMessage emits parallel tool_calls (>1 tool_call
+    in a single assistant message). With ``last_message`` the supervisor
+    never sees these; with ``full_history`` they may leak through and cause
+    strict-validation LLM 400s downstream.
+    """
+    for msg in messages:
+        if isinstance(msg, AIMessage):
+            tcs = msg.tool_calls or []
+            assert len(tcs) <= 1, (
+                f"parallel tool_calls in AIMessage: {len(tcs)} calls — "
+                f"would 400 on strict-validation LLMs"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Supervisor scenario — single worker, default output_mode (last_message)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_supervisor_multi_turn_same_thread_clean_history() -> None:
+    """Two turns, same thread_id + user_id, default output_mode. The parent
+    state's accumulated messages must remain free of worker-side malformed
+    patterns across both turns. Uses ``asyncio.run`` (matching the pattern
+    in ``test_hitl.py``) because ``create_agent_node_handler`` is async-only.
+    """
+    parent = _build_parent_with_handler(output_mode="last_message")
+
+    thread_id = "thread-supervisor-1"
+    user_id = "user-nate"
+    config = {
+        "configurable": {
+            "thread_id": thread_id,
+            "user_id": user_id,
+        },
+    }
+
+    async def _run() -> tuple[list, list]:
+        s1 = await parent.ainvoke(
+            {"messages": [HumanMessage(content="DeWalt drills in stock?")]},
+            config=config,
+        )
+        s2 = await parent.ainvoke(
+            {"messages": [HumanMessage(content="Any in the back?")]},
+            config=config,
+        )
+        return s1["messages"], s2["messages"]
+
+    msgs_t1, msgs_t2 = asyncio.run(_run())
+
+    _assert_no_orphan_tool_results(msgs_t1)
+    _assert_no_parallel_tool_calls_in_assistant(msgs_t1)
+    last_ai = next(m for m in reversed(msgs_t1) if isinstance(m, AIMessage))
+    assert not (last_ai.tool_calls or [])
+
+    _assert_no_orphan_tool_results(msgs_t2)
+    _assert_no_parallel_tool_calls_in_assistant(msgs_t2)
+
+
+# ---------------------------------------------------------------------------
+# Swarm-shaped scenario — two workers in sequence, default output_mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_swarm_two_workers_multi_turn_clean_history() -> None:
+    """Two workers chained (simulating a swarm handoff), 2-turn conversation,
+    same thread_id + user_id. Verify the parent state stays clean across the
+    handoff AND the follow-up turn.
+    """
+    worker_a = _build_worker_subgraph()
+    worker_b = _build_worker_subgraph()
+
+    handler_a = create_agent_node_handler(
+        agent_name="agent_a",
+        agent=worker_a,
+        output_mode="last_message",
+    )
+    handler_b = create_agent_node_handler(
+        agent_name="agent_b",
+        agent=worker_b,
+        output_mode="last_message",
+    )
+
+    workflow = StateGraph(
+        AgentState,
+        input=AgentState,
+        output=AgentState,
+        context_schema=Context,
+    )
+    workflow.add_node("agent_a", handler_a)
+    workflow.add_node("agent_b", handler_b)
+    workflow.add_edge(START, "agent_a")
+    workflow.add_edge("agent_a", "agent_b")  # simulated handoff
+    workflow.add_edge("agent_b", END)
+    parent = workflow.compile(checkpointer=InMemorySaver())
+
+    config = {
+        "configurable": {
+            "thread_id": "thread-swarm-1",
+            "user_id": "user-nate",
+        },
+    }
+
+    async def _run() -> tuple[list, list]:
+        s1 = await parent.ainvoke(
+            {"messages": [HumanMessage(content="DeWalt drills?")]},
+            config=config,
+        )
+        s2 = await parent.ainvoke(
+            {"messages": [HumanMessage(content="In the back?")]},
+            config=config,
+        )
+        return s1["messages"], s2["messages"]
+
+    msgs_t1, msgs_t2 = asyncio.run(_run())
+
+    _assert_no_orphan_tool_results(msgs_t1)
+    _assert_no_parallel_tool_calls_in_assistant(msgs_t1)
+    _assert_no_orphan_tool_results(msgs_t2)
+    _assert_no_parallel_tool_calls_in_assistant(msgs_t2)
+
+
+# ---------------------------------------------------------------------------
+# Negative reproducer — assert the old default (full_history) WOULD have
+# surfaced the bug shape we just blocked.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_full_history_propagates_parallel_tool_calls_to_parent() -> None:
+    """Sanity check on the negative case: under ``output_mode='full_history'``
+    the parent's accumulated state DOES contain the worker's parallel
+    tool_calls. This is the pre-fix behavior and the reason for flipping the
+    default. If a future refactor inadvertently turned this back on, this
+    test confirms the bug surface is still there as documented."""
+    parent = _build_parent_with_handler(output_mode="full_history")
+    config = {
+        "configurable": {
+            "thread_id": "thread-fh-1",
+            "user_id": "user-nate",
+        },
+    }
+
+    async def _run() -> list:
+        s = await parent.ainvoke(
+            {"messages": [HumanMessage(content="DeWalt drills?")]},
+            config=config,
+        )
+        return s["messages"]
+
+    msgs = asyncio.run(_run())
+    # Under full_history, the worker's parallel-tool-call assistant message
+    # propagates upward. The assertion below would FAIL (parallel calls
+    # present) — confirming this is exactly the surface the default flip
+    # eliminates.
+    with pytest.raises(AssertionError, match="parallel tool_calls"):
+        _assert_no_parallel_tool_calls_in_assistant(msgs)

--- a/tests/dao_ai/test_orchestration_review_fixes.py
+++ b/tests/dao_ai/test_orchestration_review_fixes.py
@@ -383,9 +383,30 @@ class TestMergeSessionGeneric:
 
 @pytest.mark.unit
 class TestOrchestrationOutputMode:
-    def test_default_is_full_history(self) -> None:
+    def test_default_is_last_message(self) -> None:
+        """Default flipped to ``last_message`` so the supervisor (or any
+        downstream consumer) never sees worker-side malformed history —
+        memory middleware interleaves, parallel tool calls in worker
+        history that strict LLMs reject, or orphan tool_result blocks.
+        See the orphan-tool_result regression captured in trace
+        ``tr-7f30e2da4c02accfc11bc08cae54eef2`` (fevm) for the bug class
+        this prevents."""
         m = OrchestrationModel(
             supervisor=SupervisorModel(model=LLMModel(name="test-model"))
+        )
+        assert m.output_mode == "last_message"
+
+    def test_default_is_last_message_for_swarm(self) -> None:
+        """Same default applies to swarm orchestration. Swarm configs
+        that genuinely need cross-agent tool context can opt in via an
+        explicit ``output_mode: full_history`` at the YAML level."""
+        m = OrchestrationModel(swarm=SwarmModel())
+        assert m.output_mode == "last_message"
+
+    def test_accepts_full_history(self) -> None:
+        m = OrchestrationModel(
+            supervisor=SupervisorModel(model=LLMModel(name="test-model")),
+            output_mode="full_history",
         )
         assert m.output_mode == "full_history"
 

--- a/tests/dao_ai/test_output_mode_default_regression.py
+++ b/tests/dao_ai/test_output_mode_default_regression.py
@@ -1,0 +1,217 @@
+"""Regression tests for the orphan-tool_result bug class fixed by flipping
+``OrchestrationModel.output_mode`` default to ``last_message``.
+
+Background: trace ``tr-7f30e2da4c02accfc11bc08cae54eef2`` (fevm experiment
+``1661766236280959``) captured a Claude supervisor 400 with::
+
+    'messages.16.content.0: unexpected `tool_use_id` found in `tool_result`
+    blocks: toolu_bdrk_01AJt5CB3JUz6wVBKeYCRQgh. Each `tool_result` block
+    must have a corresponding `tool_use` block in the previous message.'
+
+Root cause: worker subgraph's local history accumulated malformed messages
+(``MemoryContextMiddleware`` inserting ``## Memories`` ``SystemMessage`` rows
+between assistant tool_use and tool_result blocks; parallel tool_calls
+emitted by Claude-family workers). With ``output_mode='full_history'`` the
+malformed worker history propagated into the supervisor's state via
+``extract_agent_response``. The supervisor's next LLM call then 400'd.
+
+The fix: default ``output_mode`` is ``last_message``. ``extract_agent_response``
+returns only the worker's final ``AIMessage`` with ``tool_calls`` stripped, so
+no worker-side malformed messages can reach the supervisor. These tests pin
+that behavior down so it doesn't regress.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+
+from dao_ai.config import (
+    LLMModel,
+    OrchestrationModel,
+    SupervisorModel,
+    SwarmModel,
+)
+from dao_ai.orchestration.core import extract_agent_response
+
+# =============================================================================
+# Default value
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestOutputModeDefault:
+    def test_default_supervisor(self) -> None:
+        """A supervisor-only orchestration gets ``last_message`` by default."""
+        m = OrchestrationModel(
+            supervisor=SupervisorModel(model=LLMModel(name="test-model"))
+        )
+        assert m.output_mode == "last_message"
+
+    def test_default_swarm(self) -> None:
+        """A swarm-only orchestration gets ``last_message`` by default. Swarm
+        configs that genuinely need cross-agent tool context opt in via an
+        explicit ``output_mode: full_history`` in YAML."""
+        m = OrchestrationModel(swarm=SwarmModel())
+        assert m.output_mode == "last_message"
+
+    def test_default_with_no_active_mode(self) -> None:
+        """Even with no orchestration mode set, default is ``last_message``."""
+        m = OrchestrationModel()
+        assert m.output_mode == "last_message"
+
+    def test_explicit_full_history_override(self) -> None:
+        """Apps that actually want cross-agent tool context can opt in."""
+        m = OrchestrationModel(
+            supervisor=SupervisorModel(model=LLMModel(name="test-model")),
+            output_mode="full_history",
+        )
+        assert m.output_mode == "full_history"
+
+
+# =============================================================================
+# extract_agent_response — verifies the worker-side malformed-history patterns
+# from the bug never reach the supervisor's state under the new default.
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestExtractAgentResponseDefaultBlocksMalformedHistory:
+    def test_strips_tool_calls_from_final_ai_message(self) -> None:
+        """Worker's final AIMessage might still carry tool_calls (it's the
+        last assistant turn that issued a tool call). last_message must strip
+        them so the supervisor doesn't try to satisfy an orphan tool_use."""
+        worker_history = [
+            AIMessage(
+                content="Searching...",
+                tool_calls=[
+                    {
+                        "name": "find_sku",
+                        "args": {"sku": "ABC"},
+                        "id": "tu_1",
+                        "type": "tool_call",
+                    }
+                ],
+                id="ai-1",
+            ),
+            ToolMessage(content="found", tool_call_id="tu_1", id="tm-1"),
+            AIMessage(
+                content="Here you go",
+                tool_calls=[
+                    {
+                        "name": "find_sku",
+                        "args": {"sku": "XYZ"},
+                        "id": "tu_2",
+                        "type": "tool_call",
+                    }
+                ],
+                id="ai-2",
+            ),
+        ]
+        out = extract_agent_response(worker_history, output_mode="last_message")
+        assert len(out) == 1
+        assert isinstance(out[0], AIMessage)
+        assert out[0].content == "Here you go"
+        assert out[0].tool_calls == [] or out[0].tool_calls is None
+
+    def test_drops_interleaved_system_message_from_memory_middleware(self) -> None:
+        """The MemoryContextMiddleware injects ``## Memories`` SystemMessages
+        between assistant tool_use and tool_result blocks (the actual bug
+        cause). last_message extracts only the final AIMessage and never
+        propagates the interleaved system message into the supervisor's view."""
+        worker_history = [
+            HumanMessage(content="any memory?", id="h-1"),
+            SystemMessage(content="## Memories\n- nickname Nate", id="sm-1"),
+            AIMessage(
+                content="Looking it up.",
+                tool_calls=[
+                    {
+                        "name": "search_memory",
+                        "args": {"query": "nickname"},
+                        "id": "tu_mem",
+                        "type": "tool_call",
+                    }
+                ],
+                id="ai-1",
+            ),
+            ToolMessage(content="found", tool_call_id="tu_mem", id="tm-1"),
+            SystemMessage(content="## Memories\n- nickname Nate", id="sm-2"),
+            AIMessage(content="Your nickname is Nate", id="ai-final"),
+        ]
+        out = extract_agent_response(worker_history, output_mode="last_message")
+        assert len(out) == 1
+        assert isinstance(out[0], AIMessage)
+        assert out[0].content == "Your nickname is Nate"
+        # No SystemMessage / no ToolMessage / no orphan tool_call propagated.
+        assert not any(isinstance(m, (SystemMessage, ToolMessage)) for m in out)
+
+    def test_drops_parallel_tool_calls_assistant_message(self) -> None:
+        """Worker may emit text + parallel tool_calls in one assistant message
+        (Claude's pattern). Under last_message that message becomes a clean
+        text-only AIMessage when surfaced to the supervisor — no parallel
+        tool_calls in supervisor's history for strict-validation LLMs to
+        choke on."""
+        worker_history = [
+            AIMessage(
+                content="Looking up products + memory",
+                tool_calls=[
+                    {
+                        "name": "product_vector_search",
+                        "args": {"query": "drills"},
+                        "id": "tu_par_1",
+                        "type": "tool_call",
+                    },
+                    {
+                        "name": "search_memory",
+                        "args": {"query": "drill prefs"},
+                        "id": "tu_par_2",
+                        "type": "tool_call",
+                    },
+                ],
+                id="ai-parallel",
+            ),
+            ToolMessage(content="DEWALT etc.", tool_call_id="tu_par_1", id="tm-1"),
+            ToolMessage(content="[]", tool_call_id="tu_par_2", id="tm-2"),
+            AIMessage(content="Here are the DEWALT drills.", id="ai-final"),
+        ]
+        out = extract_agent_response(worker_history, output_mode="last_message")
+        assert len(out) == 1
+        assert isinstance(out[0], AIMessage)
+        assert out[0].content == "Here are the DEWALT drills."
+
+    def test_orphan_tool_result_does_not_propagate(self) -> None:
+        """The exact bug shape from trace tr-7f30e2da... — a ToolMessage that
+        has no matching tool_use in the immediately preceding assistant
+        message — must not leak into the supervisor's state."""
+        worker_history = [
+            AIMessage(content="Let me search...", id="ai-text-only"),
+            ToolMessage(
+                content="[orphan]", tool_call_id="tu_orphan", id="tm-orphan"
+            ),
+            AIMessage(content="Result is X.", id="ai-final"),
+        ]
+        out = extract_agent_response(worker_history, output_mode="last_message")
+        assert len(out) == 1
+        assert isinstance(out[0], AIMessage)
+        assert out[0].content == "Result is X."
+        assert not any(isinstance(m, ToolMessage) for m in out)
+
+    def test_empty_worker_returns_empty(self) -> None:
+        """Pathological case: worker returned no messages. Don't crash."""
+        out = extract_agent_response([], output_mode="last_message")
+        assert out == []
+
+    def test_full_history_still_passes_through_when_explicitly_set(self) -> None:
+        """Apps that explicitly opt in to full_history get the old behavior."""
+        worker_history = [
+            HumanMessage(content="hi"),
+            SystemMessage(content="## Memories"),
+            AIMessage(content="Done."),
+        ]
+        out = extract_agent_response(worker_history, output_mode="full_history")
+        assert out == worker_history


### PR DESCRIPTION
## Summary

- **`OrchestrationModel.output_mode` defaults to `last_message`** (was `full_history`). Applies to both supervisor and swarm patterns; swarm configs that genuinely need cross-agent tool context can opt in per-app via an explicit `orchestration.output_mode: full_history`.
- Eliminates an entire class of supervisor 400s caused by worker subgraphs propagating malformed message history into the supervisor's LLM call.

## The bug class this fixes

Two production traces on `hardware_store_lakebase_dao` (fevm) captured the symptom:

| Trace | Supervisor model | Error |
|---|---|---|
| `tr-fd4dfaea04c4517f43081e2c3bf0df25` | `databricks-gpt-oss-120b` | `"Multiple tool calls are not supported"` — rejected worker history containing parallel tool_calls |
| `tr-7f30e2da4c02accfc11bc08cae54eef2` | `databricks-claude-sonnet-4-5` | `"unexpected tool_use_id in tool_result blocks"` — rejected worker history containing orphan tool_results |

Same root cause, different model's validation rule: with `output_mode='full_history'`, the worker's malformed local history (interleaved `## Memories` system messages from `MemoryContextMiddleware`, parallel tool_calls from Claude-family workers) propagates upward into the supervisor's state via `extract_agent_response`. Any downstream model that strictly validates message structure 400s on the next turn.

`last_message` returns only the worker's final `AIMessage` with `tool_calls` stripped, so none of the worker-side malformed patterns can reach the supervisor.

## Test plan

- [x] **Unit tests** (`tests/dao_ai/test_output_mode_default_regression.py`) — 10 tests covering:
  - Default resolves to `last_message` for supervisor, swarm, and no-mode configs
  - Explicit `full_history` override still works
  - `extract_agent_response` strips tool_calls from final AIMessage
  - Drops interleaved system messages from memory middleware
  - Drops parallel tool_calls from worker assistant messages
  - Orphan tool_results never propagate
- [x] **Integration smoke tests** (`tests/dao_ai/test_orchestration_multi_turn.py`) — 3 tests:
  - `test_supervisor_multi_turn_same_thread_clean_history` — drives 2 turns with same `thread_id` + `user_id` through a supervisor-shaped graph, asserts no orphan tool_results / no parallel tool_calls in parent state
  - `test_swarm_two_workers_multi_turn_clean_history` — same for swarm with 2 chained workers
  - `test_full_history_propagates_parallel_tool_calls_to_parent` — negative reproducer pinning the bug surface under explicit `full_history`
- [x] Updated `TestOrchestrationOutputMode` (`tests/dao_ai/test_orchestration_review_fixes.py`) to assert the new default
- [x] Updated `test_apps_obo_partition.py` to drop `products_vector_store` and `shared_warehouse` from the non-OBO expectation list (they were flipped to OBO in PR #93)
- [x] Full pytest: 2097 passed, 0 failed
- [x] Ruff: clean
- [ ] End-to-end on fevm: redeploy `hardware_store_lakebase` `--deployment-target both` + replay the failing playground sequence

## Follow-up work (vault note `40-reference/dao-ai/vs-provisioning-recovery-followups.md`)

The default flip is a behavioral workaround for two real bugs in worker-side message assembly. The follow-ups properly fix the production of the malformed history at its source:

1. Fix `MemoryContextMiddleware.abefore_model` to return only the delta SystemMessage instead of the full messages list (or splice memories into the prompt template instead of into chat history).
2. Add defensive tool_use/tool_result pairing validation in `extract_agent_response` when output_mode is explicitly `full_history`.
3. Once 1+2 ship, revisit whether to flip the default back.

This pull request and its description were written by Isaac.