### PR TITLE
fix(ingest): route parquet through spark.read, not pd.read_parquet

### DIFF
--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -1617,8 +1617,12 @@ class DatabricksProvider(ServiceProvider):
                 data_path = data_path.resolve()
                 logger.trace("Data path resolved", path=str(data_path))
 
+                # Parquet intentionally routed to Spark's distributed reader
+                # below — pd.read_parquet on the driver OOMs on serverless for
+                # text-heavy datasets (e.g. hardware_store products.parquet:
+                # 17 MB on disk → 45 MB in pandas, dominated by the description
+                # column).
                 pandas_readers: dict[str, Callable[..., pd.DataFrame]] = {
-                    "parquet": lambda p, **kw: pd.read_parquet(p, **kw),
                     "csv": lambda p, **kw: pd.read_csv(p, **kw),
                     "json": lambda p, **kw: pd.read_json(p, **kw),
                     "excel": lambda p, **kw: pd.read_excel(p, **kw),


### PR DESCRIPTION
## Summary

- Removes `parquet` from the driver-side `pandas_readers` dict in `DatabricksProvider.create_dataset` (`src/dao_ai/providers/databricks.py:1620-1625`) so parquet falls through to the existing `spark.read.format("parquet").load(...)` branch — distributed read, no driver heap pressure.
- `csv`, `json`, `excel` remain on the pandas path (dao-ai's prior behavior).

## Why

Commit `becfb54c` (2026-03-23, "inc commit") expanded the pandas reader dict from excel-only to also cover parquet/csv/json. The parquet branch loads the entire file via `pd.read_parquet` on the driver and then copies it into the Spark JVM via `spark.createDataFrame`. For text-heavy parquet datasets the cumulative driver memory pressure exceeds the serverless `PERFORMANCE_OPTIMIZED` budget.

Measured footprint for `data/hardware_store/products.snappy.parquet`:
- 17 MB compressed on disk
- 45.82 MB in a pandas DataFrame (the `description` column alone is 29 MB)

Combined with `inventory.snappy.parquet` (27.72 MB pandas) and Spark JVM duplication during `createDataFrame`, the ingest-and-transform task OOMs reproducibly on serverless.

## Repro on `main` (before the fix)

Today, after a full workspace reset on `fevm` (deleted endpoint, model + versions, payload tables, app, deploy job, bundle state, re-uploaded via `bundle sync --full`), the deploy_job for `hardware_store_lakebase.yaml` failed on its first run AND on its automatic in-task retry — both with `Execution ran out of memory` at the same code path:

```
pandas/io/parquet.py:669 read_parquet
src/dao_ai/providers/databricks.py:1621 <lambda>
src/dao_ai/providers/databricks.py:1629 create_dataset
src/dao_ai/config.py:7926 create
```

Run: `https://fevm-nfleming-stable-aws.cloud.databricks.com/...#job/101953350350881/run/859257833289067`

## Validation

- [x] `uv run pytest tests/dao_ai/ -m unit` — 1324 passed, 4 skipped, 1 xfailed (no regressions)
- [x] `make schema` — no diff (no Pydantic models touched)
- [x] **Live deploy retry with the fix applied — `ingest-and-transform: TERMINATED/SUCCESS` in ~6 minutes** (job run `142546907343247`, same workspace, same config, same wheel build path; only this commit changed)

The deploy job is continuing through downstream tasks (provision-vector-search, unity-catalog-tools, provision-genie, generate-evaluation-data, deploy-agents, run-evaluation) at the time of PR open. Those failures, if any, are independent of the parquet ingest regression this PR addresses.

## Why not also revert csv/json from pandas?

This PR is intentionally narrow. csv/json have first-class Spark readers too, and switching them would be cleaner, but neither was directly implicated in the OOM under test. Pulling them into the same PR would expand blast radius. Worth a follow-up if anyone measures driver pressure from those formats in real workloads.

## Test plan

- [x] Unit tests pass
- [x] Reproduces the OOM on `main` with `hardware_store_lakebase.yaml` on serverless
- [x] Same config + workspace + retry sequence succeeds with this commit applied

This pull request and its description were written by Isaac.