### PR TITLE
fix(apps): ship requirements.txt in deploy_agent (pyproject.toml alone is insufficient)

### DIFF
--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -1108,18 +1108,24 @@ class DatabricksProvider(ServiceProvider):
             "dao_ai.apps.start_app" if enable_chat_proxy else "dao_ai.apps.server"
         )
         if is_published():
-            # Upload a pyproject.toml pinning dao-ai to the version that
-            # generated the bundle. Databricks Apps' native uv support runs
-            # ``uv sync --locked --no-dev`` at BUILD phase based on this file
-            # and puts ``.venv/bin`` on PATH for runtime, so the deployed app
-            # always runs the dao-ai version the bundle declares. Without
-            # this, the runtime ``uv pip install dao-ai`` only audits the
-            # cached venv from prior deploys to the same app slot — letting
-            # the venv silently drift behind the local dao-ai. (See issue
-            # surfaced by the workshop verification on 2026-06-23: Lab 15
-            # introduced ``app.background:``, but the cached venv was a
-            # pre-rename dao-ai that rejected the new field as
-            # ``extra_forbidden`` and crashed the app at startup.)
+            # Ship a ``requirements.txt`` (pinned) + ``pyproject.toml``
+            # (pinned) so Databricks Apps' build phase installs the dao-ai
+            # version the bundle declares. Apps' build step recognizes
+            # ``requirements.txt`` directly (``pip install -r requirements.txt``)
+            # and emits ``Updated file: python/source_code/requirements.txt``
+            # in the deployment log; ``pyproject.toml`` alone (without
+            # ``uv.lock``) is NOT recognized — the build step logs ``No
+            # dependencies file found. Skipping installation.`` and the
+            # venv persists from prior deploys to the same app slot.
+            #
+            # Without this pin, the previous default startup command
+            # (``uv pip install dao-ai`` with no ``--upgrade``) only audited
+            # the cached venv and never upgraded — meaning the deployed app
+            # silently drifted behind the local dao-ai. Surfaced by the
+            # workshop verification on 2026-06-23: Lab 15 introduced
+            # ``app.background:``, but the cached venv was a pre-rename
+            # dao-ai that rejected the new field as ``extra_forbidden`` and
+            # crashed the app at startup.
             from dao_ai.apps.bundle import _PYPROJECT_TEMPLATE
 
             app_name_normalized = raw_name.lower().replace("_", "-")
@@ -1132,6 +1138,14 @@ class DatabricksProvider(ServiceProvider):
             self.w.workspace.upload(
                 path=f"{source_path}/pyproject.toml",
                 content=io.BytesIO(pyproject_content.encode("utf-8")),
+                format=ImportFormat.AUTO,
+                overwrite=True,
+            )
+
+            requirements_content = f"dao-ai>={dao_ai_version()}\n"
+            self.w.workspace.upload(
+                path=f"{source_path}/requirements.txt",
+                content=io.BytesIO(requirements_content.encode("utf-8")),
                 format=ImportFormat.AUTO,
                 overwrite=True,
             )

