### PR TITLE
Add ai-gateway OBO scope; canonicalize Apps OBO scope strings; pair MCP companions

### DIFF
--- a/src/dao_ai/apps/resources.py
+++ b/src/dao_ai/apps/resources.py
@@ -105,55 +105,87 @@ DEFAULT_PERMISSIONS: dict[str, list[str]] = {
     "app": ["CAN_USE"],
 }
 
-# Valid user API scopes for Databricks Apps
-# These are the only scopes that can be requested for on-behalf-of-user access
+# Valid user API scopes for Databricks Apps OBO authorization.
+#
+# Verified June 2026 against FEVM workspace via /api/2.0/apps update probes.
+# Both canonical short names (e.g. ``files``, ``genie``, ``vector-search``)
+# and the older dotted aliases (e.g. ``files.files``, ``dashboards.genie``,
+# ``vectorsearch.vector-search-*``) are accepted by the Apps API today. We
+# keep both in the allowlist so configs that still emit the old strings
+# don't get rejected; the mapping below biases new emissions toward the
+# canonical short names.
+#
+# NOT settable manually (auto-granted): ``iam.access-control:read``,
+# ``iam.current-user:read``.
+# NOT valid OBO scopes (probe-rejected): ``catalog.volumes``, ``apps.apps``,
+# ``vector-search.search``.
 VALID_USER_API_SCOPES: set[str] = {
+    # Canonical
     "sql",
+    "genie",
+    "files",
+    "vector-search",
+    "ai-gateway",
+    "model-serving",
     "serving.serving-endpoints",
-    "vectorsearch.vector-search-indexes",
-    "files.files",
-    "dashboards.genie",
+    "postgres",
+    "workspace.workspace",
+    "mcp.external",
+    "mcp.functions",
+    "mcp.genie",
+    "mcp.vectorsearch",
     "catalog.connections",
     "catalog.catalogs:read",
     "catalog.schemas:read",
     "catalog.tables:read",
+    # Accepted aliases — older dotted forms still pass platform validation.
+    "files.files",
+    "dashboards.genie",
+    "vectorsearch.vector-search-indexes",
+    "vectorsearch.vector-search-endpoints",
 }
 
-# Mapping from resource api_scopes to valid user_api_scopes
-# Some resource scopes map directly, others need translation.
+# Resource-level api_scope -> set of user OBO scopes emitted for that resource.
 #
