### PR TITLE
fix(apps): pin dao-ai in deployed bundles + sort Genie sql_functions by (id, identifier)

### DIFF
--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -1680,6 +1680,22 @@ class GenieEntitlement(BaseModel):
         return self
 
 
+# Sort priority for ``GenieRoomModel._sort_payload_lists`` — ordered from
+# most-specific to least-specific. Entries that carry multiple of these keys
+# are sorted by ALL of them as a composite tuple (in priority order),
+# matching the Genie v2 export-proto validator's expectations. In particular,
+# ``instructions.sql_functions`` entries carry both ``id`` and ``identifier``
+# and the validator demands sort by ``(id, identifier)`` (not by either
+# field alone). Module-level because Pydantic treats leading-underscore
+# class attributes as private model attrs.
+_GENIE_SORT_KEY_PRIORITY: tuple[str, ...] = (
+    "id",
+    "identifier",
+    "column_name",
+    "display_name",
+)
+
+
 class GenieRoomModel(IsDatabricksResource, ManagedResource):
     """Databricks Genie space configuration for natural-language SQL exploration.
 
@@ -2329,8 +2345,11 @@ class GenieRoomModel(IsDatabricksResource, ManagedResource):
         """Recursively sort list-of-dicts in the serialized payload.
 
         The Genie v2 API requires all repeated entries to be sorted by
