### PR TITLE
MCP: workspace-wide Genie + `_meta` parameter support

### DIFF
--- a/config/examples/02_mcp/managed_mcp.yaml
+++ b/config/examples/02_mcp/managed_mcp.yaml
@@ -83,6 +83,10 @@ tools:
       type: mcp                                  # MCP function type
       vector_search: *retail_vector_store
                                                  # Use vector search convenience object
+      meta:                                      # Per-call _meta for Vector Search MCP
+        num_results: 5                           # Cap results to 5
+        query_type: HYBRID                       # Use hybrid search
+        include_score: true                      # Include similarity scores
       client_id: *client_id
       client_secret: *client_secret
       workspace_host: *workspace_host
@@ -93,6 +97,10 @@ tools:
     function:
       type: mcp                                  # MCP function type
       sql: true                                  # Use serverless DBSQL MCP server (no warehouse needed)
+      meta:                                      # Per-call _meta for DBSQL MCP
+        warehouse_id:                            # Pin a specific DBSQL warehouse
+          options:
+          - env: RETAIL_AI_DATABRICKS_WAREHOUSE_ID
       client_id: *client_id
       client_secret: *client_secret
       workspace_host: *workspace_host
@@ -109,12 +117,22 @@ tools:
       workspace_host: *workspace_host
 
   genie_mcp: &genie_mcp
-                                                 # Genie MCP tool configuration
+                                                 # Genie MCP tool configuration (per-space)
     name: genie_mcp
     function:
       type: mcp                                  # MCP function type
       genie_room: *retail_genie_room
                                                  # Use genie_room convenience object
+      client_id: *client_id
+      client_secret: *client_secret
+      workspace_host: *workspace_host
+
+  genie_all_mcp: &genie_all_mcp
+                                                 # Workspace-wide Genie MCP tool (all spaces)
+    name: genie_all_mcp
+    function:
+      type: mcp                                  # MCP function type
+      genie: true                                # Workspace-wide managed Genie MCP (no space_id)
       client_id: *client_id
       client_secret: *client_secret
       workspace_host: *workspace_host
@@ -132,10 +150,13 @@ agents:
     - *sql_mcp
     - *functions_mcp
     - *genie_mcp
+    - *genie_all_mcp
     prompt: |                                    # System prompt defining agent behavior
       You are a multi-purpose agent that can perform vector search, execute SQL queries via DBSQL,
-      call Unity Catalog functions, and interact with Genie rooms. Use the tools provided to answer
-      questions and perform tasks. You may need to use the tools in combination to achieve complex tasks.
+      call Unity Catalog functions, interact with a specific Genie room, and query across all Genie
+      spaces in the workspace via the workspace-wide Genie MCP server. Use the tools provided to
+      answer questions and perform tasks. You may need to use the tools in combination to achieve
+      complex tasks.
 
 app:
   name: managed_mcp_dao                                # Application name  

