### PR TITLE
Make trace_id capture reliable across in-process + Model Serving paths

### DIFF
--- a/notebooks/15_feedback_demo.py
+++ b/notebooks/15_feedback_demo.py
@@ -30,9 +30,10 @@ import sys
 import nest_asyncio
 nest_asyncio.apply()
 
-# Force synchronous trace export so log_feedback never races the async exporter
-# in notebook workloads. Set BEFORE importing dao_ai.
-os.environ.setdefault("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "false")
+# Force synchronous trace export so log_feedback never races the async exporter.
+# `setdefault` won't override a job-context "true" so use direct assignment.
+# Set BEFORE importing mlflow / dao_ai.
+os.environ["MLFLOW_ENABLE_ASYNC_TRACE_LOGGING"] = "false"
 
 sys.path.insert(0, "../src")
 
@@ -112,6 +113,8 @@ trace_id_positive = resp_positive.custom_outputs["trace_id"]
 print("assistant:", resp_positive.output[0].model_dump()["content"][0]["text"][:300])
 print("trace_id:", trace_id_positive)
 
+# Flush async trace logging so log_feedback sees the trace.
+mlflow.flush_trace_async_logging()
 log_user_feedback(
     trace_id=trace_id_positive,
     value="up",
@@ -143,6 +146,7 @@ trace_id_negative = resp_negative.custom_outputs["trace_id"]
 print("assistant:", resp_negative.output[0].model_dump()["content"][0]["text"][:300])
 print("trace_id:", trace_id_negative)
 
+mlflow.flush_trace_async_logging()
 log_user_feedback(
     trace_id=trace_id_negative,
     value="down",
@@ -167,23 +171,27 @@ from databricks.sdk import WorkspaceClient
 w = WorkspaceClient()
 endpoint_name = config.app.endpoint_name
 
-served = w.serving_endpoints.query(
-    name=endpoint_name,
-    inputs={
-        "input": [
-            {"role": "user", "content": "What aisle has 1/2 inch PVC elbows?"},
-        ],
+# Note: w.serving_endpoints.query() doesn't pass a ResponsesAgent body shape
+# cleanly — it wraps under "inputs" and the endpoint rejects with
+# "Invalid input. One of 'instances' and 'inputs' must be specified".
+# Use the raw POST to /serving-endpoints/{name}/invocations instead.
+served_dict = w.api_client.do(
+    "POST",
+    f"/serving-endpoints/{endpoint_name}/invocations",
+    body={
+        "input": [{"role": "user", "content": "What aisle has 1/2 inch PVC elbows?"}],
         "custom_inputs": {
             "configurable": {"user_id": USER, "store_num": "87887"},
             "session": {},
         },
     },
+    headers={"Content-Type": "application/json"},
 )
-served_dict = served.as_dict() if hasattr(served, "as_dict") else dict(served)
-served_trace_id = served_dict.get("custom_outputs", {}).get("trace_id")
+served_trace_id = (served_dict.get("custom_outputs") or {}).get("trace_id")
 print("Served endpoint trace_id:", served_trace_id)
 
 if served_trace_id:
+    mlflow.flush_trace_async_logging()
     log_user_feedback(
         trace_id=served_trace_id,
         value="up",

--- a/src/dao_ai/evaluation.py
+++ b/src/dao_ai/evaluation.py
@@ -546,6 +546,8 @@ def log_user_feedback(
     value: FeedbackValue | bool,
     comment: str | None = None,
     user_id: str,
+    max_attempts: int = 6,
+    backoff_seconds: float = 0.5,
 ) -> None:
     """Log a human thumbs-up/down assessment against a dao-ai trace.
 
@@ -555,19 +557,48 @@ def log_user_feedback(
     desync under concurrency or return ``None`` after the agent function
     returns.
 
+    The function flushes pending async trace exports and retries on
+    transient ``NOT_FOUND`` because, under async trace export (the default
+    for Databricks job and Model Serving workloads), the trace may not yet
+    be queryable when this function is called immediately after the agent
+    response is received.
+
     Args:
         trace_id: The MLflow trace_id pulled from ``custom_outputs``.
         value: ``"up"``, ``"down"``, or a bool. Coerced to a bool internally.
         comment: Optional free-text rationale (the user's written feedback).
         user_id: Identifier for the human providing feedback (typically email).
+        max_attempts: How many times to retry on transient NOT_FOUND.
+        backoff_seconds: Initial backoff; doubles each attempt.
     """
+    import time
+
+    from mlflow.exceptions import RestException
+
     bool_value: bool = (
         value if isinstance(value, bool) else (value == "up")
     )
-    mlflow.log_feedback(
-        trace_id=trace_id,
-        name="user_feedback",
-        value=bool_value,
-        rationale=comment,
-        source=AssessmentSource(source_type="HUMAN", source_id=user_id),
-    )
+
+    try:
+        mlflow.flush_trace_async_logging()
+    except Exception:
+        pass
+
+    attempt = 0
+    delay = backoff_seconds
+    while True:
+        try:
+            mlflow.log_feedback(
+                trace_id=trace_id,
+                name="user_feedback",
+                value=bool_value,
+                rationale=comment,
+                source=AssessmentSource(source_type="HUMAN", source_id=user_id),
+            )
+            return
+        except RestException as exc:
+            attempt += 1
+            if attempt >= max_attempts or "NOT_FOUND" not in str(exc):
+                raise
+            time.sleep(delay)
+            delay *= 2

--- a/src/dao_ai/models.py
+++ b/src/dao_ai/models.py
@@ -15,6 +15,7 @@ from typing import (
 
 import mlflow
 from databricks_langchain import ChatDatabricks
+from mlflow.entities.span import SpanType
 
 if TYPE_CHECKING:
     pass
@@ -1009,6 +1010,7 @@ class LanggraphResponsesAgent(ResponsesAgent):
         self.graph = graph
         self._prompt_versions: list = prompt_versions or []
 
+    @mlflow.trace(span_type=SpanType.AGENT, name="dao_ai_apredict")
     async def apredict(self, request: ResponsesAgentRequest) -> ResponsesAgentResponse:
         """
         Async version of predict - primary implementation for Databricks Apps.
@@ -1275,6 +1277,7 @@ class LanggraphResponsesAgent(ResponsesAgent):
             output=[output_item], custom_outputs=custom_outputs
         )
 
+    @mlflow.trace(span_type=SpanType.AGENT, name="dao_ai_apredict_stream")
     async def apredict_stream(
         self, request: ResponsesAgentRequest
     ) -> AsyncGenerator[ResponsesAgentStreamEvent, None]:


### PR DESCRIPTION
## Summary

Three follow-ups to PR #100. The original implementation worked for the Model Serving deployment path (verified end-to-end on `hardware_store_dao`) but had a latent bug in in-process invocation, plus a notebook gap.

1. **`src/dao_ai/models.py`** — Wrap `apredict` / `apredict_stream` with `@mlflow.trace(span_type=SpanType.AGENT)`. In-process callers (e.g. `agent = config.as_responses_agent(); await agent.apredict(...)`) rely on `mlflow.langchain.autolog()` to open the root trace. Autolog closes its trace when `graph.ainvoke()` returns, so `mlflow.get_active_trace_id()` returns `None` by the time we populate `custom_outputs["trace_id"]`. Adding the decorator guarantees an active root span for the function's lifetime. The Model Serving path is unchanged in behavior — the agent framework's outer trace still wraps us.

2. **`src/dao_ai/evaluation.py`** — `log_user_feedback` now flushes `mlflow.flush_trace_async_logging()` and retries `mlflow.log_feedback` on transient `RestException: NOT_FOUND`. In job / Model Serving workloads, async trace export means the trace isn't always queryable in the millisecond window between the response and `log_feedback`. 6 attempts, exponential backoff starting at 0.5s (~30s worst case).

3. **`notebooks/15_feedback_demo.py`** — Section 2 (deployed-endpoint variant) was using `WorkspaceClient.serving_endpoints.query(name=..., inputs={...})` which the SDK wraps incorrectly for a `ResponsesAgent` endpoint (it auto-adds `databricks_options` and the endpoint rejects with `"Invalid input. One of 'instances' and 'inputs' must be specified"`). Switched to `api_client.do(POST, /serving-endpoints/{name}/invocations, body=...)`. Also changed `os.environ.setdefault("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "false")` to direct assignment so a job-context default doesn't override us, and added `mlflow.flush_trace_async_logging()` before each feedback call as a belt-and-suspenders.

## Why

Without (1), the in-process notebook path (Section 1 of `15_feedback_demo.py`) raises `KeyError: 'trace_id'` because `custom_outputs` is missing the key. Without (2), every immediate `log_feedback` from a notebook job raises `RestException: NOT_FOUND` even though the trace will eventually land. Without (3), Section 2 of the demo can't talk to the deployed endpoint at all.

## Test plan

- [x] Notebook `15_feedback_demo.py` runs end-to-end as a serverless v5 notebook job on fevm:
      `https://fevm-nfleming-stable-aws.cloud.databricks.com/?o=7474649850651417#job/652684009968819/run/703080818157895`
      → `TERMINATED + SUCCESS` on first attempt with all three fixes in place.
- [x] Section 1 (in-process `agent.apredict(...)`) now returns `custom_outputs["trace_id"]` populated.
- [x] Section 2 (deployed `hardware_store_dao` Model Serving endpoint via raw POST) returns `custom_outputs["trace_id"]` populated.
- [x] `log_user_feedback` rounds-trips through both paths: trace is queryable via `mlflow.search_traces` and the `user_feedback` assessment is attached.
- [ ] Pending after merge: redeploy `hardware_store.yaml` with `dao-ai pipeline --deploy --run --deployment-target both`, re-validate Model Serving + Databricks App.

This pull request and its description were written by Isaac.