### PR TITLE
feat(apps): switch generate-bundle to Apps native uv path

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,8 @@ dao-ai pipeline --deploy -c config/my_config.yaml --profile azure-retail
 
 # Generate a deployable Databricks Apps bundle
 dao-ai generate-bundle -c config/my_config.yaml -o ./my-bundle
+# Then `cd` in and run `uv sync` to produce uv.lock — see "Deploying to
+# Databricks Apps" below for the full two-step workflow.
 
 # Interactive chat with agent
 dao-ai chat -c config/my_config.yaml
@@ -415,6 +417,36 @@ dao-ai chat -c config/my_config.yaml
 # Inspect declared parameters and resolved values
 dao-ai parameters list -c config/my_config.yaml --param catalog=nfleming
 ```
+
+### Deploying to Databricks Apps
+
+`dao-ai generate-bundle` produces a bundle skeleton (`pyproject.toml` + app/resource YAML + your config), but it deliberately does **not** generate `uv.lock`. The lock encodes URLs and pins specific to your environment, so you own it.
+
+**External users** (default index = public PyPI):
+
+```bash
+dao-ai generate-bundle -c config/my_config.yaml -o ./my-bundle
+cd ./my-bundle
+uv sync                                # produces uv.lock from public PyPI
+databricks bundle deploy -t dev -p <profile>
+databricks bundle run <app-name> -t dev -p <profile>
+```
+
+**Databricks-internal users** (local `uv` config defaults to the internal `pypi-proxy.dev.databricks.com` mirror): you need one extra step. The mirror is not reachable from Apps containers, so the lock URLs must be rewritten to public PyPI before deploy. The mirror is transparent, so hashes match — only the URLs need to change:
+
+```bash
+dao-ai generate-bundle -c config/my_config.yaml -o ./my-bundle
+cd ./my-bundle
+uv sync                                # produces uv.lock with internal-proxy URLs
+sed -i '' \
+  -e 's|pypi-proxy\.dev\.databricks\.com/packages/|files.pythonhosted.org/packages/|g' \
+  -e 's|pypi-proxy\.dev\.databricks\.com/simple/|pypi.org/simple/|g' \
+  uv.lock
+databricks bundle deploy -t dev -p <profile>
+databricks bundle run <app-name> -t dev -p <profile>
+```
+
+Apps' native uv support (announced 2026) activates automatically when `pyproject.toml` + `uv.lock` are present and `requirements.txt` is absent. The BUILD phase runs `uv sync --locked --no-dev`; the runtime command is bare `python -m dao_ai.apps.start_app` (chat-proxy variant) or `python -m dao_ai.apps.server` (no chat UI). No `uv run` wrapper needed.
 
 ### Multi-Cloud Deployment
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -108,10 +108,29 @@ The command creates a self-contained bundle directory with everything needed to 
 | `databricks.yaml` | Bundle definition with app config, resources, and scopes |
 | `<config>.yaml` | Copy of your dao-ai agent configuration (retains its original filename) |
 | `pyproject.toml` | Python project with dao-ai dependency |
-| `uv.lock` | Locked dependency resolution |
 | `.gitignore` | Ignore patterns for build artifacts |
 | `.python-version` | Python version pin (3.11) |
 | `src/<package>/` | Stub package for custom code |
+
+### Lock file: user-owned
+
+`dao-ai generate-bundle` does **not** create `uv.lock`. The lock encodes URLs and version pins that depend on the index your environment uses, so the user owns it. After `generate-bundle`, run:
+
+```bash
+cd ./my-bundle
+uv sync           # produces uv.lock from pyproject.toml against your default index
+```
+
+Apps' native uv support activates when both `pyproject.toml` and `uv.lock` are present and `requirements.txt` is absent — the BUILD phase runs `uv sync --locked --no-dev` for you.
+
+> **Databricks-internal users**: if your local `uv` config defaults to the internal `pypi-proxy.dev.databricks.com` mirror, your generated lock will contain URLs that Apps containers cannot reach. Rewrite them before deploy (hashes don't change — proxy is a transparent mirror):
+>
+> ```bash
+> sed -i '' \
+>   -e 's|pypi-proxy\.dev\.databricks\.com/packages/|files.pythonhosted.org/packages/|g' \
+>   -e 's|pypi-proxy\.dev\.databricks\.com/simple/|pypi.org/simple/|g' \
+>   uv.lock
+> ```
 
 When `app.enable_chat_proxy` is `true` (the default), the deployed app automatically clones and builds the Databricks [e2e-chatbot-app-next](https://github.com/databricks/app-templates/tree/main/e2e-chatbot-app-next) chat UI at startup. The Apps runtime has Node.js pre-installed, so no Node.js is needed on your development machine. Set `enable_chat_proxy: false` to deploy without the chat UI.
 

--- a/docs/mcp_server.md
+++ b/docs/mcp_server.md
@@ -201,12 +201,13 @@ The vector-search adapter passes the entire `args.retriever` block straight thro
 ```
 output/
 ├── databricks.yml        # bundle.engine: direct; App + bound resources