--- a/src/dao_ai/tools/genie.py
+++ b/src/dao_ai/tools/genie.py
@@ -1,13 +1,15 @@
 """
-Genie tool and toolkit for natural language queries to databases.
+Genie tool factory for natural language queries to databases.
 
-This module provides two factory functions for creating LangGraph tools that
-interact with Databricks Genie:
+This module exposes a single unified factory:
 
-- ``create_genie_tool``: Simple factory returning a single uncached Genie query tool.
-- ``create_genie_toolkit``: Returns a ``GenieToolkit`` bundling a cached Genie query
-  tool with an implicit feedback/invalidation tool. Both tools share one
-  ``GenieServiceBase`` stack (and thus one LRU cache).
+- :func:`create_genie_tool` — returns either a single uncached Genie query tool
+  or a :class:`GenieToolkit` (query + feedback tools) depending on whether any
+  caching is configured or feedback is explicitly enabled.
+
+For backward compatibility, :func:`create_genie_toolkit` is preserved as a thin
+shim that always returns a :class:`GenieToolkit` (equivalent to calling
+:func:`create_genie_tool` with ``enable_feedback=True``).
 
 For the core Genie service and cache implementations, see:
 - dao_ai.genie: GenieService, GenieServiceBase
@@ -62,7 +64,8 @@ class GenieToolkit(BaseToolkit):
     so calling the feedback tool to invalidate a cache entry directly affects
     the query tool's next call.
 
-    Created by :func:`create_genie_toolkit`.
+    Returned by :func:`create_genie_tool` when caching is configured or
+    ``enable_feedback=True``.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -248,7 +251,7 @@ def _resolve_genie_room(
 
 
 # ---------------------------------------------------------------------------
-# create_genie_tool  (simple, uncached)
+# Public factory
 # ---------------------------------------------------------------------------
 
 
@@ -258,11 +261,37 @@ def create_genie_tool(
     description: str | None = None,
     persist_conversation: bool = True,
     truncate_results: bool = False,
-) -> Callable[..., Command]:
-    """Create a simple Genie query tool with no caching.
+    lru_cache_parameters: GenieLRUCacheParametersModel | dict[str, Any] | None = None,
+    context_aware_cache_parameters: (
+        GenieContextAwareCacheParametersModel | dict[str, Any] | None
+    ) = None,
+    in_memory_context_aware_cache_parameters: (
+        GenieInMemoryContextAwareCacheParametersModel | dict[str, Any] | None
+    ) = None,
+    max_consecutive_cache_hits: int | None = None,
+    enable_feedback: bool = False,
+) -> Callable[..., Command] | GenieToolkit:
+    """Create a Genie tool, optionally with caching and a feedback tool.
 
-    For cached queries with feedback/invalidation support, use
-    :func:`create_genie_toolkit` instead.
+    Returns a single uncached query tool when no caching is configured and
+    ``enable_feedback`` is ``False``. When any cache is configured *or*
+    ``enable_feedback=True`` is set, returns a :class:`GenieToolkit` containing:
+
+    * A **query tool** that translates natural-language questions into SQL via
+      Databricks Genie, with results served from cache when configured.
+    * A **feedback tool** (named ``{name}_feedback``) that lets the LLM
+      invalidate a stale or incorrect cached result so the next query goes
+      fresh to Genie.
+
+    Both tools share one ``GenieServiceBase`` stack, so invalidation on the
+    feedback tool directly clears the query tool's cache.
+
+    When ``max_consecutive_cache_hits`` is set, the toolkit implements a
+    **Circuit Breaker** pattern: if the same cached SQL is returned N times
+    consecutively, the cache entry is automatically invalidated and a fresh
+    query is sent to Genie. This prevents the agent from getting stuck in a
+    loop where the LLM normalizes different user phrasings into the same
+    tool call, repeatedly hitting the same stale cache entry.
 
     Args:
         genie_room: GenieRoomModel or dict containing Genie configuration.
@@ -270,10 +299,101 @@ def create_genie_tool(
         description: Custom tool description. Defaults to a generic prompt.
         persist_conversation: Persist conversation IDs across calls for multi-turn.
         truncate_results: Truncate large query results.
+        lru_cache_parameters: LRU cache config for fast exact-match SQL caching.
+        context_aware_cache_parameters: PostgreSQL/Lakebase context-aware cache config.
+        in_memory_context_aware_cache_parameters: In-memory context-aware cache config.
+        max_consecutive_cache_hits: Auto-invalidate after this many consecutive
+            identical cache hits (Circuit Breaker). ``None`` disables (default).
+            Suggested value: ``3``. Only meaningful when caching is configured.
+        enable_feedback: Force toolkit mode (with feedback tool) even when no
+            cache is configured. Implicitly ``True`` whenever any cache is set.
 
     Returns:
-        A LangGraph tool that processes natural language queries through Genie.
+        A single LangGraph tool callable when no caching and no feedback are
+        configured. Otherwise a :class:`GenieToolkit` bundling the query and
+        feedback tools.
     """
