### PR TITLE
A2A demo: procurement <-> supplier with AppResource auth modes

### DIFF
--- a/config/examples/10_agent_integrations/a2a_agent.yaml
+++ b/config/examples/10_agent_integrations/a2a_agent.yaml
@@ -105,6 +105,33 @@ tools:
         #   auth_type: none
         #   (omit the ``auth`` arg)
         #
+        # --- Calling another dao-ai Databricks App (AppResource mode) ----
+        #
+        # If the remote agent is itself a dao-ai app deployed on Databricks
+        # Apps, declare it under ``resources.apps`` and reference it via
+        # the ``app`` arg instead of ``endpoint`` / ``auth`` / ``auth_type``.
+        # The factory resolves the URL from ``DatabricksAppModel.url`` and
+        # picks the auth mode from ``app.on_behalf_of_user``:
+        #
+        #     resources:
+        #       apps:
+        #         remote_dao_ai_app: &remote_dao_ai_app
+        #           name: dao-ai-some-other-app
+        #           on_behalf_of_user: true   # -> forwarded_user_token
+        #                                     # false / unset -> databricks_app_sp
+        #
+        #     tools:
+        #       remote_a2a_tool:
+        #         function:
+        #           type: factory
+        #           name: dao_ai.tools.create_a2a_agent_tool
+        #           args:
+        #             app: *remote_dao_ai_app
+        #             # ``endpoint``, ``auth``, ``auth_type`` all auto-derived.
+        #
+        # See ``config/examples/15_complete_applications/procurement_supplier_a2a/``
+        # for a full procurement <-> supplier walkthrough.
+        #
         # --- Card path overrides -----------------------------------------
         #
         # Some deployments expose the agent card at a non-standard path. Both

--- a/config/examples/15_complete_applications/README.md
+++ b/config/examples/15_complete_applications/README.md
@@ -67,6 +67,7 @@ flowchart TB
 | [`hardware_store_lakebase.yaml`](./hardware_store_lakebase.yaml) | 👔 Supervisor + 🧠 Lakebase | Supervisor with PostgreSQL memory persistence |
 | [`hardware_store_instructed.yaml`](./hardware_store_instructed.yaml) | 🎯 Instructed | Hardware store with instructed retrieval |
 | [`sporting_goods_store.yaml`](./sporting_goods_store.yaml) | 👔 Supervisor + 🧠 Lakebase | Merchandiser 360 multi-agent system for sporting goods lifecycle management |
+| [`procurement_supplier_a2a/`](./procurement_supplier_a2a/) | 🔁 A2A pair | Procurement officer agent calls a wholesale-supplier agent over the Google A2A protocol — two coordinated Databricks Apps deployments |
 
 ## Hardware Store Supervisor Architecture
 

