### PR TITLE
hardware_store_lakebase: revert supervisor model to gpt-oss-120b

### DIFF
--- a/config/examples/15_complete_applications/hardware_store_lakebase.yaml
+++ b/config/examples/15_complete_applications/hardware_store_lakebase.yaml
@@ -64,12 +64,13 @@ resources:
 
 
     fast_llm: &fast_llm
-      # NOTE: must support parallel tool calls in message history because
-      # worker agents (Claude-family) emit parallel tool_calls and the
-      # supervisor (this model) ingests that history on follow-up turns.
-      # `databricks-gpt-oss-120b` 400s with "Multiple tool calls are not
-      # supported" — see trace tr-fd4dfaea04c4517f43081e2c3bf0df25.
-      name: databricks-claude-sonnet-4-5            # Databricks serving endpoint name
+      # Reverted to gpt-oss-120b after PR #95 flipped the orchestration
+      # output_mode default to `last_message` — the supervisor no longer
+      # ingests worker tool-call history, so the original
+      # "Multiple tool calls are not supported" issue
+      # (trace tr-fd4dfaea04c4517f43081e2c3bf0df25) can't recur.
+      # Restores the cheaper/faster supervisor for routing decisions.
+      name: databricks-gpt-oss-120b                 # Databricks serving endpoint name
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
 


### PR DESCRIPTION
## Summary

- Reverts `fast_llm.name` in `hardware_store_lakebase.yaml` from `databricks-claude-sonnet-4-5` back to `databricks-gpt-oss-120b`.
- Restores the original design intent: cheap/fast model for supervisor routing decisions, smart models for workers.

## Why this is now safe

PR #94 swapped the supervisor model to claude-sonnet-4-5 as a workaround for `"Multiple tool calls are not supported"` 400s from gpt-oss-120b on supervisor turns (trace `tr-fd4dfaea04c4517f43081e2c3bf0df25`). The real bug was upstream — the orchestration framework's default `output_mode: full_history` was propagating worker tool-call history into the supervisor's LLM call. PR #95 flipped the default to `last_message`, so the supervisor's view of conversation history no longer contains worker tool exchanges at all. Any supervisor model — including gpt-oss-120b — now works without the 400.

**Depends on PR #95 being merged first.** Without #95, this would re-introduce the original bug.

## Test plan

- [x] YAML parses cleanly
- [ ] Redeploy `hardware_store_lakebase` `--deployment-target both -p fevm` from this branch (with PR #95 also on main)
- [ ] Replay the multi-turn playground sequence from trace `tr-7f30e2da4c02accfc11bc08cae54eef2` against the redeployed app. Confirm `STATUS_CODE_OK` end-to-end on the supervisor's `ChatDatabricks` span across all turns.
- [ ] Verify the supervisor's responses still route correctly (gpt-oss-120b should be capable of the routing classification — that was its original role).

This pull request and its description were written by Isaac.