### PR TITLE
fix(middleware): nest langmem memory-search traces under the parent agent trace

### DIFF
--- a/src/dao_ai/middleware/memory_context.py
+++ b/src/dao_ai/middleware/memory_context.py
@@ -30,10 +30,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+import mlflow
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import BaseMessage, SystemMessage
 from langgraph.runtime import Runtime
 from loguru import logger
+from mlflow.entities import SpanType
 
 if TYPE_CHECKING:
     from langmem.knowledge.extraction import MemoryStoreManager
@@ -122,17 +124,23 @@ class MemoryContextMiddleware(AgentMiddleware):
             logger.debug("Skipping memory search: user_id not available in context")
             return None
 
-        try:
-            memories = await self._manager.asearch(
-                query=query,
-                limit=self._limit,
-                config=config,
-            )
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Memory search failed, continuing without memory context"
-            )
-            return None
+        with mlflow.start_span(
+            name="memory_context_search",
+            span_type=SpanType.MEMORY,
+        ) as span:
+            span.set_inputs({"query": query, "limit": self._limit})
+            try:
+                memories = await self._manager.asearch(
+                    query=query,
+                    limit=self._limit,
+                    config=config,
+                )
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Memory search failed, continuing without memory context"
+                )
+                return None
+            span.set_outputs({"memories_count": len(memories or [])})
 
         if not memories:
             logger.trace("No relevant memories found", query=query[:80])

