### PR TITLE
15_feedback_demo: rely on notebook's implicit MLflow experiment

### DIFF
--- a/notebooks/15_feedback_demo.py
+++ b/notebooks/15_feedback_demo.py
@@ -63,20 +63,6 @@ print(f"App:       {config.app.name}")
 print(f"Endpoint:  {config.app.endpoint_name}")
 print(f"Agents:    {[a.name for a in config.app.agents]}")
 
-# Resolve the experiment this agent writes traces to
-EXPERIMENT_PATH = (
-    config.app.registered_model.experiment_name
-    if hasattr(config.app.registered_model, "experiment_name")
-    and config.app.registered_model.experiment_name
-    else f"/Shared/{config.app.name}"
-)
-experiment = mlflow.get_experiment_by_name(EXPERIMENT_PATH) or mlflow.set_experiment(
-    EXPERIMENT_PATH
-)
-EXPERIMENT_ID = experiment.experiment_id
-mlflow.set_experiment(experiment_id=EXPERIMENT_ID)
-print(f"Experiment: {EXPERIMENT_PATH} → id={EXPERIMENT_ID}")
-
 w = WorkspaceClient()
 USER = w.current_user.me().user_name
 print(f"User: {USER}")
@@ -227,7 +213,7 @@ for label, tid in [
 
 import pandas as pd
 
-traces = mlflow.search_traces(locations=[EXPERIMENT_ID], max_results=100)
+traces = mlflow.search_traces(max_results=100)
 print(f"total traces: {len(traces)}")
 
 


### PR DESCRIPTION
## Summary
- Drops the `hasattr(config.app.registered_model, "experiment_name")` check in `notebooks/15_feedback_demo.py` — `RegisteredModelModel` has no such field, so the conditional was dead code and always fell back to `/Shared/{app_name}`.
- Removes the explicit `set_experiment(...)` block entirely. Databricks notebooks already bind to a path-scoped MLflow experiment automatically, and that's the natural home for in-process traces from a demo notebook.
- Drops `locations=[EXPERIMENT_ID]` from `mlflow.search_traces(...)` — with no argument, it defaults to the active (implicit) experiment.

Net: −15 / +1 in a single notebook file. No object-model change.

## Why not add `experiment_name` to `RegisteredModelModel`?
`RegisteredModelModel` is UC-scoped (`schema` + `name`), and the registered model is optional when `deployment_target: apps`. An experiment path is workspace-scoped and orthogonal to UC registration, so putting it there would be a confusing fit. If we ever need a globally-overridable experiment, the natural home is `AppModel` next to `trace_location` and `monitoring` — that's a separate change.

## Test plan
- [x] Static: `rg 'EXPERIMENT_PATH|EXPERIMENT_ID' notebooks/15_feedback_demo.py` returns no matches
- [x] FEVM end-to-end: in-process `apredict` trace lands in the notebook's auto-bound MLflow experiment (`/Users/nate.fleming@databricks.com/dao-ai/notebooks/15_feedback_demo`), and `log_user_feedback` attaches a `user_feedback=True` assessment to it
- [x] FEVM end-to-end: `mlflow.search_traces(max_results=100)` finds the traced run in the implicit experiment

Section 2 (deployed Model Serving feedback) flaked on a pre-existing cross-process assessment-service race — `_wait_for_trace` confirms trace readability but `mlflow.log_feedback` 404s briefly afterward against the assessment endpoint. Independent of this refactor; tracked separately.

This pull request and its description were written by Isaac.