--- a/config/examples/15_complete_applications/procurement_supplier_a2a/README.md
+++ b/config/examples/15_complete_applications/procurement_supplier_a2a/README.md
@@ -1,0 +1,211 @@
+# Procurement <-> Supplier (A2A)
+
+End-to-end demo of two dao-ai apps speaking the
+[Google A2A (Agent-to-Agent) protocol](https://a2a-protocol.org).
+
+```text
+[user] -> procurement app -- HTTP A2A --> supplier app -> Foundation Model API
+```
+
+| App | YAML | Role |
+|-----|------|------|
+| `dao-ai-supplier-a2a` | `supplier.yaml` | Wholesale-supplier specialist. Answers SKU, pricing, lead-time, MOQ, and stock questions from an embedded catalog. Exposes A2A by default. |
+| `dao-ai-procurement-a2a` | `procurement.yaml` | Procurement-officer agent. Holds one tool — `query_supplier` — built from `dao_ai.tools.create_a2a_agent_tool`. Delegates supplier questions; adds procurement recommendation on top. |
+
+Both apps run on Foundation Model API only — no Unity Catalog tables,
+Vector Search indexes, or Genie rooms required.
+
+---
+
+## Deployment workflow
+
+The supplier MUST be deployed first so its URL is known before the
+procurement app is configured.
+
+### 1. Deploy the supplier app
+
+```bash
+cd <repo root>
+
+# (Validate first — purely local; no workspace round-trip.)
+uv run dao-ai validate \
+  -c config/examples/15_complete_applications/procurement_supplier_a2a/supplier.yaml
+
+# Deploy.
+uv run dao-ai pipeline --deploy --run \
+  -c config/examples/15_complete_applications/procurement_supplier_a2a/supplier.yaml
+```
+
+### 2. Capture the supplier URL
+
+```bash
+SUPPLIER_URL=$(databricks apps get dao-ai-supplier-a2a --output json | jq -r .url)
+echo "$SUPPLIER_URL"
+# Sanity-check the Agent Card is being served.
+curl -sf "$SUPPLIER_URL/.well-known/agent-card.json" | jq '.name, .version'
+```
+
+### 3. Provide endpoint + token to the procurement app
+
+The procurement app reads `SUPPLIER_A2A_ENDPOINT` and `SUPPLIER_A2A_TOKEN`
+from env vars OR the `procurement_supplier_a2a` secret scope. Either form
+works — env vars are easiest for local iteration; secrets are required
+for production Apps deployments.
+
+**Env-var form (local iteration / `dao-ai chat`):**
+
+```bash
+export SUPPLIER_A2A_ENDPOINT="$SUPPLIER_URL"
+# Use the procurement service principal's OAuth M2M token.
+export SUPPLIER_A2A_TOKEN=$(databricks auth token --profile <procurement-m2m-profile> | jq -r .access_token)
+```
+
+**Secret-scope form (deployed Apps):**
+
+```bash
+databricks secrets create-scope procurement_supplier_a2a
+databricks secrets put-secret procurement_supplier_a2a SUPPLIER_A2A_ENDPOINT \
+  --string-value "$SUPPLIER_URL"
+databricks secrets put-secret procurement_supplier_a2a SUPPLIER_A2A_TOKEN \
+  --string-value "$(databricks auth token --profile <procurement-m2m-profile> | jq -r .access_token)"
+```
+
+The procurement app's SP also needs `CAN_VIEW` on the supplier app — this
+is requested automatically by the `resources.apps.supplier_app` binding
+in `procurement.yaml`; review and approve it in the Apps UI on first
+deploy.
+
+### 4. Deploy the procurement app
+
+```bash
+uv run dao-ai validate \
+  -c config/examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml
+
+uv run dao-ai pipeline --deploy --run \
+  -c config/examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml
+```
+
+### 5. Try it end-to-end
+
+Pick a transport — the procurement app speaks both A2A and the MLflow
+Responses contract.
+
+**Over the Responses API (chat-style):**
+
+```bash
+PROC_URL=$(databricks apps get dao-ai-procurement-a2a --output json | jq -r .url)
+TOKEN=$(databricks auth token | jq -r .access_token)
+
+curl -sf -X POST "$PROC_URL/invocations" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      {"role": "user",
+       "content": "Quote 1,200 of ACM-HB-08 and confirm whether the lead time works for an Aug-15 build."}
+    ]
+  }' | jq
+```
+
+**Over A2A (treating the procurement app as a remote A2A agent):**
+
+```bash
+PROC_URL=$(databricks apps get dao-ai-procurement-a2a --output json | jq -r .url)
+TOKEN=$(databricks auth token | jq -r .access_token)
+
+# Inspect the procurement app's Agent Card.
+curl -sf "$PROC_URL/.well-known/agent-card.json" \
+  -H "Authorization: Bearer $TOKEN" | jq
+
+# Send a message.
+curl -sf -X POST "$PROC_URL/a2a" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "demo-1",
+    "method": "message/send",
+    "params": {
+      "message": {
+        "role": "user",
+        "parts": [
+          {"kind": "text",
+           "text": "Quote 1,200 of ACM-HB-08 and confirm the lead time works for an Aug-15 build."}
+        ]
+      }
+    }
+  }' | jq
+```
+
+`examples/a2a/client.py` in the dao-ai repo is a slightly fuller A2A
+client; it works against either app.
+
+---
+
+## What's happening under the hood
+
+1. The procurement agent receives the user message.
+2. Its prompt mandates calling `query_supplier` for supplier-domain
+   questions, so the LLM emits a tool call.
+3. `query_supplier` is a `StructuredTool` built by
+   `dao_ai.tools.create_a2a_agent_tool`. It:
+   - Resolves the supplier's Agent Card at
+     `${SUPPLIER_A2A_ENDPOINT}/.well-known/agent-card.json`.
+   - Opens an A2A `message/send` stream (JSON-RPC 2.0 over SSE).
+   - Forwards `runtime.context.thread_id` as the A2A `Message.context_id`
+     so multi-turn state persists server-side on the supplier.
+   - Drains the stream, aggregates every agent text part, and returns
+     one string to the LLM.
+4. The procurement agent layers a procurement recommendation on top of
+   the supplier's quote and returns the combined reply.
+
+MLflow traces span both apps. The procurement trace shows a `query_supplier`
+tool span with embedded A2A streaming attributes
+(`dao_ai.a2a.endpoint_url`, `dao_ai.a2a.stream.terminal_state`, etc.);
+the supplier trace shows the LLM call serving the request.
+
+---
+
+## OBO and identity propagation
+
+| Hop | OBO today? | How |
+|-----|------------|-----|
+| user -> procurement LLM | **Yes** | `procurement_llm.on_behalf_of_user: true` — the Apps proxy forwards `x-forwarded-access-token`; dao-ai routes the LLM call as the user. |
+| procurement app -> supplier app | **No (SP only)** | Cross-app OBO is not supported by Databricks Apps yet (see comment at `src/dao_ai/apps/resources.py:124`). The A2A call uses the procurement SP's OAuth M2M bearer. |
+| supplier app -> supplier LLM | **Yes** | `supplier_llm.on_behalf_of_user: true`. *If* the procurement-side A2A tool ever forwards a user token, the chain remains user-attributed end-to-end. |
+
+When cross-app OBO ships, set `on_behalf_of_user: true` on
+`resources.apps.supplier_app` in `procurement.yaml` and switch the
+A2A tool to forward the user token — both apps already have the OBO
+flag set on their LLMs.
+
+---
+
+## Iterating
+
+For tight feedback loops use `dao-ai chat` against either config:
+
+```bash
+# Local chat against the supplier alone (no A2A involved).
+uv run dao-ai chat \
+  -c config/examples/15_complete_applications/procurement_supplier_a2a/supplier.yaml
+
+# Local chat against the procurement agent. Requires the supplier app
+# to be deployed and SUPPLIER_A2A_ENDPOINT/TOKEN env vars set.
+uv run dao-ai chat \
+  -c config/examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml
+```
+
+For deploy iteration on either app, prefer
+`databricks jobs repair-run` on the failed task over a full
+`--deploy --run` cycle.
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `supplier.yaml` | Supplier-side dao-ai config (embedded catalog, no UC deps). |
+| `procurement.yaml` | Procurement-side dao-ai config (single A2A tool). |
+| `README.md` | You are here. |

--- a/config/examples/15_complete_applications/procurement_supplier_a2a/README.md
+++ b/config/examples/15_complete_applications/procurement_supplier_a2a/README.md
@@ -10,72 +10,85 @@ End-to-end demo of two dao-ai apps speaking the
 | App | YAML | Role |
 |-----|------|------|
 | `dao-ai-supplier-a2a` | `supplier.yaml` | Wholesale-supplier specialist. Answers SKU, pricing, lead-time, MOQ, and stock questions from an embedded catalog. Exposes A2A by default. |
-| `dao-ai-procurement-a2a` | `procurement.yaml` | Procurement-officer agent. Holds one tool — `query_supplier` — built from `dao_ai.tools.create_a2a_agent_tool`. Delegates supplier questions; adds procurement recommendation on top. |
+| `dao-ai-procurement-a2a` | `procurement.yaml` | Procurement-officer agent. Holds one tool — `query_supplier` — built from `dao_ai.tools.create_a2a_agent_tool` in **AppResource mode**: the supplier app is passed in directly via `app: *supplier_app`, and the tool resolves both the endpoint and the auth mode from it. |
 
 Both apps run on Foundation Model API only — no Unity Catalog tables,
 Vector Search indexes, or Genie rooms required.
 
 ---
 
+## Why AppResource mode
+
+The procurement app declares the supplier as a first-class Databricks
+App resource and hands that resource straight to the A2A tool:
+
+```yaml
+resources:
+  apps:
+    supplier_app: &supplier_app
+      name: dao-ai-supplier-a2a
+      on_behalf_of_user: true
+
+tools:
+  query_supplier:
+    function:
+      type: factory
+      name: dao_ai.tools.create_a2a_agent_tool
+      args:
+        app: *supplier_app
+```
+
+The factory then:
+
+1. Looks up the supplier app's deployed URL via
+   `DatabricksAppModel.url` (no `SUPPLIER_A2A_ENDPOINT` env var or
+   secret needed).
+2. Picks the auth mode from `supplier_app.on_behalf_of_user`:
+
+| `supplier_app.on_behalf_of_user` | Auth used | What the supplier sees |
+|---|---|---|
+| `true` (this demo) | **`forwarded_user_token`** — read `runtime.context.headers["x-forwarded-access-token"]` per call | The calling end user. Combined with `supplier_llm.on_behalf_of_user: true`, the supplier's LLM call runs as that user. |
+| `false` / unset | **`databricks_app_sp`** — mint a fresh M2M header from the ambient `WorkspaceClient().config.authenticate()` per call | The procurement service principal. Useful for server-to-server / scheduled pipelines where there's no calling user. |
+
+You can still pin `auth_type:` explicitly in the tool args to override
+the app-derived default (e.g. force App-SP M2M against an OBO-tagged
+app, or attach a custom static bearer).
+
+The tool also keeps its original **manual-endpoint mode** for external /
+non-Databricks A2A agents (Vertex, third-party Crew.ai / LangGraph,
+public agents). See
+`config/examples/10_agent_integrations/a2a_agent.yaml` for that
+variant.
+
+---
+
 ## Deployment workflow
 
-The supplier MUST be deployed first so its URL is known before the
-procurement app is configured.
+The supplier MUST be deployed first so its URL is resolvable by
+`DatabricksAppModel.url` when the procurement app boots.
 
 ### 1. Deploy the supplier app
 
 ```bash
 cd <repo root>
 
-# (Validate first — purely local; no workspace round-trip.)
 uv run dao-ai validate \
   -c config/examples/15_complete_applications/procurement_supplier_a2a/supplier.yaml
 
-# Deploy.
 uv run dao-ai pipeline --deploy --run \
   -c config/examples/15_complete_applications/procurement_supplier_a2a/supplier.yaml
 ```
 
-### 2. Capture the supplier URL
+### 2. (Optional) Sanity-check the supplier
 
 ```bash
 SUPPLIER_URL=$(databricks apps get dao-ai-supplier-a2a --output json | jq -r .url)
-echo "$SUPPLIER_URL"
-# Sanity-check the Agent Card is being served.
-curl -sf "$SUPPLIER_URL/.well-known/agent-card.json" | jq '.name, .version'
+TOKEN=$(databricks auth token | jq -r .access_token)
+curl -sf "$SUPPLIER_URL/.well-known/agent-card.json" \
+  -H "Authorization: Bearer $TOKEN" | jq '.name, .version'
 ```
 
-### 3. Provide endpoint + token to the procurement app
-
-The procurement app reads `SUPPLIER_A2A_ENDPOINT` and `SUPPLIER_A2A_TOKEN`
-from env vars OR the `procurement_supplier_a2a` secret scope. Either form
-works — env vars are easiest for local iteration; secrets are required
-for production Apps deployments.
-
-**Env-var form (local iteration / `dao-ai chat`):**
-
-```bash
-export SUPPLIER_A2A_ENDPOINT="$SUPPLIER_URL"
-# Use the procurement service principal's OAuth M2M token.
-export SUPPLIER_A2A_TOKEN=$(databricks auth token --profile <procurement-m2m-profile> | jq -r .access_token)
-```
-
-**Secret-scope form (deployed Apps):**
-
-```bash
-databricks secrets create-scope procurement_supplier_a2a
-databricks secrets put-secret procurement_supplier_a2a SUPPLIER_A2A_ENDPOINT \
-  --string-value "$SUPPLIER_URL"
-databricks secrets put-secret procurement_supplier_a2a SUPPLIER_A2A_TOKEN \
-  --string-value "$(databricks auth token --profile <procurement-m2m-profile> | jq -r .access_token)"
-```
-
-The procurement app's SP also needs `CAN_VIEW` on the supplier app — this
-is requested automatically by the `resources.apps.supplier_app` binding
-in `procurement.yaml`; review and approve it in the Apps UI on first
-deploy.
-
-### 4. Deploy the procurement app
+### 3. Deploy the procurement app
 
 ```bash
 uv run dao-ai validate \
@@ -85,17 +98,19 @@ uv run dao-ai pipeline --deploy --run \
   -c config/examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml
 ```
 
-### 5. Try it end-to-end
+No env vars, no secret scopes, no manual token minting — the
+`resources.apps.supplier_app` binding gives the procurement SP
+`CAN_VIEW` on the supplier (the platform may prompt you to approve
+this on first deploy in the Apps UI), and the A2A tool handles the
+rest at runtime.
 
-Pick a transport — the procurement app speaks both A2A and the MLflow
-Responses contract.
-
-**Over the Responses API (chat-style):**
+### 4. Try it end-to-end
 
 ```bash
 PROC_URL=$(databricks apps get dao-ai-procurement-a2a --output json | jq -r .url)
 TOKEN=$(databricks auth token | jq -r .access_token)
 
+# Responses-API form.
 curl -sf -X POST "$PROC_URL/invocations" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
@@ -105,19 +120,10 @@ curl -sf -X POST "$PROC_URL/invocations" \
        "content": "Quote 1,200 of ACM-HB-08 and confirm whether the lead time works for an Aug-15 build."}
     ]
   }' | jq
-```
 
-**Over A2A (treating the procurement app as a remote A2A agent):**
-
-```bash
-PROC_URL=$(databricks apps get dao-ai-procurement-a2a --output json | jq -r .url)
-TOKEN=$(databricks auth token | jq -r .access_token)
-
-# Inspect the procurement app's Agent Card.
+# A2A form.
 curl -sf "$PROC_URL/.well-known/agent-card.json" \
   -H "Authorization: Bearer $TOKEN" | jq
-
-# Send a message.
 curl -sf -X POST "$PROC_URL/a2a" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
@@ -142,48 +148,48 @@ client; it works against either app.
 
 ---
 
-## What's happening under the hood
+## Identity propagation (with AppResource mode)
 
-1. The procurement agent receives the user message.
-2. Its prompt mandates calling `query_supplier` for supplier-domain
-   questions, so the LLM emits a tool call.
-3. `query_supplier` is a `StructuredTool` built by
-   `dao_ai.tools.create_a2a_agent_tool`. It:
-   - Resolves the supplier's Agent Card at
-     `${SUPPLIER_A2A_ENDPOINT}/.well-known/agent-card.json`.
-   - Opens an A2A `message/send` stream (JSON-RPC 2.0 over SSE).
-   - Forwards `runtime.context.thread_id` as the A2A `Message.context_id`
-     so multi-turn state persists server-side on the supplier.
-   - Drains the stream, aggregates every agent text part, and returns
-     one string to the LLM.
-4. The procurement agent layers a procurement recommendation on top of
-   the supplier's quote and returns the combined reply.
+| Hop | Auth in this demo (`supplier_app.on_behalf_of_user: true`) | Auth with flag unset / false |
+|-----|---|---|
+| user → procurement LLM | ✅ User OBO (`procurement_llm.on_behalf_of_user: true`) | ✅ User OBO |
+| procurement app → supplier app | ✅ User bearer forwarded by the A2A tool (`forwarded_user_token`) | 🅼 Procurement-SP OAuth M2M (`databricks_app_sp`) — fresh per call via `WorkspaceClient().config.authenticate()` |
+| supplier app → supplier LLM | ✅ User OBO (`supplier_llm.on_behalf_of_user: true` sees the same user) | ⚠️ Procurement-SP OBO — the supplier's OBO-tagged LLM resolves as the procurement SP rather than a human |
 
-MLflow traces span both apps. The procurement trace shows a `query_supplier`
-tool span with embedded A2A streaming attributes
-(`dao_ai.a2a.endpoint_url`, `dao_ai.a2a.stream.terminal_state`, etc.);
-the supplier trace shows the LLM call serving the request.
+Notes:
+
+* Cross-app OBO is **not yet** supported at the Databricks Apps
+  platform layer — the `apps.apps` scope has no corresponding
+  `user_api_scope` (see `src/dao_ai/apps/resources.py:124`). The
+  forwarding above happens **at the dao-ai tool layer** and is
+  implemented in `dao_ai.tools.a2a_agent.create_a2a_agent_tool`.
+* Setting `on_behalf_of_user: true` on the procurement `apps.<key>`
+  entry is therefore not a no-op: the dao-ai factory uses it to pick
+  the right auth mode even though the platform itself doesn't emit a
+  user scope for it.
 
 ---
 
-## OBO and identity propagation
+## When to use which mode
 
-| Hop | OBO today? | How |
-|-----|------------|-----|
-| user -> procurement LLM | **Yes** | `procurement_llm.on_behalf_of_user: true` — the Apps proxy forwards `x-forwarded-access-token`; dao-ai routes the LLM call as the user. |
-| procurement app -> supplier app | **No (SP only)** | Cross-app OBO is not supported by Databricks Apps yet (see comment at `src/dao_ai/apps/resources.py:124`). The A2A call uses the procurement SP's OAuth M2M bearer. |
-| supplier app -> supplier LLM | **Yes** | `supplier_llm.on_behalf_of_user: true`. *If* the procurement-side A2A tool ever forwards a user token, the chain remains user-attributed end-to-end. |
+* **`on_behalf_of_user: true`** → end-to-end user attribution. Pick
+  this for user-facing apps where the audit trail must point at the
+  human. Inbound caller must be a user (or service that proxies a user
+  bearer), otherwise the `forwarded_user_token` mode raises a clear
+  runtime error.
+* **`on_behalf_of_user: false` / unset** → App-SP M2M. Pick this for
+  server-to-server pipelines, scheduled jobs invoking the procurement
+  app, or anywhere there's no calling user (e.g. batch reprocessing).
+  The ambient `WorkspaceClient` mints a fresh M2M header per call from
+  the auto-injected `DATABRICKS_CLIENT_ID` / `DATABRICKS_CLIENT_SECRET`
+  env vars that the Apps runtime provides.
 
-When cross-app OBO ships, set `on_behalf_of_user: true` on
-`resources.apps.supplier_app` in `procurement.yaml` and switch the
-A2A tool to forward the user token — both apps already have the OBO
-flag set on their LLMs.
+To swap modes on the fly: change the flag in `procurement.yaml`,
+re-deploy. No code edits needed.
 
 ---
 
 ## Iterating
-
-For tight feedback loops use `dao-ai chat` against either config:
 
 ```bash
 # Local chat against the supplier alone (no A2A involved).
@@ -191,7 +197,7 @@ uv run dao-ai chat \
   -c config/examples/15_complete_applications/procurement_supplier_a2a/supplier.yaml
 
 # Local chat against the procurement agent. Requires the supplier app
-# to be deployed and SUPPLIER_A2A_ENDPOINT/TOKEN env vars set.
+# to be deployed (so DatabricksAppModel.url can resolve at startup).
 uv run dao-ai chat \
   -c config/examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml
 ```
@@ -207,5 +213,5 @@ For deploy iteration on either app, prefer
 | File | Purpose |
 |------|---------|
 | `supplier.yaml` | Supplier-side dao-ai config (embedded catalog, no UC deps). |
-| `procurement.yaml` | Procurement-side dao-ai config (single A2A tool). |
+| `procurement.yaml` | Procurement-side dao-ai config (one A2A tool using AppResource mode). |
 | `README.md` | You are here. |

--- a/config/examples/15_complete_applications/procurement_supplier_a2a/README.md
+++ b/config/examples/15_complete_applications/procurement_supplier_a2a/README.md
@@ -64,8 +64,11 @@ variant.
 
 ## Deployment workflow
 
-The supplier MUST be deployed first so its URL is resolvable by
-`DatabricksAppModel.url` when the procurement app boots.
+The supplier must be deployed before the procurement app makes its
+first `query_supplier` tool call (the A2A tool resolves the supplier
+URL lazily via `DatabricksAppModel.url` on first invocation and caches
+it for the lifetime of the worker). In practice that means: deploy
+supplier first, then procurement, then exercise.
 
 ### 1. Deploy the supplier app
 
@@ -100,7 +103,7 @@ uv run dao-ai pipeline --deploy --run \
 
 No env vars, no secret scopes, no manual token minting — the
 `resources.apps.supplier_app` binding gives the procurement SP
-`CAN_VIEW` on the supplier (the platform may prompt you to approve
+`CAN_USE` on the supplier (the platform may prompt you to approve
 this on first deploy in the Apps UI), and the A2A tool handles the
 rest at runtime.
 
@@ -110,12 +113,12 @@ rest at runtime.
 PROC_URL=$(databricks apps get dao-ai-procurement-a2a --output json | jq -r .url)
 TOKEN=$(databricks auth token | jq -r .access_token)
 
-# Responses-API form.
+# Responses-API form (uses ``input``, not ``messages``).
 curl -sf -X POST "$PROC_URL/invocations" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "messages": [
+    "input": [
       {"role": "user",
        "content": "Quote 1,200 of ACM-HB-08 and confirm whether the lead time works for an Aug-15 build."}
     ]
@@ -145,6 +148,46 @@ curl -sf -X POST "$PROC_URL/a2a" \
 
 `examples/a2a/client.py` in the dao-ai repo is a slightly fuller A2A
 client; it works against either app.
+
+---
+
+## Verifying the supplier was actually called
+
+The agent's prompt forbids answering supplier-domain questions from
+memory (rule 1 in `procurement.yaml`), and all SKUs in the supplier
+catalog are fictional (`ACM-*`). So any reply containing a real
+catalog fact must have come from a live A2A call. Pick a prompt with a
+unique tell:
+
+| Prompt | Catalog fact only the supplier knows |
+|---|---|
+| "What is the current stock and lead time on ACM-DR-3?" | Stock = **72**, lead time = **14 days** |
+| "Quote me 2,500 of ACM-LT-25 at the highest bulk tier." | Tier-2 price = **$0.37**, MOQ 100, stock 3,150 |
+| "List every SKU Acme carries with its lead time." | Should enumerate all 7 SKUs in `supplier.yaml`'s embedded table |
+
+To watch it happen in real time, tail the procurement app's log stream
+in a second terminal — `create_a2a_agent_tool` logs an
+`Invoking A2A agent` line before every hop:
+
+```bash
+PROC_URL=$(databricks apps get dao-ai-procurement-a2a --output json | jq -r .url)
+TOKEN=$(databricks auth token | jq -r .access_token)
+
+curl -sN -H "Authorization: Bearer $TOKEN" "$PROC_URL/logz/stream?source=APP" \
+  | grep --line-buffered -E "Invoking A2A agent|query_supplier|dao_ai.a2a"
+```
+
+You should see something like:
+
+```
+INFO  dao_ai.tools.a2a_agent:a2a_agent - Invoking A2A agent
+  endpoint=https://dao-ai-supplier-a2a-<workspace-id>.aws.databricksapps.com
+  prompt_chars=… context_id=… user_id=… streaming=True
+```
+
+For a negative control, ask a non-supplier question (e.g. *"What's our
+internal PO approval policy?"*) — rule 4 says the agent should answer
+directly. No `Invoking A2A agent` line should appear.
 
 ---
 
@@ -196,15 +239,25 @@ re-deploy. No code edits needed.
 uv run dao-ai chat \
   -c config/examples/15_complete_applications/procurement_supplier_a2a/supplier.yaml
 
-# Local chat against the procurement agent. Requires the supplier app
-# to be deployed (so DatabricksAppModel.url can resolve at startup).
+# Local chat against the procurement agent. The supplier app does NOT
+# need to be deployed for the chat to start (the A2A tool resolves the
+# supplier URL lazily on first call). It does need to be deployed
+# before you ask any supplier-domain question, otherwise the first
+# tool call errors out.
 uv run dao-ai chat \
   -c config/examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml
 ```
 
-For deploy iteration on either app, prefer
-`databricks jobs repair-run` on the failed task over a full
-`--deploy --run` cycle.
+For deploy iteration on either app:
+
+```bash
+# Re-upload source + reapply resources (no full app restart).
+cd <generated-bundle-dir>
+databricks bundle deploy --target dev -p fevm
+
+# Or, if only the source code changed, just redeploy the app body.
+databricks apps deploy <app-name> --source-code-path ${WORKSPACE_BUNDLE_FILES_PATH} -p fevm
+```
 
 ---
 

--- a/config/examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml
+++ b/config/examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml
@@ -1,0 +1,178 @@
+# yaml-language-server: $schema=../../../../schemas/model_config_schema.json
+#
+# Procurement-side dao-ai app for the A2A procurement <-> supplier demo.
+#
+# This app deploys as a Databricks App. Its agent persona is a procurement
+# officer who delegates supplier-domain questions to the **supplier** dao-ai
+# app (``supplier.yaml`` in this directory) over the Google A2A
+# (Agent-to-Agent) protocol.
+#
+# Architecture:
+#
+#     [user] -> procurement app (Databricks App)
+#                   |
+#                   |  HTTP A2A (POST /a2a, GET /.well-known/agent-card.json)
+#                   v
+#               supplier app (Databricks App)
+#                   |
+#                   |  Foundation Model API
+#                   v
+#                databricks-gpt-5-4-mini
+#
+# The supplier app is declared as a first-class ``resources.apps`` resource
+# below so the procurement app's deployment carries an explicit dependency
+# binding (visible in the Apps UI and surfaced to the Apps platform). Note:
+# Databricks Apps does NOT yet support cross-app OBO scopes — see the
+# comment at ``src/dao_ai/apps/resources.py:124``. So the resources.apps
+# entry omits ``on_behalf_of_user`` (it would be a no-op). OBO stays on
+# the procurement LLM, where the platform DOES support it.
+#
+# Pair with ``supplier.yaml``. See ``README.md`` for the deploy workflow.
+
+variables:
+  # Base URL of the deployed supplier app. After the supplier app is
+  # deployed, its URL is available via:
+  #     databricks apps get dao-ai-supplier-a2a --output json | jq -r .url
+  # Set the env var ``SUPPLIER_A2A_ENDPOINT`` before ``dao-ai pipeline``,
+  # OR pre-populate the ``procurement_supplier_a2a`` secret scope with
+  # ``SUPPLIER_A2A_ENDPOINT``. The fallback inline value is the conventional
+  # ``-<workspace-id>.aws.databricksapps.com`` pattern but should be
+  # overridden in any real deployment.
+  supplier_endpoint: &supplier_endpoint
+    options:
+      - env: SUPPLIER_A2A_ENDPOINT
+      - scope: procurement_supplier_a2a
+        secret: SUPPLIER_A2A_ENDPOINT
+
+  # OAuth M2M token the procurement app SP uses to call the supplier app.
+  # Cross-app OBO is not supported today, so the procurement app calls the
+  # supplier with its own SP token. The token is minted via
+  # ``databricks auth token --profile <procurement-m2m-profile>`` and
+  # stored in the secret scope below — OR injected as an env var at
+  # ``app.yaml`` resource time once the supplier-app resource binding
+  # surfaces credentials (Apps platform feature).
+  supplier_token: &supplier_token
+    options:
+      - env: SUPPLIER_A2A_TOKEN
+      - scope: procurement_supplier_a2a
+        secret: SUPPLIER_A2A_TOKEN
+
+resources:
+  models:
+    procurement_llm: &procurement_llm
+      name: databricks-gpt-5-4-mini
+      temperature: 0.1
+      max_tokens: 4096
+      # OBO on the procurement-side LLM. The Databricks Apps proxy forwards
+      # the calling user's token, so inference traces are attributed to the
+      # actual user. The downstream A2A call to the supplier is still SP-
+      # authenticated until cross-app OBO ships.
+      on_behalf_of_user: true
+
+  # Declare the supplier app as a Databricks App resource of the procurement
+  # app. This becomes an ``app`` entry in the generated app.yaml resources
+  # list (see _extract_app_resources in src/dao_ai/apps/resources.py) so the
+  # cross-app dependency is explicit in the Apps UI. We intentionally do
+  # NOT set ``on_behalf_of_user`` here because cross-app OBO is not yet
+  # supported by the Databricks Apps platform — the api_scope ``apps.apps``
+  # has no corresponding user_api_scope and would be silently dropped.
+  apps:
+    supplier_app: &supplier_app
+      name: dao-ai-supplier-a2a
+
+prompts:
+  procurement_prompt: &procurement_prompt
+    name: procurement_agent_prompt
+    description: >
+      System prompt for the procurement officer agent that delegates
+      supplier-specific questions to the Acme Industrial Supply A2A agent.
+    default_template: |
+      You are a **procurement officer** for a mid-size manufacturing
+      company. You shepherd material requests from internal stakeholders
+      through the supplier-quote process.
+
+      You have one delegation tool: ``query_supplier``. It reaches the
+      ``Acme Industrial Supply`` agent over the Google A2A protocol.
+
+      # Rules
+
+      1. **Always call ``query_supplier`` for supplier-domain questions**:
+         pricing, lead times, MOQs, stock, SKU lookups, bulk quotes.
+         Do NOT answer from memory — the supplier is authoritative.
+      2. Pass the user's question through verbatim (or a lightly
+         restructured version) so the supplier has full context.
+      3. After receiving the supplier's reply:
+         - Restate the quote / answer back to the user.
+         - Add a **procurement recommendation** (1-2 sentences): is this
+           a good deal, are there alternatives to consider, do we need
+           multiple suppliers, is the lead time acceptable for our
+           typical reorder cadence?
+         - Surface any **flags** (MOQ violations, lead-time risks, stock
+           constraints) that the supplier raised.
+      4. For non-supplier questions (policy, internal process, general
+         procurement guidance), answer directly without calling the tool.
+      5. Be concise. Procurement officers value signal over filler.
+
+tools:
+  query_supplier: &query_supplier
+    name: query_supplier
+    function:
+      type: factory
+      name: dao_ai.tools.create_a2a_agent_tool
+      args:
+        name: query_supplier
+        description: |
+          Delegate a question to the Acme Industrial Supply wholesale
+          supplier agent over the Google A2A (Agent-to-Agent) protocol.
+          Use for any supplier-domain question: SKU lookups, unit and
+          bulk pricing, lead times, MOQs, and live stock. Pass the
+          procurement officer's question through as the ``prompt``
+          argument.
+        endpoint: *supplier_endpoint
+        # OAuth M2M token for the procurement app SP. Cross-app OBO is
+        # not yet supported by Databricks Apps (see header comment); the
+        # supplier-side LLM still runs as the calling user thanks to its
+        # own ``on_behalf_of_user: true`` flag and the Apps proxy chain.
+        auth: *supplier_token
+        auth_type: bearer
+        # Multi-turn continuity: runtime.context.thread_id is forwarded
+        # as A2A ``Message.context_id`` automatically, and the user_id is
+        # forwarded as ``Message.metadata["dao_ai.user_id"]``.
+        streaming: true
+
+agents:
+  procurement_agent: &procurement_agent
+    name: procurement_agent
+    description: >
+      Procurement officer agent. Delegates supplier-domain questions to
+      the Acme Industrial Supply A2A agent and adds a procurement-side
+      recommendation on top of every quote.
+    model: *procurement_llm
+    tools:
+      - *query_supplier
+    prompt: *procurement_prompt
+
+memory: &memory
+  checkpointer:
+    name: procurement_checkpointer
+
+app:
+  name: dao-ai-procurement-a2a
+  description: >
+    Procurement officer agent that calls Acme Industrial Supply via A2A.
+    Paired with supplier.yaml in this directory; see README.md.
+  log_level: INFO
+  deployment_target: apps
+  agents:
+    - *procurement_agent
+  orchestration:
+    memory: *memory
+  # Procurement app ALSO exposes the A2A surface so it can itself be
+  # called by an upstream agent (e.g. a finance or planning agent) — A2A
+  # is bidirectional by default.
+  a2a:
+    enabled: true
+  input_example:
+    messages:
+      - role: user
+        content: "We need 1,200 of M8 hex bolts (zinc, 30mm) for the Q3 line. Quote it and tell me if the lead time works for an Aug-15 build."