--- a/config/examples/02_mcp/mcp_meta_test.yaml
+++ b/config/examples/02_mcp/mcp_meta_test.yaml
@@ -1,0 +1,80 @@
+# yaml-language-server: $schema=../../../schemas/model_config_schema.json
+#
+# Lean test config for validating the two new MCP features in dao-ai:
+#   1. `genie: true`  — workspace-wide managed Genie MCP server (no space_id)
+#   2. `meta: {...}`  — per-MCP-server `_meta` parameters (MCP spec)
+#
+# Designed to deploy cleanly to a fresh fevm workspace with minimal pre-provisioned
+# resources. Uses OBO auth so the deploying user's credentials drive every MCP call.
+#
+# Required env vars (set before `dao-ai pipeline ... -d`):
+#   DAO_AI_WAREHOUSE_ID   - a SQL warehouse ID in the target workspace (for DBSQL meta)
+#
+# Optional env vars:
+#   DAO_AI_CATALOG        - UC catalog for MLflow model registration (default: main)
+#   DAO_AI_SCHEMA         - UC schema for MLflow model registration (default: default)
+
+schemas:
+  registry_schema: &registry_schema
+    catalog_name: retail_consumer_goods
+    schema_name: dao_ai_mcp_meta_test
+
+resources:
+  models:
+    default_llm: &default_llm
+      name: databricks-claude-sonnet-4
+
+tools:
+  # Feature 1: workspace-wide Genie MCP (the new `genie: true` field)
+  genie_all_mcp: &genie_all_mcp
+    name: genie_all_mcp
+    function:
+      type: mcp
+      genie: true                                      # NEW: workspace-wide Genie endpoint
+      # Use the app's own service principal (auto-injected by Databricks Apps).
+      # Omitting auth fields makes the MCP client fall back to the default
+      # Databricks SDK auth chain, which inside an App resolves to the SP token.
+
+  # Feature 2: DBSQL MCP with `_meta.warehouse_id` (the new `meta` field)
+  sql_mcp_with_meta: &sql_mcp_with_meta
+    name: sql_mcp_with_meta
+    function:
+      type: mcp
+      sql: true                                        # serverless DBSQL MCP
+      meta:                                            # NEW: per-call _meta sent on every tools/call
+        warehouse_id:                                  # pin a specific SQL warehouse
+          env: DAO_AI_WAREHOUSE_ID
+      # Use the app's own service principal (auto-injected by Databricks Apps).
+
+agents:
+  mcp_meta_test_agent: &mcp_meta_test_agent
+    name: mcp_meta_test_agent
+    model: *default_llm
+    tools:
+    - *genie_all_mcp
+    - *sql_mcp_with_meta
+    prompt: |
+      You are a Databricks data assistant for end-to-end validation of two new MCP
+      capabilities in dao-ai:
+
+        1. `genie_all_mcp` — workspace-wide Genie MCP server that can query any
+           Genie space in the workspace (no space_id needed).
+        2. `sql_mcp_with_meta` — the DBSQL MCP server with a pinned `warehouse_id`
+           injected via the `_meta` parameter.
+
+      When the user asks a SQL question, use `sql_mcp_with_meta` and call
+      `execute_sql`. When the user asks a natural-language data question that
+      spans Genie spaces, use `genie_all_mcp`. Be concise.
+
+app:
+  name: dao_ai_mcp_meta_test
+  log_level: TRACE
+  registered_model:
+    schema: *registry_schema
+    name: dao_ai_mcp_meta_test
+  agents:
+  - *mcp_meta_test_agent
+  deployment_target: apps                              # Deploy as a Databricks App
+  environment_vars:
+    DAO_AI_WAREHOUSE_ID:                               # Forwarded to the deployed app env
+      env: DAO_AI_WAREHOUSE_ID

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -158,10 +158,15 @@ tools:
       connection: *connection   # UC Connection for MCP
       sql: bool                 # Use DBSQL MCP server
       functions: *my_schema     # Use UC Functions MCP
-      genie_room: *genie        # Use Genie MCP
+      genie_room: *genie        # Use Genie MCP for a single space (per-space URL)
+      genie: bool               # Use workspace-wide Genie MCP (all spaces, no space_id)
       vector_search: *store     # Use Vector Search MCP
       include_tools: [string]   # Tools to load (allowlist, supports glob)
       exclude_tools: [string]   # Tools to exclude (denylist, supports glob)
