### PR TITLE
Simplify log_user_feedback + trim demo notebook to canonical pattern

### DIFF
--- a/notebooks/15_feedback_demo.py
+++ b/notebooks/15_feedback_demo.py
@@ -2,19 +2,17 @@
 # MAGIC %md
 # MAGIC # dao-ai Multi-Agent Feedback Demo
 # MAGIC
-# MAGIC This notebook shows the **correct** pattern for capturing thumbs-up / thumbs-down
-# MAGIC feedback against a dao-ai multi-agent response — and the anti-patterns that go
-# MAGIC wrong under concurrency or after the agent function returns.
+# MAGIC Capture thumbs-up / thumbs-down feedback against a dao-ai response. Works
+# MAGIC the same for in-process invocation, the deployed Model Serving endpoint,
+# MAGIC and the deployed Databricks App.
 # MAGIC
-# MAGIC **Golden rule:** read `trace_id` out of `response.custom_outputs["trace_id"]`.
-# MAGIC Never read it from MLflow global state in the caller.
+# MAGIC **The contract**
 # MAGIC
-# MAGIC Why this notebook exists:
-# MAGIC - dao-ai's `LanggraphResponsesAgent` runs a multi-agent graph (supervisor / swarm).
-# MAGIC   The trace_id we want is the **outer** root trace that spans every sub-agent hop,
-# MAGIC   not any single agent leg.
-# MAGIC - `apredict()` / `apredict_stream()` now both attach that outer trace_id to
-# MAGIC   `custom_outputs` so the caller never needs to read MLflow global state.
+# MAGIC - Every dao-ai response carries `custom_outputs["trace_id"]`.
+# MAGIC - In multi-agent supervisor/swarm flows, that trace_id is the **outer**
+# MAGIC   root trace whose children include every sub-agent hop.
+# MAGIC - Pass it to `dao_ai.evaluation.log_user_feedback(...)` to attach an
+# MAGIC   assessment to that exact trace.
 
 # COMMAND ----------
 
@@ -24,15 +22,16 @@
 # COMMAND ----------
 
 import asyncio
+import json
 import os
 import sys
 
 import nest_asyncio
 nest_asyncio.apply()
 
-# Force synchronous trace export so log_feedback never races the async exporter.
-# `setdefault` won't override a job-context "true" so use direct assignment.
-# Set BEFORE importing mlflow / dao_ai.
+# Force synchronous trace export so the demo's tight loop (invoke → log
+# feedback in the next cell) is deterministic. Must be set BEFORE
+# importing mlflow.
 os.environ["MLFLOW_ENABLE_ASYNC_TRACE_LOGGING"] = "false"
 
 sys.path.insert(0, "../src")
@@ -60,11 +59,11 @@ mlflow.langchain.autolog()
 # COMMAND ----------
 
 config: AppConfig = AppConfig.from_file(path=config_path)
-print(f"App: {config.app.name}")
-print(f"Endpoint: {config.app.endpoint_name}")
-print(f"Agents: {[a.name for a in config.app.agents]}")
+print(f"App:       {config.app.name}")
+print(f"Endpoint:  {config.app.endpoint_name}")
+print(f"Agents:    {[a.name for a in config.app.agents]}")
 