--- a/config/examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml
+++ b/config/examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml
@@ -135,10 +135,6 @@ agents:
       - *query_supplier
     prompt: *procurement_prompt
 
-memory: &memory
-  checkpointer:
-    name: procurement_checkpointer
-
 app:
   name: dao-ai-procurement-a2a
   description: >
@@ -148,13 +144,10 @@ app:
   deployment_target: apps
   agents:
     - *procurement_agent
-  orchestration:
-    memory: *memory
-  # Procurement app ALSO exposes the A2A surface so it can itself be
-  # called by an upstream agent (e.g. a finance or planning agent) —
-  # A2A is bidirectional by default.
-  a2a:
-    enabled: true
+  # ``a2a`` is omitted — every Databricks Apps deployment exposes A2A
+  # by default, so the procurement app is itself reachable as an A2A
+  # agent (e.g. by an upstream finance / planning agent).
+  # ``orchestration.memory`` is omitted — no HITL, no deep-agent state.
   input_example:
     messages:
       - role: user

--- a/config/examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml
+++ b/config/examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml
@@ -2,12 +2,10 @@
 #
 # Procurement-side dao-ai app for the A2A procurement <-> supplier demo.
 #
-# This app deploys as a Databricks App. Its agent persona is a procurement
-# officer who delegates supplier-domain questions to the **supplier** dao-ai
-# app (``supplier.yaml`` in this directory) over the Google A2A
+# Deploys as a Databricks App. The agent's persona is a procurement
+# officer who delegates supplier-domain questions to the **supplier**
+# dao-ai app (``supplier.yaml`` in this directory) over the Google A2A
 # (Agent-to-Agent) protocol.