-        their natural key (``id``, ``identifier``, ``column_name``, or
-        ``display_name``).
+        their natural key. For entries with multiple identifying fields
+        (e.g. ``sql_functions`` entries carry both ``id`` and ``identifier``),
+        the validator demands a composite sort over all of them — sorting by
+        only one of the fields trips the ``Invalid export proto: ... must be
+        sorted by (id, identifier)`` error.
         """
         if isinstance(obj, dict):
             for value in obj.values():
@@ -2339,10 +2358,11 @@ class GenieRoomModel(IsDatabricksResource, ManagedResource):
             for item in obj:
                 GenieRoomModel._sort_payload_lists(item)
             if obj and isinstance(obj[0], dict):
-                for key in ("column_name", "identifier", "id", "display_name"):
-                    if key in obj[0]:
-                        obj.sort(key=lambda x: (x.get(key, ""),))
-                        break
+                sort_keys = tuple(
+                    k for k in _GENIE_SORT_KEY_PRIORITY if k in obj[0]
+                )
+                if sort_keys:
+                    obj.sort(key=lambda x: tuple(x.get(k, "") for k in sort_keys))
 
     def refresh(
         self,

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -1108,11 +1108,49 @@ class DatabricksProvider(ServiceProvider):
             "dao_ai.apps.start_app" if enable_chat_proxy else "dao_ai.apps.server"
         )
         if is_published():
-            app_command = [
-                "/bin/bash",
-                "-c",
-                f"uv pip install dao-ai && python -m {entrypoint_module}",
-            ]
+            # Upload a pyproject.toml pinning dao-ai to the version that
+            # generated the bundle. Databricks Apps' native uv support runs
+            # ``uv sync --locked --no-dev`` at BUILD phase based on this file
+            # and puts ``.venv/bin`` on PATH for runtime, so the deployed app
+            # always runs the dao-ai version the bundle declares. Without
+            # this, the runtime ``uv pip install dao-ai`` only audits the
+            # cached venv from prior deploys to the same app slot — letting
+            # the venv silently drift behind the local dao-ai. (See issue
+            # surfaced by the workshop verification on 2026-06-23: Lab 15
+            # introduced ``app.background:``, but the cached venv was a
+            # pre-rename dao-ai that rejected the new field as
+            # ``extra_forbidden`` and crashed the app at startup.)
+            from dao_ai.apps.bundle import _PYPROJECT_TEMPLATE
+
+            app_name_normalized = raw_name.lower().replace("_", "-")
+            package_name = app_name_normalized.replace("-", "_")
+            pyproject_content = _PYPROJECT_TEMPLATE.format(
+                name=app_name_normalized,
+                package_name=package_name,
+                dao_ai_version=dao_ai_version(),
+            )
+            self.w.workspace.upload(
+                path=f"{source_path}/pyproject.toml",
+                content=io.BytesIO(pyproject_content.encode("utf-8")),
+                format=ImportFormat.AUTO,
+                overwrite=True,
+            )
+
+            # Stub package __init__.py so the hatch build target ``packages =
+            # ["src/<package_name>"]`` declared in ``_PYPROJECT_TEMPLATE``
+            # resolves during ``uv sync``.
+            try:
+                self.w.workspace.mkdirs(f"{source_path}/src/{package_name}")
+            except Exception:
+                pass
+            self.w.workspace.upload(
+                path=f"{source_path}/src/{package_name}/__init__.py",
+                content=io.BytesIO(b""),
+                format=ImportFormat.AUTO,
+                overwrite=True,
+            )
+
+            app_command = ["python", "-m", entrypoint_module]
             logger.info(
                 "dao-ai source for app: PyPI package",
                 version=dao_ai_version(),

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -2372,3 +2372,99 @@ def test_deploy_model_serving_links_experiment_and_grants_permissions():
                 trace_loc = call_kwargs["trace_location"]
                 assert trace_loc.catalog_name == "trace_cat"
                 assert trace_loc.schema_name == "trace_sch"
+
+
+@pytest.mark.unit
+def test_deploy_apps_agent_uploads_pyproject_with_dao_ai_version_pin(tmp_path):
+    """The published deploy path must ship a pyproject.toml that pins dao-ai
+    to the version that generated the bundle. Without this pin, Databricks Apps'
+    runtime ``uv pip install dao-ai`` only audits the cached venv from prior
+    deploys to the same app slot — letting older dao-ai linger when the bundle
+    YAML uses newer fields (e.g. ``app.background:`` introduced in 0.1.92).
+    Regression guard for the workshop verification crash on 2026-06-23.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from databricks.sdk.service.apps import (
+        App,
+        AppDeployment,
+        AppDeploymentState,
+        ApplicationState,
+    )
+    from databricks.sdk.service.iam import User
+
+    from dao_ai.config import AppConfig, AppModel
+    from dao_ai.providers.databricks import DatabricksProvider, dao_ai_version
+
+    raw_yaml: str = "app:\n  name: pin-test\n"
+    src_file = tmp_path / "dao_ai.yaml"
+    src_file.write_text(raw_yaml)
+
+    mock_config = MagicMock(spec=AppConfig)
+    mock_app = MagicMock(spec=AppModel)
+    mock_app.name = "pin-test"
+    mock_app.description = ""
+    mock_app.environment_vars = {}
+    mock_app.trace_location = None
+    mock_app.monitoring = None
+    mock_app.enable_chat_proxy = True
+    mock_config.app = mock_app
+    mock_config.source_config_path = str(src_file)
+    mock_config.rendered_yaml = raw_yaml
+    mock_config.resources = None
+    mock_config.agents = None
+    mock_config.retrievers = None
+
+    mock_existing_app = MagicMock(spec=App)
+    mock_existing_app.app_status = MagicMock(state=ApplicationState.RUNNING)
+    mock_deployment = MagicMock(spec=AppDeployment)
+    mock_deployment.status = MagicMock(state=AppDeploymentState.SUCCEEDED)
+    mock_user = MagicMock(spec=User, user_name="test.user@example.com")
+
+    with (
+        patch.object(DatabricksProvider, "__init__", return_value=None),
+        patch("dao_ai.providers.databricks.is_published", return_value=True),
+    ):
+        provider = DatabricksProvider()
+        provider.w = MagicMock()
+        provider.w.current_user.me.return_value = mock_user
+        with patch.object(
+            provider,
+            "get_or_create_experiment",
+            return_value=MagicMock(experiment_id="exp-1"),
+        ):
+            provider.w.apps.get.return_value = mock_existing_app
+            provider.w.apps.deploy_and_wait.return_value = mock_deployment
+
+            provider.deploy_apps_agent(mock_config)
+
+    # pyproject.toml must be uploaded with a hard dao-ai version pin
+    pyproject_uploads = [
+        c
+        for c in provider.w.workspace.upload.call_args_list
+        if c.kwargs.get("path", "").endswith("/pyproject.toml")
+    ]
+    assert pyproject_uploads, (
+        "Published deploy_apps_agent must upload a pyproject.toml so Apps' "
+        "native uv build phase installs dao-ai (rather than the runtime "
+        "command silently reusing a cached venv from a prior deploy)."
+    )
+    pyproject_text = pyproject_uploads[0].kwargs["content"].getvalue().decode("utf-8")
+    assert f"dao-ai>={dao_ai_version()}" in pyproject_text, (
+        f"pyproject.toml must pin dao-ai>={dao_ai_version()}; got:\n{pyproject_text}"
+    )
+
+    # app.yaml's command must be a bare ``python -m ...`` (no runtime pip
+    # install) so Apps' build-phase ``uv sync`` is the sole installer.
+    app_yaml_uploads = [
+        c
+        for c in provider.w.workspace.upload.call_args_list
+        if c.kwargs.get("path", "").endswith("/app.yaml")
+    ]
+    assert app_yaml_uploads, "expected an app.yaml upload"
+    app_yaml_text = app_yaml_uploads[0].kwargs["content"].getvalue().decode("utf-8")
+    assert "uv pip install dao-ai" not in app_yaml_text, (
+        "app.yaml must NOT issue a runtime ``uv pip install dao-ai`` — that "
+        "command audits the cached venv and never upgrades. The new path uses "
+        "the bundle's pyproject.toml + Apps' build-phase uv sync."
+    )

--- a/tests/dao_ai/test_genie_provisioning.py
+++ b/tests/dao_ai/test_genie_provisioning.py
@@ -202,6 +202,36 @@ class TestBuildSerializedSpace:
         assert fn["identifier"] == "cat.sch.find_product"
         assert "id" in fn
 
