### PR TITLE
Fix MLflow trace nesting in async agents + serverless OOM on parquet ingest

### DIFF
--- a/notebooks/08_run_examples.py
+++ b/notebooks/08_run_examples.py
@@ -83,7 +83,7 @@ from dao_ai.config import AppConfig
 
 from loguru import logger
 
-mlflow.langchain.autolog()
+mlflow.langchain.autolog(run_tracer_inline=True)
 
 config: AppConfig = AppConfig.from_file(path=config_path)
 

--- a/notebooks/09_evaluate_inferences.py
+++ b/notebooks/09_evaluate_inferences.py
@@ -91,7 +91,7 @@ from mlflow import MlflowClient
 from mlflow.entities.model_registry.model_version import ModelVersion
 from dao_ai.models import get_latest_model_version
 
-mlflow.langchain.autolog(log_traces=True)
+mlflow.langchain.autolog(log_traces=True, run_tracer_inline=True)
 
 mlflow.set_registry_uri("databricks-uc")
 mlflow_client = MlflowClient()

--- a/notebooks/15_feedback_demo.py
+++ b/notebooks/15_feedback_demo.py
@@ -54,7 +54,7 @@ from mlflow.types.responses import ResponsesAgentRequest
 from dao_ai.config import AppConfig
 from dao_ai.evaluation import log_user_feedback
 
-mlflow.langchain.autolog()
+mlflow.langchain.autolog(run_tracer_inline=True)
 
 # COMMAND ----------
 

--- a/src/dao_ai/apps/handlers.py
+++ b/src/dao_ai/apps/handlers.py
@@ -49,7 +49,7 @@ load_dotenv(dotenv_path=".env.local", override=True)
 # Configure MLflow
 mlflow.set_registry_uri("databricks-uc")
 mlflow.set_tracking_uri("databricks")
-mlflow.langchain.autolog()
+mlflow.langchain.autolog(run_tracer_inline=True)
 suppress_autolog_context_warnings()
 
 # Get config path from environment or use default

--- a/src/dao_ai/logging.py
+++ b/src/dao_ai/logging.py
@@ -27,6 +27,13 @@ def suppress_autolog_context_warnings() -> None:
 
     Call this after ``mlflow.langchain.autolog()`` in entry-point modules
     (e.g., ``model_serving.py``, ``handlers.py``).