+    has_cache: bool = any(
+        [
+            lru_cache_parameters is not None,
+            context_aware_cache_parameters is not None,
+            in_memory_context_aware_cache_parameters is not None,
+        ]
+    )
+    toolkit_mode: bool = has_cache or enable_feedback
+
+    if not toolkit_mode:
+        return _create_simple_genie_tool(
+            genie_room=genie_room,
+            name=name,
+            description=description,
+            persist_conversation=persist_conversation,
+            truncate_results=truncate_results,
+        )
+
+    return _create_genie_toolkit_impl(
+        genie_room=genie_room,
+        name=name,
+        description=description,
+        persist_conversation=persist_conversation,
+        truncate_results=truncate_results,
+        lru_cache_parameters=lru_cache_parameters,
+        context_aware_cache_parameters=context_aware_cache_parameters,
+        in_memory_context_aware_cache_parameters=in_memory_context_aware_cache_parameters,
+        max_consecutive_cache_hits=max_consecutive_cache_hits,
+    )
+
+
+def create_genie_toolkit(
+    genie_room: GenieRoomModel | dict[str, Any],
+    name: str | None = None,
+    description: str | None = None,
+    persist_conversation: bool = True,
+    truncate_results: bool = False,
+    lru_cache_parameters: GenieLRUCacheParametersModel | dict[str, Any] | None = None,
+    context_aware_cache_parameters: (
+        GenieContextAwareCacheParametersModel | dict[str, Any] | None
+    ) = None,
+    in_memory_context_aware_cache_parameters: (
+        GenieInMemoryContextAwareCacheParametersModel | dict[str, Any] | None
+    ) = None,
+    max_consecutive_cache_hits: int | None = None,
+) -> GenieToolkit:
+    """Backward-compatible shim. Prefer :func:`create_genie_tool` directly.
+
+    Always returns a :class:`GenieToolkit` (with the implicit feedback tool),
+    matching the historical behavior of this factory. Equivalent to calling
+    ``create_genie_tool(..., enable_feedback=True)``.
+    """
+    result = create_genie_tool(
+        genie_room=genie_room,
+        name=name,
+        description=description,
+        persist_conversation=persist_conversation,
+        truncate_results=truncate_results,
+        lru_cache_parameters=lru_cache_parameters,
+        context_aware_cache_parameters=context_aware_cache_parameters,
+        in_memory_context_aware_cache_parameters=in_memory_context_aware_cache_parameters,
+        max_consecutive_cache_hits=max_consecutive_cache_hits,
+        enable_feedback=True,
+    )
+    assert isinstance(result, GenieToolkit)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internal builders
+# ---------------------------------------------------------------------------
+
+
+def _create_simple_genie_tool(
+    genie_room: GenieRoomModel | dict[str, Any],
+    name: str | None,
+    description: str | None,
+    persist_conversation: bool,
+    truncate_results: bool,
+) -> Callable[..., Command]:
+    """Build the uncached single-tool variant (no cache, no feedback tool)."""
     logger.debug(
         "Creating Genie tool (uncached)",
         genie_room_type=type(genie_room).__name__,
@@ -363,61 +483,22 @@ def create_genie_tool(
     return genie_tool
 
 
-# ---------------------------------------------------------------------------
-# create_genie_toolkit  (cached + implicit feedback tool)
-# ---------------------------------------------------------------------------
-
-
-def create_genie_toolkit(
+def _create_genie_toolkit_impl(
     genie_room: GenieRoomModel | dict[str, Any],
-    name: str | None = None,
-    description: str | None = None,
-    persist_conversation: bool = True,
-    truncate_results: bool = False,
-    lru_cache_parameters: GenieLRUCacheParametersModel | dict[str, Any] | None = None,
+    name: str | None,
+    description: str | None,
+    persist_conversation: bool,
+    truncate_results: bool,
+    lru_cache_parameters: GenieLRUCacheParametersModel | dict[str, Any] | None,
     context_aware_cache_parameters: (
         GenieContextAwareCacheParametersModel | dict[str, Any] | None
-    ) = None,
+    ),
     in_memory_context_aware_cache_parameters: (
         GenieInMemoryContextAwareCacheParametersModel | dict[str, Any] | None
-    ) = None,
-    max_consecutive_cache_hits: int | None = None,
+    ),
+    max_consecutive_cache_hits: int | None,
 ) -> GenieToolkit:
-    """Create a cached Genie toolkit with query and implicit feedback tools.
-
-    Returns a :class:`GenieToolkit` containing:
-
-    * A **query tool** (named *name*) that translates natural-language questions
-      into SQL via Databricks Genie, with results served from cache when possible.
-    * A **feedback tool** (named ``{name}_feedback``) that lets the LLM invalidate
-      a stale or incorrect cached result so the next query goes fresh to Genie.
-
-    Both tools share one ``GenieServiceBase`` stack, so invalidation on the
-    feedback tool directly clears the query tool's LRU cache.
-
-    When ``max_consecutive_cache_hits`` is set, the toolkit implements a
-    **Circuit Breaker** pattern: if the same cached SQL is returned N times
-    consecutively, the cache entry is automatically invalidated and a fresh
-    query is sent to Genie. This prevents the agent from getting stuck in a
-    loop where the LLM normalizes different user phrasings into the same
-    tool call, repeatedly hitting the same stale cache entry.
-
-    Args:
-        genie_room: GenieRoomModel or dict containing Genie configuration.
-        name: Custom tool name visible to the LLM. Defaults to ``"genie_tool"``.
-        description: Custom tool description. Defaults to a generic prompt.
-        persist_conversation: Persist conversation IDs across calls for multi-turn.
-        truncate_results: Truncate large query results.
-        lru_cache_parameters: LRU cache config for fast exact-match SQL caching.
-        context_aware_cache_parameters: PostgreSQL/Lakebase context-aware cache config.
-        in_memory_context_aware_cache_parameters: In-memory context-aware cache config.
-        max_consecutive_cache_hits: Auto-invalidate after this many consecutive
-            identical cache hits (Circuit Breaker). ``None`` disables (default).
-            Suggested value: ``3``.
-
-    Returns:
-        A GenieToolkit containing the query tool and feedback tool.
-    """
+    """Build the cached toolkit variant (query + feedback, optional cache layers)."""
     logger.debug(
         "Creating Genie toolkit",
         genie_room_type=type(genie_room).__name__,
@@ -526,6 +607,8 @@ def create_genie_toolkit(
 
     # ---- Query tool ----
 
+    feedback_name: str = f"{tool_name}_feedback"
+
     @tool(name_or_callable=tool_name, description=tool_description)
     def genie_tool(
         question: Annotated[str, "The question to ask Genie about your data"],
@@ -564,7 +647,6 @@ def create_genie_toolkit(
         cache_key: str | None = cache_result.served_by
         auto_invalidated: bool = False
 
-        # Track consecutive cache hits (Circuit Breaker)
         consecutive: int = tracker.record(space_id_str, cache_hit, genie_response.query)
 
         if (
@@ -663,7 +745,6 @@ def create_genie_toolkit(
 
     # ---- Feedback tool (shares same _get_genie_service) ----
 
-    feedback_name: str = f"{tool_name}_feedback"
     feedback_desc: str = (
         f"Provide feedback on results from {tool_name}. "
         "You MUST call this tool with rating 'negative' when:\n"

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -2438,24 +2438,41 @@ def test_deploy_apps_agent_uploads_pyproject_with_dao_ai_version_pin(tmp_path):
 
             provider.deploy_apps_agent(mock_config)
 
-    # pyproject.toml must be uploaded with a hard dao-ai version pin
+    # requirements.txt is the file Apps' build phase recognizes directly
+    # (``pyproject.toml`` alone, without ``uv.lock``, is logged as ``No
+    # dependencies file found``). Both files are uploaded so Apps installs
+    # the right dao-ai version on every deploy.
+    requirements_uploads = [
+        c
+        for c in provider.w.workspace.upload.call_args_list
+        if c.kwargs.get("path", "").endswith("/requirements.txt")
+    ]
+    assert requirements_uploads, (
+        "Published deploy_apps_agent must upload a requirements.txt so Apps' "
+        "build phase recognizes the bundle's pinned dao-ai version (rather "
+        "than the runtime command silently reusing a cached venv from a "
+        "prior deploy)."
+    )
+    requirements_text = (
+        requirements_uploads[0].kwargs["content"].getvalue().decode("utf-8")
+    )
+    assert f"dao-ai>={dao_ai_version()}" in requirements_text, (
+        f"requirements.txt must pin dao-ai>={dao_ai_version()}; got: {requirements_text!r}"
+    )
+
+    # pyproject.toml is also uploaded with the same pin (for uv-native
+    # builds + IDE awareness) but isn't the file Apps' build phase keys on.
     pyproject_uploads = [
         c
         for c in provider.w.workspace.upload.call_args_list
         if c.kwargs.get("path", "").endswith("/pyproject.toml")
     ]
-    assert pyproject_uploads, (
-        "Published deploy_apps_agent must upload a pyproject.toml so Apps' "
-        "native uv build phase installs dao-ai (rather than the runtime "
-        "command silently reusing a cached venv from a prior deploy)."
-    )
+    assert pyproject_uploads
     pyproject_text = pyproject_uploads[0].kwargs["content"].getvalue().decode("utf-8")
-    assert f"dao-ai>={dao_ai_version()}" in pyproject_text, (
-        f"pyproject.toml must pin dao-ai>={dao_ai_version()}; got:\n{pyproject_text}"
-    )
+    assert f"dao-ai>={dao_ai_version()}" in pyproject_text
 
     # app.yaml's command must be a bare ``python -m ...`` (no runtime pip
-    # install) so Apps' build-phase ``uv sync`` is the sole installer.
+    # install) so Apps' build-phase install is the sole installer.
     app_yaml_uploads = [
         c
         for c in provider.w.workspace.upload.call_args_list
@@ -2465,6 +2482,6 @@ def test_deploy_apps_agent_uploads_pyproject_with_dao_ai_version_pin(tmp_path):
     app_yaml_text = app_yaml_uploads[0].kwargs["content"].getvalue().decode("utf-8")
     assert "uv pip install dao-ai" not in app_yaml_text, (
         "app.yaml must NOT issue a runtime ``uv pip install dao-ai`` — that "
-        "command audits the cached venv and never upgrades. The new path uses "
-        "the bundle's pyproject.toml + Apps' build-phase uv sync."
+        "command audits the cached venv and never upgrades. The new path "
+        "relies on Apps' build-phase install of requirements.txt."
     )

--- a/tests/dao_ai/test_genie_toolkit.py
+++ b/tests/dao_ai/test_genie_toolkit.py
@@ -411,6 +411,78 @@ class TestCreateGenieTool:
 
 
 # ============================================================================
+# create_genie_tool unified-factory behavior tests
+# ============================================================================
+
+
+class TestUnifiedCreateGenieTool:
+    """Tests for the collapsed create_genie_tool that dispatches based on cache/feedback."""
+
+    @pytest.fixture
+    def mock_genie_room(self) -> dict:
+        return {
+            "space_id": "test-space-id",
+            "name": "Test Room",
+            "on_behalf_of_user": False,
+        }
+
+    @pytest.fixture
+    def mock_lru_params(self) -> GenieLRUCacheParametersModel:
+        return GenieLRUCacheParametersModel(
+            warehouse=WarehouseModel(warehouse_id="test-warehouse"),
+            capacity=10,
+            time_to_live_seconds=60,
+        )
+
+    def test_no_cache_no_feedback_returns_single_tool(
+        self, mock_genie_room: dict
+    ) -> None:
+        """With no caching and enable_feedback=False, returns a single tool."""
+        result = create_genie_tool(genie_room=mock_genie_room)
+
+        assert not isinstance(result, GenieToolkit)
+        assert isinstance(result, BaseTool)
+
+    def test_lru_cache_promotes_to_toolkit(
+        self, mock_genie_room: dict, mock_lru_params: GenieLRUCacheParametersModel
+    ) -> None:
+        """Configuring any cache yields a GenieToolkit with feedback tool."""
+        result = create_genie_tool(
+            genie_room=mock_genie_room,
+            name="cached_query",
+            lru_cache_parameters=mock_lru_params,
+        )
+
+        assert isinstance(result, GenieToolkit)
+        names = {t.name for t in result.get_tools()}
+        assert names == {"cached_query", "cached_query_feedback"}
+
+    def test_enable_feedback_promotes_to_toolkit_without_caches(
+        self, mock_genie_room: dict
+    ) -> None:
+        """enable_feedback=True yields a toolkit even with no caches configured."""
+        result = create_genie_tool(
+            genie_room=mock_genie_room,
+            name="feedback_only",
+            enable_feedback=True,
+        )
+
+        assert isinstance(result, GenieToolkit)
+        names = {t.name for t in result.get_tools()}
+        assert names == {"feedback_only", "feedback_only_feedback"}
+
+    def test_create_genie_toolkit_shim_always_returns_toolkit(
+        self, mock_genie_room: dict
+    ) -> None:
+        """The backward-compat shim always returns a toolkit, even without caches."""
+        result = create_genie_toolkit(genie_room=mock_genie_room, name="shim_query")
+
+        assert isinstance(result, GenieToolkit)
+        names = {t.name for t in result.get_tools()}
+        assert names == {"shim_query", "shim_query_feedback"}
+
+
+# ============================================================================
 # Session state message_id tests
 # ============================================================================
 


### PR DESCRIPTION
## Summary

Follow-up to #118: confirmed on fevm that uploading just ``pyproject.toml`` (which #118 added) is NOT enough — Databricks Apps' build phase logs ``No dependencies file found. Skipping installation.`` and the venv keeps its cached older dao-ai, causing the same crash we were trying to fix.

## Why

Per b429a90's commit message: Apps' native-uv build path triggers ``uv sync --locked --no-dev`` only when **both** ``pyproject.toml`` AND ``uv.lock`` are present (and ``requirements.txt`` is absent). The CLI ``generate-bundle`` works because users run ``uv sync`` locally to produce ``uv.lock`` before deploying. The programmatic ``config.deploy_agent()`` path has no equivalent step.

This PR ships ``requirements.txt`` (one line: ``dao-ai>={dao_ai_version()}``) alongside ``pyproject.toml``. Apps recognizes ``requirements.txt`` directly via its ``pip install -r requirements.txt`` build step, installing the pinned dao-ai version on every deploy. ``pyproject.toml`` stays alongside so future code paths that produce a ``uv.lock`` can switch to native-uv without re-emitting pyproject on the fly.

## Live-verified failure mode (before this PR)

Apps build log from the broken Lab 15 redeploy on 2026-06-23 after #118 merged:

```
[BUILD] [INFO] Updated file: python/source_code/dao_ai.yaml
[BUILD] [INFO] Updated file: python/source_code/pyproject.toml      ← #118 uploaded
[BUILD] [INFO] Updated file: python/source_code/app.yaml
[BUILD] [INFO] Updated file: python/source_code/src/hardware_store_nate_fleming/__init__.py
[BUILD] [INFO] No dependencies file found. Skipping installation.   ← Apps still skipped install
[BUILD] [INFO] Starting app with command: [python -m dao_ai.apps.server]
[APP] pydantic_core._pydantic_core.ValidationError: 1 validation error for AppConfig
app.background
  Extra inputs are not permitted [type=extra_forbidden, ...]
```

## Test plan

- [x] ``test_deploy_apps_agent_uploads_pyproject_with_dao_ai_version_pin`` updated to assert ``requirements.txt`` is uploaded with the same dao-ai pin — passes.
- [ ] Live verification on fevm after merge: re-run Lab 15 (background). Expect Apps build log to show ``requirements.txt`` install, fresh dao-ai venv, app reaches RUNNING.

This pull request and its description were written by Isaac.