+    def test_sql_functions_sorted_by_id_identifier(
+        self,
+        schema: SchemaModel,
+        warehouse: WarehouseModel,
+    ):
+        """Genie's export-proto validator rejects ``instructions.sql_functions``
+        entries that are not sorted by ``(id, identifier)``. Verify the
+        ``GenieRoomModel`` emitter sorts regardless of YAML order."""
+        fn_a = FunctionModel(schema=schema, name="find_aardvark")
+        fn_m = FunctionModel(schema=schema, name="find_mango")
+        fn_z = FunctionModel(schema=schema, name="find_zebra")
+
+        room = GenieRoomModel(
+            name="Sort-Order Genie",
+            warehouse=warehouse,
+            parent_path="/Users/me@example.com/genie",
+            # Intentionally out of alphabetical order — the emitter must sort.
+            function_sources=[
+                GenieSqlFunctionSource(function=fn_z),
+                GenieSqlFunctionSource(function=fn_a),
+                GenieSqlFunctionSource(function=fn_m),
+            ],
+        )
+
+        sql_functions = room._build_serialized_space()["instructions"]["sql_functions"]
+        keys = [(entry["id"], entry["identifier"]) for entry in sql_functions]
+        assert keys == sorted(keys), (
+            f"sql_functions must be emitted sorted by (id, identifier); got {keys}"
+        )
+
     def test_sql_snippets_split_by_kind(self, fully_configured_room: GenieRoomModel):
         payload = fully_configured_room._build_serialized_space()
         snippets = payload["instructions"]["sql_snippets"]


### PR DESCRIPTION
## Summary

Two bugs surfaced by full workshop verification on fevm (`dao-ai-workshop` PR #8 + dao-ai 0.1.92):

### Bug 1 — Apps deploys silently reuse cached venv across redeploys

The published-mode `DatabricksProvider.deploy_apps_agent` path doesn't ship a `pyproject.toml` or `requirements.txt`. The generated `app.yaml` runs `uv pip install dao-ai && python -m ...` at startup — with no `--upgrade` and no version pin. Build logs show `No dependencies file found. Skipping installation.` and the runtime command audit-skips (`Audited 1 package in 15ms`), so the venv keeps whatever dao-ai version was installed on the FIRST deploy to that app slot — forever.

This bit the workshop verification: Lab 1 deployed before PyPI propagated 0.1.92; Labs 2–14 audit-skipped; Lab 15 introduced the renamed `app.background:` field; cached pre-rename dao-ai rejected it as `extra_forbidden` and crashed the app.

**Fix:** Upload a `pyproject.toml` (using the existing `_PYPROJECT_TEMPLATE`) pinning `dao-ai>={dao_ai_version()}`, and switch the command to a bare `python -m ...` so Apps' build-phase `uv sync` is the sole installer and respects the pin. Matches the dev-mode path's behavior.

### Bug 2 — Genie `sql_functions` sorted by `identifier` only, not `(id, identifier)`

`GenieRoomModel._build_serialized_space` runs all repeated entries through `_sort_payload_lists`, which previously picked the FIRST matching key from `(column_name, identifier, id, display_name)` and sorted by THAT alone. For `instructions.sql_functions` entries (which carry both `id` and `identifier`), it sorted by `identifier` only. Genie v2's export-proto validator rejects this:

```
InvalidParameterValue: Invalid export proto:
instructions.sql_functions must be sorted by (id, identifier)
```

Reproduced 4× in Lab 16.

**Fix:** `_sort_payload_lists` now builds a composite tuple key from ALL matching keys in priority order (`id`, `identifier`, `column_name`, `display_name`). The priority constant is module-level because Pydantic treats leading-underscore class attrs as private.

## Test plan

- [x] `uv run pytest tests/dao_ai/test_genie_provisioning.py` — 27 passed, 1 xfailed, 4 skipped (live-API skips)
- [x] `uv run pytest tests/dao_ai/test_databricks.py::test_deploy_apps_agent_uploads_pyproject_with_dao_ai_version_pin` — PASS
- [x] `make schema` — no diff to `schemas/model_config_schema.json`
- [x] Manual repro of Bug 2: with `function_sources=[zebra, aardvark, mango]` (out of order), emitted `sql_functions` is now sorted as `[zebra (505...), aardvark (512...), mango (ee5...)]` — composite `(id, identifier)` order ✓
- [ ] Live verification on fevm after merge: re-run Lab 15 (background) and Lab 16 (Genie provisioning) end-to-end. Lab 15 should deploy a fresh venv with pinned dao-ai and no longer crash; Lab 16's `GenieRoomModel.create()` should pass the export-proto validator and provision the space.

## References

- Workshop verification tracking note: `00-inbox/dao-ai-workshop-full-verification-2026-06-22.md` (Issues 3 + 5).
- Memory entries: `reference_dao_ai_bundle_requirements_txt.md`, `reference_dao_ai_bundle_uv_runtime_pypi_flakiness.md` — history of the bundle-deps approach.

This pull request and its description were written by Isaac.