### PR TITLE
fix(genie): emit display_name on all snippet types (filters/expressions/measures)

### DIFF
--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -2303,12 +2303,20 @@ class GenieRoomModel(IsDatabricksResource, ManagedResource):
         ):
             if not snippet_list:
                 continue
-            label_key = "display_name" if snippet_key == "filters" else "alias"
+            # Genie's export-proto validator now requires ``display_name`` on
+            # every snippet type (filters/expressions/measures); historically
+            # the schema only required ``alias`` on expressions+measures.
+            # Emit both so the payload satisfies both old and new validators.
             snippets[snippet_key] = [
                 {
                     "id": _stable_id(snippet_key, snippet.display_name, snippet.sql),
                     "sql": [snippet.sql],
-                    label_key: snippet.display_name,
+                    "display_name": snippet.display_name,
+                    **(
+                        {"alias": snippet.display_name}
+                        if snippet_key != "filters"
+                        else {}
+                    ),
                     **(
                         {"instruction": [snippet.instruction]}
                         if snippet.instruction

--- a/tests/dao_ai/test_genie_provisioning.py
+++ b/tests/dao_ai/test_genie_provisioning.py
@@ -240,6 +240,36 @@ class TestBuildSerializedSpace:
         assert snippets["filters"][0]["display_name"] == "Active products"
         assert snippets["filters"][0]["synonyms"] == ["live", "available"]
 
+    def test_sql_snippets_all_carry_display_name(
+        self,
+        schema: SchemaModel,
+        warehouse: WarehouseModel,
+    ):
+        """Genie's export-proto validator requires ``display_name`` on every
+        snippet type (filters, expressions, measures). Historically the
+        emitter wrote ``alias`` for expressions+measures and ``display_name``
+        only for filters, which trips
+        ``Invalid export proto: instructions.sql_snippets.expressions[0].display_name is required but missing``
+        against the current Genie validator. Verify all three types now
+        carry ``display_name``."""
+        room = GenieRoomModel(
+            name="Snippets Genie",
+            warehouse=warehouse,
+            parent_path="/Users/me@example.com/genie",
+            sql_filters=[GenieSqlSnippet(display_name="Active", sql="status = 'A'")],
+            sql_expressions=[
+                GenieSqlSnippet(display_name="FullName", sql="first || ' ' || last")
+            ],
+            sql_measures=[GenieSqlSnippet(display_name="Revenue", sql="SUM(amount)")],
+        )
+        snippets = room._build_serialized_space()["instructions"]["sql_snippets"]
+        for kind in ("filters", "expressions", "measures"):
+            assert kind in snippets, f"missing snippet kind {kind}"
+            for entry in snippets[kind]:
+                assert "display_name" in entry and entry["display_name"], (
+                    f"snippet kind {kind!r} entry missing display_name: {entry}"
+                )
+
     def test_benchmark_round_trips(self, fully_configured_room: GenieRoomModel):
         payload = fully_configured_room._build_serialized_space()
         question = payload["benchmarks"]["questions"][0]


### PR DESCRIPTION
## Summary

Genie's v2 export-proto validator now requires ``display_name`` on every snippet type, but ``GenieRoomModel._build_serialized_space`` historically wrote ``display_name`` only on filters and ``alias`` on expressions+measures.

Surfaced by Lab 16 retry on fevm after PR #118 landed the ``(id, identifier)`` sort fix:

```
InvalidParameterValue: Invalid export proto:
instructions.sql_snippets.expressions[0].display_name is required but missing
```

## Fix

Emit ``display_name`` on filters, expressions, and measures. Keep ``alias`` on expressions+measures for backward compatibility with any older Genie deployments that still read it.

## Test plan

- [x] New unit test ``test_sql_snippets_all_carry_display_name`` constructs one snippet per kind and asserts ``display_name`` is on each — passes.
- [x] Full ``tests/dao_ai/test_genie_provisioning.py`` still passes (27 passed, 1 xfailed, 4 skipped).
- [ ] Live verification on fevm: rerun Lab 16 (Genie provisioning) end-to-end against the new dao-ai.

This pull request and its description were written by Isaac.