+
+    Defense-in-depth: the primary fix for these warnings is
+    ``mlflow.langchain.autolog(run_tracer_inline=True)``, which keeps
+    LangChain callbacks on the main async task so the active-span
+    ``ContextVar`` doesn't get reset across thread-pool boundaries. This
+    filter remains as a safety net for code paths where autolog runs
+    without that flag.
     """
     logging.getLogger("mlflow.utils.autologging_utils").addFilter(
         _ContextVarWarningFilter()

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -1617,8 +1617,12 @@ class DatabricksProvider(ServiceProvider):
                 data_path = data_path.resolve()
                 logger.trace("Data path resolved", path=str(data_path))
 
+                # Parquet intentionally routed to Spark's distributed reader
+                # below — pd.read_parquet on the driver OOMs on serverless for
+                # text-heavy datasets (e.g. hardware_store products.parquet:
+                # 17 MB on disk → 45 MB in pandas, dominated by the description
+                # column).
                 pandas_readers: dict[str, Callable[..., pd.DataFrame]] = {
-                    "parquet": lambda p, **kw: pd.read_parquet(p, **kw),
                     "csv": lambda p, **kw: pd.read_csv(p, **kw),
                     "json": lambda p, **kw: pd.read_json(p, **kw),
                     "excel": lambda p, **kw: pd.read_excel(p, **kw),

--- a/tests/dao_ai/test_autolog_config.py
+++ b/tests/dao_ai/test_autolog_config.py
@@ -1,0 +1,156 @@
+"""Tests for the ``mlflow.langchain.autolog(run_tracer_inline=True)`` contract.
+
+dao-ai wraps the async ``apredict``/``apredict_stream`` entry points with manual
+``@mlflow.trace`` decorators *and* relies on ``mlflow.langchain.autolog`` to
+capture LangChain spans. When autolog runs callbacks on a thread-pool executor
+(the MLflow default), the manual span's ``ContextVar`` can fail to propagate
+into the worker thread, producing orphaned autolog spans and the noisy
+"ContextVar was created in a different Context" warning. Setting
+``run_tracer_inline=True`` keeps callback dispatch on the main async task so
+the autolog spans nest under the manual AGENT span the dao-ai client sees.
+
+Two layers:
+
+* ``TestAutologCallSite`` — pin every dao-ai entry-point module to
+  ``run_tracer_inline=True`` so future refactors can't silently drop it.
+* ``TestRunTracerInlineNesting`` — exercise the flag against a real
+  ``langchain_core`` runnable and assert the autolog span actually descends
+  from the manual outer span.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+from unittest.mock import patch
+
+import mlflow
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — call-site assertion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAutologCallSite:
+    """Regression guard: every dao-ai entry point must opt into inline tracing."""
+
+    @pytest.mark.parametrize(
+        "module_name",
+        ["dao_ai.apps.handlers", "dao_ai.apps.model_serving"],
+    )
+    def test_autolog_called_with_run_tracer_inline_true(
+        self, module_name: str
+    ) -> None:
+        sys.modules.pop(module_name, None)
+        with patch("mlflow.langchain.autolog") as mock_autolog, patch(
+            "mlflow.set_registry_uri"
+        ), patch("mlflow.set_tracking_uri"), patch("mlflow.tracing.set_destination"):
+            try:
+                importlib.import_module(module_name)
+            except Exception:
+                # Entry-point modules execute heavy setup at import time
+                # (AppConfig.from_file, etc.). We only need to observe the
+                # autolog kwarg, which fires before that work runs.
+                pass
+        assert (
+            mock_autolog.called
+        ), f"{module_name} did not call mlflow.langchain.autolog"
+        _, kwargs = mock_autolog.call_args
+        assert kwargs.get("run_tracer_inline") is True, (
+            f"{module_name} must call autolog(run_tracer_inline=True); "
+            f"got kwargs={kwargs}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — behavioral nesting
+# ---------------------------------------------------------------------------
+
+
+pytest.importorskip("langchain_core")
+
+
+def _run_nested_async_trace() -> str:
+    """Mimic dao-ai's pattern: an outer ``@mlflow.trace`` span wrapping an
+    async ``langchain_core`` ``ainvoke``. Returns the trace_id captured via
+    ``mlflow.get_active_trace_id()`` from inside the outer span, exactly the
+    way ``dao_ai_apredict`` exposes it in ``custom_outputs``.
+    """
+    from langchain_core.runnables import RunnableLambda
+
+    @mlflow.trace(span_type="AGENT", name="outer_agent")
+    async def outer() -> str:
+        chain = RunnableLambda(lambda x: x + "!")
+        await chain.ainvoke("hi")
+        return mlflow.get_active_trace_id()
+
+    return asyncio.run(outer())
+
+
+@pytest.fixture
+def tracing_enabled(monkeypatch, tmp_path):
+    """Re-enable MLflow tracing for this test only.
+
+    ``tests/conftest.py`` globally sets ``MLFLOW_TRACE_SAMPLING_RATIO=0`` and
+    calls ``mlflow.tracing.disable()`` to keep the test suite quiet. This
+    fixture undoes both, points tracing at a per-test file URI, and tears
+    down on exit.
+    """
+    monkeypatch.setenv("MLFLOW_TRACE_SAMPLING_RATIO", "1")
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "false")
+    # The test env points MLFLOW_EXPERIMENT_ID at a Databricks experiment;
+    # delete it so the file:// backend creates a local default experiment.
+    monkeypatch.delenv("MLFLOW_EXPERIMENT_ID", raising=False)
+    mlflow.set_tracking_uri(f"file://{tmp_path}")
+    mlflow.set_experiment("test-run-tracer-inline")
+    mlflow.tracing.enable()
+    mlflow.langchain.autolog(run_tracer_inline=True)
+    try:
+        yield
+    finally:
+        mlflow.langchain.autolog(disable=True)
+        mlflow.tracing.disable()
+
+
+@pytest.mark.unit
+class TestRunTracerInlineNesting:
+    """Prove that ``run_tracer_inline=True`` keeps autolog spans nested under
+    a manual outer span across an async boundary.
+    """
+
+    def test_langchain_spans_nest_under_outer_agent_span(
+        self, tracing_enabled
+    ) -> None:
+        trace_id = _run_nested_async_trace()
+
+        trace = mlflow.get_trace(trace_id)
+        assert trace is not None, f"trace {trace_id} not found"
+
+        spans = trace.data.spans
+        outer = next((s for s in spans if s.name == "outer_agent"), None)
+        assert outer is not None, (
+            f"expected outer_agent span; got {[s.name for s in spans]}"
+        )
+
+        # The LangChain runnable produces a span that should be a descendant
+        # of the outer_agent span (not a sibling at the root).
+        runnable = next((s for s in spans if "RunnableLambda" in s.name), None)
+        assert runnable is not None, (
+            f"expected RunnableLambda span; got {[s.name for s in spans]}"
+        )
+
+        by_id = {s.span_id: s for s in spans}
+
+        def root_of(span):
+            while span.parent_id is not None:
+                span = by_id[span.parent_id]
+            return span
+
+        assert root_of(runnable).span_id == outer.span_id, (
+            f"RunnableLambda span did not nest under outer_agent; "
+            f"its root was {root_of(runnable).name}"
+        )


### PR DESCRIPTION
Two related fixes for dao-ai's deploy + tracing path, found together while validating dao-ai end-to-end on the `fevm` workspace against `hardware_store_lakebase.yaml`. Both are independently reproducible; bundled because they need to land before any hardware_store-family deploy can produce inspectable traces.

## Fix 1 — `mlflow.langchain.autolog(run_tracer_inline=True)` at every entry point