--- a/tests/dao_ai/test_memory_context_span.py
+++ b/tests/dao_ai/test_memory_context_span.py
@@ -1,0 +1,199 @@
+"""Tests for the explicit MLflow span around ``MemoryContextMiddleware.asearch``.
+
+dao-ai's ``MemoryContextMiddleware.abefore_model`` calls langmem's
+``MemoryStoreManager.asearch``, which internally invokes a top-level LangChain
+Runnable (``query_gen.ainvoke``). Without an active MLflow span on the calling
+async task, ``mlflow.langchain.autolog`` opens a fresh root trace for that
+inner Runnable — the "Use parallel tool calling to search for distinct
+memories…" orphans observed in the experiment.
+
+The fix wraps the ``asearch`` call in ``mlflow.start_span(span_type=
+SpanType.MEMORY)``. With an active span on the contextvar, autolog correctly
+nests langmem's internal spans under it.
+
+Two layers:
+
+* ``TestMemoryContextSpan`` — import-time mock of ``mlflow.start_span`` to
+  pin the call site (name, type, set_inputs/outputs ordering).
+* ``TestMemoryContextNesting`` — exercise the same wrapping pattern against
+  a real ``langchain_core`` runnable and assert ``parent_id`` chain:
+  Runnable → memory span → outer agent span.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import mlflow
+import pytest
+
+pytest.importorskip("langchain_core")
+pytest.importorskip("langchain")
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — call-site assertion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMemoryContextSpan:
+    """Regression guard: the asearch call must be wrapped in a MEMORY span."""
+
+    def test_memory_search_opens_named_memory_span(self) -> None:
+        from langchain_core.messages import HumanMessage
+
+        from dao_ai.middleware.memory_context import MemoryContextMiddleware
+
+        manager = MagicMock()
+        manager.asearch = AsyncMock(return_value=[])
+        mw = MemoryContextMiddleware(manager=manager, limit=5)
+
+        state = {"messages": [HumanMessage(content="hi there")]}
+
+        runtime = MagicMock()
+        runtime.context = MagicMock()
+        runtime.context.user_id = "nate.fleming@databricks.com"
+        runtime.context.model_dump = MagicMock(return_value={"user_id": runtime.context.user_id})
+
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=ctx)
+        ctx.__exit__ = MagicMock(return_value=False)
+
+        with patch(
+            "dao_ai.middleware.memory_context.mlflow.start_span",
+            return_value=ctx,
+        ) as mock_start:
+            asyncio.run(mw.abefore_model(state, runtime))
+
+        mock_start.assert_called_once()
+        _, kwargs = mock_start.call_args
+        assert kwargs["name"] == "memory_context_search"
+        # span_type may be an enum or a string depending on MLflow version
+        assert str(kwargs["span_type"]).endswith("MEMORY")
+
+        ctx.set_inputs.assert_called_once()
+        inputs_arg = ctx.set_inputs.call_args.args[0]
+        assert inputs_arg["query"] == "hi there"
+        assert inputs_arg["limit"] == 5
+
+        ctx.set_outputs.assert_called_once()
+        outputs_arg = ctx.set_outputs.call_args.args[0]
+        assert outputs_arg["memories_count"] == 0
+
+        manager.asearch.assert_awaited_once()
+
+    def test_no_span_when_user_id_missing(self) -> None:
+        """Early-return guard fires before we open a span (cheap path)."""
+        from langchain_core.messages import HumanMessage
+
+        from dao_ai.middleware.memory_context import MemoryContextMiddleware
+
+        manager = MagicMock()
+        manager.asearch = AsyncMock(return_value=[])
+        mw = MemoryContextMiddleware(manager=manager, limit=5)
+
+        state = {"messages": [HumanMessage(content="hi")]}
+        runtime = MagicMock()
+        runtime.context = MagicMock()
+        runtime.context.user_id = None
+        runtime.context.model_dump = MagicMock(return_value={"user_id": None})
+
+        with patch(
+            "dao_ai.middleware.memory_context.mlflow.start_span"
+        ) as mock_start:
+            result = asyncio.run(mw.abefore_model(state, runtime))
+
+        assert result is None
+        mock_start.assert_not_called()
+        manager.asearch.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — behavioral nesting
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tracing_enabled(monkeypatch, tmp_path):
+    """Re-enable MLflow tracing for this test only.
+
+    Same shape as ``tests/dao_ai/test_autolog_config.py::tracing_enabled``:
+    overrides the suite-wide ``MLFLOW_TRACE_SAMPLING_RATIO=0`` and the
+    Databricks-bound ``MLFLOW_EXPERIMENT_ID`` so we can drive a fresh local
+    file:// backend.
+    """
+    monkeypatch.setenv("MLFLOW_TRACE_SAMPLING_RATIO", "1")
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "false")
+    monkeypatch.delenv("MLFLOW_EXPERIMENT_ID", raising=False)
+    mlflow.set_tracking_uri(f"file://{tmp_path}")
+    mlflow.set_experiment("test-memory-context-span")
+    mlflow.tracing.enable()
+    mlflow.langchain.autolog(run_tracer_inline=True)
+    try:
+        yield
+    finally:
+        mlflow.langchain.autolog(disable=True)
+        mlflow.tracing.disable()
+
+
+@pytest.mark.unit
+class TestMemoryContextNesting:
+    """Prove that a Runnable invoked inside ``mlflow.start_span(MEMORY)``
+    produces autolog spans that nest under the memory span, not as siblings.
+
+    This mirrors what happens in production: langmem's ``query_gen.ainvoke``
+    is a top-level Runnable invocation, and we want it to attach to the
+    parent memory_context_search span.
+    """
+
+    def test_inner_runnable_nests_under_memory_span(
+        self, tracing_enabled
+    ) -> None:
+        from langchain_core.runnables import RunnableLambda
+        from mlflow.entities import SpanType
+
+        async def run() -> str:
+            @mlflow.trace(span_type=SpanType.AGENT, name="outer_agent")
+            async def outer() -> str:
+                with mlflow.start_span(
+                    name="memory_context_search",
+                    span_type=SpanType.MEMORY,
+                ) as span:
+                    span.set_inputs({"query": "hi", "limit": 5})
+                    chain = RunnableLambda(lambda x: x + "!")
+                    await chain.ainvoke("hi")
+                    span.set_outputs({"memories_count": 0})
+                return mlflow.get_active_trace_id()
+
+            return await outer()
+
+        trace_id = asyncio.run(run())
+        trace = mlflow.get_trace(trace_id)
+        assert trace is not None, f"trace {trace_id} not found"
+
+        spans = list(trace.data.spans)
+        names = {s.name for s in spans}
+        assert "outer_agent" in names, f"outer_agent missing; got {names}"
+        assert "memory_context_search" in names, (
+            f"memory_context_search missing; got {names}"
+        )
+        assert any("RunnableLambda" in n for n in names), (
+            f"RunnableLambda span missing; got {names}"
+        )
+
+        outer = next(s for s in spans if s.name == "outer_agent")
+        memory_span = next(s for s in spans if s.name == "memory_context_search")
+        runnable = next(s for s in spans if "RunnableLambda" in s.name)
+
+        # The load-bearing assertion: autolog'd Runnable is a child of the
+        # manual memory span, which is itself a child of the outer agent.
+        assert memory_span.parent_id == outer.span_id, (
+            f"memory_context_search not parented to outer_agent; "
+            f"parent_id={memory_span.parent_id} expected={outer.span_id}"
+        )
+        assert runnable.parent_id == memory_span.span_id, (
+            f"RunnableLambda not parented to memory_context_search; "
+            f"parent_id={runnable.parent_id} expected={memory_span.span_id}"
+        )


### PR DESCRIPTION
## Summary

- Wraps `await self._manager.asearch(...)` in `MemoryContextMiddleware.abefore_model` (`src/dao_ai/middleware/memory_context.py`) inside an explicit `mlflow.start_span(name="memory_context_search", span_type=SpanType.MEMORY)`.
- Adds `tests/dao_ai/test_memory_context_span.py` — 3 tests, mocked call-site + real-MLflow nesting + early-return guard.

## Why

After PR #109 landed, the `hardware_store_lakebase_dao` experiment showed pairs of root traces per user query: one for the user-facing question, one named "Use parallel tool calling to search for distinct memories…". The latter is langmem's internal query-expansion LLM call, and it was creating its own root trace instead of nesting under the parent agent trace.

**Root cause is in langmem**, not in dao-ai or PR #109: at `langmem/knowledge/extraction.py:1018-1021`, `MemoryStoreManager.ainvoke` does

```python
query_text = (
    f"Use parallel tool calling to search for distinct memories relevant to this conversation.:\n\n"
    f"<convo>\n{convo}\n</convo>."
)
query_req = await self.query_gen.ainvoke(query_text, config=config)
```

where `query_gen` is a separately-constructed Runnable (`query_model.bind_tools(...)` at line 893). The bridge from dao-ai is `MemoryContextMiddleware.abefore_model` building a fresh `config = {"configurable": runtime.context.model_dump()}` — no `callbacks` propagated — so MLflow's autolog hook sees this `ainvoke` as a top-level Runnable invocation and opens a new root trace.

Fix lives in dao-ai because we can't change langmem's call shape. Setting an active manual MLflow span around `asearch` puts a trace_id on Python's `ContextVar`, which `asyncio` propagates across `await` boundaries by default. langmem's internal `query_gen.ainvoke` runs in the same async task, sees the active span via the ContextVar, and autolog correctly nests the inner spans under it.

This is the same pattern MLflow's own docs document for combining `@mlflow.trace` with autolog instrumentation, and the same pattern dao-ai already uses at `src/dao_ai/best_of_n.py:193` (wrapping parallel candidate LLM calls in `mlflow.start_span(name="best_of_n", span_type=SpanType.CHAIN)`) and `src/dao_ai/tools/vertex_agent_engine.py:371` (nested HTTP/parse wrappers).

`SpanType.MEMORY` is MLflow's canonical span type for this exact operation: *"Represents a memory operation, such as persisting context in a long-term memory db."* dao-ai's other modules already import `from mlflow.entities import SpanType` so the style fits.

## Considered alternatives

| Option | Pros | Cons | Verdict |
|---|---|---|---|
| **A (this PR):** `mlflow.start_span(SpanType.MEMORY)` around `asearch` | Minimal diff, matches dao-ai house style + MLflow docs, canonical span_type, hand-picked input/output payload | None observed | ✅ chosen |
| B: Propagate parent `RunnableConfig.callbacks` through `config` into langmem | Provider-agnostic, no extra spans | Couples dao-ai to LangChain internals, brittle if langmem stops forwarding `config["callbacks"]`, no explicit memory_context_search boundary in traces | ❌ |
| C: `@mlflow.trace` decorator on the whole `abefore_model` | One-liner | Auto-captures the full LangGraph `state` + `runtime` as span inputs (noisy / heavy); span_type/name set via decorator args still work but ergonomics are worse | ❌ |

## Code change

```diff
+import mlflow
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import BaseMessage, SystemMessage
 from langgraph.runtime import Runtime
 from loguru import logger
+from mlflow.entities import SpanType
```

```diff
-        try:
-            memories = await self._manager.asearch(
-                query=query,
-                limit=self._limit,
-                config=config,
-            )
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Memory search failed, continuing without memory context"
-            )
-            return None
+        with mlflow.start_span(
+            name="memory_context_search",
+            span_type=SpanType.MEMORY,
+        ) as span:
+            span.set_inputs({"query": query, "limit": self._limit})
+            try:
+                memories = await self._manager.asearch(
+                    query=query,
+                    limit=self._limit,
+                    config=config,
+                )
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Memory search failed, continuing without memory context"
+                )
+                return None
+            span.set_outputs({"memories_count": len(memories or [])})
```

## Test plan

- [x] `uv run pytest tests/dao_ai/test_memory_context_span.py -v` — 3/3 passed:
  - `TestMemoryContextSpan::test_memory_search_opens_named_memory_span`
  - `TestMemoryContextSpan::test_no_span_when_user_id_missing`
  - `TestMemoryContextNesting::test_inner_runnable_nests_under_memory_span` ← Layer 2 load-bearing test: asserts `RunnableLambda.parent_id == memory_span.span_id` AND `memory_span.parent_id == outer_agent.span_id` against a real MLflow `file://` backend with `mlflow.langchain.autolog(run_tracer_inline=True)` active
- [x] `uv run pytest tests/dao_ai/ -m unit` — 1330 passed, 4 skipped, 1 xfailed (no regressions)
- [x] `make schema` — no diff (no Pydantic models touched)

## Follow-up (not in this PR)

Live-deploy validation against `hardware_store_lakebase` on `fevm` once a new wheel is built and `deploy-agents` republishes the Model Serving endpoint. Expected: the experiment shows exactly one root trace per user query, with a `memory_context_search` child span containing langmem's internal LLM call. Comparison against the user's pre-fix screenshot (paired root traces) attached as evidence to the PR once captured.

This pull request and its description were written by Isaac.