-# Resource-level api_scopes that have *no* corresponding user_api_scope
-# (Databricks Apps does not expose an OBO scope for them today) are
-# deliberately omitted and fall through to the no-op branch in
-# generate_user_api_scopes:
-#   - "apps.apps"                      (DatabricksAppModel — no cross-app OBO)
-#   - "postgres" / "database.database-instances"  (Lakebase — no OBO scope;
-#     non-OBO SP access is granted via the AppResourceDatabase resource
-#     binding emitted by _extract_database_resources)
-#   - "mcp.genie" / "mcp.functions" / "mcp.vectorsearch" / "mcp.external"
-#     (MCP resource scopes; OBO falls back to the underlying Databricks
-#      scopes on the same resource, e.g. catalog.connections +
-#      serving.serving-endpoints on a ConnectionModel)
-API_SCOPE_TO_USER_SCOPE: dict[str, str] = {
-    # Direct mappings
-    "serving.serving-endpoints": "serving.serving-endpoints",
-    "vectorsearch.vector-search-indexes": "vectorsearch.vector-search-indexes",
-    "files.files": "files.files",
-    "dashboards.genie": "dashboards.genie",
-    "catalog.connections": "catalog.connections",
-    # SQL-related scopes map to "sql"
-    "sql.warehouses": "sql",
-    "sql.statement-execution": "sql",
-    # Vector search endpoints also need serving
-    "vectorsearch.vector-search-endpoints": "serving.serving-endpoints",
-    # Catalog scopes
-    "catalog.volumes": "files.files",
-    # MCP resource scopes: an OBO MCP server is reached via serving
-    # endpoints / UC connections, so surface the matching platform scopes.
-    "mcp.genie": "dashboards.genie",
-    "mcp.functions": "sql",
-    "mcp.vectorsearch": "vectorsearch.vector-search-indexes",
-    "mcp.external": "serving.serving-endpoints",
+# Pairing rule (user-confirmed): when a resource is accessible via MCP on the
+# Apps platform, its MCP companion scope is emitted *alongside* the native
+# scope. ``mcp.external`` is scoped to UC Connections only; other MCP
+# companions pair with their native sibling.
+#
+# ``ai-gateway`` is NOT in this static map — it's emitted dynamically by
+# ``generate_user_api_scopes`` only when an ``InferenceEndpointModel`` has
+# BOTH ``on_behalf_of_user=True`` AND ``ai_gateway=True``.
+#
+# Resource-level api_scopes not present here have no OBO emission:
+#   - ``apps.apps``           (DatabricksAppModel — no cross-app OBO)
+#   - bare ``mcp.*`` strings  (companions are derived from the native scope;
+#                              listing them on a resource is now a no-op)
+API_SCOPE_TO_USER_SCOPES: dict[str, frozenset[str]] = {
+    # SQL family — companion is mcp.functions
+    "sql.warehouses": frozenset({"sql", "mcp.functions"}),
+    "sql.statement-execution": frozenset({"sql", "mcp.functions"}),
+    # Vector Search — companion is mcp.vectorsearch
+    "vectorsearch.vector-search-indexes": frozenset(
+        {"vector-search", "mcp.vectorsearch"}
+    ),
+    "vectorsearch.vector-search-endpoints": frozenset(
+        {"vector-search", "mcp.vectorsearch"}
+    ),
+    # Genie — companion is mcp.genie
+    "dashboards.genie": frozenset({"genie", "mcp.genie"}),
+    # UC Connection — companion is mcp.external (ConnectionModel only)
+    "catalog.connections": frozenset({"catalog.connections", "mcp.external"}),
+    # Model Serving — no MCP companion at this layer; ai-gateway is dynamic
+    "serving.serving-endpoints": frozenset({"serving.serving-endpoints"}),
+    # Volumes / files
+    "files.files": frozenset({"files"}),
+    "catalog.volumes": frozenset({"files"}),
+    # Catalog read scopes (passed through)
+    "catalog.catalogs:read": frozenset({"catalog.catalogs:read"}),
+    "catalog.schemas:read": frozenset({"catalog.schemas:read"}),
+    "catalog.tables:read": frozenset({"catalog.tables:read"}),
+    # Lakebase Postgres — now a first-class OBO scope
+    "postgres": frozenset({"postgres"}),
 }
 
 
@@ -765,14 +797,21 @@ def generate_user_api_scopes(config: AppConfig) -> list[str]:
     # Collect api_scopes from all OBO resources and map to user_api_scopes
     for resource in obo_resources:
         for api_scope in resource.api_scopes:
-            # Map the api_scope to a valid user_api_scope
-            if api_scope in API_SCOPE_TO_USER_SCOPE:
-                user_scope = API_SCOPE_TO_USER_SCOPE[api_scope]
-                if user_scope in VALID_USER_API_SCOPES:
-                    scopes.add(user_scope)
+            companions = API_SCOPE_TO_USER_SCOPES.get(api_scope)
+            if companions is not None:
+                scopes.update(s for s in companions if s in VALID_USER_API_SCOPES)
             elif api_scope in VALID_USER_API_SCOPES:
-                # Direct match
+                # Direct match (e.g., a resource emits a user-scope verbatim)
                 scopes.add(api_scope)
+
+    # Dynamic gating: emit ``ai-gateway`` only when an InferenceEndpointModel
+    # has BOTH on_behalf_of_user=True AND ai_gateway=True. SP-side
+    # ``serving.serving-endpoints`` is unaffected — it's already emitted by
+    # the resource's api_scopes property.
+    for resource in obo_resources:
+        if isinstance(resource, InferenceEndpointModel) and resource.ai_gateway:
+            scopes.add("ai-gateway")
+            break
 
     # Always add catalog read scopes if we have any table or function access
     if any(isinstance(r, (TableModel, FunctionModel)) for r in obo_resources):

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -3323,13 +3323,13 @@ class ConnectionModel(IsDatabricksResource, HasFullName):
 
     @property
     def api_scopes(self) -> Sequence[str]:
+        # ``catalog.connections`` and ``serving.serving-endpoints`` cover the
+        # SP-side surface; OBO emission expands ``catalog.connections`` to
+        # include the ``mcp.external`` companion automatically (see
+        # apps/resources.py:API_SCOPE_TO_USER_SCOPES).
         return [
             "catalog.connections",
             "serving.serving-endpoints",
-            "mcp.genie",
-            "mcp.functions",
-            "mcp.vectorsearch",
-            "mcp.external",
         ]
 
     def as_resources(self) -> Sequence[DatabricksResource]:
@@ -4818,13 +4818,14 @@ class McpFunctionModel(BaseFunctionModel, IsDatabricksResource):
 
     @property
     def api_scopes(self) -> Sequence[str]:
-        """API scopes for MCP connections."""
+        """API scopes for an MCP connection.
+
+        OBO emission derives ``mcp.*`` companion scopes from the underlying
+        platform scope (see apps/resources.py:API_SCOPE_TO_USER_SCOPES), so
+        the resource itself just declares ``serving.serving-endpoints``.
+        """
         return [
             "serving.serving-endpoints",
-            "mcp.genie",
-            "mcp.functions",
-            "mcp.vectorsearch",
-            "mcp.external",
         ]
 
     def as_resources(self) -> Sequence[DatabricksResource]:

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -242,9 +242,16 @@ def build_auth_policy(config: AppConfig) -> AuthPolicy:
     if config.app and config.app.trace_location:
         system_resources.extend(config.app.trace_location.as_resources())
 
-    api_scopes: list[str] = sorted(
-        {scope for r in all_models if r.on_behalf_of_user for scope in r.api_scopes}
-    )
+    # Translate resource-level api_scopes to canonical OBO user scopes — the
+    # same translation used by the Databricks Apps path — so the deployed
+    # model's forwarded user token carries the strings the Apps platform
+    # recognizes (e.g. ``sql``, ``genie``, ``files``, ``vector-search``).
+    # Without this, the user token would claim dao-ai's internal
+    # ``sql.warehouses`` / ``dashboards.genie`` strings, which the platform
+    # rejects.
+    from dao_ai.apps.resources import generate_user_api_scopes
+
+    api_scopes: list[str] = generate_user_api_scopes(config)
 
     return AuthPolicy(
         system_auth_policy=SystemAuthPolicy(resources=system_resources),

--- a/tests/dao_ai/test_auth_policy.py
+++ b/tests/dao_ai/test_auth_policy.py
@@ -30,6 +30,7 @@ import pytest
 from dao_ai.config import (
     AppConfig,
     ConnectionModel,
+    DatabaseModel,
     FunctionModel,
     GenieRoomModel,
     IndexModel,
@@ -138,10 +139,13 @@ class TestPerResourceTypeAuthPolicyPartition:
         names = _policy_resource_names(policy.system_auth_policy.resources)
         assert "cat.sch.sp_idx" in names
         assert "cat.sch.obo_idx" not in names
-        # VectorStoreModel.api_scopes includes vector-search-endpoints +
-        # serving-endpoints (both are needed for query path).
+        # Canonical OBO scopes: vector-search + its mcp.vectorsearch companion
+        # (vector-search-endpoints + vector-search-indexes both translate
+        # through this pair). serving.serving-endpoints also comes from
+        # VectorStoreModel's api_scopes for the embedding model invocation.
         scopes = set(policy.user_auth_policy.api_scopes)
-        assert "vectorsearch.vector-search-endpoints" in scopes
+        assert "vector-search" in scopes
+        assert "mcp.vectorsearch" in scopes
         assert "serving.serving-endpoints" in scopes
 
     def test_warehouse_partition(self) -> None:
@@ -159,9 +163,10 @@ class TestPerResourceTypeAuthPolicyPartition:
         names = _policy_resource_names(policy.system_auth_policy.resources)
         assert "wh-sp" in names
         assert "wh-obo" not in names
+        # Canonical OBO scopes: sql + mcp.functions companion.
         scopes = set(policy.user_auth_policy.api_scopes)
-        assert "sql.warehouses" in scopes
-        assert "sql.statement-execution" in scopes
+        assert "sql" in scopes
+        assert "mcp.functions" in scopes
 
     def test_genie_room_partition(self) -> None:
         config = _config(
@@ -178,7 +183,10 @@ class TestPerResourceTypeAuthPolicyPartition:
         names = _policy_resource_names(policy.system_auth_policy.resources)
         assert "01f0sp" in names
         assert "01f0obo" not in names
-        assert "dashboards.genie" in policy.user_auth_policy.api_scopes
+        # Canonical OBO scopes: genie + mcp.genie companion.
+        scopes = set(policy.user_auth_policy.api_scopes)
+        assert "genie" in scopes
+        assert "mcp.genie" in scopes
 
     def test_function_partition(self) -> None:
         config = _config(
@@ -195,7 +203,14 @@ class TestPerResourceTypeAuthPolicyPartition:
         names = _policy_resource_names(policy.system_auth_policy.resources)
         assert "cat.sch.sp_fn" in names
         assert "cat.sch.obo_fn" not in names
-        assert "sql.statement-execution" in policy.user_auth_policy.api_scopes
+        # Canonical OBO scopes: sql + mcp.functions companion; functions also
+        # pull in catalog.*:read auto-additions.
+        scopes = set(policy.user_auth_policy.api_scopes)
+        assert "sql" in scopes
+        assert "mcp.functions" in scopes
+        assert "catalog.catalogs:read" in scopes
+        assert "catalog.schemas:read" in scopes
+        assert "catalog.tables:read" in scopes
 
     def test_table_partition(self) -> None:
         config = _config(
@@ -212,7 +227,13 @@ class TestPerResourceTypeAuthPolicyPartition:
         names = _policy_resource_names(policy.system_auth_policy.resources)
         assert "cat.sch.sp_t" in names
         assert "cat.sch.obo_t" not in names
-        assert "sql.statement-execution" in policy.user_auth_policy.api_scopes
+        # Tables: sql + mcp.functions companion + catalog.*:read auto-add.
+        scopes = set(policy.user_auth_policy.api_scopes)
+        assert "sql" in scopes
+        assert "mcp.functions" in scopes
+        assert "catalog.catalogs:read" in scopes
+        assert "catalog.schemas:read" in scopes
+        assert "catalog.tables:read" in scopes
 
     def test_volume_partition(self) -> None:
         """VolumeModel.as_resources() returns ``[]`` by design (no MLflow Resource
@@ -236,10 +257,9 @@ class TestPerResourceTypeAuthPolicyPartition:
         # appear in the system policy.
         assert "cat.sch.sp_v" not in names
         assert "cat.sch.obo_v" not in names
-        # OBO volume still pushes its scopes to the user policy.
+        # OBO volume pushes its canonical user-OBO scope.
         scopes = set(policy.user_auth_policy.api_scopes)
-        assert "files.files" in scopes
-        assert "catalog.volumes" in scopes
+        assert "files" in scopes
 
     def test_connection_partition(self) -> None:
         config = _config(
@@ -322,16 +342,23 @@ class TestAuthPolicyInvariants:
             "OBO resources leaked into SystemAuthPolicy: "
             + repr(policy.system_auth_policy.resources)
         )
-        # User policy carries every OBO-resource scope.
+        # User policy carries every OBO-resource canonical scope plus
+        # MCP companions.
         scopes = set(policy.user_auth_policy.api_scopes)
         assert "serving.serving-endpoints" in scopes
-        assert "sql.statement-execution" in scopes
-        assert "sql.warehouses" in scopes
-        assert "dashboards.genie" in scopes
-        assert "vectorsearch.vector-search-endpoints" in scopes
-        assert "files.files" in scopes
-        assert "catalog.volumes" in scopes
+        assert "sql" in scopes
+        assert "mcp.functions" in scopes
+        assert "genie" in scopes
+        assert "mcp.genie" in scopes
+        assert "vector-search" in scopes
+        assert "mcp.vectorsearch" in scopes
+        assert "files" in scopes
         assert "catalog.connections" in scopes
+        assert "mcp.external" in scopes
+        # Table + function presence triggers catalog.*:read auto-add.
+        assert "catalog.catalogs:read" in scopes
+        assert "catalog.schemas:read" in scopes
+        assert "catalog.tables:read" in scopes
 
     def test_sp_resource_never_in_user_policy_scopes(self) -> None:
         """If every declared resource is SP-backed, UserAuthPolicy is empty."""
@@ -448,3 +475,232 @@ class TestCollectResourcesWithObOFlag:
     def test_resources_none_returns_empty(self) -> None:
         config = AppConfig()
         assert _collect_resources_with_obo_flag(config) == ()
+
+
+# ---------------------------------------------------------------------------
+# Canonical-string + AI Gateway gating + MCP companion pairing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCanonicalUserApiScopes:
+    """The Apps OBO platform expects canonical strings (``sql``, ``genie``,
+    ``files``, ``vector-search``, ``ai-gateway``, …). dao-ai's resource models
+    declare older dotted resource-scope names (``sql.warehouses``,
+    ``dashboards.genie``, …) internally — these MUST be translated before
+    they leave the dao-ai boundary, on both Apps and Model Serving surfaces.
+    """
+
+    def test_canonical_strings_emitted_not_dao_internal_names(self) -> None:
+        """A mixed OBO config produces canonical strings, never dao-ai's
+        internal resource-scope names."""
+        config = _config(
+            warehouses={
+                "wh": WarehouseModel(
+                    name="w", warehouse_id="wh-1", on_behalf_of_user=True
+                )
+            },
+            genie_rooms={
+                "g": GenieRoomModel(name="g", space_id="01f0", on_behalf_of_user=True)
+            },
+            volumes={
+                "v": VolumeModel(schema=_SCHEMA, name="v", on_behalf_of_user=True)
+            },
+            vector_stores={
+                "vs": VectorStoreModel(
+                    index=IndexModel(schema=_SCHEMA, name="idx"),
+                    on_behalf_of_user=True,
+                )
+            },
+        )
+        scopes = set(build_auth_policy(config).user_auth_policy.api_scopes)
+        # Canonical strings present:
+        assert {"sql", "genie", "files", "vector-search"} <= scopes
+        # dao-ai internal resource-scope names absent:
+        leaked_internal = {
+            "sql.warehouses",
+            "sql.statement-execution",
+            "dashboards.genie",
+            "files.files",
+            "catalog.volumes",
+            "vectorsearch.vector-search-indexes",
+            "vectorsearch.vector-search-endpoints",
+        } & scopes
+        assert leaked_internal == set(), (
+            f"Internal resource-scope names leaked to UserAuthPolicy: "
+            f"{leaked_internal}"
+        )
+
+
+@pytest.mark.unit
+class TestMcpCompanionPairing:
+    """Each native OBO scope emits its MCP companion automatically.
+    Pairings (user-confirmed): sql ↔ mcp.functions, genie ↔ mcp.genie,
+    vector-search ↔ mcp.vectorsearch, catalog.connections ↔ mcp.external.
+    """
+
+    def test_sql_pairs_with_mcp_functions(self) -> None:
+        config = _config(
+            warehouses={
+                "wh": WarehouseModel(
+                    name="w", warehouse_id="wh-1", on_behalf_of_user=True
+                )
+            }
+        )
+        scopes = set(build_auth_policy(config).user_auth_policy.api_scopes)
+        assert "sql" in scopes
+        assert "mcp.functions" in scopes
+
+    def test_genie_pairs_with_mcp_genie(self) -> None:
+        config = _config(
+            genie_rooms={
+                "g": GenieRoomModel(name="g", space_id="01f0", on_behalf_of_user=True)
+            }
+        )
+        scopes = set(build_auth_policy(config).user_auth_policy.api_scopes)
+        assert "genie" in scopes
+        assert "mcp.genie" in scopes
+
+    def test_vector_search_pairs_with_mcp_vectorsearch(self) -> None:
+        config = _config(
+            vector_stores={
+                "vs": VectorStoreModel(
+                    index=IndexModel(schema=_SCHEMA, name="idx"),
+                    on_behalf_of_user=True,
+                )
+            }
+        )
+        scopes = set(build_auth_policy(config).user_auth_policy.api_scopes)
+        assert "vector-search" in scopes
+        assert "mcp.vectorsearch" in scopes
+
+    def test_connection_pairs_with_mcp_external(self) -> None:
+        config = _config(
+            connections={
+                "c": ConnectionModel(name="c", on_behalf_of_user=True)
+            }
+        )
+        scopes = set(build_auth_policy(config).user_auth_policy.api_scopes)
+        assert "catalog.connections" in scopes
+        assert "mcp.external" in scopes
+
+    def test_mcp_external_scoped_to_connection_only(self) -> None:
+        """``mcp.external`` is the UC Connection's companion — it MUST NOT be
+        emitted for SQL/Vector/Genie OBO resources."""
+        config = _config(
+            warehouses={
+                "wh": WarehouseModel(
+                    name="w", warehouse_id="wh-1", on_behalf_of_user=True
+                )
+            },
+            genie_rooms={
+                "g": GenieRoomModel(name="g", space_id="01f0", on_behalf_of_user=True)
+            },
+            vector_stores={
+                "vs": VectorStoreModel(
+                    index=IndexModel(schema=_SCHEMA, name="idx"),
+                    on_behalf_of_user=True,
+                )
+            },
+        )
+        scopes = set(build_auth_policy(config).user_auth_policy.api_scopes)
+        assert "mcp.external" not in scopes
+
+
+@pytest.mark.unit
+class TestAiGatewayGating:
+    """``ai-gateway`` is emitted only when an ``InferenceEndpointModel`` has
+    BOTH ``on_behalf_of_user=True`` AND ``ai_gateway=True``."""
+
+    def test_both_flags_true_emits_ai_gateway(self) -> None:
+        config = _config(
+            models={
+                "obo_gw": InferenceEndpointModel(
+                    name="claude-via-gw",
+                    on_behalf_of_user=True,
+                    ai_gateway=True,
+                ),
+            }
+        )
+        scopes = set(build_auth_policy(config).user_auth_policy.api_scopes)
+        assert "ai-gateway" in scopes
+        assert "serving.serving-endpoints" in scopes
+
+    def test_obo_only_no_gateway_omits_ai_gateway(self) -> None:
+        """OBO LLM without ai_gateway flag must NOT emit ai-gateway."""
+        config = _config(
+            models={
+                "obo": InferenceEndpointModel(
+                    name="claude",
+                    on_behalf_of_user=True,
+                    ai_gateway=False,
+                ),
+            }
+        )
+        scopes = set(build_auth_policy(config).user_auth_policy.api_scopes)
+        assert "ai-gateway" not in scopes
+        assert "serving.serving-endpoints" in scopes
+
+    def test_gateway_only_no_obo_omits_ai_gateway(self) -> None:
+        """SP-backed LLM with ai_gateway flag must NOT emit ai-gateway as a
+        user scope — there's no user token to scope it to. The LLM stays in
+        the system policy and no user_api_scope is emitted for it."""
+        config = _config(
+            models={
+                "sp_gw": InferenceEndpointModel(
+                    name="claude-sp-gw",
+                    on_behalf_of_user=False,
+                    ai_gateway=True,
+                ),
+            }
+        )
+        policy = build_auth_policy(config)
+        assert "ai-gateway" not in policy.user_auth_policy.api_scopes
+        # The model still lands in system policy as an SP resource.
+        names = _policy_resource_names(policy.system_auth_policy.resources)
+        assert "claude-sp-gw" in names
+
+    def test_neither_flag_no_ai_gateway(self) -> None:
+        config = _config(
+            models={
+                "sp": InferenceEndpointModel(
+                    name="claude-sp",
+                    on_behalf_of_user=False,
+                    ai_gateway=False,
+                ),
+            }
+        )
+        scopes = set(build_auth_policy(config).user_auth_policy.api_scopes)
+        assert "ai-gateway" not in scopes
+
+
+@pytest.mark.unit
+class TestPostgresObO:
+    """``postgres`` is now a first-class OBO scope. A Lakebase database with
+    ``on_behalf_of_user=True`` must contribute ``postgres`` to the user
+    policy, and the database resource itself must NOT leak into the system
+    policy."""
+
+    def test_lakebase_obo_emits_postgres_scope(self) -> None:
+        config = _config(
+            databases={
+                "lb": DatabaseModel(
+                    project="lb-project",
+                    on_behalf_of_user=True,
+                ),
+            }
+        )
+        policy = build_auth_policy(config)
+        assert "postgres" in policy.user_auth_policy.api_scopes
+
+    def test_lakebase_sp_does_not_emit_postgres_user_scope(self) -> None:
+        config = _config(
+            databases={
+                "lb": DatabaseModel(
+                    project="lb-project",
+                    on_behalf_of_user=False,
+                ),
+            }
+        )
+        policy = build_auth_policy(config)
+        assert "postgres" not in policy.user_auth_policy.api_scopes

--- a/tests/dao_ai/test_mcp.py
+++ b/tests/dao_ai/test_mcp.py
@@ -174,11 +174,10 @@ def test_mcp_function_with_uc_connection():
         == "https://workspace.databricks.com/api/2.0/mcp/external/github_u2m_connection"
     )
 
-    # Verify that connection has the expected API scopes
-    assert "mcp.genie" in connection.api_scopes
-    assert "mcp.functions" in connection.api_scopes
-    assert "mcp.vectorsearch" in connection.api_scopes
-    assert "mcp.external" in connection.api_scopes
+    # ConnectionModel declares only its native SP-side scopes;
+    # ``mcp.external`` (the MCP companion) is emitted automatically at the
+    # OBO user-scope layer via API_SCOPE_TO_USER_SCOPES (see
+    # tests/dao_ai/test_auth_policy.py::TestMcpCompanionPairing).
     assert "catalog.connections" in connection.api_scopes
     assert "serving.serving-endpoints" in connection.api_scopes
 
@@ -228,11 +227,9 @@ def test_mcp_function_with_connection_only():
     assert mcp_function_model.connection.name == "github_u2m_connection"
     assert mcp_function_model.url is None  # URL will be constructed at runtime
 
-    # Verify that connection has the expected API scopes
-    assert "mcp.genie" in connection.api_scopes
-    assert "mcp.functions" in connection.api_scopes
-    assert "mcp.vectorsearch" in connection.api_scopes
-    assert "mcp.external" in connection.api_scopes
+    # ConnectionModel declares only its native SP-side scopes; ``mcp.external``
+    # (the MCP companion) is emitted automatically at the OBO user-scope
+    # layer via API_SCOPE_TO_USER_SCOPES.
     assert "catalog.connections" in connection.api_scopes
     assert "serving.serving-endpoints" in connection.api_scopes
 

--- a/validation/RESULTS.md
+++ b/validation/RESULTS.md
@@ -111,20 +111,52 @@ Loaded a real (existing) dao-ai OBO example config through both surfaces and con
 - Model Serving `UserAuthPolicy.api_scopes` = same list (identical)
 - FEVM Apps API accepted the full set in a real update call
 
-## What was NOT exercised in this pass (deferred)
+## Phase 2b — Real end-to-end deploys against FEVM existing resources
 
-The plan also called for: real end-to-end inference against active endpoints using a forwarded user token, JWT scope-claim decoding, and MLflow trace identity inspection. Those require:
+Two real dao-ai bundles built via `dao-ai generate-bundle --development` and deployed to FEVM via `databricks bundle deploy`. Both used existing FEVM resources (Genie space `01f164d91cb71e63a36d9545d86c7424` "dao-ai genie provisioning test", vector index `retail_consumer_goods.hardware_store.products_index`, UC functions `find_product_by_sku/upc`).
 
-- The target downstream resources to actually exist on FEVM with the right UC grants (warehouse, vector search index, Genie space, Lakebase project, etc.).
-- A consenting user session on each app (OBO apps require explicit user consent on first access).
-- A real MLflow agent log + register + serving-endpoint create cycle (~10 min/scenario).
+| App | `ai_gateway` flag | Deployed `user_api_scopes` (read from `/api/2.0/apps`) |
+|---|---|---|
+| `obo-validation-gw-on` | `true` | `[ai-gateway, catalog.catalogs:read, catalog.schemas:read, catalog.tables:read, genie, mcp.functions, mcp.genie, mcp.vectorsearch, serving.serving-endpoints, sql, vector-search]` |
+| `obo-validation-gw-off` | `false` | `[catalog.catalogs:read, catalog.schemas:read, catalog.tables:read, genie, mcp.functions, mcp.genie, serving.serving-endpoints, sql]` |
 
-The scope-string contract has been fully proven: every string dao-ai emits is accepted by the Apps platform, and Apps and Model Serving emit identical sets. Downstream inference + trace identity is a fuller end-to-end test that should run as its own campaign with the resource inventory provisioned first.
+Both apps reached `compute=ACTIVE` and `deploy=SUCCEEDED`. Logs show: OBO middleware enabled, agent created with the expected tool counts (gw-on: 3 tools, gw-off: 2), uvicorn listening on 8000. Expected `_create_obo_uc_tool` warnings appeared at startup ("User does not have USE CATALOG …") — the **app SP correctly cannot introspect** OBO-marked functions, which is the intended OBO behavior (introspection happens with the user token at runtime).
+
+### JWT scope-claim decoding from live `x-forwarded-access-token`
+
+A real inference probe (`POST /invocations` with my user token) was made against each running app. The dao-ai server reflects the request headers into `custom_outputs.configurable.headers`, including the platform's `x-forwarded-access-token` JWT. Decoding the `scope` claim:
+
+```
+gw-on:  ai-gateway catalog.catalogs:read catalog.schemas:read catalog.tables:read
+        genie iam.access-control:read iam.current-user:read mcp.functions
+        mcp.genie mcp.vectorsearch serving.serving-endpoints sql vector-search
+        → contains ai-gateway? True
+
+gw-off: catalog.catalogs:read catalog.schemas:read catalog.tables:read genie
+        iam.access-control:read iam.current-user:read mcp.functions mcp.genie
+        serving.serving-endpoints sql
+        → contains ai-gateway? False
+```
+
+The JWT claim matches the deployed app's `user_api_scopes` plus the two platform-auto-granted defaults (`iam.access-control:read`, `iam.current-user:read`). **AI Gateway gating works end-to-end**: dao-ai config → bundle generation → Apps platform → user token claim.
+
+### MLflow traces
+
+Both apps produced complete MLflow traces in their experiments:
+
+- `gw-on` experiment `3360342003324839`: trace `tr-c0a358f6b90dd31c569efdaca2272d78` — state `OK`, 3.413s, 9 spans, 15525 tokens. Request `"hi"`, response is Claude's retail assistant greeting.
+- `gw-on` second trace `tr-ae483066379d51c2bdd58ed65fb990ce` — `What is 2+2?`, response confirms inference path works.
+- `mlflow.user` tag = the app SP UUID — this is the trace **author**, not the OBO end user. End-user identity lives in the JWT `sub` claim (`nate.fleming@databricks.com` here), which the app code can read off `x-forwarded-access-token` and propagate to its own request log if needed.
+
+### Apps platform acceptance — bundle path proven
+
+The `databricks bundle deploy` path goes: `dao-ai generate-bundle` → `databricks.yaml` → `databricks bundle deploy` → `POST /api/2.0/apps` (create or update). The deployed apps' actual `user_api_scopes` (read back from `/api/2.0/apps`) match what `generate_user_api_scopes` produced. End-to-end contract proven on the path users actually deploy with.
 
 ## Cleanup
 
-- Probe app `scope-probe-nf` deleted from FEVM after Phase 0/2.
-- No other temporary resources created in the workspace.
+- Probe app `scope-probe-nf` deleted (Phase 0/2).
+- `obo-validation-gw-on` and `obo-validation-gw-off` apps + experiments deleted via `databricks bundle destroy`.
+- Local bundle dirs `/tmp/obo-val-gw-*` removed.
 
 ## Test counts
 

--- a/validation/RESULTS.md
+++ b/validation/RESULTS.md
@@ -1,0 +1,133 @@
+# OBO Scope Validation Campaign — Results
+
+**Date:** 2026-06-11
+**Workspace:** FEVM (`fevm-nfleming-stable-aws.cloud.databricks.com`)
+**Branch:** `feat/obo-scopes-ai-gateway`
+
+## Phase 0 — Canonical scope strings (probed against FEVM Apps API)
+
+Probed every candidate string via `databricks apps update <probe> --json '{"user_api_scopes":["<scope>"]}'` on a throwaway probe app. The Apps API either echoes the scope back (ACCEPTED) or returns `The specified scope <X> is not a valid scope.` (REJECTED).
+
+### Accepted (canonical)
+
+| Scope | Resource surface it grants |
+|---|---|
+| `sql` | SQL warehouse / statement execution |
+| `genie` | Genie spaces (conversational analytics) |
+| `files` | UC Volume / workspace files |
+| `vector-search` | Vector Search endpoints + indexes |
+| `ai-gateway` | AI Gateway-fronted endpoint invocation |
+| `model-serving` | Model Serving endpoint management |
+| `serving.serving-endpoints` | Invoke Model Serving endpoints |
+| `postgres` | Lakebase Postgres database access |
+| `workspace.workspace` | Workspace folder / notebook files |
+| `mcp.external` | External MCP server (UC Connection) |
+| `mcp.functions` | Managed UC Function MCP server |
+| `mcp.genie` | Managed Genie MCP server |
+| `mcp.vectorsearch` | Managed Vector Search MCP server |
+| `catalog.connections` | UC Connections / Lakehouse Federation |
+| `catalog.catalogs:read` | UC catalogs (read) |
+| `catalog.schemas:read` | UC schemas (read) |
+| `catalog.tables:read` | UC tables (read) |
+
+### Accepted aliases (legacy names — kept in `VALID_USER_API_SCOPES` to avoid breaking older configs)
+
+- `files.files` (alias for `files`)
+- `dashboards.genie` (alias for `genie`)
+- `vectorsearch.vector-search-indexes` (alias for `vector-search`)
+- `vectorsearch.vector-search-endpoints` (alias for `vector-search`)
+
+### Rejected (NOT valid OBO scopes)
+
+| Scope | Why |
+|---|---|
+| `vector-search.search` | Wrong string — actual scope is `vector-search` |
+| `catalog.volumes` | Not exposed as user OBO scope; use `files` for volume access |
+| `apps.apps` | Not exposed as user OBO scope |
+| `iam.access-control:read` | Auto-granted default; cannot be set manually |
+| `iam.current-user:read` | Auto-granted default; cannot be set manually |
+
+## Phase 1 — Code changes
+
+See commit `418ef1f` on branch `feat/obo-scopes-ai-gateway`.
+
+- `src/dao_ai/apps/resources.py` — `VALID_USER_API_SCOPES` rewritten with canonical + aliases; `API_SCOPE_TO_USER_SCOPE` (1:1) replaced with `API_SCOPE_TO_USER_SCOPES` (1:set) for additive MCP companion emission; `generate_user_api_scopes` gates `ai-gateway` on `InferenceEndpointModel.on_behalf_of_user AND .ai_gateway`.
+- `src/dao_ai/config.py` — `ConnectionModel.api_scopes` and `McpFunctionModel.api_scopes` no longer hand-roll `mcp.*` strings (companions are derived).
+- `src/dao_ai/providers/databricks.py` — `build_auth_policy` now delegates `api_scopes` generation to `generate_user_api_scopes`, unifying Apps and Model Serving emission.
+
+## Phase 2 — Validation matrix (12 scenarios, both surfaces)
+
+`validation/scenarios.py` defines 12 scenarios covering: AI Gateway gating (4 cases — all 4 combinations of `on_behalf_of_user` × `ai_gateway`), each OBO resource type in isolation (warehouse, genie, vector-search, volume, connection, lakebase, table+function), and a "mixed all OBO with gateway" scenario combining every resource type.
+
+### Surface 1: `generate_user_api_scopes(config)` — Apps path
+
+| # | Scenario | Result | Emitted scopes |
+|---|---|---|---|
+| 1 | llm-sp-no-gw | ✅ | `[]` |
+| 2 | llm-obo-no-gw | ✅ | `[serving.serving-endpoints]` |
+| 3 | llm-obo-with-gw | ✅ | `[ai-gateway, serving.serving-endpoints]` |
+| 4 | llm-sp-with-gw-NEGATIVE | ✅ | `[]` — `ai-gateway` correctly suppressed |
+| 5 | warehouse-obo | ✅ | `[mcp.functions, sql]` |
+| 6 | genie-obo | ✅ | `[genie, mcp.genie]` |
+| 7 | vector-search-obo | ✅ | `[mcp.vectorsearch, serving.serving-endpoints, vector-search]` |
+| 8 | volume-obo | ✅ | `[files]` |
+| 9 | connection-obo | ✅ | `[catalog.connections, mcp.external, serving.serving-endpoints]` |
+| 10 | lakebase-obo | ✅ | `[postgres]` |
+| 11 | table-and-function-obo | ✅ | `[catalog.catalogs:read, catalog.schemas:read, catalog.tables:read, mcp.functions, sql]` |
+| 12 | mixed-all-obo-with-gw | ✅ | `[ai-gateway, catalog.catalogs:read, catalog.connections, catalog.schemas:read, catalog.tables:read, files, genie, mcp.external, mcp.functions, mcp.genie, mcp.vectorsearch, postgres, serving.serving-endpoints, sql, vector-search]` |
+
+Run: `uv run python validation/run_unit_check.py`.
+
+### Surface 2: `build_auth_policy(config).user_auth_policy.api_scopes` — Model Serving path
+
+Every scenario produced the **identical** scope set on the Model Serving path. The unification via `build_auth_policy → generate_user_api_scopes` means both surfaces are guaranteed to emit the same strings (verified per-scenario in `run_serving_policy_check.py`).
+
+Run: `uv run python validation/run_serving_policy_check.py`.
+
+### Apps platform acceptance — real `PATCH /api/2.0/apps/...` against FEVM
+
+For every scenario with a non-empty scope set, sent the expected set in a real Apps update call and confirmed the platform echoed back the exact set with no `INVALID_SCOPE` rejection.
+
+| Scenario | Apps platform response |
+|---|---|
+| llm-obo-no-gw | ✓ 1 scope accepted |
+| llm-obo-with-gw | ✓ 2 scopes accepted |
+| warehouse-obo | ✓ 2 scopes accepted |
+| genie-obo | ✓ 2 scopes accepted |
+| vector-search-obo | ✓ 3 scopes accepted |
+| volume-obo | ✓ 1 scope accepted |
+| connection-obo | ✓ 3 scopes accepted |
+| lakebase-obo | ✓ 1 scope accepted |
+| table-and-function-obo | ✓ 5 scopes accepted |
+| mixed-all-obo-with-gw | ✓ 15 scopes accepted |
+
+Run: `python validation/run_apps_probe.py --profile fevm --app scope-probe-nf`.
+
+### Real example config — `config/examples/06_on_behalf_of_user/obo_basic.yaml`
+
+Loaded a real (existing) dao-ai OBO example config through both surfaces and confirmed:
+
+- Apps `user_api_scopes` = `[catalog.catalogs:read, catalog.schemas:read, catalog.tables:read, genie, mcp.functions, mcp.genie, serving.serving-endpoints, sql]`
+- Model Serving `UserAuthPolicy.api_scopes` = same list (identical)
+- FEVM Apps API accepted the full set in a real update call
+
+## What was NOT exercised in this pass (deferred)
+
+The plan also called for: real end-to-end inference against active endpoints using a forwarded user token, JWT scope-claim decoding, and MLflow trace identity inspection. Those require:
+
+- The target downstream resources to actually exist on FEVM with the right UC grants (warehouse, vector search index, Genie space, Lakebase project, etc.).
+- A consenting user session on each app (OBO apps require explicit user consent on first access).
+- A real MLflow agent log + register + serving-endpoint create cycle (~10 min/scenario).
+
+The scope-string contract has been fully proven: every string dao-ai emits is accepted by the Apps platform, and Apps and Model Serving emit identical sets. Downstream inference + trace identity is a fuller end-to-end test that should run as its own campaign with the resource inventory provisioned first.
+
+## Cleanup
+
+- Probe app `scope-probe-nf` deleted from FEVM after Phase 0/2.
+- No other temporary resources created in the workspace.
+
+## Test counts
+
+- Unit + integration tests in `tests/dao_ai/test_auth_policy.py` and `tests/dao_ai/test_apps_obo_partition.py`: **48 passed** (36 pre-existing, 12 new for ai-gateway gating, MCP companion pairing, postgres OBO, canonical-string invariant).
+- `tests/dao_ai/test_mcp.py`: **8 passed, 1 skipped** (2 tests updated to reflect new `ConnectionModel.api_scopes` shape).
+- Full suite: **2249 passed**, 8 failed (all pre-existing real-API tests unrelated to scope changes — Genie and reranking integration tests that hit live indexes), 56 skipped.

--- a/validation/configs/obo_ai_gateway_off.yaml
+++ b/validation/configs/obo_ai_gateway_off.yaml
@@ -1,0 +1,78 @@
+# yaml-language-server: $schema=../../schemas/model_config_schema.json
+#
+# Negative-control validation config: OBO ON but ai_gateway=false.
+# Asserts ai-gateway is NOT emitted on the deployed app.
+
+parameters:
+  catalog:
+    description: Unity Catalog catalog name
+    default: retail_consumer_goods
+  schema:
+    description: Schema within the catalog
+    default: hardware_store
+
+schemas:
+  demo_schema: &demo_schema
+    catalog_name: ${var.catalog}
+    schema_name: ${var.schema}
+
+resources:
+  models:
+    default_llm: &default_llm
+      name: databricks-claude-sonnet-4-5
+      temperature: 0.1
+      max_tokens: 4096
+      on_behalf_of_user: true
+      ai_gateway: false   # ← negative control
+
+  genie_rooms:
+    retail_genie: &retail_genie
+      name: "Retail Genie (validation no-gw)"
+      space_id: 01f164d91cb71e63a36d9545d86c7424
+      on_behalf_of_user: true
+
+  functions:
+    find_product_sku: &find_product_sku
+      schema: *demo_schema
+      name: find_product_by_sku
+      on_behalf_of_user: true
+
+tools:
+  product_sku_lookup: &product_sku_lookup
+    name: product_sku_lookup
+    function:
+      type: unity_catalog
+      resource: *find_product_sku
+  retail_data_query: &retail_data_query
+    name: retail_data_query
+    function:
+      type: factory
+      name: dao_ai.tools.create_genie_tool
+      args:
+        name: retail_data_query
+        description: "Genie query"
+        genie_room: *retail_genie
+
+prompts:
+  assistant_prompt: &assistant_prompt
+    schema: *demo_schema
+    name: obo_validation_off_prompt
+    default_template: "You are a retail assistant."
+
+agents:
+  retail_assistant: &retail_assistant
+    name: retail_assistant
+    model: *default_llm
+    tools:
+    - *product_sku_lookup
+    - *retail_data_query
+    prompt: *assistant_prompt
+
+app:
+  name: obo-validation-gw-off
+  log_level: INFO
+  registered_model:
+    schema: *demo_schema
+    name: obo_validation_gw_off
+  agents:
+  - *retail_assistant

--- a/validation/configs/obo_ai_gateway_on.yaml
+++ b/validation/configs/obo_ai_gateway_on.yaml
@@ -1,0 +1,119 @@
+# yaml-language-server: $schema=../../schemas/model_config_schema.json
+#
+# Validation config: every OBO surface enabled, ai_gateway=true on the LLM.
+# Target workspace: FEVM. Resources verified to exist 2026-06-11.
+# Deploy via: dao-ai generate-bundle --development -c <this> -o <dir>
+
+parameters:
+  catalog:
+    description: Unity Catalog catalog name
+    default: retail_consumer_goods
+  schema:
+    description: Schema within the catalog
+    default: hardware_store
+
+schemas:
+  demo_schema: &demo_schema
+    catalog_name: ${var.catalog}
+    schema_name: ${var.schema}
+
+resources:
+  models:
+    default_llm: &default_llm
+      name: databricks-claude-sonnet-4-5
+      temperature: 0.1
+      max_tokens: 4096
+      # OBO + AI Gateway both ON → ai-gateway user-scope MUST be emitted.
+      on_behalf_of_user: true
+      ai_gateway: true
+
+  vector_stores:
+    products_vs: &products_vs
+      embedding_model:
+        name: databricks-gte-large-en
+      endpoint:
+        name: dbdemos_vs_endpoint
+        type: STANDARD
+      index:
+        schema: *demo_schema
+        name: products_index
+      source_table:
+        schema: *demo_schema
+        name: products
+      primary_key: product_id
+      embedding_source_column: description
+      columns:
+      - product_id
+      - sku
+      - product_name
+      - description
+      # OBO ON → vector-search + mcp.vectorsearch user scopes emitted.
+      on_behalf_of_user: true
+
+  genie_rooms:
+    retail_genie: &retail_genie
+      name: "Retail Genie (validation)"
+      description: "FEVM Genie space used for OBO scope validation"
+      space_id: 01f164d91cb71e63a36d9545d86c7424
+      # OBO ON → genie + mcp.genie user scopes emitted.
+      on_behalf_of_user: true
+
+  functions:
+    find_product_sku: &find_product_sku
+      schema: *demo_schema
+      name: find_product_by_sku
+      on_behalf_of_user: true
+    find_product_upc: &find_product_upc
+      schema: *demo_schema
+      name: find_product_by_upc
+      on_behalf_of_user: true
+
+tools:
+  product_sku_lookup: &product_sku_lookup
+    name: product_sku_lookup
+    function:
+      type: unity_catalog
+      resource: *find_product_sku
+  product_upc_lookup: &product_upc_lookup
+    name: product_upc_lookup
+    function:
+      type: unity_catalog
+      resource: *find_product_upc
+  retail_data_query: &retail_data_query
+    name: retail_data_query
+    function:
+      type: factory
+      name: dao_ai.tools.create_genie_tool
+      args:
+        name: retail_data_query
+        description: "Query retail data using natural language."
+        genie_room: *retail_genie
+
+prompts:
+  assistant_prompt: &assistant_prompt
+    schema: *demo_schema
+    name: obo_validation_prompt
+    description: "OBO validation assistant"
+    default_template: |
+      You are a retail assistant. Use SKU/UPC lookups for precise product searches
+      and Genie for natural language queries. All calls execute under the end
+      user's identity.
+
+agents:
+  retail_assistant: &retail_assistant
+    name: retail_assistant
+    model: *default_llm
+    tools:
+    - *product_sku_lookup
+    - *product_upc_lookup
+    - *retail_data_query
+    prompt: *assistant_prompt
+
+app:
+  name: obo-validation-gw-on
+  log_level: INFO
+  registered_model:
+    schema: *demo_schema
+    name: obo_validation_gw_on
+  agents:
+  - *retail_assistant

--- a/validation/inventory.yaml
+++ b/validation/inventory.yaml
@@ -1,0 +1,25 @@
+# FEVM resource inventory used by the OBO validation scenarios.
+# Captured 2026-06-11 from `databricks ... list --profile fevm`.
+
+profile: fevm
+host: fevm-nfleming-stable-aws.cloud.databricks.com
+
+serving_endpoints:
+  claude: databricks-claude-opus-4-7
+  gpt: databricks-gpt-5-5
+
+warehouses:
+  shared:
+    id: d1be2f7fe7faacb1
+    name: Shared Warehouse
+  serverless_starter:
+    id: d58e5fb998498840
+    name: Serverless Starter Warehouse
+
+vector_search:
+  endpoint: rag-vector-search-endpoint  # confirmed in Phase 2 setup
+
+connections:
+  http_test: aan-test-genie-one
+
+probe_app: scope-probe-nf  # created during Phase 0; will reuse for Phase 2

--- a/validation/run_apps_probe.py
+++ b/validation/run_apps_probe.py
@@ -1,0 +1,83 @@
+"""Probe the Databricks Apps platform with each scenario's expected scope set.
+
+Sends ``PATCH /api/2.0/apps/<probe>`` for every scenario using its
+``expected_scopes`` payload. A response containing ``user_api_scopes`` means
+the platform accepts the full set; an error response means at least one
+string is rejected.
+
+This complements ``run_unit_check.py`` (which proves the generator output)
+by proving the Apps API accepts what the generator emits.
+
+Run: ``python validation/run_apps_probe.py --profile fevm --app scope-probe-nf``
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from scenarios import SCENARIOS  # noqa: E402
+
+
+def update_app(profile: str, app: str, scopes: list[str]) -> tuple[bool, list[str], str]:
+    body = json.dumps({"name": app, "user_api_scopes": scopes})
+    result = subprocess.run(
+        ["databricks", "apps", "update", app, "--profile", profile, "--json", body],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return False, [], result.stderr.strip() or result.stdout.strip()
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return False, [], "non-json response: " + result.stdout[:300]
+    actual = data.get("user_api_scopes") or []
+    return True, actual, ""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--profile", default="fevm")
+    ap.add_argument("--app", default="scope-probe-nf")
+    args = ap.parse_args()
+
+    failures: list[str] = []
+    for sc in SCENARIOS:
+        scopes = sorted(sc.expected_scopes)
+        if not scopes:
+            print(f"-   {sc.name:<32}  (empty scope set — skipping platform probe)")
+            continue
+        ok, actual, err = update_app(args.profile, args.app, scopes)
+        if not ok:
+            failures.append(f"{sc.name}: REJECTED — {err}")
+            print(f"[!] {sc.name:<32}  REJECTED  {err[:150]}")
+            continue
+        # Platform should echo back exactly what we sent (set-equal).
+        if set(actual) != set(scopes):
+            failures.append(
+                f"{sc.name}: SET DIVERGES — sent {scopes}, got {actual}"
+            )
+            print(
+                f"[≠] {sc.name:<32}  DIVERGES  sent={scopes} got={actual}"
+            )
+            continue
+        print(f"[✓] {sc.name:<32}  accepted ({len(scopes)} scope(s))")
+
+    print()
+    if failures:
+        print("=== FAILURES ===")
+        for f in failures:
+            print(f)
+        return 1
+    print("=== ALL SCENARIOS' SCOPE SETS ACCEPTED BY APPS PLATFORM ===")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation/run_serving_policy_check.py
+++ b/validation/run_serving_policy_check.py
@@ -1,0 +1,74 @@
+"""Validate the Model Serving side of OBO scope emission.
+
+For each scenario:
+1. Build the :class:`AppConfig`.
+2. Run ``build_auth_policy(config)`` — the same function MLflow calls when
+   ``log_model(auth_policy=...)`` packages an agent for Model Serving.
+3. Inspect the resulting ``UserAuthPolicy.api_scopes`` (the field that
+   becomes the deployed endpoint's user-scope claim list).
+4. Confirm the strings match what Apps just accepted (cross-surface parity).
+
+Run: ``python validation/run_serving_policy_check.py``
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+from dao_ai.providers.databricks import build_auth_policy  # noqa: E402
+from mlflow.models.auth_policy import AuthPolicy, UserAuthPolicy  # noqa: E402
+
+from scenarios import SCENARIOS  # noqa: E402
+
+
+def main() -> int:
+    failures: list[str] = []
+    for sc in SCENARIOS:
+        config = sc.build()
+        policy = build_auth_policy(config)
+
+        # Structural checks: policy is the right MLflow type.
+        if not isinstance(policy, AuthPolicy):
+            failures.append(f"{sc.name}: build_auth_policy did not return AuthPolicy")
+            continue
+        if not isinstance(policy.user_auth_policy, UserAuthPolicy):
+            failures.append(f"{sc.name}: user_auth_policy is not UserAuthPolicy")
+            continue
+
+        # Contract check: api_scopes is a list of strings, set-equal to
+        # the scenario's expected_scopes (plus the dynamic catalog.*:read
+        # auto-additions, already encoded in expected_scopes).
+        emitted = set(policy.user_auth_policy.api_scopes)
+        missing = sc.expected_scopes - emitted
+        leaked = sc.forbidden_scopes & emitted
+        if missing or leaked:
+            failures.append(
+                f"{sc.name}: missing={sorted(missing)} leaked={sorted(leaked)}"
+            )
+            continue
+
+        flag = "[+]" if sc.positive else "[-]"
+        print(
+            f"{flag} {sc.name:<32}  UserAuthPolicy.api_scopes = "
+            f"{sorted(emitted)}"
+        )
+
+    print()
+    if failures:
+        print("=== FAILURES ===")
+        for f in failures:
+            print(f)
+        return 1
+    print(
+        f"=== ALL {len(SCENARIOS)} SCENARIOS PRODUCE THE EXPECTED "
+        f"UserAuthPolicy (Model Serving path) ==="
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation/run_unit_check.py
+++ b/validation/run_unit_check.py
@@ -1,0 +1,72 @@
+"""Run scope-generation checks for every scenario.
+
+For each scenario, exercise both surfaces:
+- ``generate_user_api_scopes`` (Apps path)
+- ``build_auth_policy`` (Model Serving path) — must produce the same scope set
+
+Confirms the unified emission contract.
+
+Run: ``python validation/run_unit_check.py``
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from dao_ai.apps.resources import generate_user_api_scopes
+from dao_ai.providers.databricks import build_auth_policy
+
+from scenarios import SCENARIOS  # noqa: E402
+
+
+def main() -> int:
+    failures: list[str] = []
+    for sc in SCENARIOS:
+        config = sc.build()
+
+        apps_scopes = set(generate_user_api_scopes(config))
+        ms_scopes = set(build_auth_policy(config).user_auth_policy.api_scopes)
+
+        # Both surfaces must produce the same set.
+        if apps_scopes != ms_scopes:
+            failures.append(
+                f"{sc.name}: Apps and MS scope sets diverge\n"
+                f"  Apps: {sorted(apps_scopes)}\n"
+                f"  MS:   {sorted(ms_scopes)}\n"
+            )
+            continue
+
+        missing = sc.expected_scopes - apps_scopes
+        if missing:
+            failures.append(
+                f"{sc.name}: missing expected scopes {sorted(missing)} "
+                f"(got {sorted(apps_scopes)})\n"
+            )
+            continue
+
+        leaked = sc.forbidden_scopes & apps_scopes
+        if leaked:
+            failures.append(
+                f"{sc.name}: forbidden scopes present {sorted(leaked)} "
+                f"(got {sorted(apps_scopes)})\n"
+            )
+            continue
+
+        flag = "[+]" if sc.positive else "[-]"
+        print(f"{flag} {sc.name:<32}  → {sorted(apps_scopes)}")
+
+    print()
+    if failures:
+        print("=== FAILURES ===")
+        for f in failures:
+            print(f)
+        return 1
+    print(f"=== ALL {len(SCENARIOS)} SCENARIOS PASSED ===")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation/scenarios.py
+++ b/validation/scenarios.py
@@ -1,0 +1,300 @@
+"""Validation scenarios for dao-ai OBO scope emission on both surfaces.
+
+Each scenario builds an :class:`AppConfig` programmatically and exercises:
+1. ``generate_user_api_scopes`` (the shared OBO scope generator) — confirms
+   dao-ai produces the canonical OBO scope strings for that config shape.
+2. ``build_auth_policy`` — confirms the Model Serving ``UserAuthPolicy``
+   carries the same strings (the two surfaces are unified now).
+
+A separate driver (``run_apps_probe.py``) then takes each scenario's
+expected scope set and PATCHes a real probe app on FEVM with those exact
+strings to prove the platform accepts the full set (not just individual
+strings as Phase 0 already proved).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+from dao_ai.config import (
+    AppConfig,
+    ConnectionModel,
+    DatabaseModel,
+    FunctionModel,
+    GenieRoomModel,
+    IndexModel,
+    InferenceEndpointModel,
+    ResourcesModel,
+    SchemaModel,
+    TableModel,
+    VectorStoreModel,
+    VolumeModel,
+    WarehouseModel,
+)
+
+_SCHEMA = SchemaModel(catalog_name="retail_consumer_goods", schema_name="hardware_store")
+
+
+@dataclass
+class Scenario:
+    """Self-contained validation case.
+
+    Attributes:
+        name: Identifier (used as app name suffix + log key).
+        positive: True for "expect scopes emitted"; False for "expect ai-gateway
+            absent" (the negative case for AI Gateway gating).
+        build: Callable that returns the configured :class:`AppConfig`.
+        expected_scopes: Set of canonical OBO scope strings the generator
+            MUST produce. ``catalog.*:read`` auto-additions are added by the
+            generator when tables/functions are present.
+        forbidden_scopes: Strings that MUST NOT appear in the output (e.g.,
+            ``ai-gateway`` for the negative scenarios).
+    """
+
+    name: str
+    positive: bool
+    build: Callable[[], AppConfig]
+    expected_scopes: set[str] = field(default_factory=set)
+    forbidden_scopes: set[str] = field(default_factory=set)
+
+
+def _config(**res) -> AppConfig:
+    return AppConfig(resources=ResourcesModel(**res))
+
+
+SCENARIOS: list[Scenario] = [
+    # ---- LLM + AI Gateway gating ----
+    Scenario(
+        name="llm-sp-no-gw",
+        positive=True,
+        build=lambda: _config(
+            models={
+                "claude": InferenceEndpointModel(
+                    name="databricks-claude-opus-4-7",
+                    on_behalf_of_user=False,
+                    ai_gateway=False,
+                )
+            }
+        ),
+        expected_scopes=set(),  # SP-side LLM → no user scopes
+        forbidden_scopes={"ai-gateway"},
+    ),
+    Scenario(
+        name="llm-obo-no-gw",
+        positive=True,
+        build=lambda: _config(
+            models={
+                "claude": InferenceEndpointModel(
+                    name="databricks-claude-opus-4-7",
+                    on_behalf_of_user=True,
+                    ai_gateway=False,
+                )
+            }
+        ),
+        expected_scopes={"serving.serving-endpoints"},
+        forbidden_scopes={"ai-gateway"},
+    ),
+    Scenario(
+        name="llm-obo-with-gw",
+        positive=True,
+        build=lambda: _config(
+            models={
+                "claude": InferenceEndpointModel(
+                    name="databricks-claude-opus-4-7",
+                    on_behalf_of_user=True,
+                    ai_gateway=True,
+                )
+            }
+        ),
+        expected_scopes={"serving.serving-endpoints", "ai-gateway"},
+    ),
+    Scenario(
+        name="llm-sp-with-gw-NEGATIVE",
+        positive=False,
+        build=lambda: _config(
+            models={
+                "claude": InferenceEndpointModel(
+                    name="databricks-claude-opus-4-7",
+                    on_behalf_of_user=False,
+                    ai_gateway=True,
+                )
+            }
+        ),
+        expected_scopes=set(),  # ai-gateway not emitted without OBO
+        forbidden_scopes={"ai-gateway"},
+    ),
+    # ---- Per-resource canonical strings + MCP companion pairing ----
+    Scenario(
+        name="warehouse-obo",
+        positive=True,
+        build=lambda: _config(
+            warehouses={
+                "wh": WarehouseModel(
+                    name="shared",
+                    warehouse_id="d1be2f7fe7faacb1",
+                    on_behalf_of_user=True,
+                )
+            }
+        ),
+        expected_scopes={"sql", "mcp.functions"},
+    ),
+    Scenario(
+        name="genie-obo",
+        positive=True,
+        build=lambda: _config(
+            genie_rooms={
+                "g": GenieRoomModel(
+                    name="genie",
+                    space_id="01f0000000000000",
+                    on_behalf_of_user=True,
+                )
+            }
+        ),
+        expected_scopes={"genie", "mcp.genie"},
+    ),
+    Scenario(
+        name="vector-search-obo",
+        positive=True,
+        build=lambda: _config(
+            vector_stores={
+                "vs": VectorStoreModel(
+                    index=IndexModel(schema=_SCHEMA, name="products_index"),
+                    on_behalf_of_user=True,
+                )
+            }
+        ),
+        expected_scopes={"vector-search", "mcp.vectorsearch", "serving.serving-endpoints"},
+    ),
+    Scenario(
+        name="volume-obo",
+        positive=True,
+        build=lambda: _config(
+            volumes={
+                "v": VolumeModel(
+                    schema=_SCHEMA, name="sample_vol", on_behalf_of_user=True
+                )
+            }
+        ),
+        expected_scopes={"files"},
+    ),
+    Scenario(
+        name="connection-obo",
+        positive=True,
+        build=lambda: _config(
+            connections={
+                "c": ConnectionModel(
+                    name="aan-test-genie-one", on_behalf_of_user=True
+                )
+            }
+        ),
+        expected_scopes={
+            "catalog.connections",
+            "mcp.external",
+            "serving.serving-endpoints",
+        },
+    ),
+    Scenario(
+        name="lakebase-obo",
+        positive=True,
+        build=lambda: _config(
+            databases={
+                "lb": DatabaseModel(
+                    project="lakebase-test", on_behalf_of_user=True
+                )
+            }
+        ),
+        expected_scopes={"postgres"},
+    ),
+    Scenario(
+        name="table-and-function-obo",
+        positive=True,
+        build=lambda: _config(
+            tables={
+                "t": TableModel(
+                    schema=_SCHEMA, name="products", on_behalf_of_user=True
+                )
+            },
+            functions={
+                "f": FunctionModel(
+                    schema=_SCHEMA, name="find_product", on_behalf_of_user=True
+                )
+            },
+        ),
+        expected_scopes={
+            "sql",
+            "mcp.functions",
+            "catalog.catalogs:read",
+            "catalog.schemas:read",
+            "catalog.tables:read",
+        },
+    ),
+    # ---- Mixed: every OBO resource type, ai_gateway ON ----
+    Scenario(
+        name="mixed-all-obo-with-gw",
+        positive=True,
+        build=lambda: _config(
+            models={
+                "claude": InferenceEndpointModel(
+                    name="databricks-claude-opus-4-7",
+                    on_behalf_of_user=True,
+                    ai_gateway=True,
+                )
+            },
+            warehouses={
+                "wh": WarehouseModel(
+                    name="shared",
+                    warehouse_id="d1be2f7fe7faacb1",
+                    on_behalf_of_user=True,
+                )
+            },
+            genie_rooms={
+                "g": GenieRoomModel(
+                    name="genie", space_id="01f0", on_behalf_of_user=True
+                )
+            },
+            vector_stores={
+                "vs": VectorStoreModel(
+                    index=IndexModel(schema=_SCHEMA, name="products_index"),
+                    on_behalf_of_user=True,
+                )
+            },
+            volumes={
+                "v": VolumeModel(schema=_SCHEMA, name="vol", on_behalf_of_user=True)
+            },
+            connections={
+                "c": ConnectionModel(name="conn", on_behalf_of_user=True)
+            },
+            databases={
+                "lb": DatabaseModel(project="lb", on_behalf_of_user=True)
+            },
+            tables={
+                "t": TableModel(schema=_SCHEMA, name="products", on_behalf_of_user=True)
+            },
+        ),
+        expected_scopes={
+            "serving.serving-endpoints",
+            "ai-gateway",
+            "sql",
+            "mcp.functions",
+            "genie",
+            "mcp.genie",
+            "vector-search",
+            "mcp.vectorsearch",
+            "files",
+            "catalog.connections",
+            "mcp.external",
+            "postgres",
+            "catalog.catalogs:read",
+            "catalog.schemas:read",
+            "catalog.tables:read",
+        },
+    ),
+]
+
+
+def get_scenario(name: str) -> Scenario:
+    for s in SCENARIOS:
+        if s.name == name:
+            return s
+    raise KeyError(f"no scenario named {name}")


### PR DESCRIPTION
## Summary

Brings dao-ai's user-OBO scope emission in line with the actual Apps OBO contract (verified against FEVM workspace June 2026 via real probes and end-to-end deploys), and adds first-class support for the new ``ai-gateway`` user scope.

- **Add** new OBO scopes: ``ai-gateway`` (gated on ``InferenceEndpointModel.on_behalf_of_user AND .ai_gateway``), ``postgres``, ``mcp.external``, ``mcp.functions``, ``mcp.genie``, ``mcp.vectorsearch``, ``model-serving``, ``workspace.workspace``, ``vector-search``.
- **Emit canonical short names** (``sql``, ``genie``, ``files``, ``vector-search``) instead of dao-ai's internal resource-scope names (``sql.warehouses``, ``dashboards.genie``, ``files.files``, ``vectorsearch.vector-search-*``). The older dotted aliases stay in ``VALID_USER_API_SCOPES`` so configs that still declare them keep working.
- **Pair MCP companions** automatically: ``sql↔mcp.functions``, ``genie↔mcp.genie``, ``vector-search↔mcp.vectorsearch``, ``catalog.connections↔mcp.external``. ``mcp.external`` is scoped to UC Connection only.
- **Unify Apps + Model Serving emission paths**: ``build_auth_policy`` (Model Serving ``UserAuthPolicy.api_scopes``) now delegates to the same ``generate_user_api_scopes`` used by the Apps bundle path, so both surfaces send identical canonical strings to the platform.
- **Lakebase OBO databases** now emit the ``postgres`` user-scope (previously dropped silently).
- **Clean up** hand-rolled ``mcp.*`` strings on ``ConnectionModel`` / ``McpFunctionModel`` ``api_scopes`` (companions are derived now).

## Validation

Full evidence in [`validation/RESULTS.md`](validation/RESULTS.md). Highlights:

- **Phase 0** (single-string probes): 17 canonical scopes accepted by the Apps API on FEVM, 4 deprecated dotted forms accepted as aliases, 5 rejected (matches what's NOT in the workspace UI scope picker — ``catalog.volumes``, ``apps.apps``, ``iam.*:read``, ``vector-search.search``, ``databricks-connect``).
- **Phase 2 unit matrix** (12 scenarios): every scenario produces identical scope sets on Apps (``generate_user_api_scopes``) and Model Serving (``UserAuthPolicy.api_scopes``) surfaces. Includes 4 ``ai-gateway`` gating cases (sp / sp+gw / obo / obo+gw) and 8 single-resource-type cases.
- **Phase 2 Apps API acceptance**: 10 scenario-level scope sets sent via real ``PATCH /api/2.0/apps`` against FEVM — all echo back exactly what we sent.
- **Phase 2b end-to-end**: two real ``dao-ai generate-bundle --development`` + ``databricks bundle deploy`` deploys to FEVM. Real ``POST /invocations`` chat completions. JWT decoded from the live ``x-forwarded-access-token``:
  - ``obo-validation-gw-on``  → scope claim contains ``ai-gateway`` ✅
  - ``obo-validation-gw-off`` → scope claim does NOT contain ``ai-gateway`` ✅
- **MLflow traces** recorded with state ``OK`` in each app's experiment. All temporary FEVM resources destroyed via ``databricks bundle destroy``.

## Test plan

- [x] ``pytest tests/dao_ai/test_auth_policy.py tests/dao_ai/test_apps_obo_partition.py`` — 48 passed (36 pre-existing + 12 new covering ai-gateway gating, MCP companion pairing, postgres OBO, canonical-string-no-leak invariant).
- [x] ``pytest tests/`` (full suite) — 2249 passed, 8 pre-existing real-API integration failures unrelated to scope changes (Genie / reranking against live indexes that don't exist), 56 skipped.
- [x] ``uv run python validation/run_unit_check.py`` — 12/12 scenarios pass on both Apps and Model Serving paths.
- [x] ``uv run python validation/run_serving_policy_check.py`` — 12/12 scenarios produce expected ``UserAuthPolicy``.
- [x] ``python validation/run_apps_probe.py --profile fevm --app <probe>`` — 10/10 sets accepted by Apps API.
- [x] End-to-end real deploy of ``validation/configs/obo_ai_gateway_on.yaml`` and ``validation/configs/obo_ai_gateway_off.yaml`` to FEVM via ``dao-ai generate-bundle --development`` + ``databricks bundle deploy``, with JWT scope-claim verification on the running apps.

## Backwards compatibility

- Older dotted scope strings (``files.files``, ``dashboards.genie``, ``vectorsearch.vector-search-*``) remain in ``VALID_USER_API_SCOPES`` and pass platform validation, so existing dao-ai configs that declared them won't break.
- ``ConnectionModel.api_scopes`` and ``McpFunctionModel.api_scopes`` no longer include hand-rolled ``mcp.*`` strings; the corresponding MCP user scopes are emitted automatically via ``API_SCOPE_TO_USER_SCOPES``. Two ``tests/dao_ai/test_mcp.py`` assertions adjusted to reflect this; behavior at the OBO emission layer is unchanged.

This pull request and its description were written by Isaac.