**Commits:**
- `fix(apps): set run_tracer_inline=True in Databricks Apps handler`
- `chore(notebooks): align run_tracer_inline across autolog call sites`
- `test(autolog): pin run_tracer_inline=True at entry points + nesting`
- `docs(logging): note suppress_autolog_context_warnings is defense-in-depth`

**Why:** `dao_ai_apredict` / `dao_ai_apredict_stream` (`src/dao_ai/models.py:1013,1280`) wrap async LangGraph execution in a manual `@mlflow.trace(span_type=SpanType.AGENT)` span, then surface `mlflow.get_active_trace_id()` as `custom_outputs["trace_id"]` (the v0.1.87 feedback contract). Without `run_tracer_inline=True`, LangChain's async callback manager dispatches callback events to a thread-pool executor; the active-span `ContextVar` set by the outer `@mlflow.trace` decorator doesn't reliably propagate across that boundary. Symptom: "ContextVar was created in a different Context" warnings and autolog spans that may not nest under the AGENT span the dao-ai client sees.

`model_serving.py` already had the flag. `apps/handlers.py` and three notebooks were missing it. The existing `suppress_autolog_context_warnings()` filter was masking the warning; this PR addresses the root cause and keeps the filter as defense-in-depth.

MLflow's own docstring confirms this is the intended use:
> Set to True if you use manual @mlflow.trace decorators within LangGraph nodes or tools and need them properly nested in the autolog trace.

**Files changed:**
- `src/dao_ai/apps/handlers.py:52`
- `src/dao_ai/logging.py` (docstring)
- `notebooks/{08_run_examples,09_evaluate_inferences,15_feedback_demo}.py`
- `tests/dao_ai/test_autolog_config.py` (new — Layer 1 + Layer 2 tests)

## Fix 2 — Route parquet ingest through `spark.read.format("parquet")`, not `pd.read_parquet`

**Commit:** `fix(ingest): route parquet through spark.read, not pd.read_parquet`

**Why:** Commit `becfb54c` (2026-03-23, "inc commit") in `src/dao_ai/providers/databricks.py:1620-1634` expanded driver-side pandas loading from excel-only to also cover parquet/csv/json. The parquet branch loads the entire file via `pd.read_parquet` on the driver and then copies it into the Spark JVM via `spark.createDataFrame`. For text-heavy parquet datasets the cumulative driver memory pressure exceeds the serverless `PERFORMANCE_OPTIMIZED` budget.

Measured footprint for `data/hardware_store/products.snappy.parquet`:
- 17 MB compressed on disk
- 45.82 MB in pandas DataFrame (`description` column alone is 29 MB)

Combined with `inventory.snappy.parquet` (27.72 MB pandas) plus Spark JVM duplication during `createDataFrame`, the `ingest-and-transform` task OOMs reproducibly. Verified across:
- Original failed deploy + `repair-run --rerun-all-failed-tasks`
- A clean-workspace retry (endpoint, model, payload tables, app, deploy job, bundle state all deleted, `bundle sync --full` re-upload) — still OOMed twice with the same signature

This PR removes `parquet` from the `pandas_readers` dict so it falls through to the existing `spark.read.format("parquet").load(...)` branch — distributed read, no driver heap pressure. `csv`, `json`, `excel` stay on the pandas path (dao-ai's prior behavior).

**Files changed:**
- `src/dao_ai/providers/databricks.py:1620-1625`

## Test plan

- [x] `uv run pytest tests/dao_ai/ -m unit` — 1324 unit tests passed (no regressions either fix)
- [x] `make schema` — no diff (neither fix touches Pydantic models)
- [x] **Live end-to-end deploy of `hardware_store_lakebase.yaml` on `fevm`** — full pipeline 8/8 SUCCESS (run `473259223213223`):
  - `ingest-and-transform` SUCCESS in ~5 min (was OOMing in ~3 min on `main`)
  - `provision-lakebase`, `provision-vector-search`, `unity-catalog-tools`, `provision-genie`, `generate-evaluation-data` all SUCCESS
  - `deploy-agents` SUCCESS — published Model Serving endpoint v4 + Apps deploy
  - `run-evaluation` SUCCESS — dao-ai eval flow against the live endpoint completed cleanly
- [x] **Inference + trace validation against the deployed agent:**
  - 8/8 inference requests succeeded (4 against Model Serving, 4 against Databricks App)
  - Tools captured in traces: `product_vector_search_tool`, `retail_consumer_goods__hardware_store__find_product_by_sku`, `retail_consumer_goods__hardware_store__find_inventory_by_upc`, `handoff_to_inventory`, `handoff_to_product`, `handoff_to_recommendation`, `search_memory`
  - Traces show 22-27 spans each (AGENT, CHAIN, CHAT_MODEL, TOOL, RETRIEVER span types)
  - **Zero ERROR-status spans** across all inspected traces
  - **No orphaned spans** — all descend from root
  - `custom_outputs["trace_id"]` populated on every response

This pull request and its description were written by Isaac.