+      meta:                     # _meta sent on every tool call (MCP spec, public preview on Databricks)
+        warehouse_id: string    # DBSQL: pin a specific warehouse
+        num_results: int        # Vector Search: cap result count
+        # ... any other server-specific keys (see Databricks managed MCP docs)
       human_in_the_loop:        # Optional approval gate
         review_prompt: string
         allowed_decisions: [approve, edit, reject]

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -1,5 +1,3 @@
-Resolved 280 packages in 7ms
-Checked 249 packages in 82ms
 {
   "$defs": {
     "A2AModel": {
@@ -5503,7 +5501,7 @@ Checked 249 packages in 82ms
             }
           ],
           "default": null,
-          "description": "Direct MCP server URL. Mutually exclusive with app, connection, genie_room, sql, vector_search, functions.",
+          "description": "Direct MCP server URL. Mutually exclusive with app, connection, genie_room, genie, sql, vector_search, functions.",
           "title": "Url"
         },
         "headers": {
@@ -5595,6 +5593,19 @@ Checked 249 packages in 82ms
           "default": null,
           "description": "Genie space exposed as an MCP server for natural-language SQL."
         },
+        "genie": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Enable the workspace-wide Databricks Genie MCP server (queries across all Genie spaces in the workspace, no space_id required).",
+          "title": "Genie"
+        },
         "sql": {
           "anyOf": [
             {
@@ -5651,6 +5662,47 @@ Checked 249 packages in 82ms
           "default": null,
           "description": "Optional list of tool names or glob patterns to exclude from the MCP server. Tools matching these patterns will not be loaded. Takes precedence over include_tools. Supports glob patterns: * (any chars), ? (single char), [abc] (char set). Examples: ['drop_*', 'delete_*', 'execute_ddl']",
           "title": "Exclude Tools"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/CompositeVariableModel"
+                  },
+                  {
+                    "$ref": "#/$defs/EnvironmentVariableModel"
+                  },
+                  {
+                    "$ref": "#/$defs/SecretVariableModel"
+                  },
+                  {
+                    "$ref": "#/$defs/PrimitiveVariableModel"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Per-MCP-server `_meta` parameters (MCP spec). Sent as `_meta` on every tools/call request to this server. Common Databricks keys: warehouse_id (DBSQL); num_results, filters, query_type, columns, score_threshold, include_score, columns_to_rerank (Vector Search). Values support AnyVariable (env vars, secrets, defaults).",
+          "title": "Meta"
         }
       },
       "title": "McpFunctionModel",

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -4723,7 +4723,7 @@ class McpFunctionModel(BaseFunctionModel, IsDatabricksResource):
     )
     url: Optional[AnyVariable] = Field(
         default=None,
-        description="Direct MCP server URL. Mutually exclusive with app, connection, genie_room, sql, vector_search, functions.",
+        description="Direct MCP server URL. Mutually exclusive with app, connection, genie_room, genie, sql, vector_search, functions.",
     )
     headers: dict[str, AnyVariable] = Field(
         default_factory=dict,
@@ -4748,6 +4748,10 @@ class McpFunctionModel(BaseFunctionModel, IsDatabricksResource):
     genie_room: Optional[GenieRoomModel] = Field(
         default=None,
         description="Genie space exposed as an MCP server for natural-language SQL.",
+    )
+    genie: Optional[bool] = Field(
+        default=None,
+        description="Enable the workspace-wide Databricks Genie MCP server (queries across all Genie spaces in the workspace, no space_id required).",
     )
     sql: Optional[bool] = Field(
         default=None,
@@ -4775,6 +4779,16 @@ class McpFunctionModel(BaseFunctionModel, IsDatabricksResource):
             "Takes precedence over include_tools. "
             "Supports glob patterns: * (any chars), ? (single char), [abc] (char set). "
             "Examples: ['drop_*', 'delete_*', 'execute_ddl']"
+        ),
+    )
+    meta: Optional[dict[str, AnyVariable]] = Field(
+        default=None,
+        description=(
+            "Per-MCP-server `_meta` parameters (MCP spec). Sent as `_meta` on every "
+            "tools/call request to this server. Common Databricks keys: "
+            "warehouse_id (DBSQL); num_results, filters, query_type, columns, "
+            "score_threshold, include_score, columns_to_rerank (Vector Search). "
+            "Values support AnyVariable (env vars, secrets, defaults)."
         ),
     )
 