-#
-# Architecture:
 #
 #     [user] -> procurement app (Databricks App)
 #                   |
@@ -19,43 +17,17 @@
 #                   v
 #                databricks-gpt-5-4-mini
 #
-# The supplier app is declared as a first-class ``resources.apps`` resource
-# below so the procurement app's deployment carries an explicit dependency
-# binding (visible in the Apps UI and surfaced to the Apps platform). Note:
-# Databricks Apps does NOT yet support cross-app OBO scopes — see the
-# comment at ``src/dao_ai/apps/resources.py:124``. So the resources.apps
-# entry omits ``on_behalf_of_user`` (it would be a no-op). OBO stays on
-# the procurement LLM, where the platform DOES support it.
+# The supplier app is declared under ``resources.apps`` and passed
+# directly to the ``query_supplier`` A2A tool via ``app: *supplier_app``.
+# The tool then:
+#
+#   1. Resolves the supplier's URL via ``DatabricksAppModel.url`` (no
+#      env vars / secrets needed).
+#   2. Picks an auth mode based on ``supplier_app.on_behalf_of_user``:
+#        * ``true``  -> forwarded_user_token  (user OBO end-to-end)
+#        * ``false`` -> databricks_app_sp     (procurement-SP M2M)
 #
 # Pair with ``supplier.yaml``. See ``README.md`` for the deploy workflow.
-
-variables:
-  # Base URL of the deployed supplier app. After the supplier app is
-  # deployed, its URL is available via:
-  #     databricks apps get dao-ai-supplier-a2a --output json | jq -r .url
-  # Set the env var ``SUPPLIER_A2A_ENDPOINT`` before ``dao-ai pipeline``,
-  # OR pre-populate the ``procurement_supplier_a2a`` secret scope with
-  # ``SUPPLIER_A2A_ENDPOINT``. The fallback inline value is the conventional
-  # ``-<workspace-id>.aws.databricksapps.com`` pattern but should be
-  # overridden in any real deployment.
-  supplier_endpoint: &supplier_endpoint
-    options:
-      - env: SUPPLIER_A2A_ENDPOINT
-      - scope: procurement_supplier_a2a
-        secret: SUPPLIER_A2A_ENDPOINT
-
-  # OAuth M2M token the procurement app SP uses to call the supplier app.
-  # Cross-app OBO is not supported today, so the procurement app calls the
-  # supplier with its own SP token. The token is minted via
-  # ``databricks auth token --profile <procurement-m2m-profile>`` and
-  # stored in the secret scope below — OR injected as an env var at
-  # ``app.yaml`` resource time once the supplier-app resource binding
-  # surfaces credentials (Apps platform feature).
-  supplier_token: &supplier_token
-    options:
-      - env: SUPPLIER_A2A_TOKEN
-      - scope: procurement_supplier_a2a
-        secret: SUPPLIER_A2A_TOKEN
 
 resources:
   models:
@@ -63,54 +35,66 @@ resources:
       name: databricks-gpt-5-4-mini
       temperature: 0.1
       max_tokens: 4096
-      # OBO on the procurement-side LLM. The Databricks Apps proxy forwards
-      # the calling user's token, so inference traces are attributed to the
-      # actual user. The downstream A2A call to the supplier is still SP-
-      # authenticated until cross-app OBO ships.
+      # OBO on the procurement-side LLM. The Databricks Apps proxy
+      # forwards the calling user's token (``x-forwarded-access-token``),
+      # so inference traces are attributed to the actual user. When the
+      # tool's auth mode is ``forwarded_user_token`` (the default below)
+      # that same token is propagated to the supplier app.
       on_behalf_of_user: true
 
-  # Declare the supplier app as a Databricks App resource of the procurement
-  # app. This becomes an ``app`` entry in the generated app.yaml resources
-  # list (see _extract_app_resources in src/dao_ai/apps/resources.py) so the
-  # cross-app dependency is explicit in the Apps UI. We intentionally do
-  # NOT set ``on_behalf_of_user`` here because cross-app OBO is not yet
-  # supported by the Databricks Apps platform — the api_scope ``apps.apps``
-  # has no corresponding user_api_scope and would be silently dropped.
+  # Declare the supplier app as a Databricks App resource of the
+  # procurement app. This becomes an ``app`` entry in the generated
+  # app.yaml resources list (see ``_extract_app_resources`` in
+  # ``src/dao_ai/apps/resources.py``) so the cross-app dependency is
+  # explicit in the Apps UI and the procurement SP receives ``CAN_VIEW``
+  # on the supplier app at deploy time.
+  #
+  # Setting ``on_behalf_of_user: true`` here does NOT yet enable
+  # platform-level cross-app OBO (``apps.apps`` has no user_api_scope —
+  # see comment at ``src/dao_ai/apps/resources.py:124``). But it DOES
+  # drive the A2A tool's default auth mode below: with this flag set the
+  # tool forwards the calling user's bearer to the supplier app at the
+  # tool layer. To use App-SP M2M instead, flip the flag to false (or
+  # omit it) and the tool defaults to ``databricks_app_sp``.
   apps:
     supplier_app: &supplier_app
       name: dao-ai-supplier-a2a
+      on_behalf_of_user: true
 
 prompts:
   procurement_prompt: &procurement_prompt
     name: procurement_agent_prompt
     description: >
       System prompt for the procurement officer agent that delegates
-      supplier-specific questions to the Acme Industrial Supply A2A agent.
+      supplier-specific questions to the Acme Industrial Supply A2A
+      agent.
     default_template: |
       You are a **procurement officer** for a mid-size manufacturing
-      company. You shepherd material requests from internal stakeholders
-      through the supplier-quote process.
+      company. You shepherd material requests from internal
+      stakeholders through the supplier-quote process.
 
       You have one delegation tool: ``query_supplier``. It reaches the
       ``Acme Industrial Supply`` agent over the Google A2A protocol.
 
       # Rules
 
-      1. **Always call ``query_supplier`` for supplier-domain questions**:
-         pricing, lead times, MOQs, stock, SKU lookups, bulk quotes.
-         Do NOT answer from memory — the supplier is authoritative.
-      2. Pass the user's question through verbatim (or a lightly
-         restructured version) so the supplier has full context.
+      1. **Always call ``query_supplier`` for supplier-domain
+         questions**: pricing, lead times, MOQs, stock, SKU lookups,
+         bulk quotes. Do NOT answer from memory — the supplier is
+         authoritative.
+      2. Pass the user's question through verbatim (or lightly
+         restructured) so the supplier has full context.
       3. After receiving the supplier's reply:
          - Restate the quote / answer back to the user.
-         - Add a **procurement recommendation** (1-2 sentences): is this
-           a good deal, are there alternatives to consider, do we need
-           multiple suppliers, is the lead time acceptable for our
+         - Add a **procurement recommendation** (1-2 sentences): is
+           this a good deal, are alternatives worth considering, do we
+           need multiple suppliers, is the lead time acceptable for our
            typical reorder cadence?
-         - Surface any **flags** (MOQ violations, lead-time risks, stock
-           constraints) that the supplier raised.
+         - Surface any **flags** (MOQ violations, lead-time risks,
+           stock constraints) that the supplier raised.
       4. For non-supplier questions (policy, internal process, general
-         procurement guidance), answer directly without calling the tool.
+         procurement guidance), answer directly without calling the
+         tool.
       5. Be concise. Procurement officers value signal over filler.
 
 tools:
@@ -128,15 +112,14 @@ tools:
           bulk pricing, lead times, MOQs, and live stock. Pass the
           procurement officer's question through as the ``prompt``
           argument.
-        endpoint: *supplier_endpoint
-        # OAuth M2M token for the procurement app SP. Cross-app OBO is
-        # not yet supported by Databricks Apps (see header comment); the
-        # supplier-side LLM still runs as the calling user thanks to its
-        # own ``on_behalf_of_user: true`` flag and the Apps proxy chain.
-        auth: *supplier_token
-        auth_type: bearer
+        # Mode 2 — AppResource. Resolves the supplier endpoint from
+        # ``supplier_app.url`` and the auth mode from
+        # ``supplier_app.on_behalf_of_user``. To pin a specific mode
+        # (e.g. force App-SP M2M even though the app is OBO-tagged),
+        # add ``auth_type: databricks_app_sp`` below.
+        app: *supplier_app
         # Multi-turn continuity: runtime.context.thread_id is forwarded