-├── app.yaml              # command: ["uv", "run", "dao-ai-mcp-server"]
+├── app.yaml              # command: ["dao-ai-mcp-server"]
 ├── pyproject.toml        # dao-ai[mcp]>=<version>
-├── requirements.txt      # uv
 ├── <your-config>.yaml    # rendered with parameters: stripped
 └── README.md             # generated deploy snippet
 ```
+
+After `generate-mcp`, run `uv sync` in the output directory to produce `uv.lock` from your environment. Databricks Apps' native uv support then activates at deploy: BUILD runs `uv sync --locked --no-dev` and the runtime command `["dao-ai-mcp-server"]` invokes the console script installed in `.venv/bin/`. Databricks-internal users need to rewrite internal-proxy URLs in the lock before deploy — see `docs/cli-reference.md` for the sed one-liner.
 
 ### CLI flags
 

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -89,11 +89,6 @@ bundle_config_schema.json
 dao_ai_schema.json
 """
 
-# Databricks Apps' runtime auto-installs Python deps from requirements.txt.
-# We ship just `uv` so the rest of the dependency graph (including dao-ai)
-# resolves from pyproject.toml + uv.lock at app startup via `uv run`.
-_REQUIREMENTS_TXT_CONTENT = "uv\n"
-
 _PYPROJECT_TEMPLATE = """\
 [build-system]
 requires = ["hatchling"]
@@ -370,10 +365,13 @@ def _build_app_block(
 
     user_api_scopes = generate_user_api_scopes(config)
 
+    # Bare `python -m` — no `uv run` wrapper. Apps' native uv support runs
+    # `uv sync --locked --no-dev` at BUILD phase and puts .venv/bin on PATH,
+    # so the runtime `python` is already venv-python with dao-ai installed.
     app_command: list[str] = (
-        ["uv", "run", "python", "-m", "dao_ai.apps.start_app"]
+        ["python", "-m", "dao_ai.apps.start_app"]
         if enable_chat_proxy
-        else ["uv", "run", "python", "-m", "dao_ai.apps.server"]
+        else ["python", "-m", "dao_ai.apps.server"]
     )
 
     app_def: dict[str, Any] = {
@@ -721,39 +719,11 @@ def write_bundle(
             logger.info(f"Created stub package src/{package_name}/")
             written.append(f"src/{package_name}/__init__.py")
 
-    # Generate uv.lock so the app runtime uses uv to install from pyproject.toml.
-    # When force=True, delete any existing lock first. Otherwise `uv lock` is
-    # a no-op when pyproject.toml hasn't changed, even if the local wheel it
-    # points at has been rebuilt with a new hash — leading to hash-mismatch
-    # failures on deploy.
-    lock_path: Path = output_dir / "uv.lock"
-    if force and lock_path.exists():
-        lock_path.unlink()
-        logger.info("Removed existing uv.lock for regeneration (force)")
-
-    logger.info("Resolving dependencies with uv lock...")
-    result = subprocess.run(
-        ["uv", "lock"],
-        cwd=output_dir,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode == 0:
-        written.append("uv.lock")
-        logger.info("Generated uv.lock")
-    else:
-        logger.error(f"Failed to generate uv.lock: {result.stderr.strip()}")
-        print(
-            f"  ERROR: uv lock failed. The app will not install dependencies correctly.\n"
-            f"         {result.stderr.strip()}"
-        )
-
     _track(
         output_dir / ".gitignore",
         _GITIGNORE_DEV_CONTENT if development else _GITIGNORE_CONTENT,
     )
     _track(output_dir / ".python-version", "3.11\n")
-    _track(output_dir / "requirements.txt", _REQUIREMENTS_TXT_CONTENT)
 
     print(f"\nBundle generated in {output_dir}/\n")
     for name in written:
@@ -766,7 +736,9 @@ def write_bundle(
 
     print("\nNext steps:")
     print(f"  cd {output_dir}")
-    print("  uv sync")
+    print("  uv sync                              # generate uv.lock against your env")
+    print("  # Databricks-internal users only: rewrite internal-proxy URLs in the lock")
+    print("  # so Apps containers can fetch from public PyPI (see README).")
     print("  databricks bundle deploy --target dev")
     print(f"  databricks bundle run {app_name} --target dev")
     print()

--- a/src/dao_ai/mcp/generate.py
+++ b/src/dao_ai/mcp/generate.py
@@ -6,11 +6,10 @@ of :func:`dao_ai.apps.bundle.write_bundle` but produces an MCP-only artifact:
 * ``databricks.yml`` — DAB with ``bundle.engine: direct`` and the App resource
   bindings derived from ``config.tools`` (filtered to entries with registered
   MCP adapters).
-* ``app.yaml`` — ``command: ["uv", "run", "dao-ai-mcp-server"]`` plus env vars
-  matching the App resource bindings.
+* ``app.yaml`` — ``command: ["dao-ai-mcp-server"]`` plus env vars matching the
+  App resource bindings.
 * ``pyproject.toml`` — single dep ``dao-ai[mcp]>=<current-version>``; declares
   ``dao-ai-mcp-server`` as a re-exported script.
-* ``requirements.txt`` — ``uv`` only.
 * ``dao_ai.yaml`` — the rendered (param-substituted) config, stripped of its
   top-level ``parameters:`` block.
 * ``README.md`` — generated deploy snippet listing required ``--var`` flags.
@@ -38,7 +37,10 @@ from dao_ai.mcp.adapters import get_adapter
 from dao_ai.mcp.adapters import vector_search as _vector_search_adapter  # noqa: F401
 
 DEFAULT_CONFIG_FILENAME = "dao_ai.yaml"
-APP_COMMAND: list[str] = ["uv", "run", "dao-ai-mcp-server"]
+# Bare console-script entry. Apps' native uv support runs `uv sync --locked
+# --no-dev` at BUILD phase, which installs `dao-ai-mcp-server` into
+# .venv/bin/ and puts that on PATH for the runtime.
+APP_COMMAND: list[str] = ["dao-ai-mcp-server"]
 
 
 def write_mcp_bundle(
@@ -101,7 +103,6 @@ def write_mcp_bundle(
         output_dir / "pyproject.toml",
         _render_pyproject(app_name=app_name, wheel_filename=wheel_filename),
     )
-    _write(output_dir / "requirements.txt", "uv\n")
 
     rendered: str | None = getattr(config, "_rendered_yaml", None)
     if rendered is not None:
@@ -128,6 +129,9 @@ def write_mcp_bundle(
 
     print("\nNext steps:")
     print(f"  cd {output_dir}")
+    print("  uv sync                              # generate uv.lock against your env")
+    print("  # Databricks-internal users only: rewrite internal-proxy URLs in the lock")
+    print("  # so Apps containers can fetch from public PyPI (see README).")
     print("  databricks bundle validate -t dev -p <profile>")
     print("  databricks bundle deploy -t dev -p <profile>")
     print()

--- a/tests/dao_ai/mcp/test_mcp_generate.py
+++ b/tests/dao_ai/mcp/test_mcp_generate.py
@@ -25,13 +25,19 @@ def test_write_mcp_bundle_emits_expected_files(tmp_path: Path) -> None:
         "databricks.yml",
         "app.yaml",
         "pyproject.toml",
-        "requirements.txt",
         "README.md",
     }
     produced = {p.name for p in out.iterdir() if p.is_file()}
     assert expected.issubset(produced)
+    assert "requirements.txt" not in produced, (
+        "MCP bundle must not ship requirements.txt — its presence would "
+        "force Apps onto the legacy pip-install path and skip native uv."
+    )
+    assert "uv.lock" not in produced, (
+        "MCP bundle must not ship uv.lock — lock is user-owned and "
+        "produced by `uv sync` after generate-mcp."
+    )
 
-    assert (out / "requirements.txt").read_text().strip() == "uv"
     pyproject = (out / "pyproject.toml").read_text()
     assert "dao-ai[mcp]" in pyproject
     assert 'dao-ai-mcp-server = "dao_ai.mcp.server:main"' in pyproject
@@ -41,8 +47,12 @@ def test_write_mcp_bundle_emits_expected_files(tmp_path: Path) -> None:
     assert "apps:" in databricks
 
     app_yaml = (out / "app.yaml").read_text()
-    assert 'uv' in app_yaml
+    # Bare console-script command — no `uv run` wrapper. Apps' native uv
+    # BUILD installs the console script into .venv/bin/ for the runtime.
     assert 'dao-ai-mcp-server' in app_yaml
+    assert 'uv' not in app_yaml, (
+        f"app.yaml must not reference `uv` in the runtime command; got:\n{app_yaml}"
+    )
 
 
 @pytest.mark.unit

--- a/tests/dao_ai/test_config_vars.py
+++ b/tests/dao_ai/test_config_vars.py
@@ -1005,12 +1005,15 @@ def test_write_bundle_bakes_resolved_values_and_drops_parameters(
 
 
 @pytest.mark.unit
-def test_write_bundle_emits_requirements_txt_and_uv_run_command(
+def test_write_bundle_uses_apps_native_uv_path(
     parameterised_config_path: Path, tmp_path: Path
 ) -> None:
-    """The generated bundle must ship a requirements.txt (so Databricks Apps
-    auto-installs `uv`) and an app `command:` that starts with `uv run`.
-    Without both, the App container's runtime venv is missing dao_ai.
+    """The generated bundle must NOT ship requirements.txt and must NOT ship
+    a uv.lock. Both would short-circuit Apps' native uv support (which
+    activates when pyproject.toml + uv.lock are present AND requirements.txt
+    is absent). The user runs `uv sync` themselves to produce their own lock.
+    The app `command:` must be bare `python -m …` — no `uv run` wrapper —
+    because Apps' native uv BUILD populates .venv/ and venv-python is on PATH.
     """
     from dao_ai.apps.bundle import write_bundle
 
@@ -1024,8 +1027,19 @@ def test_write_bundle_emits_requirements_txt_and_uv_run_command(
 
     write_bundle(config, out_dir, force=True, development=False)
 
-    req = (out_dir / "requirements.txt").read_text().strip().splitlines()
-    assert req == ["uv"], f"requirements.txt should contain only `uv`; got {req!r}"
+    assert not (out_dir / "requirements.txt").exists(), (
+        "Generated bundle must not ship requirements.txt — its presence "
+        "would force Apps onto the legacy pip-install path and skip "
+        "native uv support."
+    )
+    assert not (out_dir / "uv.lock").exists(), (
+        "Generated bundle must not ship uv.lock — lock is user-owned and "
+        "should be produced by `uv sync` after generate-bundle."
+    )
+    assert (out_dir / "pyproject.toml").exists(), (
+        "pyproject.toml must be present so `uv sync` has something to "
+        "resolve from."
+    )
 
     # The trimmed databricks.yaml carries bundle/include/targets/artifacts only;
     # the App + experiment block lives in resources/app.yml so users can drop
@@ -1042,11 +1056,8 @@ def test_write_bundle_emits_requirements_txt_and_uv_run_command(
     app_yaml = yaml.safe_load((out_dir / "resources" / "app.yml").read_text())
     app_name = next(iter(app_yaml["resources"]["apps"]))
     cmd = app_yaml["resources"]["apps"][app_name]["config"]["command"]
-    assert cmd[:2] == ["uv", "run"], (
-        f"App command must start with `uv run`; got {cmd!r}"
-    )
-    assert cmd[2:] == ["python", "-m", "dao_ai.apps.start_app"], (
-        f"App command tail unexpected: {cmd!r}"
+    assert cmd == ["python", "-m", "dao_ai.apps.start_app"], (
+        f"App command must be bare python (no uv run wrapper); got {cmd!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- **Root cause**: dao-ai's `generate-bundle` shipped `requirements.txt = "uv\n"` + `pyproject.toml` + an internally-generated `uv.lock`. Apps prioritized `requirements.txt`, the new native-uv path never activated, and `uv run` at runtime re-resolved 250+ packages from `pypi-proxy.dev.databricks.com` on every cold-start — a host the Apps team confirmed workspaces cannot reach (`#eng-databricks-apps` 2026-04-15, Alan Jackoway). Net effect: every fresh deploy crashed at startup on whichever random transitive package the proxy dropped that second.
- **Fix**: stop emitting `requirements.txt`, stop emitting `uv.lock` (environment-dependent user artifact — running `uv lock` inside the generator baked the generator's index URLs into a file users would inherit), drop the `uv run` wrapper from the runtime command. Apps' native uv support then activates: BUILD runs `uv sync --locked --no-dev`, runtime is bare `python -m dao_ai.apps.{start_app,server}`. Same three changes applied symmetrically to the MCP generator (`dao-ai-mcp-server` console script in `.venv/bin/`).
- **Docs**: README/cli-reference document the new two-step workflow (`generate-bundle` → `uv sync`) and a Databricks-internal sed one-liner for users whose local `uv` config points at the internal mirror — the mirror is a transparent mirror of `files.pythonhosted.org`, so URL rewriting preserves hashes.

## Test plan

- [x] 40/40 bundle + mcp unit tests pass
- [x] Full unit suite: 1355 passed, 1 pre-existing environmental flake (`test_create_dao_ai_graph` hits a live embeddings endpoint with an expired PAT) unrelated to this change
- [x] End-to-end smoke on \`fevm\` workspace:
  - [x] \`dao-ai generate-bundle\` output contains NO \`requirements.txt\`, NO \`uv.lock\`, YES \`pyproject.toml\` + \`.python-version\`
  - [x] \`uv sync\` produces a working lock from the generated \`pyproject.toml\`
  - [x] URL rewrite (\`sed pypi-proxy → files.pythonhosted.org\`) preserves hashes; \`uv sync --locked\` still passes
  - [x] \`databricks bundle deploy\` + \`bundle run\` succeed
  - [x] App logs show \`[BUILD] [INFO] Dependencies installed successfully with uv.\` (native-uv path active) and \`[APP] Starting app with command: [python -m dao_ai.apps.start_app]\` (bare python, no \`uv run\` wrapper)
  - [x] \`/invocations\` returns a \`ResponsesAgent\` JSON envelope with \`trace_id\` — full inference round-trip works
  - [x] \`databricks bundle destroy\` cleanup succeeds
- [ ] Reviewer: confirm bare console-script \`["dao-ai-mcp-server"]\` resolves in \`.venv/bin/\` for an MCP-server deploy (verified for chat-proxy variant; MCP variant follows the same \`.venv/bin\` PATH pattern but not exercised in this PR's smoke).

This pull request and its description were written by Isaac.