-# Resolve the experiment the deployed agent writes traces to
+# Resolve the experiment this agent writes traces to
 EXPERIMENT_PATH = (
     config.app.registered_model.experiment_name
     if hasattr(config.app.registered_model, "experiment_name")
@@ -78,104 +77,57 @@ EXPERIMENT_ID = experiment.experiment_id
 mlflow.set_experiment(experiment_id=EXPERIMENT_ID)
 print(f"Experiment: {EXPERIMENT_PATH} → id={EXPERIMENT_ID}")
 
-USER = WorkspaceClient().current_user.me().user_name
+w = WorkspaceClient()
+USER = w.current_user.me().user_name
 print(f"User: {USER}")
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 1. Happy path — in-process multi-agent invocation
+# MAGIC ## 1. In-process invocation
 # MAGIC
-# MAGIC 1. Build the graph + ResponsesAgent from config.
-# MAGIC 2. `await agent.apredict(request)` — `mlflow.langchain.autolog()` opens the root trace.
-# MAGIC 3. Read `trace_id` from `response.custom_outputs["trace_id"]`.
-# MAGIC 4. `log_user_feedback(trace_id=..., value="up"/"down", ...)`.
+# MAGIC Build the agent locally from config, call `apredict`, read `trace_id`
+# MAGIC from `custom_outputs`, log feedback.
 
 # COMMAND ----------
 
 agent = config.as_responses_agent()
 
-req_positive = ResponsesAgentRequest(
+req = ResponsesAgentRequest(
     input=[
         {"role": "user", "content": "Can you recommend a lamp for my oak side table?"}
     ],
     custom_inputs={
-        "configurable": {
-            "user_id": USER,
-            "store_num": "87887",
-        },
+        "configurable": {"user_id": USER, "store_num": "87887"},
         "session": {},
     },
 )
 
-resp_positive = asyncio.run(agent.apredict(req_positive))
-trace_id_positive = resp_positive.custom_outputs["trace_id"]
-print("assistant:", resp_positive.output[0].model_dump()["content"][0]["text"][:300])
-print("trace_id:", trace_id_positive)
+resp = asyncio.run(agent.apredict(req))
+trace_id_in_process = resp.custom_outputs["trace_id"]
+print("assistant:", resp.output[0].model_dump()["content"][0]["text"][:300])
+print("trace_id:", trace_id_in_process)
 
-# Flush async trace logging so log_feedback sees the trace.
-mlflow.flush_trace_async_logging()
 log_user_feedback(
-    trace_id=trace_id_positive,
+    trace_id=trace_id_in_process,
     value="up",
-    comment="Multi-agent answer was relevant and concise.",
+    comment="In-process apredict: multi-agent answer was good.",
     user_id=USER,
 )
-print("Logged positive feedback ✓")
-
-# COMMAND ----------
-
-req_negative = ResponsesAgentRequest(
-    input=[
-        {
-            "role": "user",
-            "content": "Do you carry left-handed metric crescent wrenches for stainless?",
-        }
-    ],
-    custom_inputs={
-        "configurable": {
-            "user_id": USER,
-            "store_num": "87887",
-        },
-        "session": {},
-    },
-)
-
-resp_negative = asyncio.run(agent.apredict(req_negative))
-trace_id_negative = resp_negative.custom_outputs["trace_id"]
-print("assistant:", resp_negative.output[0].model_dump()["content"][0]["text"][:300])
-print("trace_id:", trace_id_negative)
-
-mlflow.flush_trace_async_logging()
-log_user_feedback(
-    trace_id=trace_id_negative,
-    value="down",
-    comment="Wrong — the response missed that the part doesn't exist.",
-    user_id=USER,
-)
-print("Logged negative feedback ✓")
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 2. Deployed endpoint variant — query Model Serving
+# MAGIC ## 2. Deployed Model Serving endpoint
 # MAGIC
-# MAGIC Once `databricks.agents.deploy(...)` has shipped the agent, you can hit the served
-# MAGIC endpoint directly. The deployed endpoint returns the same `custom_outputs.trace_id`
-# MAGIC shape, so the feedback-logging pattern is identical.
+# MAGIC POST to `/serving-endpoints/{endpoint}/invocations`. Same response
+# MAGIC shape, same `custom_outputs["trace_id"]` contract.
 
 # COMMAND ----------
 
-from databricks.sdk import WorkspaceClient
+endpoint_name: str = config.app.endpoint_name
 
-w = WorkspaceClient()
-endpoint_name = config.app.endpoint_name
-
-# Note: w.serving_endpoints.query() doesn't pass a ResponsesAgent body shape
-# cleanly — it wraps under "inputs" and the endpoint rejects with
-# "Invalid input. One of 'instances' and 'inputs' must be specified".
-# Use the raw POST to /serving-endpoints/{name}/invocations instead.
-served_dict = w.api_client.do(
+ms_response: dict = w.api_client.do(
     "POST",
     f"/serving-endpoints/{endpoint_name}/invocations",
     body={
@@ -187,221 +139,126 @@ served_dict = w.api_client.do(
     },
     headers={"Content-Type": "application/json"},
 )
-served_trace_id = (served_dict.get("custom_outputs") or {}).get("trace_id")
-print("Served endpoint trace_id:", served_trace_id)
+trace_id_ms = ms_response["custom_outputs"]["trace_id"]
+print("assistant:", ms_response["output"][0]["content"][0]["text"][:300])
+print("trace_id:", trace_id_ms)
 
-if served_trace_id:
-    mlflow.flush_trace_async_logging()
-    log_user_feedback(
-        trace_id=served_trace_id,
-        value="up",
-        comment="Served endpoint round-trip worked.",
-        user_id=USER,
-    )
-    print("Logged feedback against deployed-endpoint trace ✓")
-else:
-    print(
-        "No trace_id in custom_outputs — either the endpoint is running an older "
-        "dao-ai build or autolog isn't enabled in the served model."
-    )
+log_user_feedback(
+    trace_id=trace_id_ms,
+    value="up",
+    comment="Model Serving endpoint: returned the right aisle.",
+    user_id=USER,
+)
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 3. Multi-agent verification
+# MAGIC ## 3. Deployed Databricks App
 # MAGIC
-# MAGIC The supervisor pattern routes one user turn through up to N sub-agents.
-# MAGIC `mlflow.langchain.autolog()` opens a single root trace per `apredict()` call;
-# MAGIC sub-agent invocations become child spans under that root. The trace_id in
-# MAGIC `custom_outputs` IS that root trace — so feedback attaches at the correct level.
+# MAGIC The App is also a `ResponsesAgent` server. Hit `{app_url}/invocations`
+# MAGIC with a Databricks bearer token — same JSON shape, same contract.
 
 # COMMAND ----------
 
-trace = mlflow.get_trace(trace_id_positive)
-spans = trace.search_spans()
-print(f"Total spans in trace: {len(spans)}")
-print()
-print("Top-level span (root of the multi-agent turn):")
-root = next((s for s in spans if s.parent_id is None), None)
-if root:
-    print(f"  name={root.name!r} span_type={root.span_type}")
-print()
-print("Sub-agent / tool spans nested under the root (first 15):")
-for s in spans[:15]:
-    indent = "  " if s.parent_id else ""
-    print(f"  {indent}{s.span_type:>15} | {s.name}")
+import requests
 
-# COMMAND ----------
+# Resolve the deployed App URL by name
+app_name: str = config.app.name.replace("_", "-")
+app_info = w.apps.get(name=app_name)
+app_url: str = app_info.url
+print(f"App: {app_name} → {app_url}")
 
-# MAGIC %md
-# MAGIC ## 4. Anti-patterns — DO NOT COPY
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ### 4a. Reading `get_last_active_trace_id()` from the caller
-# MAGIC
-# MAGIC Races with concurrent invocations and with autolog flushes from sibling calls.
-# MAGIC "Last" is not "this".
-
-# COMMAND ----------
-
-req_a = ResponsesAgentRequest(
-    input=[{"role": "user", "content": "What time does the store open?"}],
-    custom_inputs={
-        "configurable": {"user_id": USER, "store_num": "87887"},
-        "session": {},
+token: str = w.config.authenticate()["Authorization"].removeprefix("Bearer ").strip()
+r = requests.post(
+    f"{app_url}/invocations",
+    headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+    json={
+        "input": [{"role": "user", "content": "Do you carry gluten-free pasta?"}],
+        "custom_inputs": {
+            "configurable": {"user_id": USER, "store_num": "87887"},
+            "session": {},
+        },
     },
+    timeout=120,
 )
-resp_a = asyncio.run(agent.apredict(req_a))
+r.raise_for_status()
+app_response = r.json()
+trace_id_app = app_response["custom_outputs"]["trace_id"]
+print("assistant:", app_response["output"][0]["content"][0]["text"][:300])
+print("trace_id:", trace_id_app)
 
-# WRONG: read from MLflow global state instead of the response
-wrong_trace_id = mlflow.get_last_active_trace_id()
-right_trace_id = resp_a.custom_outputs["trace_id"]
-print(" wrong  (global state):", wrong_trace_id)
-print(" right  (custom_outputs):", right_trace_id)
-print(
-    " — In a single-threaded notebook these may coincide.\n"
-    " — Under concurrent invocations they diverge and feedback attaches to the wrong trace."
+log_user_feedback(
+    trace_id=trace_id_app,
+    value="down",
+    comment="Databricks App: answer was off-topic for a hardware store.",
+    user_id=USER,
 )
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ### 4b. Reading `get_current_active_span()` from the caller
+# MAGIC ## 4. Verify the trace is the OUTER multi-agent root
 # MAGIC
-# MAGIC The span opened inside `apredict()` is closed once the function returns.
-# MAGIC There is no active span in the caller's stack.
+# MAGIC Inspect the span tree under each trace_id. The root span should be of
+# MAGIC type `AGENT`; children should include the supervisor, middleware,
+# MAGIC and handoff into one or more sub-agents.
 
 # COMMAND ----------
 
-# `resp_a` was already produced above. After apredict() returns, no span is active here.
-active = mlflow.get_current_active_span()
-print("active span in caller:", active)  # → None
-
-try:
-    bad = active.trace_id  # noqa: F841 — demonstrates AttributeError on None
-except AttributeError as e:
-    print("AttributeError as expected:", e)
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ### 4c. Legacy `log_assessment` / `Assessment(...)` shape
-# MAGIC
-# MAGIC MLflow 2.x preview API. MLflow 3 split this into `log_feedback` (human / LLM-judge
-# MAGIC assessments) and `log_expectation` (ground truth) with typed kwargs.
-
-# COMMAND ----------
-
-try:
-    from mlflow.entities import Assessment  # may not exist or may have different signature
-
-    legacy = Assessment(  # type: ignore[call-arg]
-        name="user_feedback",
-        value=True,
-        rationale="legacy shape",
+for label, tid in [
+    ("in-process ", trace_id_in_process),
+    ("model serv. ", trace_id_ms),
+    ("app         ", trace_id_app),
+]:
+    trace = mlflow.get_trace(tid)
+    spans = trace.search_spans()
+    root_spans = [s for s in spans if s.parent_id is None]
+    print(
+        f"[{label}] trace_id={tid} | spans={len(spans)} | "
+        f"root={root_spans[0].name!r} ({root_spans[0].span_type})"
     )
-    mlflow.log_assessment(trace_id=right_trace_id, assessment=legacy)  # type: ignore[attr-defined]
-except (ImportError, AttributeError, TypeError) as e:
-    print("Legacy shape failed as expected:", type(e).__name__, e)
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 5. Search & verify
-# MAGIC
-# MAGIC Confirm the happy-path traces show up with `user_feedback` assessments attached.
+# MAGIC ## 5. Search & verify feedback rows
 
 # COMMAND ----------
 
 import pandas as pd
 
-all_traces = mlflow.search_traces(locations=[EXPERIMENT_ID], max_results=50)
-print(f"Total traces returned: {len(all_traces)}")
-all_traces[["trace_id", "request_time"]].head(10)
+traces = mlflow.search_traces(locations=[EXPERIMENT_ID], max_results=100)
+print(f"total traces: {len(traces)}")
 
-# COMMAND ----------
 
-def has_positive_feedback(assessments) -> bool:
+def has_user_feedback(assessments) -> bool:
     return any(
-        a.get("assessment_name") == "user_feedback"
-        and a.get("feedback", {}).get("value") is True
-        for a in (assessments or [])
+        a.get("assessment_name") == "user_feedback" for a in (assessments or [])
     )
 
 
-def has_negative_feedback(assessments) -> bool:
-    return any(
-        a.get("assessment_name") == "user_feedback"
-        and a.get("feedback", {}).get("value") is False
-        for a in (assessments or [])
-    )
-
-
-positive_mask = all_traces["assessments"].apply(has_positive_feedback)
-negative_mask = all_traces["assessments"].apply(has_negative_feedback)
-print(f"Positive feedback traces: {int(positive_mask.sum())}")
-print(f"Negative feedback traces: {int(negative_mask.sum())}")
-all_traces[positive_mask | negative_mask][["trace_id"]].head()
+feedback_mask = traces["assessments"].apply(has_user_feedback)
+print(f"traces with user_feedback assessments: {int(feedback_mask.sum())}")
+traces[feedback_mask][["trace_id", "request_time"]].head()
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 6. SQL — query traces with feedback
-# MAGIC
-# MAGIC Register the `search_traces` DataFrame as a Spark temp view and query it via SQL.
-# MAGIC `request_time` is BIGINT epoch-ms — wrap with `timestamp_millis(...)` before truncating.
+# MAGIC SQL view — flatten `assessments` and pull just the `user_feedback` rows.
 
 # COMMAND ----------
 
-spark.createDataFrame(all_traces).createOrReplaceTempView("dao_ai_traces")
-spark.sql("SELECT COUNT(*) AS trace_count FROM dao_ai_traces").show()
+spark.createDataFrame(traces).createOrReplaceTempView("dao_ai_traces")
 
 # COMMAND ----------
 
 # MAGIC %sql
 # MAGIC SELECT
 # MAGIC   trace_id,
-# MAGIC   request_time,
-# MAGIC   a.assessment_name,
 # MAGIC   a.feedback.value      AS feedback_value,
-# MAGIC   a.rationale            AS comment,
-# MAGIC   a.source.source_id     AS user_id
+# MAGIC   a.rationale           AS comment,
+# MAGIC   a.source.source_id    AS user_id
 # MAGIC FROM dao_ai_traces
 # MAGIC LATERAL VIEW EXPLODE(assessments) AS a
 # MAGIC WHERE a.assessment_name = 'user_feedback'
 # MAGIC ORDER BY request_time DESC
-
-# COMMAND ----------
-
-# MAGIC %sql
-# MAGIC -- Daily up/down volume (operator dashboard)
-# MAGIC SELECT
-# MAGIC   DATE(timestamp_millis(request_time))                        AS day,
-# MAGIC   SUM(CASE WHEN a.feedback.value = TRUE  THEN 1 ELSE 0 END)   AS thumbs_up,
-# MAGIC   SUM(CASE WHEN a.feedback.value = FALSE THEN 1 ELSE 0 END)   AS thumbs_down,
-# MAGIC   COUNT(*)                                                    AS feedback_events
-# MAGIC FROM dao_ai_traces
-# MAGIC LATERAL VIEW EXPLODE(assessments) AS a
-# MAGIC WHERE a.assessment_name = 'user_feedback'
-# MAGIC GROUP BY DATE(timestamp_millis(request_time))
-# MAGIC ORDER BY day DESC
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## Summary
-# MAGIC
-# MAGIC | Section | Pattern | Outcome |
-# MAGIC |---|---|---|
-# MAGIC | 1 (happy path) | `trace_id` from `custom_outputs`, in-process multi-agent | feedback attaches to outer trace |
-# MAGIC | 2 (deployed) | same pattern via Model Serving endpoint | identical contract on the wire |
-# MAGIC | 3 (verification) | inspect span tree under the trace_id | confirms it's the OUTER root, not a sub-agent leg |
-# MAGIC | 4a | `get_last_active_trace_id()` in caller | ⚠️ fragile under concurrency |
-# MAGIC | 4b | `get_current_active_span()` in caller | ❌ `AttributeError` on `None` |
-# MAGIC | 4c | deprecated `Assessment` / `log_assessment` | ❌ ImportError / AttributeError |
-# MAGIC
-# MAGIC The Databricks App + the Node.js feedback route in
-# MAGIC `e2e-chatbot-app-next/server/src/routes/feedback.ts` both write to the same
-# MAGIC MLflow trace store the SQL queries above read from — one source of truth.

--- a/src/dao_ai/evaluation.py
+++ b/src/dao_ai/evaluation.py
@@ -546,10 +546,8 @@ def log_user_feedback(
     value: FeedbackValue | bool,
     comment: str | None = None,
     user_id: str,
-    max_attempts: int = 6,
-    backoff_seconds: float = 0.5,
 ) -> None:
-    """Log a human thumbs-up/down assessment against a dao-ai trace.
+    """Attach a human ``user_feedback`` assessment to a dao-ai trace.
 
     The ``trace_id`` MUST come from ``response.custom_outputs["trace_id"]``
     on the agent response. Reading it from ``mlflow.get_last_active_trace_id()``
@@ -557,48 +555,29 @@ def log_user_feedback(
     desync under concurrency or return ``None`` after the agent function
     returns.
 
-    The function flushes pending async trace exports and retries on
-    transient ``NOT_FOUND`` because, under async trace export (the default
-    for Databricks job and Model Serving workloads), the trace may not yet
-    be queryable when this function is called immediately after the agent
-    response is received.
-
     Args:
         trace_id: The MLflow trace_id pulled from ``custom_outputs``.
         value: ``"up"``, ``"down"``, or a bool. Coerced to a bool internally.
         comment: Optional free-text rationale (the user's written feedback).
         user_id: Identifier for the human providing feedback (typically email).
-        max_attempts: How many times to retry on transient NOT_FOUND.
-        backoff_seconds: Initial backoff; doubles each attempt.
     """
-    import time
-
-    from mlflow.exceptions import RestException
-
-    bool_value: bool = (
-        value if isinstance(value, bool) else (value == "up")
+    bool_value: bool = value if isinstance(value, bool) else value == "up"
+    logger.info(
+        "Logging user_feedback assessment",
+        trace_id=trace_id,
+        value=bool_value,
+        user_id=user_id,
     )
-
-    try:
-        mlflow.flush_trace_async_logging()
-    except Exception:
-        pass
-
-    attempt = 0
-    delay = backoff_seconds
-    while True:
-        try:
-            mlflow.log_feedback(
-                trace_id=trace_id,
-                name="user_feedback",
-                value=bool_value,
-                rationale=comment,
-                source=AssessmentSource(source_type="HUMAN", source_id=user_id),
-            )
-            return
-        except RestException as exc:
-            attempt += 1
-            if attempt >= max_attempts or "NOT_FOUND" not in str(exc):
-                raise
-            time.sleep(delay)
-            delay *= 2
+    # Flush pending async trace exports so the trace is queryable on the
+    # tracking server before we attach an assessment to it. This is the
+    # supported MLflow 3 sync barrier for async logging contexts (jobs,
+    # Model Serving, Databricks Apps).
+    mlflow.flush_trace_async_logging()
+    mlflow.log_feedback(
+        trace_id=trace_id,
+        name="user_feedback",
+        value=bool_value,
+        rationale=comment,
+        source=AssessmentSource(source_type="HUMAN", source_id=user_id),
+    )
+    logger.info("Logged user_feedback assessment", trace_id=trace_id)

--- a/src/dao_ai/evaluation.py
+++ b/src/dao_ai/evaluation.py
@@ -540,6 +540,47 @@ def delete_monitoring_scorers() -> list[str]:
     return deleted
 
 
+def _wait_for_trace(
+    trace_id: str,
+    *,
+    timeout_seconds: float = 30.0,
+    initial_delay_seconds: float = 0.5,
+) -> None:
+    """Block until a remote trace is queryable on the MLflow tracking server.
+
+    When the trace is created by a different process (a Databricks App or
+    Model Serving endpoint), there is a short propagation delay between
+    the response coming back with ``custom_outputs["trace_id"]`` and the
+    trace being visible to ``mlflow.get_trace``. This polls with
+    exponential backoff until the trace is queryable or the timeout
+    elapses. Returns immediately if the trace is already there.
+    """
+    import time
+
+    from mlflow.exceptions import MlflowException, RestException
+
+    deadline: float = time.monotonic() + timeout_seconds
+    delay: float = initial_delay_seconds
+    while True:
+        try:
+            mlflow.get_trace(trace_id)
+            return
+        except (RestException, MlflowException) as exc:
+            if "NOT_FOUND" not in str(exc) and "not found" not in str(exc).lower():
+                raise
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Trace {trace_id} not queryable after {timeout_seconds}s"
+                ) from exc
+            logger.debug(
+                "Trace not yet queryable, waiting",
+                trace_id=trace_id,
+                delay_seconds=delay,
+            )
+            time.sleep(delay)
+            delay = min(delay * 2, 4.0)
+
+
 def log_user_feedback(
     *,
     trace_id: str,
@@ -555,6 +596,10 @@ def log_user_feedback(
     desync under concurrency or return ``None`` after the agent function
     returns.
 
+    Waits for the trace to be queryable on the MLflow tracking server
+    before attaching the assessment (handles the small propagation window
+    between an agent response returning and the trace being visible).
+
     Args:
         trace_id: The MLflow trace_id pulled from ``custom_outputs``.
         value: ``"up"``, ``"down"``, or a bool. Coerced to a bool internally.
@@ -568,11 +613,7 @@ def log_user_feedback(
         value=bool_value,
         user_id=user_id,
     )
-    # Flush pending async trace exports so the trace is queryable on the
-    # tracking server before we attach an assessment to it. This is the
-    # supported MLflow 3 sync barrier for async logging contexts (jobs,
-    # Model Serving, Databricks Apps).
-    mlflow.flush_trace_async_logging()
+    _wait_for_trace(trace_id)
     mlflow.log_feedback(
         trace_id=trace_id,
         name="user_feedback",


### PR DESCRIPTION
## Summary

Two commits, refining the v0.1.86 / v0.1.87 work. Both are now validated end-to-end against the redeployed `hardware_store_dao` on fevm:

- **Model Serving** `POST /serving-endpoints/hardware_store_dao/invocations` returns `custom_outputs.trace_id`, span tree shows the outer multi-agent root (`AGENT|predict` → supervisor → `handoff_to_recommendation`).
- **Databricks App** `POST https://hardware-store-dao-.../invocations` returns `custom_outputs.trace_id`, `log_user_feedback` succeeds end-to-end after the helper's new propagation wait.

### Commit 1 — `3277ec1` Drop legacy retry/anti-pattern scaffolding

`src/dao_ai/evaluation.py`
- Remove the retry-with-backoff loop on `RestException NOT_FOUND` (the previous workaround).
- Add structured `logger.info` on entry + after successful log.

`notebooks/15_feedback_demo.py`
- Drop Section 4 anti-patterns (`get_last_active_trace_id`, `get_current_active_span`, legacy `Assessment`).
- Add Section 3 — POST to the deployed Databricks App's `/invocations` — alongside the in-process and Model Serving paths.
- Collapse Section 6 to one `LATERAL VIEW EXPLODE` SQL query showing feedback rows.

### Commit 2 — `d80bf59` Wait for trace queryability in `log_user_feedback`

Validation against the deployed App surfaced a real distributed-systems issue: the App emits its trace in a different process and ships it on its own schedule. There's a small window where `response.custom_outputs["trace_id"]` is returned but the trace isn't yet queryable on the tracking server, causing `mlflow.log_feedback` to raise `NOT_FOUND`.

`mlflow.flush_trace_async_logging()` was the wrong tool: it flushes the LOCAL process's queue, not the App's. It also raised `NoneType` when no local queue existed.

Replaced with a `_wait_for_trace(trace_id, timeout_seconds=30.0)` helper that polls `mlflow.get_trace` with exponential backoff (0.5s → 4s cap) until the trace is queryable on the tracking server. In production UI flows where the user clicks thumbs-up seconds/minutes after the response, the first poll succeeds and the wait is effectively a no-op. The hard 30s timeout raises `TimeoutError`. `logger.debug` between polls; fully type-hinted.

## Test plan

- [x] `dao-ai pipeline --deploy --run --deployment-target both --profile fevm --config config/examples/15_complete_applications/hardware_store.yaml` (deploy step succeeded; deploy_agents run `925379059627589` TERMINATED + SUCCESS — Model Serving endpoint + App both updated to v0.1.87 wheel).
- [x] Validation script `/tmp/validate_both_targets.py` PASSED:
  - Model Serving: trace_id ✓, 40 spans, root `AGENT|predict`, handoffs to recommendation + supervisor, `user_feedback` assessment attached.
  - Databricks App: trace_id ✓, `_wait_for_trace` resolved propagation in ~1-2s, `log_user_feedback` succeeded.
- [ ] Pending (separate concern): downstream `mlflow.get_trace` view of App traces takes longer than 30s to materialize spans for the UI; this does NOT block feedback attachment.

This pull request and its description were written by Isaac.