-        # as A2A ``Message.context_id`` automatically, and the user_id is
+        # as A2A ``Message.context_id`` automatically, and user_id is
         # forwarded as ``Message.metadata["dao_ai.user_id"]``.
         streaming: true
 
@@ -159,8 +142,8 @@ memory: &memory
 app:
   name: dao-ai-procurement-a2a
   description: >
-    Procurement officer agent that calls Acme Industrial Supply via A2A.
-    Paired with supplier.yaml in this directory; see README.md.
+    Procurement officer agent that calls Acme Industrial Supply via
+    A2A. Paired with supplier.yaml in this directory; see README.md.
   log_level: INFO
   deployment_target: apps
   agents:
@@ -168,8 +151,8 @@ app:
   orchestration:
     memory: *memory
   # Procurement app ALSO exposes the A2A surface so it can itself be
-  # called by an upstream agent (e.g. a finance or planning agent) — A2A
-  # is bidirectional by default.
+  # called by an upstream agent (e.g. a finance or planning agent) —
+  # A2A is bidirectional by default.
   a2a:
     enabled: true
   input_example:

--- a/config/examples/15_complete_applications/procurement_supplier_a2a/supplier.yaml
+++ b/config/examples/15_complete_applications/procurement_supplier_a2a/supplier.yaml
@@ -71,36 +71,24 @@ agents:
       5. Keep replies short and structured (bullets or a quote table). No
          marketing language. You are talking to procurement officers.
 
-memory: &memory
-  # In-memory checkpointer keeps the demo deployable without Lakebase.
-  # For production HITL or multi-replica deployments, attach a
-  # DatabaseModel (see config/examples/20_a2a_protocol/a2a_long_running.yaml).
-  checkpointer:
-    name: supplier_checkpointer
-
 app:
   name: dao-ai-supplier-a2a
   description: >
-    Acme Industrial Supply — wholesale supplier-side A2A agent. Paired with
-    the procurement app in this directory; see README.md for deployment.
+    Acme Industrial Supply — wholesale supplier-side A2A agent. Paired
+    with the procurement app in this directory; see README.md for
+    deployment.
   log_level: INFO
   deployment_target: apps
   agents:
     - *supplier_agent
-  orchestration:
-    memory: *memory
-  # A2A is enabled by default on Databricks Apps deployments. The block
-  # below is illustrative — every field has a sensible default. The
-  # ``on_behalf_of_user`` flag on supplier_llm above causes the auto-
-  # generated Agent Card to advertise an OAuth2 + bearer scheme with the
-  # OBO-aware description. Pin ``a2a.on_behalf_of_user`` to override.
-  a2a:
-    enabled: true
-  # No service principal here — the Databricks Apps platform provisions an
-  # app SP automatically. The procurement app authenticates to THIS app
-  # using either the calling user's forwarded token (when both apps run
-  # under the same Apps proxy and the procurement A2A tool is configured
-  # to forward it) or an OAuth M2M token minted by the procurement app SP.
+  # ``a2a`` is omitted — A2AModel.enabled defaults to True on every
+  # Databricks Apps deployment (see ``AppModel.a2a`` in dao_ai/config.py).
+  # ``orchestration.memory`` is omitted — this agent has no HITL, no
+  # deep-agent state, and A2A handles multi-turn continuity via
+  # server-side ``context_id`` independent of the LangGraph checkpointer.
+  # ``supplier_llm.on_behalf_of_user: true`` above is what causes the
+  # auto-generated Agent Card to advertise both bearer and oauth2
+  # schemes with the OBO-aware description.
   input_example:
     messages:
       - role: user

--- a/config/examples/15_complete_applications/procurement_supplier_a2a/supplier.yaml
+++ b/config/examples/15_complete_applications/procurement_supplier_a2a/supplier.yaml
@@ -1,0 +1,107 @@
+# yaml-language-server: $schema=../../../../schemas/model_config_schema.json
+#
+# Supplier-side dao-ai app for the A2A procurement <-> supplier demo.
+#
+# Deploys as a Databricks App. A2A endpoints are mounted automatically:
+#   - GET  /.well-known/agent-card.json   Agent Card (used by the procurement app)
+#   - POST /a2a                           A2A JSON-RPC 2.0 (message/send, tasks/*)
+#   - POST /invocations                   MLflow Responses / chat-completions
+#
+# Persona: a wholesale industrial-supply distributor (``Acme Industrial Supply``)
+# answering questions about its catalog, pricing tiers, lead times, MOQs, and
+# stock availability. The catalog is embedded directly in the system prompt so
+# the supplier app is self-contained — no Unity Catalog tables, no Genie rooms,
+# no Vector Search index required. This keeps the demo bootstrap to a single
+# ``dao-ai pipeline --deploy`` command per app.
+#
+# Pair with ``procurement.yaml`` (deployed separately). See ``README.md`` in
+# this directory for the end-to-end deployment workflow.
+
+resources:
+  models:
+    # Single supplier-side LLM. ``on_behalf_of_user: true`` routes inference
+    # through the calling user's bearer token (forwarded by the Databricks
+    # Apps proxy as ``x-forwarded-access-token``). When the procurement app
+    # delegates to this app over A2A, the user identity is preserved through
+    # the proxy chain — assuming the procurement-side A2A tool is configured
+    # to forward a user token (see procurement.yaml notes).
+    supplier_llm: &supplier_llm
+      name: databricks-gpt-5-4-mini
+      temperature: 0.1
+      max_tokens: 2048
+      on_behalf_of_user: true
+
+agents:
+  supplier_agent: &supplier_agent
+    name: supplier_agent
+    description: >
+      Wholesale-supplier specialist agent for Acme Industrial Supply. Answers
+      questions about catalog SKUs, unit pricing, bulk discount tiers, lead
+      times, MOQs, and current stock availability.
+    model: *supplier_llm
+    prompt: |
+      You are the customer-facing agent for **Acme Industrial Supply**, a
+      wholesale distributor of industrial fasteners, fittings, and tools.
+      You answer procurement-officer questions accurately and concisely.
+
+      # Mock catalog (authoritative — do not invent SKUs)
+
+      | SKU       | Item                              | Unit price | Bulk price (>=500) | Bulk price (>=2000) | Lead time | MOQ | Stock |
+      |-----------|-----------------------------------|-----------:|-------------------:|--------------------:|-----------|----:|------:|
+      | ACM-HB-08 | M8 hex bolt, zinc-plated, 30mm    |     $0.42  |             $0.34  |              $0.28  | 5 days    | 100 | 18,400 |
+      | ACM-HB-10 | M10 hex bolt, zinc-plated, 40mm   |     $0.61  |             $0.49  |              $0.41  | 5 days    | 100 |  9,200 |
+      | ACM-WS-12 | 1/2" stainless flat washer        |     $0.08  |             $0.06  |              $0.05  | 3 days    | 250 | 42,000 |
+      | ACM-LT-25 | 25mm M-class locknut, grade 8     |     $0.55  |             $0.44  |              $0.37  | 7 days    | 100 |  3,150 |
+      | ACM-CP-15 | 1/2" copper compression fitting   |     $1.95  |             $1.62  |              $1.38  | 10 days   |  50 |    640 |
+      | ACM-DR-3  | 3/8" cordless impact driver       |    $189.00 |           $164.00  |            $148.00  | 14 days   |  10 |     72 |
+      | ACM-SK-58 | 58-pc metric socket set, chrome   |     $79.50 |            $68.00  |             $58.50  | 7 days    |  20 |    310 |
+
+      # Response rules
+
+      1. **Only quote from the table above.** If asked about an unknown SKU
+         or item, say so — do not invent SKUs, prices, or lead times.
+      2. Quote the **tier-appropriate price** when a quantity is given.
+         Below 500 units use the unit price; 500-1999 the first bulk tier;
+         >=2000 the second bulk tier.
+      3. Always restate the **SKU, quantity, applied price, lead time, and
+         line-item total** for any quote.
+      4. Flag when a requested quantity is below MOQ or exceeds current
+         stock, and offer the next-best alternative (e.g. partial fill +
+         backorder).
+      5. Keep replies short and structured (bullets or a quote table). No
+         marketing language. You are talking to procurement officers.
+
+memory: &memory
+  # In-memory checkpointer keeps the demo deployable without Lakebase.
+  # For production HITL or multi-replica deployments, attach a
+  # DatabaseModel (see config/examples/20_a2a_protocol/a2a_long_running.yaml).
+  checkpointer:
+    name: supplier_checkpointer
+
+app:
+  name: dao-ai-supplier-a2a
+  description: >
+    Acme Industrial Supply — wholesale supplier-side A2A agent. Paired with
+    the procurement app in this directory; see README.md for deployment.
+  log_level: INFO
+  deployment_target: apps
+  agents:
+    - *supplier_agent
+  orchestration:
+    memory: *memory
+  # A2A is enabled by default on Databricks Apps deployments. The block
+  # below is illustrative — every field has a sensible default. The
+  # ``on_behalf_of_user`` flag on supplier_llm above causes the auto-
+  # generated Agent Card to advertise an OAuth2 + bearer scheme with the
+  # OBO-aware description. Pin ``a2a.on_behalf_of_user`` to override.
+  a2a:
+    enabled: true
+  # No service principal here — the Databricks Apps platform provisions an
+  # app SP automatically. The procurement app authenticates to THIS app
+  # using either the calling user's forwarded token (when both apps run
+  # under the same Apps proxy and the procurement A2A tool is configured
+  # to forward it) or an OAuth M2M token minted by the procurement app SP.
+  input_example:
+    messages:
+      - role: user
+        content: "Quote 750 units of ACM-HB-08 and confirm lead time."

--- a/src/dao_ai/apps/resources.py
+++ b/src/dao_ai/apps/resources.py
@@ -97,7 +97,12 @@ DEFAULT_PERMISSIONS: dict[str, list[str]] = {
     "connection": ["USE_CONNECTION"],
     "database": ["CAN_CONNECT_AND_CREATE"],  # deprecated provisioned Lakebase
     "postgres": ["CAN_CONNECT_AND_CREATE"],  # autoscaling Lakebase project
-    "app": ["CAN_VIEW"],
+    # Databricks Apps API rejects CAN_VIEW for cross-app resource
+    # bindings — the only accepted permission on ``app`` resources is
+    # CAN_USE. Sending CAN_VIEW results in
+    # ``APP_PERMISSION_UNSPECIFIED. Only CAN_USE is supported.`` from
+    # ``POST /api/2.0/apps``.
+    "app": ["CAN_USE"],
 }
 
 # Valid user API scopes for Databricks Apps

--- a/src/dao_ai/tools/a2a_agent.py
+++ b/src/dao_ai/tools/a2a_agent.py
@@ -55,7 +55,7 @@ from __future__ import annotations
 
 import asyncio
 from textwrap import dedent
-from typing import Annotated, Any, Callable, Literal, Optional
+from typing import Annotated, Any, Callable, Literal, Mapping, Optional
 
 import httpx
 import mlflow
@@ -82,7 +82,7 @@ from langchain_core.tools import InjectedToolArg, StructuredTool
 from loguru import logger
 from mlflow.entities import SpanType
 