@@ -4842,12 +4856,14 @@ class McpFunctionModel(BaseFunctionModel, IsDatabricksResource):
         - If app is set, retrieves URL from Databricks App via workspace client
         - If connection is set, constructs URL from connection
         - If genie_room is set, constructs Genie MCP URL
+        - If genie is set, constructs workspace-wide Genie MCP URL (no space_id)
         - If sql is set, constructs DBSQL MCP URL (serverless)
         - If vector_search is set, constructs Vector Search MCP URL
         - If functions is set, constructs UC Functions MCP URL
 
         URL patterns (per https://docs.databricks.com/aws/en/generative-ai/mcp/managed-mcp):
-        - Genie: https://{host}/api/2.0/mcp/genie/{space_id}
+        - Genie (per-space): https://{host}/api/2.0/mcp/genie/{space_id}
+        - Genie (workspace-wide): https://{host}/api/2.0/mcp/genie (all spaces)
         - DBSQL: https://{host}/api/2.0/mcp/sql (serverless, workspace-level)
         - Vector Search: https://{host}/api/2.0/mcp/vector-search/{catalog}/{schema}
         - UC Functions: https://{host}/api/2.0/mcp/functions/{catalog}/{schema}
@@ -4866,10 +4882,14 @@ class McpFunctionModel(BaseFunctionModel, IsDatabricksResource):
             connection_name: str = self.connection.name
             return f"{workspace_host}/api/2.0/mcp/external/{connection_name}"
 
-        # Genie Room
+        # Genie Room (per-space)
         if self.genie_room:
             space_id: str = value_of(self.genie_room.space_id)
             return f"{workspace_host}/api/2.0/mcp/genie/{space_id}"
+
+        # Workspace-wide Genie MCP server (serverless, no space_id)
+        if self.genie:
+            return f"{workspace_host}/api/2.0/mcp/genie"
 
         # DBSQL MCP server (serverless, workspace-level)
         if self.sql:
@@ -4939,7 +4959,7 @@ class McpFunctionModel(BaseFunctionModel, IsDatabricksResource):
 
         raise ValueError(
             "No URL source configured. Provide one of: url, app, connection, genie_room, "
-            "sql, vector_search, or functions"
+            "genie, sql, vector_search, or functions"
         )
 
     @field_serializer("transport")
@@ -4958,6 +4978,7 @@ class McpFunctionModel(BaseFunctionModel, IsDatabricksResource):
             ("app", self.app),
             ("connection", self.connection),
             ("genie_room", self.genie_room),
+            ("genie", self.genie),
             ("sql", self.sql),
             ("vector_search", self.vector_search),
             ("functions", self.functions),
@@ -4971,13 +4992,13 @@ class McpFunctionModel(BaseFunctionModel, IsDatabricksResource):
             if len(provided_sources) == 0:
                 raise ValueError(
                     "For STREAMABLE_HTTP transport, exactly one of the following must be provided: "
-                    "url, app, connection, genie_room, sql, vector_search, or functions"
+                    "url, app, connection, genie_room, genie, sql, vector_search, or functions"
                 )
             if len(provided_sources) > 1:
                 raise ValueError(
                     f"For STREAMABLE_HTTP transport, only one URL source can be provided. "
                     f"Found: {', '.join(provided_sources)}. "
-                    f"Please provide only one of: url, app, connection, genie_room, sql, vector_search, or functions"
+                    f"Please provide only one of: url, app, connection, genie_room, genie, sql, vector_search, or functions"
                 )
 
         if self.transport == TransportType.STDIO:

--- a/src/dao_ai/tools/mcp.py
+++ b/src/dao_ai/tools/mcp.py
@@ -37,6 +37,7 @@ from dao_ai.config import (
     IsDatabricksResource,
     McpFunctionModel,
     TransportType,
+    value_of,
 )
 from dao_ai.state import Context
 from dao_ai.tools.tracing import ResourceInfo, set_resource_attributes
@@ -151,6 +152,17 @@ def _should_include_tool(
 
     # Default: include all tools
     return True
+
+
+def _resolve_meta(meta: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Resolve AnyVariable values in a meta dict to concrete primitives.
+
+    Returns None if meta is unset or empty so we don't send an empty _meta
+    on the wire (which would still be valid but adds noise).
+    """
+    if not meta:
+        return None
+    return {key: value_of(val) for key, val in meta.items()}
 
 
 def _has_auth_configured(resource: IsDatabricksResource) -> bool:
@@ -589,7 +601,7 @@ async def acreate_mcp_tools(
             try:
                 async with invocation_client.session("mcp_function") as session:
                     result: CallToolResult = await session.call_tool(
-                        mcp_tool.name, kwargs
+                        mcp_tool.name, kwargs, meta=_resolve_meta(function.meta)
                     )
 
                     text_result: str = _extract_text_content(result)
@@ -719,7 +731,7 @@ def create_mcp_tools(
             try:
                 async with invocation_client.session("mcp_function") as session:
                     result: CallToolResult = await session.call_tool(
-                        mcp_tool.name, kwargs
+                        mcp_tool.name, kwargs, meta=_resolve_meta(function.meta)
                     )
 
                     # Extract text content, avoiding extra fields

--- a/tests/dao_ai/test_function_parsing.py
+++ b/tests/dao_ai/test_function_parsing.py
@@ -182,7 +182,7 @@ class TestFunctionModelParsing:
 
         with pytest.raises(
             ValidationError,
-            match="url, app, connection, genie_room, sql, vector_search, or functions",
+            match="url, app, connection, genie_room, genie, sql, vector_search, or functions",
         ):
             ToolModel(**yaml_data)
 

--- a/tests/dao_ai/test_mcp.py
+++ b/tests/dao_ai/test_mcp.py
@@ -202,7 +202,7 @@ def test_mcp_function_validation_requires_url_or_connection():
     # Should raise ValueError when no URL source is provided
     with pytest.raises(
         ValidationError,
-        match="url, app, connection, genie_room, sql, vector_search, or functions",
+        match="url, app, connection, genie_room, genie, sql, vector_search, or functions",
     ):
         McpFunctionModel(
             transport=TransportType.STREAMABLE_HTTP,

--- a/tests/dao_ai/test_mcp_filtering_integration.py
+++ b/tests/dao_ai/test_mcp_filtering_integration.py
@@ -4,6 +4,7 @@ Integration tests for MCP tool filtering and list_mcp_tools.
 Tests the end-to-end filtering behavior with mock MCP servers.
 """
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -13,6 +14,7 @@ from dao_ai.config import DatabricksAppModel, McpFunctionModel
 from dao_ai.tools.mcp import (
     MCPToolInfo,
     _build_connection_config,
+    _resolve_meta,
     create_mcp_tools,
     list_mcp_tools,
 )
@@ -984,3 +986,86 @@ class TestBuildConnectionConfigUnifiedAuth:
 
                 # Verify app's workspace client was used, not function's
                 mock_provider_class.assert_called_once_with(app_ws)
+
+
+class TestResolveMeta:
+    """Unit tests for _resolve_meta helper that resolves AnyVariable values."""
+
+    def test_returns_none_for_unset(self):
+        """None input returns None — caller should not send an empty _meta."""
+        assert _resolve_meta(None) is None
+
+    def test_returns_none_for_empty_dict(self):
+        """Empty dict input returns None to avoid empty wire payload."""
+        assert _resolve_meta({}) is None
+
+    def test_passes_plain_values_through(self):
+        """Plain str/int/bool values resolve to themselves via value_of()."""
+        result = _resolve_meta(
+            {"warehouse_id": "abc123", "num_results": 5, "include_score": True}
+        )
+        assert result == {
+            "warehouse_id": "abc123",
+            "num_results": 5,
+            "include_score": True,
+        }
+
+    def test_resolves_environment_variable(self, monkeypatch):
+        """AnyVariable env references are resolved at call time."""
+        monkeypatch.setenv("TEST_WAREHOUSE_ID", "wh_from_env")
+        # Construct an McpFunctionModel so Pydantic parses the env-var spec
+        # into an EnvironmentVariableModel via the AnyVariable union.
+        function = McpFunctionModel(
+            type="mcp",
+            url="http://test.com/mcp",
+            meta={"warehouse_id": {"env": "TEST_WAREHOUSE_ID"}},
+        )
+        result = _resolve_meta(function.meta)
+        assert result == {"warehouse_id": "wh_from_env"}
+
+
+class TestMCPMetaInjection:
+    """Verify configured _meta is passed to session.call_tool()."""
+
+    @patch("dao_ai.tools.mcp.MultiServerMCPClient")
+    def test_call_tool_receives_meta_when_configured(
+        self, mock_client_class, mock_mcp_tools
+    ):
+        """meta from config is forwarded to ClientSession.call_tool()."""
+        mock_client = _setup_mock_client(mock_client_class, mock_mcp_tools)
+        mock_session = mock_client.session.return_value.__aenter__.return_value
+
+        function = McpFunctionModel(
+            type="mcp",
+            url="http://test.com/mcp",
+            meta={"warehouse_id": "abc123"},
+            include_tools=["query_sales"],
+        )
+
+        tools = create_mcp_tools(function)
+        assert len(tools) == 1
+        asyncio.run(tools[0].ainvoke({}))
+
+        mock_session.call_tool.assert_called_once()
+        call_kwargs = mock_session.call_tool.call_args.kwargs
+        assert call_kwargs.get("meta") == {"warehouse_id": "abc123"}
+
+    @patch("dao_ai.tools.mcp.MultiServerMCPClient")
+    def test_call_tool_meta_is_none_when_not_configured(
+        self, mock_client_class, mock_mcp_tools
+    ):
+        """meta is None on call_tool when not configured — no empty _meta on wire."""
+        mock_client = _setup_mock_client(mock_client_class, mock_mcp_tools)
+        mock_session = mock_client.session.return_value.__aenter__.return_value
+
+        function = McpFunctionModel(
+            type="mcp",
+            url="http://test.com/mcp",
+            include_tools=["query_sales"],
+        )
+
+        tools = create_mcp_tools(function)
+        asyncio.run(tools[0].ainvoke({}))
+
+        mock_session.call_tool.assert_called_once()
+        assert mock_session.call_tool.call_args.kwargs.get("meta") is None

--- a/tests/dao_ai/test_mcp_function_model.py
+++ b/tests/dao_ai/test_mcp_function_model.py
@@ -26,7 +26,7 @@ class TestMcpFunctionModelValidation:
         """Test that missing URL source raises validation error."""
         with pytest.raises(
             ValidationError,
-            match="url, app, connection, genie_room, sql, vector_search, or functions",
+            match="url, app, connection, genie_room, genie, sql, vector_search, or functions",
         ):
             McpFunctionModel(
                 transport=TransportType.STREAMABLE_HTTP,
@@ -67,6 +67,18 @@ class TestMcpFunctionModelValidation:
                 transport=TransportType.STREAMABLE_HTTP,
                 genie_room=GenieRoomModel(name="test_genie", space_id="space_123"),
                 sql=True,
+                workspace_host="https://workspace.com",
+            )
+
+    def test_genie_and_genie_room_mutually_exclusive(self):
+        """Test that genie (workspace-wide) and genie_room (per-space) cannot be provided together."""
+        with pytest.raises(
+            ValidationError, match="only one URL source can be provided"
+        ):
+            McpFunctionModel(
+                transport=TransportType.STREAMABLE_HTTP,
+                genie=True,
+                genie_room=GenieRoomModel(name="test_genie", space_id="space_123"),
                 workspace_host="https://workspace.com",
             )
 
@@ -141,6 +153,17 @@ class TestMcpFunctionModelUrlGeneration:
         )
         # Per Databricks MCP documentation, the DBSQL MCP server is serverless and workspace-level
         expected = "https://adb-123.azuredatabricks.net/api/2.0/mcp/sql"
+        assert model.mcp_url == expected
+
+    def test_genie_workspace_wide_url_generation(self):
+        """Test URL generation for workspace-wide Genie MCP server (no space_id)."""
+        model = McpFunctionModel(
+            transport=TransportType.STREAMABLE_HTTP,
+            genie=True,
+            workspace_host="https://adb-123.azuredatabricks.net",
+        )
+        # Workspace-wide Genie MCP server has no space_id; it queries across all spaces
+        expected = "https://adb-123.azuredatabricks.net/api/2.0/mcp/genie"
         assert model.mcp_url == expected
 
     @patch("dao_ai.providers.databricks.VectorSearchClient")
@@ -272,6 +295,56 @@ class TestMcpFunctionModelProperties:
             == "streamable_http"
         )
         assert model.serialize_transport(TransportType.STDIO) == "stdio"
+
+
+class TestMcpFunctionModelMeta:
+    """Test the _meta parameter field (MCP spec, public preview on Databricks)."""
+
+    def test_meta_defaults_to_none(self):
+        """Test that meta defaults to None when not provided."""
+        model = McpFunctionModel(
+            transport=TransportType.STREAMABLE_HTTP,
+            sql=True,
+            workspace_host="https://workspace.com",
+        )
+        assert model.meta is None
+
+    def test_meta_parses_plain_values(self):
+        """Test that plain string/int/bool values in meta are preserved."""
+        model = McpFunctionModel(
+            transport=TransportType.STREAMABLE_HTTP,
+            sql=True,
+            meta={
+                "warehouse_id": "abc123",
+                "num_results": 5,
+                "include_score": True,
+            },
+            workspace_host="https://workspace.com",
+        )
+        assert model.meta == {
+            "warehouse_id": "abc123",
+            "num_results": 5,
+            "include_score": True,
+        }
+
+    def test_meta_compatible_with_other_url_sources(self):
+        """Test that meta can be combined with any URL source (not mutually exclusive)."""
+        # Plain url source
+        m1 = McpFunctionModel(
+            transport=TransportType.STREAMABLE_HTTP,
+            url="https://example.com/mcp",
+            meta={"warehouse_id": "abc"},
+        )
+        assert m1.meta == {"warehouse_id": "abc"}
+
+        # Genie workspace-wide
+        m2 = McpFunctionModel(
+            transport=TransportType.STREAMABLE_HTTP,
+            genie=True,
+            meta={"some_key": "value"},
+            workspace_host="https://workspace.com",
+        )
+        assert m2.meta == {"some_key": "value"}
 
 
 class TestMcpFunctionModelAuthValidation:


### PR DESCRIPTION
## Summary

Adds two new fields to `McpFunctionModel` for the recently-shipped Databricks managed MCP capabilities:

- **`genie: true`** — workspace-wide Genie MCP server (`/api/2.0/mcp/genie`, no `space_id`). Mirrors `sql: true`. Existing `genie_room: {...}` is unchanged for the per-space variant.
- **`meta: {key: value, ...}`** — per-MCP-server `_meta` parameters (MCP spec). Sent on every `tools/call` to every MCP server type. Values support `AnyVariable` so `warehouse_id` can come from a secret or env var.

Total diff: ~287 added / ~18 removed across 10 files.

## What changed

| File | Change |
|---|---|
| `src/dao_ai/config.py` | New `genie: Optional[bool]` and `meta: Optional[dict[str, AnyVariable]]` on `McpFunctionModel`; `mcp_url` returns `/api/2.0/mcp/genie` for workspace-wide; `validate_mutually_exclusive` includes `genie` |
| `src/dao_ai/tools/mcp.py` | New `_resolve_meta()` helper; both `session.call_tool()` call sites (async + sync wrappers) now pass `meta=_resolve_meta(function.meta)` |
| `schemas/model_config_schema.json` | Regenerated via `make schema` — `genie` (bool) and `meta` (object of AnyVariable values) appear under `McpFunctionModel` |
| `docs/configuration-reference.md` | New `genie:` and `meta:` lines in the MCP-specific options block |
| `config/examples/02_mcp/managed_mcp.yaml` | Adds `genie_all_mcp` (workspace-wide variant) and `meta` blocks on `sql_mcp` (`warehouse_id` from env) + `vector_search_mcp` (`num_results`, `query_type`, `include_score`); both wired into the agent |
| `config/examples/02_mcp/mcp_meta_test.yaml` | **New** lean test config exercising both features with minimal external deps — what the fevm validation used |
| `tests/dao_ai/test_mcp_function_model.py` | New `TestMcpFunctionModelMeta` + 2 `genie` tests in existing classes; 1 existing error-message assertion updated for the new `genie` entry in the URL-source list |
| `tests/dao_ai/test_mcp_filtering_integration.py` | New `TestResolveMeta` (helper unit tests) + `TestMCPMetaInjection` (mocked `MultiServerMCPClient` confirming `meta=` reaches `call_tool`) |
| `tests/dao_ai/test_mcp.py`, `tests/dao_ai/test_function_parsing.py` | Updated 2 existing error-message assertions for the new `genie` entry |

## Verification

- ✅ **`make test`**: 2198 passed (only pre-existing reranking integration tests fail due to missing UC index — unrelated env issue)
- ✅ **132 MCP-related tests pass cleanly**
- ✅ **End-to-end on fevm Databricks Apps**:
  - Bundle deployed (`/tmp/dao-ai-mcp-meta-test`), app running at `https://dao-ai-mcp-meta-test-7474649850651417.aws.databricksapps.com`
  - Startup logs confirmed both MCP servers discovered: Genie at `…/api/2.0/mcp/genie` (no space_id), DBSQL at `…/api/2.0/mcp/sql` with `meta={'warehouse_id': EnvironmentVariableModel(env='DAO_AI_WAREHOUSE_ID')}`
  - LLM-driven `execute_sql` call to the deployed app routed through the pinned warehouse `d1be2f7fe7faacb1` — initial `PERMISSION_DENIED` referenced that **specific** warehouse (proving `_meta` reached the wire and the server honored it), then succeeded after granting CAN_USE
  - Client received `**42**` from `SELECT 42 as answer`

## `meta` applies to every MCP server type

Same code path runs for managed (`sql`/`genie`/`genie_room`/`vector_search`/`functions`), Databricks App-hosted, UC Connection, direct URL, and STDIO transports. The MCP spec defines `_meta` as free-form metadata; Databricks-managed servers honor specific keys (DBSQL: `warehouse_id`; Vector Search: `num_results`/`filters`/`query_type`/`columns`/`score_threshold`/`include_score`/`columns_to_rerank`). Custom and external MCP servers can interpret whatever keys they implement.

## Test plan
- [x] Unit tests cover `meta` parsing, default-None behavior, `_resolve_meta` helper (None/empty/plain/AnyVariable cases)
- [x] Mocked invocation test asserts `call_tool` receives the configured `meta` dict
- [x] Mocked invocation test asserts `meta` is `None` on the wire when unset (no empty `_meta`)
- [x] `genie: true` URL generation + mutual-exclusion with `genie_room` and `sql`
- [x] Real Databricks MCP server invocation: `_meta.warehouse_id` round-trip verified on fevm
- [x] Schema regenerated; both new fields appear with correct types

This pull request and its description were written by Isaac.