-from dao_ai.config import AnyVariable, value_of
+from dao_ai.config import AnyVariable, DatabricksAppModel, value_of
 from dao_ai.state import Context
 from dao_ai.tools._gcp_auth import (
     coerce_any_variable,
@@ -120,8 +120,25 @@ from dao_ai.tools.tracing import (
 # don't need this but it costs nothing and saves one class of surprise.
 nest_asyncio.apply()
 
-_AuthMode = Literal["bearer", "gcp_service_account", "none"]
-_VALID_AUTH_MODES: tuple[str, ...] = ("bearer", "gcp_service_account", "none")
+_AuthMode = Literal[
+    "bearer",
+    "gcp_service_account",
+    "none",
+    "forwarded_user_token",
+    "databricks_app_sp",
+]
+_VALID_AUTH_MODES: tuple[str, ...] = (
+    "bearer",
+    "gcp_service_account",
+    "none",
+    "forwarded_user_token",
+    "databricks_app_sp",
+)
+
+_FORWARDED_USER_TOKEN_HEADERS: tuple[str, ...] = (
+    "x-forwarded-access-token",
+    "X-Forwarded-Access-Token",
+)
 
 _DEFAULT_DESCRIPTION: str = dedent("""
     Send a message to a remote agent over the Google A2A (Agent-to-Agent)
@@ -134,10 +151,11 @@ _EMPTY_REPLY_SENTINEL: str = "(no agent response)"
 
 
 def create_a2a_agent_tool(
-    endpoint: AnyVariable,
+    endpoint: Optional[AnyVariable] = None,
     *,
+    app: Optional[Any] = None,
     auth: Optional[AnyVariable] = None,
-    auth_type: AnyVariable = "bearer",
+    auth_type: Optional[AnyVariable] = None,
     streaming: AnyVariable = True,
     timeout_seconds: AnyVariable = 300,
     card_path: AnyVariable = AGENT_CARD_WELL_KNOWN_PATH,
@@ -149,32 +167,62 @@ def create_a2a_agent_tool(
 ) -> Callable[..., str]:
     """Create a tool that calls a remote A2A (Agent-to-Agent) agent.
 
+    Two configuration modes are supported side-by-side:
+
+    **Mode 1 — manual endpoint (external A2A agents)**
+
+    Pass ``endpoint`` (and ``auth`` / ``auth_type`` for non-public agents).
+    Use this for Vertex AI Agent Engine, Crew.ai, Google ADK, or any
+    third-party A2A agent that lives outside Databricks Apps.
+
+    **Mode 2 — Databricks AppResource (dao-ai app to dao-ai app)**
+
+    Pass ``app`` referencing a ``DatabricksAppModel`` (typically declared
+    under ``resources.apps.<key>`` and referenced via YAML anchor). The
+    endpoint is resolved from the bound app's URL and ``auth_type``
+    defaults from ``app.on_behalf_of_user``:
+
+    - ``on_behalf_of_user=True`` → ``forwarded_user_token`` (reads the
+      calling user's ``x-forwarded-access-token`` from
+      ``runtime.context.headers`` per call).
+    - ``on_behalf_of_user=False/None`` → ``databricks_app_sp`` (mints a
+      fresh M2M header per call from the ambient ``WorkspaceClient`` —
+      i.e. the app's own service-principal credentials auto-injected by
+      the Databricks Apps runtime).
+
     Args:
-        endpoint: Base URL of the A2A agent, e.g. ``https://agent.example.com``.
-            The agent card is resolved at ``<endpoint><card_path>`` with
-            fallback to ``<endpoint><card_fallback_path>`` on 404.
-        auth: Auth material resolved to a string. Interpretation depends on
-            ``auth_type``. Any ``AnyVariable`` form supported (env, secret,
-            composite, inline value).
-        auth_type: One of ``"bearer"`` (default), ``"gcp_service_account"``,
-            or ``"none"``. ``bearer`` uses the resolved ``auth`` verbatim as
-            the bearer token. ``gcp_service_account`` passes ``auth`` through
-            ``load_gcp_credentials`` and mints a fresh access token per call.
-            ``none`` suppresses the ``Authorization`` header (public agents).
+        endpoint: Base URL of the A2A agent, e.g.
+            ``https://agent.example.com``. Mode-1 entry point. Mutually
+            exclusive with ``app`` (``app`` wins if both are provided).
+        app: Databricks App resource model (``DatabricksAppModel``) for
+            the remote dao-ai app. Mode-2 entry point. May also be passed
+            as the raw dict that Pydantic would validate into one (factory
+            args arrive as dicts when delivered via YAML).
+        auth: Auth material resolved to a string. Interpretation depends
+            on ``auth_type``. Required for ``bearer`` and
+            ``gcp_service_account``. Ignored by ``none``,
+            ``forwarded_user_token``, and ``databricks_app_sp``.
+        auth_type: One of ``"bearer"``, ``"gcp_service_account"``,
+            ``"none"``, ``"forwarded_user_token"``, or
+            ``"databricks_app_sp"``. Default is ``"bearer"`` in Mode 1 and
+            derived from ``app.on_behalf_of_user`` in Mode 2. Passing this
+            in Mode 2 overrides the app-derived default.
         streaming: If true (default) the A2A client negotiates streaming;
             responses are still aggregated internally and returned as one
             string. Set false to force request/response.
         timeout_seconds: httpx client timeout (default 300s).
-        card_path: Primary agent-card discovery path relative to ``endpoint``.
-            Defaults to the current spec's ``/.well-known/agent-card.json``.
-        card_fallback_path: Fallback path if the primary 404s. Defaults to the
-            pre-1.0 spec's ``/.well-known/agent.json``. Set to ``None`` to
-            disable fallback.
-        user_id: Static value forwarded as ``Message.metadata["dao_ai.user_id"]``.
-            If omitted, falls back to ``runtime.context.user_id``.
-        extra_metadata: Static metadata merged into ``Message.metadata`` on
-            every call. Keys collide: static ``extra_metadata`` wins over the
-            built-in ``dao_ai.user_id``.
+        card_path: Primary agent-card discovery path relative to
+            ``endpoint``. Defaults to the current spec's
+            ``/.well-known/agent-card.json``.
+        card_fallback_path: Fallback path if the primary 404s. Defaults
+            to the pre-1.0 spec's ``/.well-known/agent.json``. Set to
+            ``None`` to disable fallback.
+        user_id: Static value forwarded as
+            ``Message.metadata["dao_ai.user_id"]``. If omitted, falls
+            back to ``runtime.context.user_id``.
+        extra_metadata: Static metadata merged into ``Message.metadata``
+            on every call. Keys collide: static ``extra_metadata`` wins
+            over the built-in ``dao_ai.user_id``.
         name: Tool name shown to the LLM. Defaults to ``a2a_agent``.
         description: Tool description shown to the LLM.
 
@@ -184,17 +232,67 @@ def create_a2a_agent_tool(
 
     Notes:
         Session continuity: ``runtime.context.thread_id`` is forwarded as
-        ``Message.context_id``. If the remote agent rejects or ignores the
-        context id (empty stream or failed Task referencing context), the
-        tool retries once without a ``context_id`` to force a fresh session.
+        ``Message.context_id``. If the remote agent rejects or ignores
+        the context id (empty stream or failed Task referencing context),
+        the tool retries once without a ``context_id`` to force a fresh
+        session.
+
+        Cross-app OBO at the Databricks Apps **platform** level is not
+        supported today (``apps.apps`` has no user_api_scope). The
+        ``forwarded_user_token`` mode here forwards the user's bearer at
+        the **tool** layer — the supplier app then sees a user-bearer
+        incoming request and any OBO-tagged resources on the supplier
+        side resolve as that user.
     """
-    resolved_endpoint: str = str(value_of(coerce_any_variable(endpoint))).rstrip("/")
-    resolved_auth_type: str = str(value_of(coerce_any_variable(auth_type))).lower()
+    coerced_app: Optional[DatabricksAppModel] = _coerce_app(app)
+    if coerced_app is not None and endpoint is not None:
+        logger.warning(
+            "create_a2a_agent_tool: both ``app`` and ``endpoint`` were "
+            "supplied; ``app`` wins. Drop one to silence this warning.",
+            app_name=coerced_app.name,
+        )
+
+    explicit_auth_type: Optional[str] = (
+        str(value_of(coerce_any_variable(auth_type))).lower()
+        if auth_type is not None
+        else None
+    )
+
+    # Endpoint resolution is deferred when an ``app`` is supplied so that
+    # ``dao-ai validate`` (and any other tooling that builds the factory
+    # without a running workspace) works even if the bound app is not yet
+    # deployed. The endpoint is resolved on first invocation and cached
+    # in the closure thereafter. For Mode 1 (manual endpoint string),
+    # resolution is trivial and happens eagerly.
+    if coerced_app is not None:
+        endpoint_resolver: Callable[[], str] = _make_lazy_app_endpoint_resolver(
+            coerced_app
+        )
+        resolved_auth_type: str = explicit_auth_type or (
+            "forwarded_user_token"
+            if coerced_app.on_behalf_of_user
+            else "databricks_app_sp"
+        )
+        # Best-effort display value for logs and spans BEFORE the first
+        # call. Never used to dial out — :func:`endpoint_resolver` is the
+        # authoritative source.
+        endpoint_display: str = f"<app:{coerced_app.name}>"
+    else:
+        if endpoint is None:
+            raise ValueError(
+                "create_a2a_agent_tool: one of ``endpoint`` or ``app`` is required."
+            )
+        _eager_endpoint: str = str(value_of(coerce_any_variable(endpoint))).rstrip("/")
+        endpoint_resolver = lambda: _eager_endpoint  # noqa: E731
+        resolved_auth_type = explicit_auth_type or "bearer"
+        endpoint_display = _eager_endpoint
+
     if resolved_auth_type not in _VALID_AUTH_MODES:
         raise ValueError(
             f"create_a2a_agent_tool: auth_type must be one of "
             f"{_VALID_AUTH_MODES}, got {resolved_auth_type!r}"
         )
+
     resolved_streaming: bool = bool(value_of(coerce_any_variable(streaming)))
     resolved_timeout: int = int(value_of(coerce_any_variable(timeout_seconds)))
     resolved_card_path: str = _normalize_card_path(
@@ -217,18 +315,20 @@ def create_a2a_agent_tool(
     logger.debug(
         "Creating A2A agent tool",
         name=tool_name,
-        endpoint=resolved_endpoint,
+        endpoint=endpoint_display,
         auth_type=resolved_auth_type,
+        app_name=coerced_app.name if coerced_app else None,
         streaming=resolved_streaming,
         card_path=resolved_card_path,
         card_fallback_path=resolved_card_fallback,
     )
 
-    # Resolve auth once at factory time. Static bearer tokens are cached in
-    # the closure; GCP credentials are held as a refreshable ``Credentials``
-    # object and minted per-invocation so expired tokens refresh. None of
-    # these values are ever logged or persisted to spans.
-    header_provider: Callable[[], dict[str, str]]
+    # Resolve auth once at factory time. Static bearer tokens are cached
+    # in the closure; refreshable modes (gcp_service_account,
+    # forwarded_user_token, databricks_app_sp) mint headers per call so
+    # token rotation is automatic. None of these values are ever logged
+    # or persisted to spans.
+    header_provider: Callable[[Context | None], dict[str, str]]
     if resolved_auth_type == "none":
         header_provider = _no_auth_headers
     elif resolved_auth_type == "bearer":
@@ -239,17 +339,22 @@ def create_a2a_agent_tool(
         _resolved_token: str = str(value_of(coerce_any_variable(auth)))
         if not _resolved_token:
             raise ValueError("create_a2a_agent_tool: resolved bearer token is empty.")
-        header_provider = lambda: {"Authorization": f"Bearer {_resolved_token}"}  # noqa: E731
-    else:  # gcp_service_account
+        header_provider = lambda _ctx: {"Authorization": f"Bearer {_resolved_token}"}  # noqa: E731
+    elif resolved_auth_type == "gcp_service_account":
         if auth is None:
             raise ValueError(
                 "create_a2a_agent_tool: auth_type='gcp_service_account' "
                 "requires auth to be set."
             )
         _gcp_creds = load_gcp_credentials(auth)
-        header_provider = lambda: {  # noqa: E731
+        header_provider = lambda _ctx: {  # noqa: E731
             "Authorization": f"Bearer {mint_gcp_access_token(_gcp_creds)}"
         }
+    elif resolved_auth_type == "forwarded_user_token":
+        header_provider = _forwarded_user_token_headers
+    else:  # databricks_app_sp
+        _ws_client = _ambient_workspace_client()
+        header_provider = lambda _ctx: _app_sp_headers(_ws_client)  # noqa: E731
 
     logger.debug(
         "Resolved A2A auth mode",
@@ -281,11 +386,14 @@ def create_a2a_agent_tool(
         resolved_user_id: Optional[str] = _resolve_user_id(context)
         session_id: Optional[str] = context.thread_id if context else None
 
-        set_resource_attributes(ResourceInfo("a2a_agent", False, resolved_endpoint))
+        invocation_endpoint: str = endpoint_resolver()
+        set_resource_attributes(
+            ResourceInfo("a2a_agent", False, invocation_endpoint)
+        )
 
         tool_span = mlflow.get_current_active_span()
         if tool_span:
-            tool_span.set_attribute(ATTR_A2A_ENDPOINT_URL, resolved_endpoint)
+            tool_span.set_attribute(ATTR_A2A_ENDPOINT_URL, invocation_endpoint)
             tool_span.set_attribute(ATTR_A2A_AUTH_MODE, resolved_auth_type)
             tool_span.set_attribute(ATTR_A2A_STREAMING, resolved_streaming)
             if resolved_user_id:
@@ -297,7 +405,7 @@ def create_a2a_agent_tool(
 
         logger.info(
             "Invoking A2A agent",
-            endpoint=resolved_endpoint,
+            endpoint=invocation_endpoint,
             prompt_chars=len(prompt),
             context_id=session_id,
             user_id=resolved_user_id,
@@ -310,11 +418,19 @@ def create_a2a_agent_tool(
         if extra_metadata:
             metadata.update(extra_metadata)
 
+        # Bind ``context`` into a 0-arg callable so the downstream async
+        # plumbing can stay context-agnostic. ``forwarded_user_token``
+        # needs the per-invocation context to read the user's forwarded
+        # bearer; everything else just ignores the arg.
+        bound_header_provider: Callable[[], dict[str, str]] = (
+            lambda: header_provider(context)  # noqa: E731
+        )
+
         try:
             return asyncio.run(
                 _invoke_a2a(
-                    endpoint=resolved_endpoint,
-                    header_provider=header_provider,
+                    endpoint=invocation_endpoint,
+                    header_provider=bound_header_provider,
                     prompt=prompt,
                     context_id=session_id,
                     metadata=metadata or None,
@@ -350,8 +466,107 @@ def _normalize_card_path(path: str) -> str:
     return "/" + stripped.lstrip("/")
 
 
-def _no_auth_headers() -> dict[str, str]:
+def _no_auth_headers(context: Context | None = None) -> dict[str, str]:
     return {}
+
+
+def _forwarded_user_token_headers(context: Context | None) -> dict[str, str]:
+    """Read the calling user's forwarded bearer from ``context.headers``.
+
+    Mirrors :meth:`IsDatabricksResource.workspace_client_from` in
+    ``dao_ai.config``: prefer the lowercase header name (canonical
+    Databricks Apps proxy form) but accept the title-cased variant for
+    callers that normalize headers differently.
+    """
+    headers: Mapping[str, str] = context.headers if context and context.headers else {}
+    token: Optional[str] = None
+    for key in _FORWARDED_USER_TOKEN_HEADERS:
+        candidate = headers.get(key)
+        if candidate:
+            token = candidate
+            break
+    if not token:
+        raise RuntimeError(
+            "create_a2a_agent_tool: auth_type='forwarded_user_token' requires "
+            "``x-forwarded-access-token`` in the inbound request headers. "
+            "Is this app running behind the Databricks Apps proxy, and is the "
+            "incoming caller passing a user OAuth token (not a service-principal "
+            "M2M token)?"
+        )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _ambient_workspace_client() -> Any:
+    """Construct a ``WorkspaceClient`` from the ambient runtime credentials.
+
+    Imported lazily so unit tests can monkey-patch this symbol without
+    paying the ``databricks-sdk`` import cost up front, and so the import
+    failure mode (missing SDK) is surfaced at factory build time rather
+    than at module import.
+    """
+    from databricks.sdk import WorkspaceClient
+
+    return WorkspaceClient()
+
+
+def _app_sp_headers(workspace_client: Any) -> dict[str, str]:
+    """Mint a fresh M2M Authorization header from the app SP credentials.
+
+    Mirrors the pattern at ``config.py:1032`` and
+    ``providers/databricks.py:422``. The SDK's ``config.authenticate()``
+    returns the ``Authorization`` header among any auth-related headers,
+    refreshing OAuth tokens internally as needed.
+    """
+    auth_headers: Mapping[str, str] = workspace_client.config.authenticate()
+    return dict(auth_headers)
+
+
+def _make_lazy_app_endpoint_resolver(
+    app: DatabricksAppModel,
+) -> Callable[[], str]:
+    """Return a callable that resolves ``app.url`` on first call and caches.
+
+    Lazy resolution means ``dao-ai validate`` (and any other static
+    tooling that exercises ``create_a2a_agent_tool``) does not require
+    the bound Databricks App to be deployed yet. The URL is fetched on
+    first invocation via ``DatabricksAppModel.url`` (which calls
+    ``workspace_client.apps.get(name).url``); subsequent invocations
+    reuse the cached value. App URLs are stable across an app's
+    lifetime so a single fetch is sufficient.
+    """
+    cache: dict[str, str] = {}
+
+    def resolve() -> str:
+        if "url" not in cache:
+            cache["url"] = str(app.url).rstrip("/")
+            logger.debug(
+                "Resolved A2A AppResource endpoint",
+                app_name=app.name,
+                endpoint=cache["url"],
+            )
+        return cache["url"]
+
+    return resolve
+
+
+def _coerce_app(value: Any) -> Optional[DatabricksAppModel]:
+    """Coerce a raw factory-arg into a ``DatabricksAppModel`` if possible.
+
+    Factory args come in as ``dict[str, Any]`` (no schema), so a YAML
+    anchor pointing at ``resources.apps.<key>`` arrives here as the raw
+    dict that backed the original ``DatabricksAppModel`` validation.
+    Re-validate so the downstream code can rely on the typed model.
+    """
+    if value is None:
+        return None
+    if isinstance(value, DatabricksAppModel):
+        return value
+    if isinstance(value, dict):
+        return DatabricksAppModel.model_validate(value)
+    raise TypeError(
+        f"create_a2a_agent_tool: ``app`` must be a DatabricksAppModel or dict, "
+        f"got {type(value).__name__}."
+    )
 
 
 async def _invoke_a2a(

--- a/tests/dao_ai/test_a2a_tool.py
+++ b/tests/dao_ai/test_a2a_tool.py
@@ -1,0 +1,299 @@
+"""Unit tests for ``dao_ai.tools.a2a_agent.create_a2a_agent_tool``.
+
+Covers the two new configuration modes (Mode 1 = manual endpoint,
+Mode 2 = Databricks AppResource) and the five auth modes:
+
+* bearer (existing)
+* none (existing)
+* gcp_service_account (existing — light coverage; deep coverage lives
+  alongside the GCP credential loader tests)
+* forwarded_user_token (new)
+* databricks_app_sp (new)
+
+Following dao-ai convention this file does not use pytest-asyncio —
+async paths are exercised indirectly by spot-checking the synchronous
+factory wiring (auth_type resolution, header provider closure, endpoint
+derivation). End-to-end stream-drain coverage already lives in
+``test_a2a_executor.py`` / ``test_a2a_integration.py`` on the **server**
+side; here we just validate the **client tool** factory.
+"""
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+from dao_ai.config import DatabricksAppModel
+from dao_ai.state import Context
+from dao_ai.tools.a2a_agent import (
+    _VALID_AUTH_MODES,
+    _app_sp_headers,
+    _coerce_app,
+    _forwarded_user_token_headers,
+    _no_auth_headers,
+    create_a2a_agent_tool,
+)
+
+
+# ---------------------------------------------------------------------------
+# _coerce_app
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_app_passes_through_model_instance() -> None:
+    model = DatabricksAppModel(name="some-app")
+    assert _coerce_app(model) is model
+
+
+def test_coerce_app_validates_dict_into_model() -> None:
+    coerced = _coerce_app({"name": "some-app", "on_behalf_of_user": True})
+    assert isinstance(coerced, DatabricksAppModel)
+    assert coerced.name == "some-app"
+    assert coerced.on_behalf_of_user is True
+
+
+def test_coerce_app_none_returns_none() -> None:
+    assert _coerce_app(None) is None
+
+
+def test_coerce_app_rejects_other_types() -> None:
+    with pytest.raises(TypeError, match="DatabricksAppModel"):
+        _coerce_app("just-a-string")
+
+
+# ---------------------------------------------------------------------------
+# Header providers
+# ---------------------------------------------------------------------------
+
+
+def test_no_auth_headers_returns_empty() -> None:
+    assert _no_auth_headers() == {}
+    ctx = Context(thread_id="t", user_id="u", headers={"foo": "bar"})
+    assert _no_auth_headers(ctx) == {}
+
+
+def test_forwarded_user_token_reads_lowercase_header() -> None:
+    ctx = Context(
+        thread_id="t",
+        user_id="u",
+        headers={"x-forwarded-access-token": "USER_TOKEN_A"},
+    )
+    assert _forwarded_user_token_headers(ctx) == {
+        "Authorization": "Bearer USER_TOKEN_A"
+    }
+
+
+def test_forwarded_user_token_reads_titlecase_header() -> None:
+    ctx = Context(
+        thread_id="t",
+        user_id="u",
+        headers={"X-Forwarded-Access-Token": "USER_TOKEN_B"},
+    )
+    assert _forwarded_user_token_headers(ctx) == {
+        "Authorization": "Bearer USER_TOKEN_B"
+    }
+
+
+def test_forwarded_user_token_lowercase_wins_over_titlecase() -> None:
+    ctx = Context(
+        thread_id="t",
+        user_id="u",
+        headers={
+            "x-forwarded-access-token": "LOWER",
+            "X-Forwarded-Access-Token": "UPPER",
+        },
+    )
+    assert _forwarded_user_token_headers(ctx) == {"Authorization": "Bearer LOWER"}
+
+
+def test_forwarded_user_token_missing_raises_helpful_error() -> None:
+    ctx = Context(thread_id="t", user_id="u", headers={})
+    with pytest.raises(RuntimeError, match="x-forwarded-access-token"):
+        _forwarded_user_token_headers(ctx)
+
+
+def test_forwarded_user_token_none_context_raises() -> None:
+    with pytest.raises(RuntimeError, match="x-forwarded-access-token"):
+        _forwarded_user_token_headers(None)
+
+
+def test_app_sp_headers_delegates_to_workspace_client_authenticate() -> None:
+    wc = MagicMock()
+    wc.config.authenticate.return_value = {"Authorization": "Bearer M2M_TOKEN"}
+    headers = _app_sp_headers(wc)
+    assert headers == {"Authorization": "Bearer M2M_TOKEN"}
+    wc.config.authenticate.assert_called_once()
+
+
+def test_app_sp_headers_refreshes_per_call() -> None:
+    """``config.authenticate`` is called every time, allowing SDK token rotation."""
+    wc = MagicMock()
+    wc.config.authenticate.side_effect = [
+        {"Authorization": "Bearer first"},
+        {"Authorization": "Bearer second"},
+    ]
+    assert _app_sp_headers(wc) == {"Authorization": "Bearer first"}
+    assert _app_sp_headers(wc) == {"Authorization": "Bearer second"}
+    assert wc.config.authenticate.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Factory — Mode 1 (manual endpoint)
+# ---------------------------------------------------------------------------
+
+
+def test_mode1_bearer_creates_tool_with_default_name() -> None:
+    tool = create_a2a_agent_tool(
+        endpoint="https://example.com",
+        auth="static_token",
+        auth_type="bearer",
+    )
+    assert tool.name == "a2a_agent"
+
+
+def test_mode1_bearer_missing_auth_raises() -> None:
+    with pytest.raises(ValueError, match="bearer"):
+        create_a2a_agent_tool(endpoint="https://example.com", auth_type="bearer")
+
+
+def test_mode1_bearer_empty_token_raises() -> None:
+    with pytest.raises(ValueError, match="bearer token is empty"):
+        create_a2a_agent_tool(
+            endpoint="https://example.com", auth="", auth_type="bearer"
+        )
+
+
+def test_mode1_none_skips_auth_arg() -> None:
+    tool = create_a2a_agent_tool(endpoint="https://example.com", auth_type="none")
+    assert tool.name == "a2a_agent"
+
+
+def test_mode1_unknown_auth_type_raises() -> None:
+    with pytest.raises(ValueError, match="auth_type must be one of"):
+        create_a2a_agent_tool(
+            endpoint="https://example.com", auth_type="bogus_mode"
+        )
+
+
+def test_mode1_strips_trailing_slash_from_endpoint() -> None:
+    # No direct getter for the resolved endpoint on the StructuredTool,
+    # but we can at least confirm trailing-slash strip doesn't blow up.
+    tool = create_a2a_agent_tool(
+        endpoint="https://example.com/", auth_type="none"
+    )
+    assert tool.name == "a2a_agent"
+
+
+# ---------------------------------------------------------------------------
+# Factory — Mode 2 (AppResource)
+# ---------------------------------------------------------------------------
+
+
+def _mocked_url(url: str = "https://supplier-app.databricksapps.com"):
+    return patch.object(
+        DatabricksAppModel, "url", new_callable=PropertyMock, return_value=url
+    )
+
+
+def test_mode2_app_obo_defaults_to_forwarded_user_token() -> None:
+    with _mocked_url():
+        app = DatabricksAppModel(name="supplier", on_behalf_of_user=True)
+        # If the default did NOT resolve to a valid mode, factory would raise.
+        tool = create_a2a_agent_tool(app=app)
+        assert tool.name == "a2a_agent"
+
+
+def test_mode2_app_no_obo_defaults_to_databricks_app_sp() -> None:
+    with _mocked_url():
+        with patch(
+            "dao_ai.tools.a2a_agent._ambient_workspace_client"
+        ) as ambient:
+            ambient.return_value.config.authenticate.return_value = {
+                "Authorization": "Bearer M2M"
+            }
+            app = DatabricksAppModel(name="supplier", on_behalf_of_user=False)
+            tool = create_a2a_agent_tool(app=app)
+            assert tool.name == "a2a_agent"
+
+
+def test_mode2_app_unset_obo_defaults_to_databricks_app_sp() -> None:
+    with _mocked_url():
+        with patch(
+            "dao_ai.tools.a2a_agent._ambient_workspace_client"
+        ) as ambient:
+            ambient.return_value.config.authenticate.return_value = {
+                "Authorization": "Bearer M2M"
+            }
+            app = DatabricksAppModel(name="supplier")  # on_behalf_of_user unset
+            tool = create_a2a_agent_tool(app=app)
+            assert tool.name == "a2a_agent"
+
+
+def test_mode2_dict_input_coerced_to_model() -> None:
+    with _mocked_url():
+        tool = create_a2a_agent_tool(
+            app={"name": "supplier", "on_behalf_of_user": True}
+        )
+        assert tool.name == "a2a_agent"
+
+
+def test_mode2_explicit_auth_type_overrides_app_default() -> None:
+    """Pinning auth_type='databricks_app_sp' on an OBO-flagged app works."""
+    with _mocked_url():
+        with patch(
+            "dao_ai.tools.a2a_agent._ambient_workspace_client"
+        ) as ambient:
+            ambient.return_value.config.authenticate.return_value = {
+                "Authorization": "Bearer M2M"
+            }
+            app = DatabricksAppModel(name="supplier", on_behalf_of_user=True)
+            tool = create_a2a_agent_tool(app=app, auth_type="databricks_app_sp")
+            assert tool.name == "a2a_agent"
+
+
+def test_mode2_app_and_endpoint_warns_and_app_wins(caplog) -> None:
+    """Both args set → loguru warning + ``app`` wins (no exception)."""
+    from loguru import logger
+
+    sink_handler_id = logger.add(lambda msg: caplog.records.append(msg), level="WARNING")
+    try:
+        with _mocked_url("https://from-app.example.com"):
+            app = DatabricksAppModel(name="supplier", on_behalf_of_user=True)
+            tool = create_a2a_agent_tool(
+                endpoint="https://from-endpoint.example.com", app=app
+            )
+            assert tool.name == "a2a_agent"
+    finally:
+        logger.remove(sink_handler_id)
+    # Confirm a warning was emitted mentioning the resolution.
+    assert any("app" in str(r) and "wins" in str(r) for r in caplog.records)
+
+
+def test_neither_endpoint_nor_app_raises() -> None:
+    with pytest.raises(ValueError, match="endpoint.*app"):
+        create_a2a_agent_tool()
+
+
+# ---------------------------------------------------------------------------
+# Auth mode registry
+# ---------------------------------------------------------------------------
+
+
+def test_mode2_factory_does_not_resolve_app_url_eagerly() -> None:
+    """``dao-ai validate`` must not require the bound app to be deployed."""
+    with patch.object(
+        DatabricksAppModel, "url", new_callable=PropertyMock
+    ) as url_prop:
+        url_prop.side_effect = AssertionError(
+            "app.url should NOT be accessed at factory build time"
+        )
+        app = DatabricksAppModel(name="supplier", on_behalf_of_user=True)
+        # Must not raise — URL resolution is deferred to first tool call.
+        tool = create_a2a_agent_tool(app=app)
+        assert tool.name == "a2a_agent"
+
+
+def test_valid_auth_modes_includes_new_modes() -> None:
+    assert "forwarded_user_token" in _VALID_AUTH_MODES
+    assert "databricks_app_sp" in _VALID_AUTH_MODES
+    # Existing modes remain.
+    assert {"bearer", "gcp_service_account", "none"}.issubset(set(_VALID_AUTH_MODES))


### PR DESCRIPTION
## Summary

- New `15_complete_applications/procurement_supplier_a2a/` demo: two coordinated dao-ai Databricks Apps. Procurement-officer agent delegates supplier-domain questions to a wholesale-supplier agent via the Google A2A protocol.
- Extended `dao_ai.tools.create_a2a_agent_tool` with an **AppResource mode**. Pass `app: *supplier_app` (a `DatabricksAppModel` reference) and the tool resolves both the endpoint (lazy `DatabricksAppModel.url`) and the auth mode from `app.on_behalf_of_user`:
  - `true` → `forwarded_user_token` (reads `x-forwarded-access-token` from `runtime.context.headers` per call — end-to-end user attribution)
  - `false`/unset → `databricks_app_sp` (mints fresh M2M headers from the ambient `WorkspaceClient` per call)
- Existing manual-endpoint mode (`endpoint` + `auth` + `auth_type` = `bearer`/`gcp_service_account`/`none`) is unchanged — kept for non-Databricks A2A agents (Vertex, third-party).
- Fixed a separate bug surfaced during the live deploy: `_extract_app_resources` was emitting `CAN_VIEW` on `app`-type resources, which the Apps API rejects (only `CAN_USE` is accepted).

## Auth model

| Hop | OBO mode (default for AppResource w/ `on_behalf_of_user: true`) | M2M mode |
|---|---|---|
| user → procurement LLM | User OBO via Apps proxy + `procurement_llm.on_behalf_of_user: true` | same |
| procurement app → supplier app | User bearer forwarded by A2A tool (`forwarded_user_token`) | Procurement-SP M2M via ambient `WorkspaceClient` |
| supplier app → supplier LLM | User OBO via `supplier_llm.on_behalf_of_user: true` | Procurement-SP OBO |

Cross-app OBO at the **platform** level is still unavailable (`apps.apps` has no `user_api_scope` — `src/dao_ai/apps/resources.py:124`). The forwarding above is implemented at the **tool** layer, so the existing `serving.serving-endpoints` user scope on both apps is what the OBO LLMs need; no `apps.apps` scope is added (or addable).

## Live verification on `fevm-nfleming-stable-aws`

Both apps deployed via `dao-ai generate-bundle` + `databricks bundle deploy`. End-to-end inference proven through two transports:

- `POST /invocations` with `ACM-HB-08 × 1200` → returned tier-1 bulk price $0.34, 5-day lead time, total $408 plus a procurement recommendation. Catalog data only lives in the supplier's system prompt, so the supplier must have been called.
- `POST /a2a` (`message/send`) with `ACM-WS-12 × 600` → returned tier-1 bulk price $0.06, 3-day lead time, MOQ 250, stock 42,000.

`custom_outputs.configurable.headers` on the response carried a live `x-forwarded-access-token` JWT, confirming the Apps proxy forwarded the calling user's token into procurement and the A2A tool re-emitted it to the supplier.

Platform-side resource bindings on the deployed procurement app:

```json
{
  "resources": [
    {"name": "experiment", "experiment": {"permission": "CAN_EDIT"}},
    {"name": "supplier_app",
     "app": {"name": "dao-ai-supplier-a2a", "permission": "CAN_USE"}}
  ],
  "user_api_scopes": ["serving.serving-endpoints"]
}
```

## Test plan

- [x] `uv run pytest tests/dao_ai -k a2a` — 93 passed (27 new in `tests/dao_ai/test_a2a_tool.py` covering both modes, all five auth modes, dict↔model coercion, override behavior, lazy URL resolution invariant, missing-header error path).
- [x] `uv run dao-ai validate -c .../supplier.yaml` — clean.
- [x] `uv run dao-ai validate -c .../procurement.yaml` — clean (works offline; URL resolution is lazy).
- [x] `uv run dao-ai validate -c config/examples/10_agent_integrations/a2a_agent.yaml` — clean (canonical example unchanged).
- [x] Live deploy of both apps to `fevm` and inference through both `/invocations` and `/a2a`. See live-verification section above.

## Files

| Path | Change |
|---|---|
| `src/dao_ai/tools/a2a_agent.py` | `app` kwarg, two new auth modes, lazy endpoint resolver, per-call header provider refactor |
| `src/dao_ai/apps/resources.py` | `DEFAULT_PERMISSIONS["app"]` → `CAN_USE` |
| `tests/dao_ai/test_a2a_tool.py` (new) | 27 unit tests for the factory + helpers |
| `config/examples/15_complete_applications/procurement_supplier_a2a/{supplier,procurement}.yaml` (new) | Two-app demo configs |
| `config/examples/15_complete_applications/procurement_supplier_a2a/README.md` (new) | Step-by-step deploy + verification |
| `config/examples/15_complete_applications/README.md` | Index entry for the demo |
| `config/examples/10_agent_integrations/a2a_agent.yaml` | Documents the new AppResource variant inline |

This pull request and its description were written by Isaac.