### PR TITLE
feat: first-class type: genie / vector_search / search tool shapes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ distclean: clean
 	$(FIND) $(SRC_DIR) $(TEST_DIR) \( -name __pycache__ -a -type d \) -prune -exec rm -rf {} \;
 
 schema: depends
-	@$(PYTHON) -c "from dao_ai.config import AppConfig; import json; print(json.dumps(AppConfig.model_json_schema(), indent=2))"
+	@$(UV) run --quiet python -c "from dao_ai.config import AppConfig; import json; print(json.dumps(AppConfig.model_json_schema(), indent=2))"
 
 test: 
 	$(PYTEST) -ra --tb=short $(TEST_DIR)

--- a/config/examples/01_getting_started/minimal.yaml
+++ b/config/examples/01_getting_started/minimal.yaml
@@ -41,23 +41,18 @@ tools:
   genie_tool: &genie_tool
     name: genie
     function:
-      type: factory                                 # Tool type: factory function
-      name: dao_ai.tools.create_genie_tool          # Factory function path
-      args:                                         # Arguments passed to factory
-        name: my_genie_tool
-        description: My Answers questions about genie
-        genie_room: *retail_genie_room
-                                                    # Reference to Genie room config
+      type: genie                                   # First-class Genie tool type
+      name: my_genie_tool
+      description: My Answers questions about genie
+      genie_room: *retail_genie_room                # Reference to Genie room config
 
   vector_search_tool: &vector_search_tool
     name: vector_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        vector_store: *products_vector_store
-        name: product_search
-        description: Product Search
+      type: vector_search                           # First-class Vector Search tool type
+      vector_store: *products_vector_store
+      name: product_search
+      description: Product Search
 
 agents:
   simple_agent: &simple_agent

--- a/config/examples/03_reranking/instruction_aware_reranking.yaml
+++ b/config/examples/03_reranking/instruction_aware_reranking.yaml
@@ -151,18 +151,16 @@ tools:
   instruction_aware_search_tool: &instruction_aware_search_tool
     name: instruction_aware_product_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *instruction_aware_retriever
-        name: instruction_aware_product_search
-        description: |
-          Search for products with constraint-aware reranking.
-          Best for queries with explicit constraints:
-          - Price limits ("under $100", "between $50-200")
-          - Brand preferences ("Milwaukee", "not DeWalt")
-          - Category filters ("power tools", "paint")
-          Results are reranked to prioritize constraint matches.
+      type: vector_search
+      retriever: *instruction_aware_retriever
+      name: instruction_aware_product_search
+      description: |
+        Search for products with constraint-aware reranking.
+        Best for queries with explicit constraints:
+        - Price limits ("under $100", "between $50-200")
+        - Brand preferences ("Milwaukee", "not DeWalt")
+        - Category filters ("power tools", "paint")
+        Results are reranked to prioritize constraint matches.
 
 agents:
   # Agent using instruction-aware reranking

--- a/config/examples/03_reranking/vector_search_with_reranking.yaml
+++ b/config/examples/03_reranking/vector_search_with_reranking.yaml
@@ -122,43 +122,37 @@ tools:
   default_reranked_tool: &default_reranked_tool
     name: reranked_product_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *default_reranked_retriever
-        name: reranked_product_search
-        description: |
-          Search for products with reranking enabled.
-          Retrieves 50 candidates and reranks them using FlashRank
-          with the default model (ms-marco-MiniLM-L-12-v2).
+      type: vector_search
+      retriever: *default_reranked_retriever
+      name: reranked_product_search
+      description: |
+        Search for products with reranking enabled.
+        Retrieves 50 candidates and reranks them using FlashRank
+        with the default model (ms-marco-MiniLM-L-12-v2).
 
   # Tool 3: Vector search with fast reranking
   fast_reranked_tool: &fast_reranked_tool
     name: fast_reranked_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *fast_reranked_retriever
-        name: fast_reranked_search
-        description: |
-          Fast product search with lightweight reranking.
-          Retrieves 100 candidates, reranks with a fast model,
-          and returns the top 5 most relevant results.
+      type: vector_search
+      retriever: *fast_reranked_retriever
+      name: fast_reranked_search
+      description: |
+        Fast product search with lightweight reranking.
+        Retrieves 100 candidates, reranks with a fast model,
+        and returns the top 5 most relevant results.
 
   # Tool 4: Vector search with accurate reranking
   accurate_reranked_tool: &accurate_reranked_tool
     name: accurate_product_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *accurate_reranked_retriever
-        name: accurate_product_search
-        description: |
-          High-accuracy product search combining hybrid search and reranking.
-          Uses HYBRID query type for better initial recall, then reranks
-          using a more accurate model to return the best 10 results.
+      type: vector_search
+      retriever: *accurate_reranked_retriever
+      name: accurate_product_search
+      description: |
+        High-accuracy product search combining hybrid search and reranking.
+        Uses HYBRID query type for better initial recall, then reranks
+        using a more accurate model to return the best 10 results.
 
 agents:
   # Agent with default reranking

--- a/config/examples/04_genie/genie_basic.yaml
+++ b/config/examples/04_genie/genie_basic.yaml
@@ -48,13 +48,10 @@ tools:
   genie_tool: &genie_tool
     name: genie
     function:
-      type: factory                                 # Tool type: factory function
-      name: dao_ai.tools.create_genie_tool       # Factory function path
-      args:                                         # Arguments passed to factory
-        name: my_genie_tool
-        description: Answers questions about retail products and inventory
-        genie_room: *retail_genie_room
-                                                    # Reference to Genie room config
+      type: genie                                   # First-class Genie tool type
+      name: my_genie_tool
+      description: Answers questions about retail products and inventory
+      genie_room: *retail_genie_room                # Reference to Genie room config
 
 
 agents:

--- a/config/examples/04_genie/genie_context_aware_cache.yaml
+++ b/config/examples/04_genie/genie_context_aware_cache.yaml
@@ -85,36 +85,29 @@ tools:
   genie_tool: &genie_tool
     name: genie
     function:
-      type: factory                                 # Tool type: factory function
-      name: dao_ai.tools.create_genie_toolkit       # Factory function path (toolkit bundles query + feedback tools)
-      args:                                         # Arguments passed to factory
-        name: my_genie_tool
-        description: Answers questions about retail products and inventory
-        genie_room: *retail_genie_room
-                                                    # Reference to Genie room config
+      type: genie                                   # First-class Genie tool type — any cache promotes to toolkit (query + feedback)
+      name: my_genie_tool
+      description: Answers questions about retail products and inventory
+      genie_room: *retail_genie_room                # Reference to Genie room config
 
-        # L1 Cache: LRU (Least Recently Used) - Fast exact match
-        lru_cache_parameters:
-          warehouse: *shared_endpoint_warehouse
-                                                    # Warehouse to re-execute cached SQL
-          capacity: 100                             # Maximum number of cached entries
-          time_to_live_seconds: 3600                # Cache entries expire after 1 hour
+      # L1 Cache: LRU (Least Recently Used) - Fast exact match
+      lru_cache:
+        warehouse: *shared_endpoint_warehouse       # Warehouse to re-execute cached SQL
+        capacity: 100                               # Maximum number of cached entries
+        time_to_live_seconds: 3600                  # Cache entries expire after 1 hour
 
-        # L2 Cache: Context-Aware - Similarity-based lookup
-        context_aware_cache_parameters:
-          database: *context_aware_cache_db
-                                                    # PostgreSQL database for cache storage
-          warehouse: *shared_endpoint_warehouse
-                                                    # Warehouse used to re-execute cached SQL
-          embedding_model: *embedding_model
-                                                    # Reference to embedding model
-          # embedding_dims: 1024                    # Auto-detected if omitted (recommended)
-          similarity_threshold: 0.85                # Minimum similarity (L2 distance converted to 0-1)
-          time_to_live_seconds: 86400               # Cache entries expire after 1 day
-          # Note: Cache is automatically partitioned by genie space_id
-          # Note: Expired entries are cleaned up via "refresh on hit" strategy
+      # L2 Cache: Context-Aware - Similarity-based lookup
+      context_aware_cache:
+        database: *context_aware_cache_db           # PostgreSQL database for cache storage
+        warehouse: *shared_endpoint_warehouse       # Warehouse used to re-execute cached SQL
+        embedding_model: *embedding_model           # Reference to embedding model
+        # embedding_dims: 1024                      # Auto-detected if omitted (recommended)
+        similarity_threshold: 0.85                  # Minimum similarity (L2 distance converted to 0-1)
+        time_to_live_seconds: 86400                 # Cache entries expire after 1 day
+        # Note: Cache is automatically partitioned by genie space_id
+        # Note: Expired entries are cleaned up via "refresh on hit" strategy
 
-        persist_conversation: true
+      persist_conversation: true
 
 
 agents:

--- a/config/examples/04_genie/genie_in_memory_context_aware_cache.yaml
+++ b/config/examples/04_genie/genie_in_memory_context_aware_cache.yaml
@@ -91,49 +91,44 @@ tools:
   genie_tool: &genie_tool
     name: genie
     function:
-      type: factory                                 # Tool type: factory function
-      name: dao_ai.tools.create_genie_toolkit       # Factory function path (toolkit bundles query + feedback tools)
-      args:                                         # Arguments passed to factory
-        name: my_genie_tool
-        description: Answers questions about retail products and inventory
-        genie_room: *retail_genie_room
-                                                    # Reference to Genie room config
+      type: genie                                   # First-class Genie tool type — any cache promotes to toolkit (query + feedback)
+      name: my_genie_tool
+      description: Answers questions about retail products and inventory
+      genie_room: *retail_genie_room                # Reference to Genie room config
 
-        # Optional L1 Cache: LRU (Least Recently Used) - Fast exact match
-        # Uncomment to enable LRU cache in front of context-aware cache
-        # lru_cache_parameters:
-        #   warehouse: *shared_endpoint_warehouse     # Warehouse to re-execute cached SQL
-        #   capacity: 100                             # Maximum number of cached entries
-        #   time_to_live_seconds: 3600                # Cache entries expire after 1 hour
+      # Optional L1 Cache: LRU (Least Recently Used) - Fast exact match
+      # Uncomment to enable LRU cache in front of context-aware cache
+      # lru_cache:
+      #   warehouse: *shared_endpoint_warehouse     # Warehouse to re-execute cached SQL
+      #   capacity: 100                             # Maximum number of cached entries
+      #   time_to_live_seconds: 3600                # Cache entries expire after 1 hour
 
-        # In-Memory Context-Aware Cache: Similarity-based lookup with LRU eviction (NO database required)
-        # Default settings optimized for ~30 users on 8GB machine:
-        #   - Capacity: 10,000 entries (~200MB, ~330 queries/user)
-        #   - Eviction: LRU (Least Recently Used) keeps hot queries cached
-        #   - TTL: 1 week (accommodates weekly work patterns)
-        #   - Memory: ~4-5% of 8GB system
-        in_memory_context_aware_cache_parameters:
-          warehouse: *shared_endpoint_warehouse
-                                                    # Warehouse used to re-execute cached SQL
-          embedding_model: *embedding_model
-                                                    # Reference to embedding model
-          # embedding_dims: 1024                    # Auto-detected if omitted (recommended)
-          similarity_threshold: 0.85                # Minimum similarity for question matching (L2 distance to 0-1)
-          context_similarity_threshold: 0.80        # Minimum similarity for context matching
-          # time_to_live_seconds: 604800            # Cache entries expire after 1 week (default)
-          # capacity: 10000                         # Max cache entries, LRU eviction when full (default: 10000, ~200MB)
-          #                                         # Adjust for different scenarios:
-          #                                         #   - Small (5-10 users):  capacity: 1000  (~20MB)
-          #                                         #   - Medium (30 users):   capacity: 10000 (~200MB, default)
-          #                                         #   - Large (100 users):   capacity: 30000 (~600MB)
-          #                                         #   - Unlimited:           capacity: null  (not recommended - unbounded memory)
-          context_window_size: 3                    # Number of previous conversation turns to include
-          # max_context_tokens: 2000                # Maximum context length (default: 2000)
-          # question_weight: 0.6                    # Weight for question similarity (default: 0.6)
-          # context_weight: 0.4                     # Weight for context similarity (default: 0.4)
-          # Note: question_weight + context_weight must equal 1.0
+      # In-Memory Context-Aware Cache: Similarity-based lookup with LRU eviction (NO database required)
+      # Default settings optimized for ~30 users on 8GB machine:
+      #   - Capacity: 10,000 entries (~200MB, ~330 queries/user)
+      #   - Eviction: LRU (Least Recently Used) keeps hot queries cached
+      #   - TTL: 1 week (accommodates weekly work patterns)
+      #   - Memory: ~4-5% of 8GB system
+      in_memory_context_aware_cache:
+        warehouse: *shared_endpoint_warehouse       # Warehouse used to re-execute cached SQL
+        embedding_model: *embedding_model           # Reference to embedding model
+        # embedding_dims: 1024                      # Auto-detected if omitted (recommended)
+        similarity_threshold: 0.85                  # Minimum similarity for question matching (L2 distance to 0-1)
+        context_similarity_threshold: 0.80          # Minimum similarity for context matching
+        # time_to_live_seconds: 604800              # Cache entries expire after 1 week (default)
+        # capacity: 10000                           # Max cache entries, LRU eviction when full (default: 10000, ~200MB)
+        #                                           # Adjust for different scenarios:
+        #                                           #   - Small (5-10 users):  capacity: 1000  (~20MB)
+        #                                           #   - Medium (30 users):   capacity: 10000 (~200MB, default)
+        #                                           #   - Large (100 users):   capacity: 30000 (~600MB)
+        #                                           #   - Unlimited:           capacity: null  (not recommended - unbounded memory)
+        context_window_size: 3                      # Number of previous conversation turns to include
+        # max_context_tokens: 2000                  # Maximum context length (default: 2000)
+        # question_weight: 0.6                      # Weight for question similarity (default: 0.6)
+        # context_weight: 0.4                       # Weight for context similarity (default: 0.4)
+        # Note: question_weight + context_weight must equal 1.0
 
-        persist_conversation: true
+      persist_conversation: true
 
 
 agents:

--- a/config/examples/04_genie/genie_lru_cache.yaml
+++ b/config/examples/04_genie/genie_lru_cache.yaml
@@ -67,19 +67,15 @@ tools:
   genie_tool: &genie_tool
     name: genie
     function:
-      type: factory                                 # Tool type: factory function
-      name: dao_ai.tools.create_genie_toolkit    # Factory function path (toolkit bundles query + feedback tools)
-      args:                                         # Arguments passed to factory
-        name: my_genie_tool
-        description: Answers questions about retail products and inventory
-        genie_room: *retail_genie_room
-                                                    # Reference to Genie room config
-        lru_cache_parameters:                       # LRU cache configuration for SQL query caching
-          warehouse: *shared_endpoint_warehouse
-                                                    # Warehouse used to re-execute cached SQL
-          capacity: 100                             # Maximum number of queries to cache
-          time_to_live_seconds: 86400               # Cache entries expire after 1 day (default)
-        persist_conversation: true
+      type: genie                                   # First-class Genie tool type — LRU cache promotes to toolkit (query + feedback)
+      name: my_genie_tool
+      description: Answers questions about retail products and inventory
+      genie_room: *retail_genie_room                # Reference to Genie room config
+      lru_cache:                                    # LRU cache configuration for SQL query caching
+        warehouse: *shared_endpoint_warehouse       # Warehouse used to re-execute cached SQL
+        capacity: 100                               # Maximum number of queries to cache
+        time_to_live_seconds: 86400                 # Cache entries expire after 1 day (default)
+      persist_conversation: true
 
 
 agents:

--- a/config/examples/04_genie/genie_with_context_management.yaml
+++ b/config/examples/04_genie/genie_with_context_management.yaml
@@ -35,12 +35,10 @@ tools:
   genie_tool: &genie_tool
     name: genie
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_tool
-      args:
-        name: sporting_goods_analytics
-        description: Analyze sales performance, pricing strategies, margins, promotions, and revenue across stores and channels for sporting goods
-        genie_room: *genie_room
+      type: genie
+      name: sporting_goods_analytics
+      description: Analyze sales performance, pricing strategies, margins, promotions, and revenue across stores and channels for sporting goods
+      genie_room: *genie_room
 
 middleware:
   context_editor: &context_editor

--- a/config/examples/04_genie/genie_with_conversation_id.yaml
+++ b/config/examples/04_genie/genie_with_conversation_id.yaml
@@ -100,14 +100,11 @@ tools:
   genie_tool: &genie_tool
     name: genie
     function:
-      type: factory                                 # Tool type: factory function
-      name: dao_ai.tools.create_genie_tool       # Factory function path
-      args:                                         # Arguments passed to factory
-        name: my_genie_tool
-        description: "Answer questions about quick serve restaurant, ingredients, inventory, processes and operations."
-        genie_room: *retail_genie_room
-                                                    # Reference to Genie room config
-        persist_conversation: true
+      type: genie                                   # First-class Genie tool type
+      name: my_genie_tool
+      description: "Answer questions about quick serve restaurant, ingredients, inventory, processes and operations."
+      genie_room: *retail_genie_room                # Reference to Genie room config
+      persist_conversation: true
 
 
 agents:

--- a/config/examples/06_on_behalf_of_user/obo_basic.yaml
+++ b/config/examples/06_on_behalf_of_user/obo_basic.yaml
@@ -120,13 +120,11 @@ tools:
   retail_data_query: &retail_data_query
     name: retail_data_query
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_tool
-      args:
-        name: retail_data_query
-        description: "Query retail data using natural language. Access is controlled by user permissions."
-        genie_room: *retail_genie
-                                   # OBO inherited from genie_room resource
+      type: genie
+      name: retail_data_query
+      description: "Query retail data using natural language. Access is controlled by user permissions."
+      genie_room: *retail_genie
+                                 # OBO inherited from genie_room resource
 
 # =============================================================================
 # PROMPTS

--- a/config/examples/08_guardrails/guardrails_basic.yaml
+++ b/config/examples/08_guardrails/guardrails_basic.yaml
@@ -156,8 +156,7 @@ tools:
   search_tool: &search_tool
     name: search
     function:
-      type: factory
-      name: dao_ai.tools.create_search_tool
+      type: search
 
   # Simple greeting tool  
   greeting_tool: &greeting_tool

--- a/config/examples/10_agent_integrations/vertex_agent_engine.yaml
+++ b/config/examples/10_agent_integrations/vertex_agent_engine.yaml
@@ -163,35 +163,31 @@ tools:
   sales_genie_tool: &sales_genie_tool
     name: sales_analytics
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_tool
-      args:
-        name: sales_analytics
-        description: |
-          Query customer, sales, and product analytics for the retail
-          business. Use for questions about top-selling/most-ordered
-          products, revenue by product or category, pricing, order status,
-          payment methods, customer segmentation, and purchasing patterns.
-        genie_room: *sales_genie_room
+      type: genie
+      name: sales_analytics
+      description: |
+        Query customer, sales, and product analytics for the retail
+        business. Use for questions about top-selling/most-ordered
+        products, revenue by product or category, pricing, order status,
+        payment methods, customer segmentation, and purchasing patterns.
+      genie_room: *sales_genie_room
 
   # Genie — logistics operations & tracking.
   logistics_genie_tool: &logistics_genie_tool
     name: logistics_analytics
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_tool
-      args:
-        name: logistics_analytics
-        description: |
-          Query logistics operations and package tracking data. Use for
-          questions about carrier performance and cost, shipment volume,
-          transit/delivery times, shipment status, delay investigation,
-          package tracking events, and warehouse network capacity or
-          geographic coverage.
+      type: genie
+      name: logistics_analytics
+      description: |
+        Query logistics operations and package tracking data. Use for
+        questions about carrier performance and cost, shipment volume,
+        transit/delivery times, shipment status, delay investigation,
+        package tracking events, and warehouse network capacity or
+        geographic coverage.
 
-          Does NOT cover order items, returns, damages, inventory levels,
-          or financials beyond shipping costs — route those elsewhere.
-        genie_room: *logistics_genie_room
+        Does NOT cover order items, returns, damages, inventory levels,
+        or financials beyond shipping costs — route those elsewhere.
+      genie_room: *logistics_genie_room
 
   # Vertex AI Agent Engine — customer service domain expertise.
   customer_service_tool: &customer_service_tool

--- a/config/examples/11_prompt_engineering/prompt_optimization.yaml
+++ b/config/examples/11_prompt_engineering/prompt_optimization.yaml
@@ -149,13 +149,11 @@ tools:
   find_product_details_by_description_tool: &find_product_details_by_description_tool
     name: vector_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *products_retriever
-                                                    # Reference to retriever config
-        name: product_vector_search_tool            # Tool instance name
-        description: "Search for products by description"  # Tool description
+      type: vector_search
+      retriever: *products_retriever
+                                                  # Reference to retriever config
+      name: product_vector_search_tool            # Tool instance name
+      description: "Search for products by description"  # Tool description
 
 
 

--- a/config/examples/11_prompt_engineering/prompt_registry.yaml
+++ b/config/examples/11_prompt_engineering/prompt_registry.yaml
@@ -208,13 +208,11 @@ tools:
   find_product_details_by_description_tool: &find_product_details_by_description_tool
     name: vector_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *products_retriever
-                                                    # Reference to retriever config
-        name: product_vector_search_tool            # Tool instance name
-        description: "Search for products by description"  # Tool description
+      type: vector_search
+      retriever: *products_retriever
+                                                  # Reference to retriever config
+      name: product_vector_search_tool            # Tool instance name
+      description: "Search for products by description"  # Tool description
 
   # ---------------------------------------------------------------------------
   # UNITY CATALOG TOOLS

--- a/config/examples/12_middleware/combined_middleware.yaml
+++ b/config/examples/12_middleware/combined_middleware.yaml
@@ -95,12 +95,10 @@ tools:
   genie_tool: &genie_tool
     name: genie
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_tool
-      args:
-        name: retail_genie_tool
-        description: Query retail data
-        genie_room: *retail_genie
+      type: genie
+      name: retail_genie_tool
+      description: Query retail data
+      genie_room: *retail_genie
 
 agents:
   # ---------------------------------------------------------------------------

--- a/config/examples/12_middleware/context_management.yaml
+++ b/config/examples/12_middleware/context_management.yaml
@@ -58,20 +58,16 @@ tools:
   genie_tool: &genie_tool
     name: genie
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_tool
-      args:
-        name: retail_genie_tool
-        description: Query retail data using natural language
-        genie_room: *retail_genie
+      type: genie
+      name: retail_genie_tool
+      description: Query retail data using natural language
+      genie_room: *retail_genie
 
   # Search tool - returns verbose web content
   search_tool: &search_tool
     name: search_web
     function:
-      type: factory
-      name: dao_ai.tools.create_search_tool
-      args: {}
+      type: search
 
   # Time tool - returns small output
   time_tool: &time_tool

--- a/config/examples/12_middleware/custom_field_validation.yaml
+++ b/config/examples/12_middleware/custom_field_validation.yaml
@@ -115,12 +115,10 @@ tools:
   genie_tool: &genie_tool
     name: genie
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_tool
-      args:
-        name: retail_genie_tool
-        description: Query retail data using natural language
-        genie_room: *retail_genie
+      type: genie
+      name: retail_genie_tool
+      description: Query retail data using natural language
+      genie_room: *retail_genie
 
 # =============================================================================
 # AGENTS

--- a/config/examples/12_middleware/limit_middleware.yaml
+++ b/config/examples/12_middleware/limit_middleware.yaml
@@ -58,20 +58,16 @@ tools:
   genie_tool: &genie_tool
     name: genie
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_tool
-      args:
-        name: retail_genie_tool
-        description: Query retail data using natural language
-        genie_room: *retail_genie
+      type: genie
+      name: retail_genie_tool
+      description: Query retail data using natural language
+      genie_room: *retail_genie
 
   # Web search tool - rate-limited operation
   search_tool: &search_tool
     name: search_web
     function:
-      type: factory
-      name: dao_ai.tools.create_search_tool
-      args: {}
+      type: search
 
   # Time tool - lightweight, no limits needed
   time_tool: &time_tool

--- a/config/examples/12_middleware/logging_middleware.yaml
+++ b/config/examples/12_middleware/logging_middleware.yaml
@@ -86,12 +86,10 @@ tools:
   genie_tool: &genie_tool
     name: genie
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_tool
-      args:
-        name: retail_genie_tool
-        description: Query retail data
-        genie_room: *retail_genie
+      type: genie
+      name: retail_genie_tool
+      description: Query retail data
+      genie_room: *retail_genie
 
   current_time: &current_time
     name: current_time

--- a/config/examples/12_middleware/pii_middleware.yaml
+++ b/config/examples/12_middleware/pii_middleware.yaml
@@ -57,12 +57,10 @@ tools:
   genie_tool: &genie_tool
     name: genie
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_tool
-      args:
-        name: retail_genie_tool
-        description: Query retail data using natural language
-        genie_room: *retail_genie
+      type: genie
+      name: retail_genie_tool
+      description: Query retail data using natural language
+      genie_room: *retail_genie
 
   time_tool: &time_tool
     name: current_time

--- a/config/examples/12_middleware/retry_middleware.yaml
+++ b/config/examples/12_middleware/retry_middleware.yaml
@@ -57,20 +57,16 @@ tools:
   genie_tool: &genie_tool
     name: genie
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_tool
-      args:
-        name: retail_genie_tool
-        description: Query retail data using natural language
-        genie_room: *retail_genie
+      type: genie
+      name: retail_genie_tool
+      description: Query retail data using natural language
+      genie_room: *retail_genie
 
   # External API tool - may hit rate limits
   search_tool: &search_tool
     name: search_web
     function:
-      type: factory
-      name: dao_ai.tools.create_search_tool
-      args: {}
+      type: search
 
   # Simple time tool
   time_tool: &time_tool

--- a/config/examples/12_middleware/tool_selector_middleware.yaml
+++ b/config/examples/12_middleware/tool_selector_middleware.yaml
@@ -81,12 +81,10 @@ tools:
   genie_tool: &genie_tool
     name: genie
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_tool
-      args:
-        name: retail_genie_tool
-        description: Query retail sales and product data using natural language
-        genie_room: *retail_genie
+      type: genie
+      name: retail_genie_tool
+      description: Query retail sales and product data using natural language
+      genie_room: *retail_genie
 
   sql_query_tool: &sql_query_tool
     name: execute_sql
@@ -103,9 +101,7 @@ tools:
   search_tool: &search_tool
     name: search_web
     function:
-      type: factory
-      name: dao_ai.tools.create_search_tool
-      args: {}
+      type: search
 
   wikipedia_tool: &wikipedia_tool
     name: search_wikipedia

--- a/config/examples/15_complete_applications/brick_store.yaml
+++ b/config/examples/15_complete_applications/brick_store.yaml
@@ -458,22 +458,18 @@ tools:
   product_vector_search_tool: &product_vector_search_tool
     name: product_vector_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *products_retriever
-        name: product_vector_search_tool
-        description: "Search the product catalog by description, brand, department, color, or size. Use when the user describes the product rather than providing a SKU or UPC."
+      type: vector_search
+      retriever: *products_retriever
+      name: product_vector_search_tool
+      description: "Search the product catalog by description, brand, department, color, or size. Use when the user describes the product rather than providing a SKU or UPC."
 
   find_store_details_by_location_tool: &find_store_details_by_location_tool
     name: find_store_details_by_location
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *stores_retriever
-        name: find_store_details_by_location_tool
-        description: "Search for store details by location, neighborhood, or store name (e.g., 'Downtown Market', 'Marina'). Returns store id, address, city, state, and full details text."
+      type: vector_search
+      retriever: *stores_retriever
+      name: find_store_details_by_location_tool
+      description: "Search for store details by location, neighborhood, or store name (e.g., 'Downtown Market', 'Marina'). Returns store id, address, city, state, and full details text."
 
   # ---------------------------------------------------------------------------
   # Unity Catalog tools — product / inventory / store primitives
@@ -578,55 +574,51 @@ tools:
   store_ops_analytics_tool: &store_ops_analytics_tool
     name: query_store_ops_analytics
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_toolkit
-      args:
-        name: query_store_ops_analytics
-        description: >
-          Natural-language analytics over store_ops data: sales trends,
-          inventory turnover, BOPIS performance, customer feedback,
-          appointment volume, and category-level insights. Use for
-          aggregate or trend questions, not single-SKU lookups.
-        genie_room: *brickstore_genie_room
-        lru_cache_parameters:
-          warehouse: *brickstore_warehouse
-          capacity: 100
-          time_to_live_seconds: 3600
-          invalidate_on_empty_result: true
-        context_aware_cache_parameters:
-          database: *retail_database
-          warehouse: *brickstore_warehouse
-          embedding_model: *embedding_model
-          similarity_threshold: 0.85
-          time_to_live_seconds: 86400
-          invalidate_on_empty_result: true
-        persist_conversation: true
+      type: genie
+      name: query_store_ops_analytics
+      description: >
+        Natural-language analytics over store_ops data: sales trends,
+        inventory turnover, BOPIS performance, customer feedback,
+        appointment volume, and category-level insights. Use for
+        aggregate or trend questions, not single-SKU lookups.
+      genie_room: *brickstore_genie_room
+      lru_cache:
+        warehouse: *brickstore_warehouse
+        capacity: 100
+        time_to_live_seconds: 3600
+        invalidate_on_empty_result: true
+      context_aware_cache:
+        database: *retail_database
+        warehouse: *brickstore_warehouse
+        embedding_model: *embedding_model
+        similarity_threshold: 0.85
+        time_to_live_seconds: 86400
+        invalidate_on_empty_result: true
+      persist_conversation: true
 
   employee_insights_tool: &employee_insights_tool
     name: query_employee_insights
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_toolkit
-      args:
-        name: query_employee_insights
-        description: >
-          Natural-language analytics over employee performance, task
-          assignment, and manager data. Use for cross-department or
-          cross-store team questions that aren't a single-employee lookup.
-        genie_room: *brickstore_genie_room
-        lru_cache_parameters:
-          warehouse: *brickstore_warehouse
-          capacity: 100
-          time_to_live_seconds: 3600
-          invalidate_on_empty_result: true
-        context_aware_cache_parameters:
-          database: *retail_database
-          warehouse: *brickstore_warehouse
-          embedding_model: *embedding_model
-          similarity_threshold: 0.85
-          time_to_live_seconds: 86400
-          invalidate_on_empty_result: true
-        persist_conversation: true
+      type: genie
+      name: query_employee_insights
+      description: >
+        Natural-language analytics over employee performance, task
+        assignment, and manager data. Use for cross-department or
+        cross-store team questions that aren't a single-employee lookup.
+      genie_room: *brickstore_genie_room
+      lru_cache:
+        warehouse: *brickstore_warehouse
+        capacity: 100
+        time_to_live_seconds: 3600
+        invalidate_on_empty_result: true
+      context_aware_cache:
+        database: *retail_database
+        warehouse: *brickstore_warehouse
+        embedding_model: *embedding_model
+        similarity_threshold: 0.85
+        time_to_live_seconds: 86400
+        invalidate_on_empty_result: true
+      persist_conversation: true
 
   # ---------------------------------------------------------------------------
   # Utility tools

--- a/config/examples/15_complete_applications/deep_research.yaml
+++ b/config/examples/15_complete_applications/deep_research.yaml
@@ -115,13 +115,11 @@ tools:
   executive_research_genie_tool: &executive_research_genie_tool
     name: executive_research_genie_tool
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_tool
-      args:
-        name: executive_research_genie_tool
-        description: Query the data warehouse for comprehensive business metrics including customer KPIs, financial performance, operational data, employee metrics, inventory levels, and sales data. 
-          Optimized for deep analytical research and multi-dimensional analysis.
-        genie_room: *executive_research_genie_room
+      type: genie
+      name: executive_research_genie_tool
+      description: Query the data warehouse for comprehensive business metrics including customer KPIs, financial performance, operational data, employee metrics, inventory levels, and sales data. 
+        Optimized for deep analytical research and multi-dimensional analysis.
+      genie_room: *executive_research_genie_room
 
 agents:
   research_lead: &research_lead

--- a/config/examples/15_complete_applications/executive_assistant.yaml
+++ b/config/examples/15_complete_applications/executive_assistant.yaml
@@ -32,13 +32,11 @@ tools:
   executive_assistant_genie_tool: &executive_assistant_genie_tool
     name: executive_assistant_genie_tool
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_tool
-      args:
-        name: executive_assistant_genie_tool
-        description: Query the data warehouse for customer KPIs, business metrics, employee performance, inventory data, and other operational insights. Use this tool multiple times as needed to 
-          gather comprehensive data for executive-level analysis and recommendations.
-        genie_room: *executive_assistant_genie_room
+      type: genie
+      name: executive_assistant_genie_tool
+      description: Query the data warehouse for customer KPIs, business metrics, employee performance, inventory data, and other operational insights. Use this tool multiple times as needed to 
+        gather comprehensive data for executive-level analysis and recommendations.
+      genie_room: *executive_assistant_genie_room
 
 
   tavily_search_tool: &tavily_search_tool

--- a/config/examples/15_complete_applications/genie_and_genie_mcp.yaml
+++ b/config/examples/15_complete_applications/genie_and_genie_mcp.yaml
@@ -114,13 +114,11 @@ tools:
   genie_tool: &genie_tool
     name: genie_tool
     function:
-      type: factory                                 # Tool type: factory function
-      name: dao_ai.tools.create_genie_tool       # Factory function path
-      args:                                         # Arguments passed to factory
-        name: genie_tool
-        description: Answers questions about retail products and inventory
-        genie_room: *retail_genie_room
-                                                    # Reference to Genie room config
+      type: genie  # Tool type: factory function
+      name: genie_tool
+      description: Answers questions about retail products and inventory
+      genie_room: *retail_genie_room
+                                                  # Reference to Genie room config
 
   genie_mcp: &genie_mcp
                                                  # Genie MCP tool configuration

--- a/config/examples/15_complete_applications/genie_vector_search_hybrid.yaml
+++ b/config/examples/15_complete_applications/genie_vector_search_hybrid.yaml
@@ -88,24 +88,20 @@ tools:
   genie_tool: &genie_tool
     name: genie
     function:
-      type: factory                                 # Tool type: factory function
-      name: dao_ai.tools.create_genie_tool       # Factory function path
-      args:                                         # Arguments passed to factory
-        name: my_genie_tool
-        description: My Answers questions about genie
-        genie_room: *retail_genie_room
-                                                    # Reference to Genie room config
+      type: genie  # Tool type: factory function
+      name: my_genie_tool
+      description: My Answers questions about genie
+      genie_room: *retail_genie_room
+                                                  # Reference to Genie room config
 
   vector_search_tool: &vector_search_tool
     name: vector_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *products_retriever
-                                                    # Reference to retriever config
-        name: product_vector_search_tool            # Tool instance name
-        description: "Search for products using vector search"  # Tool description
+      type: vector_search
+      retriever: *products_retriever
+                                                  # Reference to retriever config
+      name: product_vector_search_tool            # Tool instance name
+      description: "Search for products using vector search"  # Tool description
 
 
 agents:

--- a/config/examples/15_complete_applications/hardware_store.yaml
+++ b/config/examples/15_complete_applications/hardware_store.yaml
@@ -165,13 +165,11 @@ tools:
   find_product_details_by_description_tool: &find_product_details_by_description_tool
     name: vector_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *products_retriever
-                                                    # Reference to retriever config
-        name: product_vector_search_tool            # Tool instance name
-        description: "Search for products by description"  # Tool description
+      type: vector_search
+      retriever: *products_retriever
+                                                  # Reference to retriever config
+      name: product_vector_search_tool            # Tool instance name
+      description: "Search for products by description"  # Tool description
 
   # ---------------------------------------------------------------------------
   # UNITY CATALOG TOOLS

--- a/config/examples/15_complete_applications/hardware_store_instructed.yaml
+++ b/config/examples/15_complete_applications/hardware_store_instructed.yaml
@@ -225,18 +225,16 @@ tools:
   find_product_details_by_description_tool: &find_product_details_by_description_tool
     name: product_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *products_retriever_instructed
-        name: product_search
-        description: |
-          Search for products by description with intelligent query understanding.
-          Automatically extracts brand, category, and feature filters from natural language.
-          Best for queries like:
-          - "Milwaukee cordless drills under 18V"
-          - "paint supplies excluding spray cans"
-          - "DeWalt or Makita power saws"
+      type: vector_search
+      retriever: *products_retriever_instructed
+      name: product_search
+      description: |
+        Search for products by description with intelligent query understanding.
+        Automatically extracts brand, category, and feature filters from natural language.
+        Best for queries like:
+        - "Milwaukee cordless drills under 18V"
+        - "paint supplies excluding spray cans"
+        - "DeWalt or Makita power saws"
 
   # Unity Catalog tools
   find_product_by_sku_tool: &find_product_by_sku_tool

--- a/config/examples/15_complete_applications/hardware_store_lakebase.yaml
+++ b/config/examples/15_complete_applications/hardware_store_lakebase.yaml
@@ -212,13 +212,10 @@ tools:
   find_product_details_by_description_tool: &find_product_details_by_description_tool
     name: vector_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *products_retriever
-                                                    # Reference to retriever config
-        name: product_vector_search_tool            # Tool instance name
-        description: "Search for products by description"  # Tool description
+      type: vector_search                           # First-class Vector Search tool type
+      retriever: *products_retriever                # Reference to retriever config
+      name: product_vector_search_tool              # Tool instance name
+      description: "Search for products by description"  # Tool description
 
   # ---------------------------------------------------------------------------
   # UNITY CATALOG TOOLS

--- a/config/examples/15_complete_applications/hardware_store_swarm.yaml
+++ b/config/examples/15_complete_applications/hardware_store_swarm.yaml
@@ -160,13 +160,11 @@ tools:
   find_product_details_by_description_tool: &find_product_details_by_description_tool
     name: find_product_details_by_description
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *products_retriever
-                                                    # Reference to retriever config
-        name: product_vector_search_tool            # Tool instance name
-        description: "Search for products using vector search"  # Tool description
+      type: vector_search
+      retriever: *products_retriever
+                                                  # Reference to retriever config
+      name: product_vector_search_tool            # Tool instance name
+      description: "Search for products using vector search"  # Tool description
 
   # ---------------------------------------------------------------------------
   # UNITY CATALOG TOOLS

--- a/config/examples/15_complete_applications/loyalty_offer_personalization.yaml
+++ b/config/examples/15_complete_applications/loyalty_offer_personalization.yaml
@@ -372,12 +372,10 @@ tools:
   offer_search_tool: &offer_search_tool
     name: offer_catalog_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *offer_catalog_retriever
-        name: offer_catalog_search
-        description: "Search the active offer catalog by description, brand, category, discount depth, or seasonal tag. Use when the operator describes the offer rather than naming an offer_id."
+      type: vector_search
+      retriever: *offer_catalog_retriever
+      name: offer_catalog_search
+      description: "Search the active offer catalog by description, brand, category, discount depth, or seasonal tag. Use when the operator describes the offer rather than naming an offer_id."
 
   # ---------------------------------------------------------------------------
   # Unity Catalog SQL function tools
@@ -428,48 +426,44 @@ tools:
   segment_analytics_tool: &segment_analytics_tool
     name: query_segment_analytics
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_toolkit
-      args:
-        name: query_segment_analytics
-        description: "Genie analytics over customer_features, receipts, and offer rankings. Use for cross-segment / cross-customer questions: top-N, brand mix, segment-level aggregates."
-        genie_room: *loyalty_genie_room
-        lru_cache_parameters:
-          warehouse: *loyalty_warehouse
-          capacity: 100
-          time_to_live_seconds: 3600
-          invalidate_on_empty_result: true
-        context_aware_cache_parameters:
-          database: *loyalty_database
-          warehouse: *loyalty_warehouse
-          embedding_model: *embedding_model
-          similarity_threshold: 0.85
-          time_to_live_seconds: 86400
-          invalidate_on_empty_result: true
-        persist_conversation: true
+      type: genie
+      name: query_segment_analytics
+      description: "Genie analytics over customer_features, receipts, and offer rankings. Use for cross-segment / cross-customer questions: top-N, brand mix, segment-level aggregates."
+      genie_room: *loyalty_genie_room
+      lru_cache:
+        warehouse: *loyalty_warehouse
+        capacity: 100
+        time_to_live_seconds: 3600
+        invalidate_on_empty_result: true
+      context_aware_cache:
+        database: *loyalty_database
+        warehouse: *loyalty_warehouse
+        embedding_model: *embedding_model
+        similarity_threshold: 0.85
+        time_to_live_seconds: 86400
+        invalidate_on_empty_result: true
+      persist_conversation: true
 
   redemption_outcomes_tool: &redemption_outcomes_tool
     name: query_redemption_outcomes
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_toolkit
-      args:
-        name: query_redemption_outcomes
-        description: "Genie analytics over redemptions joined to offer_catalog and customer_features. Use for 'did offer X lift...', under/over-performing offers, redemption rate by tier."
-        genie_room: *loyalty_genie_room
-        lru_cache_parameters:
-          warehouse: *loyalty_warehouse
-          capacity: 100
-          time_to_live_seconds: 3600
-          invalidate_on_empty_result: true
-        context_aware_cache_parameters:
-          database: *loyalty_database
-          warehouse: *loyalty_warehouse
-          embedding_model: *embedding_model
-          similarity_threshold: 0.85
-          time_to_live_seconds: 86400
-          invalidate_on_empty_result: true
-        persist_conversation: true
+      type: genie
+      name: query_redemption_outcomes
+      description: "Genie analytics over redemptions joined to offer_catalog and customer_features. Use for 'did offer X lift...', under/over-performing offers, redemption rate by tier."
+      genie_room: *loyalty_genie_room
+      lru_cache:
+        warehouse: *loyalty_warehouse
+        capacity: 100
+        time_to_live_seconds: 3600
+        invalidate_on_empty_result: true
+      context_aware_cache:
+        database: *loyalty_database
+        warehouse: *loyalty_warehouse
+        embedding_model: *embedding_model
+        similarity_threshold: 0.85
+        time_to_live_seconds: 86400
+        invalidate_on_empty_result: true
+      persist_conversation: true
 
   # ---------------------------------------------------------------------------
   # Utility tools

--- a/config/examples/15_complete_applications/sporting_goods_store.yaml
+++ b/config/examples/15_complete_applications/sporting_goods_store.yaml
@@ -396,12 +396,10 @@ tools:
   find_product_details_by_description_tool: &find_product_details_by_description_tool
     name: product_vector_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *products_retriever
-        name: product_vector_search_tool
-        description: "Search for sporting goods products by description, brand, sport, or category"
+      type: vector_search
+      retriever: *products_retriever
+      name: product_vector_search_tool
+      description: "Search for sporting goods products by description, brand, sport, or category"
 
   # Unity Catalog tools
   find_product_by_sku_tool: &find_product_by_sku_tool
@@ -444,48 +442,44 @@ tools:
   merchandising_analytics_tool: &merchandising_analytics_tool
     name: merchandising_analytics
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_toolkit
-      args:
-        name: query_merchandising_analytics
-        description: "Query merchandising analytics for assortment planning, demand forecasting, purchase order status, category performance, seasonal trends, and vendor analysis"
-        genie_room: *merchandising_analytics_room
-        lru_cache_parameters:
-          warehouse: *shared_warehouse
-          capacity: 100
-          time_to_live_seconds: 3600
-          invalidate_on_empty_result: true
-        context_aware_cache_parameters:
-          database: *retail_database
-          warehouse: *shared_warehouse
-          embedding_model: *embedding_model
-          similarity_threshold: 0.85
-          time_to_live_seconds: 86400
-          invalidate_on_empty_result: true
-        persist_conversation: true
+      type: genie
+      name: query_merchandising_analytics
+      description: "Query merchandising analytics for assortment planning, demand forecasting, purchase order status, category performance, seasonal trends, and vendor analysis"
+      genie_room: *merchandising_analytics_room
+      lru_cache:
+        warehouse: *shared_warehouse
+        capacity: 100
+        time_to_live_seconds: 3600
+        invalidate_on_empty_result: true
+      context_aware_cache:
+        database: *retail_database
+        warehouse: *shared_warehouse
+        embedding_model: *embedding_model
+        similarity_threshold: 0.85
+        time_to_live_seconds: 86400
+        invalidate_on_empty_result: true
+      persist_conversation: true
 
   sales_pricing_analytics_tool: &sales_pricing_analytics_tool
     name: sales_pricing_analytics
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_toolkit
-      args:
-        name: query_sales_pricing
-        description: "Query sales performance, pricing analytics, margin analysis, promotional effectiveness, revenue by store/channel, and competitive pricing intelligence"
-        genie_room: *sales_pricing_room
-        lru_cache_parameters:
-          warehouse: *shared_warehouse
-          capacity: 100
-          time_to_live_seconds: 3600
-          invalidate_on_empty_result: true
-        context_aware_cache_parameters:
-          database: *retail_database
-          warehouse: *shared_warehouse
-          embedding_model: *embedding_model
-          similarity_threshold: 0.85
-          time_to_live_seconds: 86400
-          invalidate_on_empty_result: true
-        persist_conversation: true
+      type: genie
+      name: query_sales_pricing
+      description: "Query sales performance, pricing analytics, margin analysis, promotional effectiveness, revenue by store/channel, and competitive pricing intelligence"
+      genie_room: *sales_pricing_room
+      lru_cache:
+        warehouse: *shared_warehouse
+        capacity: 100
+        time_to_live_seconds: 3600
+        invalidate_on_empty_result: true
+      context_aware_cache:
+        database: *retail_database
+        warehouse: *shared_warehouse
+        embedding_model: *embedding_model
+        similarity_threshold: 0.85
+        time_to_live_seconds: 86400
+        invalidate_on_empty_result: true
+      persist_conversation: true
 
   # Utility tools
   current_time_tool: &current_time_tool

--- a/config/examples/15_complete_applications/sporting_goods_store_mcp.yaml
+++ b/config/examples/15_complete_applications/sporting_goods_store_mcp.yaml
@@ -190,67 +190,61 @@ tools:
   product_vector_search:
     name: product_vector_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *products_retriever
-        name: product_vector_search
-        description: "Search for sporting goods products by description, brand, sport, or category."
+      type: vector_search
+      retriever: *products_retriever
+      name: product_vector_search
+      description: "Search for sporting goods products by description, brand, sport, or category."
 
   # ---- Genie toolkits (each exposes a query + a feedback MCP tool) ----
   merchandising_analytics:
     name: merchandising_analytics
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_toolkit
-      args:
-        name: merchandising_analytics
-        description: "Query merchandising analytics for assortment planning, demand forecasting, purchase orders, category performance, seasonal trends, and vendor analysis."
-        genie_room: *merchandising_analytics_room
-        lru_cache_parameters:
-          warehouse: *shared_warehouse
-          capacity: 100
-          time_to_live_seconds: 3600
-          invalidate_on_empty_result: true
-        context_aware_cache_parameters:
-          database: *retail_database
-          warehouse: *shared_warehouse
-          embedding_model: *embedding_model
-          # The cache table is multi-tenant via the space_id column — multiple
-          # Genie spaces (and multiple MCP/agent deployments pointing at the
-          # same Lakebase) coexist in one shared table with row-level isolation.
-          # The dao-ai default table names (genie_context_aware_cache /
-          # genie_prompt_history) are correct for that pattern. Only override
-          # table_name + prompt_history_table when you've hit Lakebase's
-          # NOINHERIT-on-DATABRICKS_SUPERUSER ownership lock-down and the
-          # easier path (have the project owner drop the orphaned tables or
-          # promote the new App SP) isn't available — see docs/mcp_server.md.
-          similarity_threshold: 0.85
-          time_to_live_seconds: 86400
-          invalidate_on_empty_result: true
-        persist_conversation: true
+      type: genie
+      name: merchandising_analytics
+      description: "Query merchandising analytics for assortment planning, demand forecasting, purchase orders, category performance, seasonal trends, and vendor analysis."
+      genie_room: *merchandising_analytics_room
+      lru_cache:
+        warehouse: *shared_warehouse
+        capacity: 100
+        time_to_live_seconds: 3600
+        invalidate_on_empty_result: true
+      context_aware_cache:
+        database: *retail_database
+        warehouse: *shared_warehouse
+        embedding_model: *embedding_model
+        # The cache table is multi-tenant via the space_id column — multiple
+        # Genie spaces (and multiple MCP/agent deployments pointing at the
+        # same Lakebase) coexist in one shared table with row-level isolation.
+        # The dao-ai default table names (genie_context_aware_cache /
+        # genie_prompt_history) are correct for that pattern. Only override
+        # table_name + prompt_history_table when you've hit Lakebase's
+        # NOINHERIT-on-DATABRICKS_SUPERUSER ownership lock-down and the
+        # easier path (have the project owner drop the orphaned tables or
+        # promote the new App SP) isn't available — see docs/mcp_server.md.
+        similarity_threshold: 0.85
+        time_to_live_seconds: 86400
+        invalidate_on_empty_result: true
+      persist_conversation: true
 
   sales_pricing_analytics:
     name: sales_pricing_analytics
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_toolkit
-      args:
-        name: sales_pricing_analytics
-        description: "Query sales performance, pricing analytics, margin analysis, promotional effectiveness, revenue by store/channel."
-        genie_room: *sales_pricing_room
-        lru_cache_parameters:
-          warehouse: *shared_warehouse
-          capacity: 100
-          time_to_live_seconds: 3600
-          invalidate_on_empty_result: true
-        context_aware_cache_parameters:
-          database: *retail_database
-          warehouse: *shared_warehouse
-          embedding_model: *embedding_model
-          # Shares the same default cache tables with the merchandising
-          # toolkit above — entries are isolated via the space_id column.
-          similarity_threshold: 0.85
-          time_to_live_seconds: 86400
-          invalidate_on_empty_result: true
-        persist_conversation: true
+      type: genie
+      name: sales_pricing_analytics
+      description: "Query sales performance, pricing analytics, margin analysis, promotional effectiveness, revenue by store/channel."
+      genie_room: *sales_pricing_room
+      lru_cache:
+        warehouse: *shared_warehouse
+        capacity: 100
+        time_to_live_seconds: 3600
+        invalidate_on_empty_result: true
+      context_aware_cache:
+        database: *retail_database
+        warehouse: *shared_warehouse
+        embedding_model: *embedding_model
+        # Shares the same default cache tables with the merchandising
+        # toolkit above — entries are isolated via the space_id column.
+        similarity_threshold: 0.85
+        time_to_live_seconds: 86400
+        invalidate_on_empty_result: true
+      persist_conversation: true

--- a/config/examples/15_complete_applications/sporting_goods_store_slim.yaml
+++ b/config/examples/15_complete_applications/sporting_goods_store_slim.yaml
@@ -291,12 +291,10 @@ tools:
   find_product_details_by_description_tool: &find_product_details_by_description_tool
     name: product_vector_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *products_retriever
-        name: product_vector_search_tool
-        description: "Search for sporting goods products by description, brand, sport, or category"
+      type: vector_search
+      retriever: *products_retriever
+      name: product_vector_search_tool
+      description: "Search for sporting goods products by description, brand, sport, or category"
 
   # Unity Catalog tools
   find_product_by_sku_tool: &find_product_by_sku_tool
@@ -321,48 +319,44 @@ tools:
   merchandising_analytics_tool: &merchandising_analytics_tool
     name: merchandising_analytics
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_toolkit
-      args:
-        name: query_merchandising_analytics
-        description: "Query merchandising analytics for assortment planning, demand forecasting, purchase order status, category performance, seasonal trends, and vendor analysis"
-        genie_room: *merchandising_analytics_room
-        lru_cache_parameters:
-          warehouse: *shared_warehouse
-          capacity: 100
-          time_to_live_seconds: 3600
-          invalidate_on_empty_result: true
-        context_aware_cache_parameters:
-          database: *retail_database
-          warehouse: *shared_warehouse
-          embedding_model: *embedding_model
-          similarity_threshold: 0.85
-          time_to_live_seconds: 86400
-          invalidate_on_empty_result: true
-        persist_conversation: true
+      type: genie
+      name: query_merchandising_analytics
+      description: "Query merchandising analytics for assortment planning, demand forecasting, purchase order status, category performance, seasonal trends, and vendor analysis"
+      genie_room: *merchandising_analytics_room
+      lru_cache:
+        warehouse: *shared_warehouse
+        capacity: 100
+        time_to_live_seconds: 3600
+        invalidate_on_empty_result: true
+      context_aware_cache:
+        database: *retail_database
+        warehouse: *shared_warehouse
+        embedding_model: *embedding_model
+        similarity_threshold: 0.85
+        time_to_live_seconds: 86400
+        invalidate_on_empty_result: true
+      persist_conversation: true
 
   sales_pricing_analytics_tool: &sales_pricing_analytics_tool
     name: sales_pricing_analytics
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_toolkit
-      args:
-        name: query_sales_pricing
-        description: "Query sales performance, pricing analytics, margin analysis, promotional effectiveness, revenue by store/channel, and competitive pricing intelligence"
-        genie_room: *sales_pricing_room
-        lru_cache_parameters:
-          warehouse: *shared_warehouse
-          capacity: 100
-          time_to_live_seconds: 3600
-          invalidate_on_empty_result: true
-        context_aware_cache_parameters:
-          database: *retail_database
-          warehouse: *shared_warehouse
-          embedding_model: *embedding_model
-          similarity_threshold: 0.85
-          time_to_live_seconds: 86400
-          invalidate_on_empty_result: true
-        persist_conversation: true
+      type: genie
+      name: query_sales_pricing
+      description: "Query sales performance, pricing analytics, margin analysis, promotional effectiveness, revenue by store/channel, and competitive pricing intelligence"
+      genie_room: *sales_pricing_room
+      lru_cache:
+        warehouse: *shared_warehouse
+        capacity: 100
+        time_to_live_seconds: 3600
+        invalidate_on_empty_result: true
+      context_aware_cache:
+        database: *retail_database
+        warehouse: *shared_warehouse
+        embedding_model: *embedding_model
+        similarity_threshold: 0.85
+        time_to_live_seconds: 86400
+        invalidate_on_empty_result: true
+      persist_conversation: true
 
   # Utility tools
   current_time_tool: &current_time_tool

--- a/config/examples/16_instructed_retriever/full_pipeline.yaml
+++ b/config/examples/16_instructed_retriever/full_pipeline.yaml
@@ -174,16 +174,14 @@ tools:
   full_pipeline_search_tool: &full_pipeline_search_tool
     name: intelligent_product_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *full_pipeline_retriever
-        name: intelligent_product_search
-        description: |
-          Intelligent product search with automatic query routing.
-          - Simple queries: Fast standard search path
-          - Complex queries: Full pipeline with decomposition, RRF, and verification
-          Handles brand preferences, category filters, and product exclusions.
+      type: vector_search
+      retriever: *full_pipeline_retriever
+      name: intelligent_product_search
+      description: |
+        Intelligent product search with automatic query routing.
+        - Simple queries: Fast standard search path
+        - Complex queries: Full pipeline with decomposition, RRF, and verification
+        Handles brand preferences, category filters, and product exclusions.
 
 agents:
   intelligent_search_agent: &intelligent_search_agent

--- a/config/examples/16_instructed_retriever/instructed_retriever.yaml
+++ b/config/examples/16_instructed_retriever/instructed_retriever.yaml
@@ -159,31 +159,27 @@ tools:
   standard_search_tool: &standard_search_tool
     name: standard_product_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *standard_retriever
-        name: standard_product_search
-        description: |
-          Search for products using standard vector similarity search.
-          Use this for simple queries without complex constraints.
+      type: vector_search
+      retriever: *standard_retriever
+      name: standard_product_search
+      description: |
+        Search for products using standard vector similarity search.
+        Use this for simple queries without complex constraints.
 
   # Instructed search tool
   instructed_search_tool: &instructed_search_tool
     name: instructed_product_search
     function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *instructed_retriever
-        name: instructed_product_search
-        description: |
-          Search for products with intelligent query decomposition.
-          Automatically extracts metadata filters from natural language.
-          Best for queries with:
-          - Brand preferences ("Milwaukee", "excluding DeWalt")
-          - Category filters ("power tools", "paint")
-          - Product exclusions ("not Makita")
+      type: vector_search
+      retriever: *instructed_retriever
+      name: instructed_product_search
+      description: |
+        Search for products with intelligent query decomposition.
+        Automatically extracts metadata filters from natural language.
+        Best for queries with:
+        - Brand preferences ("Milwaukee", "excluding DeWalt")
+        - Category filters ("power tools", "paint")
+        - Product exclusions ("not Makita")
 
 agents:
   # Agent using standard search

--- a/config/examples/16_test_scenarios/genie_provisioning_only.yaml
+++ b/config/examples/16_test_scenarios/genie_provisioning_only.yaml
@@ -77,12 +77,10 @@ tools:
   genie_tool: &genie_tool
     name: genie
     function:
-      type: factory
-      name: dao_ai.tools.create_genie_toolkit
-      args:
-        name: query_loyalty_genie
-        description: "Query the test Genie space."
-        genie_room: *test_room
+      type: genie
+      name: query_loyalty_genie
+      description: "Query the test Genie space."
+      genie_room: *test_room
 
 agents:
   test_agent: &test_agent

--- a/config/examples/README.md
+++ b/config/examples/README.md
@@ -2,6 +2,28 @@
 
 Welcome to the DAO AI examples! This directory contains ready-to-use configurations organized in a **numbered, progressive learning path**.
 
+## 🆕 First-class tool types
+
+The most common tools (Genie, Vector Search, web Search) are now first-class
+members of the tool config — no factory import path required. The original
+`type: factory` shape keeps working forever, but the shorter `type: genie` /
+`type: vector_search` / `type: search` shape is the recommended starting point.
+
+| Tool | Old shape (still works) | New shape (preferred) |
+| --- | --- | --- |
+| Genie | `type: factory`, `name: dao_ai.tools.create_genie_tool`, `args: { genie_room: ..., lru_cache_parameters: ... }` | `type: genie`, `genie_room: ...`, `lru_cache: ...` |
+| Vector Search | `type: factory`, `name: dao_ai.tools.create_vector_search_tool`, `args: { retriever: ... }` | `type: vector_search`, `retriever: ...` |
+| Web Search | `type: factory`, `name: dao_ai.tools.create_search_tool` | `type: search` |
+
+Genie with caching (LRU + context-aware) now lives under a single tool type —
+any cache configured promotes the tool to a toolkit (query + feedback) just
+like `create_genie_toolkit` did. `lru_cache_parameters` → `lru_cache`,
+`context_aware_cache_parameters` → `context_aware_cache`,
+`in_memory_context_aware_cache_parameters` → `in_memory_context_aware_cache`.
+
+See `04_genie/genie_basic.yaml` (uncached) and `04_genie/genie_lru_cache.yaml`
+(toolkit with feedback) for the canonical shapes.
+
 ## 🗺️ Learning Path
 
 Follow the numbered directories from 01 to 11 for a structured learning experience:

--- a/docs/genie_context_aware_cache_prompt_history.md
+++ b/docs/genie_context_aware_cache_prompt_history.md
@@ -1,5 +1,7 @@
 # Genie Context-Aware Cache - Prompt History
 
+> **Config field naming.** This document uses the `context_aware_cache_parameters` field name from the original `create_genie_toolkit` factory args. On the first-class `type: genie` tool shape, the equivalent field is `context_aware_cache` (no `_parameters` suffix). Both shapes accept the same nested fields described below.
+
 ## Overview
 
 The Genie context-aware cache now includes **prompt history tracking** to solve the conversation continuity problem where cache hits created "holes" in conversation context.

--- a/docs/key-capabilities.md
+++ b/docs/key-capabilities.md
@@ -61,35 +61,75 @@ dao-ai deploy -c config.yaml --target apps
 
 **What are tools?** Tools are actions an agent can perform — like querying a database, calling an API, or running custom code.
 
-DAO supports four types of tools, each suited for different use cases:
+DAO supports several first-class tool types plus an escape hatch for arbitrary factory functions:
 
 | Tool Type | Use Case | Example |
 |-----------|----------|---------|
-| **Python** | Custom business logic | `dao_ai.tools.current_time_tool` |
-| **Factory** | Complex initialization with config | `create_vector_search_tool(retriever=...)`, `create_genie_tool(genie_room=...)` |
-| **Inline** | Quick prototyping, simple tools defined in YAML | Define tool code directly in config |
-| **Agent Endpoint** | Call external agents as tools | `create_agent_endpoint_tool(llm=...)` for Agent Bricks, Kasal |
-| **Unity Catalog** | Governed SQL functions | `catalog.schema.find_product_by_sku` |
-| **MCP** | External services via Model Context Protocol | GitHub, Slack, custom APIs |
+| **Genie** | Natural-language SQL via a Genie space, with optional caching | `type: genie` + `genie_room: *room` |
+| **Vector Search** | Semantic / hybrid search over a vector index, with optional instructed retrieval | `type: vector_search` + `retriever: *retriever` |
+| **Search** | Web search (DuckDuckGo) | `type: search` |
+| **Unity Catalog** | Governed SQL functions | `type: unity_catalog` + `resource: *fn` |
+| **MCP** | External services via Model Context Protocol | `type: mcp` + `connection: *mcp_conn` |
+| **Python** | Custom business logic — direct function import | `type: python` + `name: my_pkg.my_tool` |
+| **Inline** | Quick prototyping — define tool code directly in YAML | `type: inline` + `code:` |
+| **Factory** | Escape hatch for arbitrary factory functions not yet first-class | `type: factory` + `name: dao_ai.tools.<factory>` |
 
 ```yaml
 tools:
-  # Python function - direct import
+  # Genie - first-class, no factory boilerplate
+  sales_genie:
+    name: sales_genie
+    function:
+      type: genie
+      genie_room: *sales_genie_room
+      name: query_sales
+      description: "Query sales analytics by region, product, time period."
+      # Add caching → tool becomes a toolkit (query + feedback) automatically
+      lru_cache:
+        warehouse: *shared_warehouse
+        capacity: 100
+        time_to_live_seconds: 3600
+
+  # Vector Search - first-class, supports instructed retriever
+  product_search:
+    name: product_search
+    function:
+      type: vector_search
+      retriever: *products_retriever     # or: vector_store: *products_vs
+      name: product_search
+      description: "Search the product catalog by description / brand / category."
+
+  # Web Search (DuckDuckGo) - zero config
+  web_search:
+    name: web_search
+    function:
+      type: search
+
+  # Unity Catalog - governed SQL function
+  sku_lookup:
+    name: find_product_by_sku
+    function:
+      type: unity_catalog
+      resource: *find_product_by_sku
+
+  # MCP - external service integration
+  github_mcp:
+    name: github
+    function:
+      type: mcp
+      transport: streamable_http
+      connection: *github_connection
+
+  # Python - direct import
   time_tool:
+    name: current_time
     function:
       type: python
       name: dao_ai.tools.current_time_tool
 
-  # Factory - initialized with config
-  search_tool:
-    function:
-      type: factory
-      name: dao_ai.tools.create_vector_search_tool
-      args:
-        retriever: *products_retriever
-
   # Inline - define tool code directly in YAML (great for prototyping)
   calculator:
+    name: calculator
     function:
       type: inline
       code: |
@@ -100,8 +140,9 @@ tools:
             """Evaluate a mathematical expression."""
             return str(eval(expression))
 
-  # Agent Endpoint - call external agents
+  # Factory - escape hatch for custom factories
   specialist_agent:
+    name: specialist
     function:
       type: factory
       name: dao_ai.tools.create_agent_endpoint_tool
@@ -109,21 +150,23 @@ tools:
         llm: *external_agent_endpoint
         name: specialist
         description: "Delegate to external specialist agent"
-
-  # Unity Catalog - governed SQL function
-  sku_lookup:
-    function:
-      type: unity_catalog
-      name: find_product_by_sku
-      schema: *retail_schema
-
-  # MCP - external service integration
-  github_mcp:
-    function:
-      type: mcp
-      transport: streamable_http
-      connection: *github_connection
 ```
+
+### Migrating from `type: factory` to first-class types
+
+The old `type: factory + name: dao_ai.tools.create_*` shape continues to work indefinitely — no deprecation. If you're starting fresh, prefer the first-class types below for the most common cases:
+
+| Old shape (still works) | New shape |
+| --- | --- |
+| `type: factory`, `name: dao_ai.tools.create_genie_tool`, `args: { genie_room: ..., lru_cache_parameters: ... }` | `type: genie`, `genie_room: ...`, `lru_cache: ...` |
+| `type: factory`, `name: dao_ai.tools.create_genie_toolkit`, `args: { genie_room: ..., lru_cache_parameters: ..., context_aware_cache_parameters: ... }` | `type: genie`, `genie_room: ...`, `lru_cache: ...`, `context_aware_cache: ...` (any cache promotes to toolkit) |
+| `type: factory`, `name: dao_ai.tools.create_vector_search_tool`, `args: { retriever: ... }` | `type: vector_search`, `retriever: ...` |
+| `type: factory`, `name: dao_ai.tools.create_search_tool` | `type: search` |
+
+Cache parameter field renames on `type: genie`:
+- `lru_cache_parameters` → `lru_cache`
+- `context_aware_cache_parameters` → `context_aware_cache`
+- `in_memory_context_aware_cache_parameters` → `in_memory_context_aware_cache`
 
 ## 3. On-Behalf-Of User Support
 
@@ -182,34 +225,35 @@ The same agent code enforces different permissions for each user automatically.
 
 **💰 Cost savings:** If users frequently ask "What's our inventory?", the first query costs $X (Genie API call). Subsequent similar queries cost only pennies (just running SQL).
 
-DAO provides **two-tier caching** for Genie natural language queries, dramatically reducing costs and latency:
+DAO provides **two-tier caching** for Genie natural language queries, dramatically reducing costs and latency. Configure on the first-class `type: genie` tool — adding any cache automatically promotes the tool to a toolkit (query + feedback).
 
 ```yaml
 genie_tool:
+  name: sales_genie
   function:
-    type: factory
-    name: dao_ai.tools.create_genie_tool
-    args:
-      genie_room: *retail_genie_room
-      
-      # L1: Fast O(1) exact match lookup
-      lru_cache_parameters:
-        warehouse: *warehouse
-        capacity: 1000                   # Max cached queries (default: 1000)
-        time_to_live_seconds: 86400      # 1 day (default), use -1 or None for never expire
+    type: genie
+    genie_room: *retail_genie_room
+    name: query_sales
+    description: "Query sales analytics by region, product, time period."
 
-      # L2: Context-aware similarity search via pg_vector (cosine similarity)
-      context_aware_cache_parameters:
-        database: *postgres_db
-        warehouse: *warehouse
-        embedding_model: *embedding_model  # Default: databricks-gte-large-en
-        similarity_threshold: 0.85         # 0.0-1.0 (default: 0.85), higher = stricter
-        time_to_live_seconds: 86400        # 1 day (default), use -1 or None for never expire
-        table_name: genie_context_aware_cache   # Optional, default: genie_context_aware_cache
-        # IVFFlat index tuning (auto-computed by default, scales to 1M+ rows)
-        # ivfflat_lists: null              # Auto: max(100, sqrt(row_count))
-        # ivfflat_probes: null             # Auto: max(10, sqrt(lists))
-        # ivfflat_candidates: 20           # Top-K for Python reranking
+    # L1: Fast O(1) exact match lookup
+    lru_cache:
+      warehouse: *warehouse
+      capacity: 1000                   # Max cached queries (default: 1000)
+      time_to_live_seconds: 86400      # 1 day (default), use -1 or None for never expire
+
+    # L2: Context-aware similarity search via pg_vector (cosine similarity)
+    context_aware_cache:
+      database: *postgres_db
+      warehouse: *warehouse
+      embedding_model: *embedding_model  # Default: databricks-gte-large-en
+      similarity_threshold: 0.85         # 0.0-1.0 (default: 0.85), higher = stricter
+      time_to_live_seconds: 86400        # 1 day (default), use -1 or None for never expire
+      table_name: genie_context_aware_cache   # Optional, default: genie_context_aware_cache
+      # IVFFlat index tuning (auto-computed by default, scales to 1M+ rows)
+      # ivfflat_lists: null              # Auto: max(100, sqrt(row_count))
+      # ivfflat_probes: null             # Auto: max(10, sqrt(lists))
+      # ivfflat_candidates: 20           # Top-K for Python reranking
 ```
 
 ### Cache Architecture
@@ -300,25 +344,24 @@ Uses in-memory storage without external database dependencies:
 
 ```yaml
 genie_tool:
+  name: sales_genie
   function:
-    type: factory
-    name: dao_ai.tools.create_genie_tool
-    args:
-      genie_room: *retail_genie_room
-      
-      # In-memory context-aware cache (no database required)
-      in_memory_context_aware_cache_parameters:
-        warehouse: *warehouse
-        embedding_model: *embedding_model  # Default: databricks-gte-large-en
-        similarity_threshold: 0.85         # 0.0-1.0 (default: 0.85)
-        time_to_live_seconds: 86400        # 1 day (default), use -1 or None for never expire
-        capacity: 1000                     # Max cache entries (LRU eviction when full)
-        context_window_size: 4             # Number of previous conversation turns (default)
-        context_similarity_threshold: 0.80 # Minimum context similarity (bidirectional skip)
-        question_weight: 0.6               # Weight for question similarity
-        context_weight: 0.4                # Weight for context similarity
-        embedding_dims: null               # Auto-detected from model
-        max_context_tokens: 2000           # Max context token length
+    type: genie
+    genie_room: *retail_genie_room
+
+    # In-memory context-aware cache (no database required)
+    in_memory_context_aware_cache:
+      warehouse: *warehouse
+      embedding_model: *embedding_model  # Default: databricks-gte-large-en
+      similarity_threshold: 0.85         # 0.0-1.0 (default: 0.85)
+      time_to_live_seconds: 86400        # 1 day (default), use -1 or None for never expire
+      capacity: 1000                     # Max cache entries (LRU eviction when full)
+      context_window_size: 4             # Number of previous conversation turns (default)
+      context_similarity_threshold: 0.80 # Minimum context similarity (bidirectional skip)
+      question_weight: 0.6               # Weight for question similarity
+      context_weight: 0.4                # Weight for context similarity
+      embedding_dims: null               # Auto-detected from model
+      max_context_tokens: 2000           # Max context token length
 ```
 
 | Parameter | Default | Description |
@@ -379,7 +422,7 @@ The `question_weight` and `context_weight` parameters control how question vs co
 
 ### Cache Invalidation and Auto-Recovery
 
-When using `create_genie_toolkit`, the toolkit includes a **feedback tool** (`{name}_feedback`) that the LLM can call to invalidate stale cache entries. This is critical because LLMs tend to normalize user questions into canonical forms before calling tools -- rephrasing a question rarely produces a different cache key.
+When any cache is configured on a `type: genie` tool, the tool is automatically promoted to a toolkit that includes a **feedback tool** (`{name}_feedback`). The LLM can call this tool to invalidate stale cache entries. This is critical because LLMs tend to normalize user questions into canonical forms before calling tools — rephrasing a question rarely produces a different cache key.
 
 **Feedback tool:** Call with `rating='negative'` when results are wrong, empty, or don't match the question. This invalidates the cached SQL across all cache layers and sends feedback to the Genie API.
 
@@ -387,17 +430,18 @@ When using `create_genie_toolkit`, the toolkit includes a **feedback tool** (`{n
 
 ```yaml
 genie_tool:
+  name: sales_genie
   function:
-    type: factory
-    name: dao_ai.tools.create_genie_toolkit
-    args:
-      genie_room: *retail_genie_room
-      lru_cache_parameters:
-        warehouse: *warehouse
-        capacity: 1000
-        time_to_live_seconds: 86400
-      max_consecutive_cache_hits: 3   # Auto-invalidate after 3 identical cache hits
+    type: genie
+    genie_room: *retail_genie_room
+    lru_cache:
+      warehouse: *warehouse
+      capacity: 1000
+      time_to_live_seconds: 86400
+    max_consecutive_cache_hits: 3   # Auto-invalidate after 3 identical cache hits
 ```
+
+**Force toolkit mode without caches:** Set `enable_feedback: true` on a `type: genie` tool to get the feedback tool even when no cache is configured.
 
 ```mermaid
 graph LR

--- a/docs/mcp_server.md
+++ b/docs/mcp_server.md
@@ -157,6 +157,8 @@ The `app:` and `agents:` blocks are **intentionally omitted** — the MCP server
 
 See `config/examples/15_complete_applications/sporting_goods_store_mcp.yaml` for a worked example.
 
+> **Note on tool types in MCP configs.** The MCP server adapter currently matches on the factory **name** (`dao_ai.tools.create_genie_toolkit` / `dao_ai.tools.create_vector_search_tool`) as its discriminator. For MCP server configs you must use the `type: factory` shape shown below — the first-class `type: genie` / `type: vector_search` shapes are supported by agent runtimes but not yet by the MCP adapter. (Agent-runtime configs can mix both shapes freely; only the MCP server is the constraint here.)
+
 ### Cache parameters
 
 A `create_genie_toolkit` tool entry can configure both cache layers:

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -1,3 +1,5 @@
+Resolved 293 packages in 6ms
+Checked 256 packages in 17ms
 {
   "$defs": {
     "A2AModel": {
@@ -3607,6 +3609,129 @@
       "title": "GenieExampleSql",
       "type": "object"
     },
+    "GenieInMemoryContextAwareCacheParametersModel": {
+      "additionalProperties": false,
+      "description": "Configuration for in-memory context-aware cache (no database required).\n\nThis cache stores embeddings and cache entries entirely in memory, providing\ncontext-aware similarity matching without requiring external database dependencies\nlike PostgreSQL or Databricks Lakebase.\n\nDefault settings are tuned for ~30 users on an 8GB machine:\n- Capacity: 10,000 entries (~200MB memory, ~330 queries per user)\n- Eviction: LRU (Least Recently Used) - keeps frequently accessed queries\n- TTL: 1 week (accommodates weekly work patterns and batch jobs)\n- Memory overhead: ~4-5% of 8GB system\n\nThe LRU eviction strategy ensures hot queries stay cached while cold queries\nare evicted, providing better hit rates than FIFO eviction.\n\nFor larger deployments or memory-constrained environments, adjust capacity and TTL accordingly.\n\nUse this when:\n- No external database access is available\n- Single-instance deployments (cache not shared across instances)\n- Cache persistence across restarts is not required\n- Cache sizes are moderate (hundreds to low thousands of entries)\n\nFor multi-instance deployments or large cache sizes, use GenieContextAwareCacheParametersModel\nwith PostgreSQL backend instead.",
+      "properties": {
+        "time_to_live_seconds": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 604800,
+          "description": "Cache entry TTL in seconds. Default: 1 week (604800s). None or negative = never expires.",
+          "title": "Time To Live Seconds"
+        },
+        "similarity_threshold": {
+          "default": 0.85,
+          "description": "Minimum similarity score (0-1) for question matching.",
+          "title": "Similarity Threshold",
+          "type": "number"
+        },
+        "context_similarity_threshold": {
+          "default": 0.8,
+          "description": "Minimum similarity score (0-1) for conversation context matching.",
+          "title": "Context Similarity Threshold",
+          "type": "number"
+        },
+        "question_weight": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 0.6,
+          "description": "Weight for question similarity in the combined score (0-1). Computed as 1 - context_weight if omitted.",
+          "title": "Question Weight"
+        },
+        "context_weight": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Weight for context similarity in the combined score (0-1). Computed as 1 - question_weight if omitted.",
+          "title": "Context Weight"
+        },
+        "embedding_model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/InferenceEndpointModel"
+            }
+          ],
+          "default": "databricks-gte-large-en",
+          "description": "Embedding model endpoint for generating similarity vectors.",
+          "title": "Embedding Model"
+        },
+        "embedding_dims": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Embedding vector dimensions. Auto-detected from the model if not set.",
+          "title": "Embedding Dims"
+        },
+        "warehouse": {
+          "$ref": "#/$defs/WarehouseModel",
+          "description": "SQL warehouse used by the Genie API for query execution."
+        },
+        "context_window_size": {
+          "default": 3,
+          "description": "Number of previous conversation turns included as context for matching.",
+          "title": "Context Window Size",
+          "type": "integer"
+        },
+        "max_context_tokens": {
+          "default": 2000,
+          "description": "Maximum token length for context to prevent oversized embeddings.",
+          "title": "Max Context Tokens",
+          "type": "integer"
+        },
+        "invalidate_on_empty_result": {
+          "default": false,
+          "description": "When true, cached SQL that returns an empty result set is treated as stale: the cache entry is invalidated and the question is re-sent to Genie. Useful when cached queries contain date-relative expressions like CURRENT_DATE() that become invalid as underlying data ages.",
+          "title": "Invalidate On Empty Result",
+          "type": "boolean"
+        },
+        "capacity": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 10000,
+          "description": "Maximum cache entries (~200MB at 10000 with 1024-dim embeddings). LRU eviction when full. None = unlimited.",
+          "title": "Capacity"
+        }
+      },
+      "required": [
+        "warehouse"
+      ],
+      "title": "GenieInMemoryContextAwareCacheParametersModel",
+      "type": "object"
+    },
     "GenieJoinSpec": {
       "additionalProperties": true,
       "description": "A trusted join relationship between two Genie data sources.",
@@ -3682,6 +3807,46 @@
         "sql"
       ],
       "title": "GenieJoinSpec",
+      "type": "object"
+    },
+    "GenieLRUCacheParametersModel": {
+      "additionalProperties": false,
+      "description": "Configuration for a simple LRU (Least Recently Used) Genie response cache.",
+      "properties": {
+        "capacity": {
+          "default": 1000,
+          "description": "Maximum number of cached responses before LRU eviction.",
+          "title": "Capacity",
+          "type": "integer"
+        },
+        "time_to_live_seconds": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 86400,
+          "description": "Cache entry TTL in seconds. None or negative = entries never expire. Default: 1 day.",
+          "title": "Time To Live Seconds"
+        },
+        "warehouse": {
+          "$ref": "#/$defs/WarehouseModel",
+          "description": "SQL warehouse used by the Genie API for query execution."
+        },
+        "invalidate_on_empty_result": {
+          "default": false,
+          "description": "When true, cached SQL that returns an empty result set is treated as stale: the cache entry is invalidated and the question is re-sent to Genie. Useful when cached queries contain date-relative expressions like CURRENT_DATE() that become invalid as underlying data ages.",
+          "title": "Invalidate On Empty Result",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "warehouse"
+      ],
+      "title": "GenieLRUCacheParametersModel",
       "type": "object"
     },
     "GenieMetricViewSource": {
@@ -4338,6 +4503,133 @@
         "table"
       ],
       "title": "GenieTableSource",
+      "type": "object"
+    },
+    "GenieToolModel": {
+      "additionalProperties": false,
+      "description": "First-class Genie tool that delegates to ``dao_ai.tools.create_genie_tool``.\n\nEquivalent to ``type: factory + name: dao_ai.tools.create_genie_tool``, but\nwith typed fields so beginners get IDE autocomplete and JSON-schema\nvalidation. Returns a single uncached tool when no caching is configured,\nor a ``GenieToolkit`` (query + feedback tools) when any cache is set or\n``enable_feedback=True``.",
+      "properties": {
+        "type": {
+          "const": "genie",
+          "default": "genie",
+          "description": "Function type discriminator. Must be 'genie'.",
+          "title": "Type",
+          "type": "string"
+        },
+        "human_in_the_loop": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HumanInTheLoopModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Human-in-the-loop approval configuration for this tool."
+        },
+        "genie_room": {
+          "$ref": "#/$defs/GenieRoomModel",
+          "description": "Genie space configuration."
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Tool name visible to the LLM. Defaults to 'genie_tool'.",
+          "title": "Name"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Tool description shown to the LLM during function calling.",
+          "title": "Description"
+        },
+        "persist_conversation": {
+          "default": true,
+          "description": "Persist conversation IDs across calls for multi-turn Genie chats.",
+          "title": "Persist Conversation",
+          "type": "boolean"
+        },
+        "truncate_results": {
+          "default": false,
+          "description": "Truncate large query results returned by Genie.",
+          "title": "Truncate Results",
+          "type": "boolean"
+        },
+        "lru_cache": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GenieLRUCacheParametersModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "LRU cache configuration for fast exact-match SQL caching."
+        },
+        "context_aware_cache": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GenieContextAwareCacheParametersModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "PostgreSQL/Lakebase context-aware (semantic) cache configuration."
+        },
+        "in_memory_context_aware_cache": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GenieInMemoryContextAwareCacheParametersModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "In-memory context-aware (semantic) cache configuration."
+        },
+        "max_consecutive_cache_hits": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Circuit breaker: auto-invalidate after this many consecutive identical cache hits. None disables. Suggested value: 3.",
+          "title": "Max Consecutive Cache Hits"
+        },
+        "enable_feedback": {
+          "default": false,
+          "description": "Force toolkit mode (with feedback tool) even when no cache is configured. Implicitly true whenever any cache is set.",
+          "title": "Enable Feedback",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "genie_room"
+      ],
+      "title": "GenieToolModel",
       "type": "object"
     },
     "GuardrailModel": {
@@ -7043,6 +7335,33 @@
       "title": "SearchParametersModel",
       "type": "object"
     },
+    "SearchToolModel": {
+      "additionalProperties": false,
+      "description": "First-class web search tool that delegates to ``dao_ai.tools.create_search_tool``.\n\nEquivalent to ``type: factory + name: dao_ai.tools.create_search_tool``.\nNo configuration required.",
+      "properties": {
+        "type": {
+          "const": "search",
+          "default": "search",
+          "description": "Function type discriminator. Must be 'search'.",
+          "title": "Type",
+          "type": "string"
+        },
+        "human_in_the_loop": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HumanInTheLoopModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Human-in-the-loop approval configuration for this tool."
+        }
+      },
+      "title": "SearchToolModel",
+      "type": "object"
+    },
     "SecretVariableModel": {
       "description": "A variable resolved from a Databricks secret scope at runtime.",
       "properties": {
@@ -7744,6 +8063,15 @@
               "$ref": "#/$defs/McpFunctionModel"
             },
             {
+              "$ref": "#/$defs/GenieToolModel"
+            },
+            {
+              "$ref": "#/$defs/VectorSearchToolModel"
+            },
+            {
+              "$ref": "#/$defs/SearchToolModel"
+            },
+            {
               "type": "string"
             }
           ],
@@ -8034,6 +8362,83 @@
       ],
       "title": "VectorSearchEndpointType",
       "type": "string"
+    },
+    "VectorSearchToolModel": {
+      "additionalProperties": false,
+      "description": "First-class Vector Search tool that delegates to ``dao_ai.tools.create_vector_search_tool``.\n\nEquivalent to ``type: factory + name: dao_ai.tools.create_vector_search_tool``,\nbut with typed fields. Exactly one of ``retriever`` or ``vector_store`` is\nrequired.",
+      "properties": {
+        "type": {
+          "const": "vector_search",
+          "default": "vector_search",
+          "description": "Function type discriminator. Must be 'vector_search'.",
+          "title": "Type",
+          "type": "string"
+        },
+        "human_in_the_loop": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HumanInTheLoopModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Human-in-the-loop approval configuration for this tool."
+        },
+        "retriever": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RetrieverModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Full retriever configuration with search parameters and reranking. Mutually exclusive with vector_store."
+        },
+        "vector_store": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VectorStoreModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Direct vector store reference (uses default search parameters). Mutually exclusive with retriever."
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Tool name visible to the LLM.",
+          "title": "Name"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Tool description shown to the LLM during function calling.",
+          "title": "Description"
+        }
+      },
+      "title": "VectorSearchToolModel",
+      "type": "object"
     },
     "VectorStoreModel": {
       "additionalProperties": false,

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -1,5 +1,3 @@
-Resolved 293 packages in 6ms
-Checked 256 packages in 17ms
 {
   "$defs": {
     "A2AModel": {

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -2303,12 +2303,20 @@ class GenieRoomModel(IsDatabricksResource, ManagedResource):
         ):
             if not snippet_list:
                 continue
-            label_key = "display_name" if snippet_key == "filters" else "alias"
+            # Genie's export-proto validator now requires ``display_name`` on
+            # every snippet type (filters/expressions/measures); historically
+            # the schema only required ``alias`` on expressions+measures.
+            # Emit both so the payload satisfies both old and new validators.
             snippets[snippet_key] = [
                 {
                     "id": _stable_id(snippet_key, snippet.display_name, snippet.sql),
                     "sql": [snippet.sql],
-                    label_key: snippet.display_name,
+                    "display_name": snippet.display_name,
+                    **(
+                        {"alias": snippet.display_name}
+                        if snippet_key != "filters"
+                        else {}
+                    ),
                     **(
                         {"instruction": [snippet.instruction]}
                         if snippet.instruction

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -4525,6 +4525,9 @@ class FunctionType(str, Enum):
     UNITY_CATALOG = "unity_catalog"
     MCP = "mcp"
     INLINE = "inline"
+    GENIE = "genie"
+    VECTOR_SEARCH = "vector_search"
+    SEARCH = "search"
 
 
 class HumanInTheLoopModel(BaseModel):
@@ -4586,7 +4589,7 @@ class BaseFunctionModel(ABC, BaseModel):
         discriminator="type",
     )
     type: FunctionType = Field(
-        description="Function type discriminator (python, factory, inline, mcp, unity_catalog).",
+        description="Function type discriminator (python, factory, inline, mcp, unity_catalog, genie, vector_search, search).",
     )
     human_in_the_loop: Optional[HumanInTheLoopModel] = Field(
         default=None,
@@ -5128,6 +5131,164 @@ class UnityCatalogFunctionModel(BaseFunctionModel):
         return create_uc_tools(self)
 
 
+class GenieToolModel(BaseFunctionModel):
+    """First-class Genie tool that delegates to ``dao_ai.tools.create_genie_tool``.
+
+    Equivalent to ``type: factory + name: dao_ai.tools.create_genie_tool``, but
+    with typed fields so beginners get IDE autocomplete and JSON-schema
+    validation. Returns a single uncached tool when no caching is configured,
+    or a ``GenieToolkit`` (query + feedback tools) when any cache is set or
+    ``enable_feedback=True``.
+    """
+
+    model_config = ConfigDict(use_enum_values=True, extra="forbid")
+    type: Literal[FunctionType.GENIE] = Field(
+        default=FunctionType.GENIE,
+        description="Function type discriminator. Must be 'genie'.",
+    )
+    genie_room: GenieRoomModel = Field(
+        description="Genie space configuration.",
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="Tool name visible to the LLM. Defaults to 'genie_tool'.",
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="Tool description shown to the LLM during function calling.",
+    )
+    persist_conversation: bool = Field(
+        default=True,
+        description="Persist conversation IDs across calls for multi-turn Genie chats.",
+    )
+    truncate_results: bool = Field(
+        default=False,
+        description="Truncate large query results returned by Genie.",
+    )
+    lru_cache: Optional[GenieLRUCacheParametersModel] = Field(
+        default=None,
+        description="LRU cache configuration for fast exact-match SQL caching.",
+    )
+    context_aware_cache: Optional[GenieContextAwareCacheParametersModel] = Field(
+        default=None,
+        description="PostgreSQL/Lakebase context-aware (semantic) cache configuration.",
+    )
+    in_memory_context_aware_cache: Optional[
+        GenieInMemoryContextAwareCacheParametersModel
+    ] = Field(
+        default=None,
+        description="In-memory context-aware (semantic) cache configuration.",
+    )
+    max_consecutive_cache_hits: Optional[int] = Field(
+        default=None,
+        description=(
+            "Circuit breaker: auto-invalidate after this many consecutive "
+            "identical cache hits. None disables. Suggested value: 3."
+        ),
+    )
+    enable_feedback: bool = Field(
+        default=False,
+        description=(
+            "Force toolkit mode (with feedback tool) even when no cache is "
+            "configured. Implicitly true whenever any cache is set."
+        ),
+    )
+
+    def as_tools(self, **kwargs: Any) -> Sequence[RunnableLike]:
+        from dao_ai.tools import create_genie_tool
+        from dao_ai.tools.genie import GenieToolkit
+
+        result = create_genie_tool(
+            genie_room=self.genie_room,
+            name=self.name,
+            description=self.description,
+            persist_conversation=self.persist_conversation,
+            truncate_results=self.truncate_results,
+            lru_cache_parameters=self.lru_cache,
+            context_aware_cache_parameters=self.context_aware_cache,
+            in_memory_context_aware_cache_parameters=self.in_memory_context_aware_cache,
+            max_consecutive_cache_hits=self.max_consecutive_cache_hits,
+            enable_feedback=self.enable_feedback,
+        )
+        if isinstance(result, GenieToolkit):
+            return result.get_tools()
+        return [result]
+
+
+class VectorSearchToolModel(BaseFunctionModel):
+    """First-class Vector Search tool that delegates to ``dao_ai.tools.create_vector_search_tool``.
+
+    Equivalent to ``type: factory + name: dao_ai.tools.create_vector_search_tool``,
+    but with typed fields. Exactly one of ``retriever`` or ``vector_store`` is
+    required.
+    """
+
+    model_config = ConfigDict(use_enum_values=True, extra="forbid")
+    type: Literal[FunctionType.VECTOR_SEARCH] = Field(
+        default=FunctionType.VECTOR_SEARCH,
+        description="Function type discriminator. Must be 'vector_search'.",
+    )
+    retriever: Optional[RetrieverModel] = Field(
+        default=None,
+        description="Full retriever configuration with search parameters and reranking. Mutually exclusive with vector_store.",
+    )
+    vector_store: Optional[VectorStoreModel] = Field(
+        default=None,
+        description="Direct vector store reference (uses default search parameters). Mutually exclusive with retriever.",
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="Tool name visible to the LLM.",
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="Tool description shown to the LLM during function calling.",
+    )
+
+    @model_validator(mode="after")
+    def _retriever_or_vector_store(self) -> Self:
+        if self.retriever is None and self.vector_store is None:
+            raise ValueError(
+                "VectorSearchToolModel requires exactly one of 'retriever' or 'vector_store'."
+            )
+        if self.retriever is not None and self.vector_store is not None:
+            raise ValueError(
+                "VectorSearchToolModel cannot accept both 'retriever' and 'vector_store'."
+            )
+        return self
+
+    def as_tools(self, **kwargs: Any) -> Sequence[RunnableLike]:
+        from dao_ai.tools import create_vector_search_tool
+
+        return [
+            create_vector_search_tool(
+                retriever=self.retriever,
+                vector_store=self.vector_store,
+                name=self.name,
+                description=self.description,
+            )
+        ]
+
+
+class SearchToolModel(BaseFunctionModel):
+    """First-class web search tool that delegates to ``dao_ai.tools.create_search_tool``.
+
+    Equivalent to ``type: factory + name: dao_ai.tools.create_search_tool``.
+    No configuration required.
+    """
+
+    model_config = ConfigDict(use_enum_values=True, extra="forbid")
+    type: Literal[FunctionType.SEARCH] = Field(
+        default=FunctionType.SEARCH,
+        description="Function type discriminator. Must be 'search'.",
+    )
+
+    def as_tools(self, **kwargs: Any) -> Sequence[RunnableLike]:
+        from dao_ai.tools import create_search_tool
+
+        return [create_search_tool()]
+
+
 AnyTool: TypeAlias = (
     Union[
         PythonFunctionModel,
@@ -5135,6 +5296,9 @@ AnyTool: TypeAlias = (
         InlineFunctionModel,
         UnityCatalogFunctionModel,
         McpFunctionModel,
+        GenieToolModel,
+        VectorSearchToolModel,
+        SearchToolModel,
     ]
     | str
 )

--- a/src/dao_ai/tools/genie.py
+++ b/src/dao_ai/tools/genie.py
@@ -1,13 +1,15 @@
 """
-Genie tool and toolkit for natural language queries to databases.
+Genie tool factory for natural language queries to databases.
 
-This module provides two factory functions for creating LangGraph tools that
-interact with Databricks Genie:
+This module exposes a single unified factory:
 
-- ``create_genie_tool``: Simple factory returning a single uncached Genie query tool.
-- ``create_genie_toolkit``: Returns a ``GenieToolkit`` bundling a cached Genie query
-  tool with an implicit feedback/invalidation tool. Both tools share one
-  ``GenieServiceBase`` stack (and thus one LRU cache).
+- :func:`create_genie_tool` — returns either a single uncached Genie query tool
+  or a :class:`GenieToolkit` (query + feedback tools) depending on whether any
+  caching is configured or feedback is explicitly enabled.
+
+For backward compatibility, :func:`create_genie_toolkit` is preserved as a thin
+shim that always returns a :class:`GenieToolkit` (equivalent to calling
+:func:`create_genie_tool` with ``enable_feedback=True``).
 
 For the core Genie service and cache implementations, see:
 - dao_ai.genie: GenieService, GenieServiceBase
@@ -62,7 +64,8 @@ class GenieToolkit(BaseToolkit):
     so calling the feedback tool to invalidate a cache entry directly affects
     the query tool's next call.
 
-    Created by :func:`create_genie_toolkit`.
+    Returned by :func:`create_genie_tool` when caching is configured or
+    ``enable_feedback=True``.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -248,7 +251,7 @@ def _resolve_genie_room(
 
 
 # ---------------------------------------------------------------------------
-# create_genie_tool  (simple, uncached)
+# Public factory
 # ---------------------------------------------------------------------------
 
 
@@ -258,11 +261,37 @@ def create_genie_tool(
     description: str | None = None,
     persist_conversation: bool = True,
     truncate_results: bool = False,
-) -> Callable[..., Command]:
-    """Create a simple Genie query tool with no caching.
+    lru_cache_parameters: GenieLRUCacheParametersModel | dict[str, Any] | None = None,
+    context_aware_cache_parameters: (
+        GenieContextAwareCacheParametersModel | dict[str, Any] | None
+    ) = None,
+    in_memory_context_aware_cache_parameters: (
+        GenieInMemoryContextAwareCacheParametersModel | dict[str, Any] | None
+    ) = None,
+    max_consecutive_cache_hits: int | None = None,
+    enable_feedback: bool = False,
+) -> Callable[..., Command] | GenieToolkit:
+    """Create a Genie tool, optionally with caching and a feedback tool.
 
-    For cached queries with feedback/invalidation support, use
-    :func:`create_genie_toolkit` instead.
+    Returns a single uncached query tool when no caching is configured and
+    ``enable_feedback`` is ``False``. When any cache is configured *or*
+    ``enable_feedback=True`` is set, returns a :class:`GenieToolkit` containing:
+
+    * A **query tool** that translates natural-language questions into SQL via
+      Databricks Genie, with results served from cache when configured.
+    * A **feedback tool** (named ``{name}_feedback``) that lets the LLM
+      invalidate a stale or incorrect cached result so the next query goes
+      fresh to Genie.
+
+    Both tools share one ``GenieServiceBase`` stack, so invalidation on the
+    feedback tool directly clears the query tool's cache.
+
+    When ``max_consecutive_cache_hits`` is set, the toolkit implements a
+    **Circuit Breaker** pattern: if the same cached SQL is returned N times
+    consecutively, the cache entry is automatically invalidated and a fresh
+    query is sent to Genie. This prevents the agent from getting stuck in a
+    loop where the LLM normalizes different user phrasings into the same
+    tool call, repeatedly hitting the same stale cache entry.
 
     Args:
         genie_room: GenieRoomModel or dict containing Genie configuration.
@@ -270,10 +299,101 @@ def create_genie_tool(
         description: Custom tool description. Defaults to a generic prompt.
         persist_conversation: Persist conversation IDs across calls for multi-turn.
         truncate_results: Truncate large query results.
+        lru_cache_parameters: LRU cache config for fast exact-match SQL caching.
+        context_aware_cache_parameters: PostgreSQL/Lakebase context-aware cache config.
+        in_memory_context_aware_cache_parameters: In-memory context-aware cache config.
+        max_consecutive_cache_hits: Auto-invalidate after this many consecutive
+            identical cache hits (Circuit Breaker). ``None`` disables (default).
+            Suggested value: ``3``. Only meaningful when caching is configured.
+        enable_feedback: Force toolkit mode (with feedback tool) even when no
+            cache is configured. Implicitly ``True`` whenever any cache is set.
 
     Returns:
-        A LangGraph tool that processes natural language queries through Genie.
+        A single LangGraph tool callable when no caching and no feedback are
+        configured. Otherwise a :class:`GenieToolkit` bundling the query and
+        feedback tools.
     """
+    has_cache: bool = any(
+        [
+            lru_cache_parameters is not None,
+            context_aware_cache_parameters is not None,
+            in_memory_context_aware_cache_parameters is not None,
+        ]
+    )
+    toolkit_mode: bool = has_cache or enable_feedback
+
+    if not toolkit_mode:
+        return _create_simple_genie_tool(
+            genie_room=genie_room,
+            name=name,
+            description=description,
+            persist_conversation=persist_conversation,
+            truncate_results=truncate_results,
+        )
+
+    return _create_genie_toolkit_impl(
+        genie_room=genie_room,
+        name=name,
+        description=description,
+        persist_conversation=persist_conversation,
+        truncate_results=truncate_results,
+        lru_cache_parameters=lru_cache_parameters,
+        context_aware_cache_parameters=context_aware_cache_parameters,
+        in_memory_context_aware_cache_parameters=in_memory_context_aware_cache_parameters,
+        max_consecutive_cache_hits=max_consecutive_cache_hits,
+    )
+
+
+def create_genie_toolkit(
+    genie_room: GenieRoomModel | dict[str, Any],
+    name: str | None = None,
+    description: str | None = None,
+    persist_conversation: bool = True,
+    truncate_results: bool = False,
+    lru_cache_parameters: GenieLRUCacheParametersModel | dict[str, Any] | None = None,
+    context_aware_cache_parameters: (
+        GenieContextAwareCacheParametersModel | dict[str, Any] | None
+    ) = None,
+    in_memory_context_aware_cache_parameters: (
+        GenieInMemoryContextAwareCacheParametersModel | dict[str, Any] | None
+    ) = None,
+    max_consecutive_cache_hits: int | None = None,
+) -> GenieToolkit:
+    """Backward-compatible shim. Prefer :func:`create_genie_tool` directly.
+
+    Always returns a :class:`GenieToolkit` (with the implicit feedback tool),
+    matching the historical behavior of this factory. Equivalent to calling
+    ``create_genie_tool(..., enable_feedback=True)``.
+    """
+    result = create_genie_tool(
+        genie_room=genie_room,
+        name=name,
+        description=description,
+        persist_conversation=persist_conversation,
+        truncate_results=truncate_results,
+        lru_cache_parameters=lru_cache_parameters,
+        context_aware_cache_parameters=context_aware_cache_parameters,
+        in_memory_context_aware_cache_parameters=in_memory_context_aware_cache_parameters,
+        max_consecutive_cache_hits=max_consecutive_cache_hits,
+        enable_feedback=True,
+    )
+    assert isinstance(result, GenieToolkit)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internal builders
+# ---------------------------------------------------------------------------
+
+
+def _create_simple_genie_tool(
+    genie_room: GenieRoomModel | dict[str, Any],
+    name: str | None,
+    description: str | None,
+    persist_conversation: bool,
+    truncate_results: bool,
+) -> Callable[..., Command]:
+    """Build the uncached single-tool variant (no cache, no feedback tool)."""
     logger.debug(
         "Creating Genie tool (uncached)",
         genie_room_type=type(genie_room).__name__,
@@ -363,61 +483,22 @@ def create_genie_tool(
     return genie_tool
 
 
-# ---------------------------------------------------------------------------
-# create_genie_toolkit  (cached + implicit feedback tool)
-# ---------------------------------------------------------------------------
-
-
-def create_genie_toolkit(
+def _create_genie_toolkit_impl(
     genie_room: GenieRoomModel | dict[str, Any],
-    name: str | None = None,
-    description: str | None = None,
-    persist_conversation: bool = True,
-    truncate_results: bool = False,
-    lru_cache_parameters: GenieLRUCacheParametersModel | dict[str, Any] | None = None,
+    name: str | None,
+    description: str | None,
+    persist_conversation: bool,
+    truncate_results: bool,
+    lru_cache_parameters: GenieLRUCacheParametersModel | dict[str, Any] | None,
     context_aware_cache_parameters: (
         GenieContextAwareCacheParametersModel | dict[str, Any] | None
-    ) = None,
+    ),
     in_memory_context_aware_cache_parameters: (
         GenieInMemoryContextAwareCacheParametersModel | dict[str, Any] | None
-    ) = None,
-    max_consecutive_cache_hits: int | None = None,
+    ),
+    max_consecutive_cache_hits: int | None,
 ) -> GenieToolkit:
-    """Create a cached Genie toolkit with query and implicit feedback tools.
-
-    Returns a :class:`GenieToolkit` containing:
-
-    * A **query tool** (named *name*) that translates natural-language questions
-      into SQL via Databricks Genie, with results served from cache when possible.
-    * A **feedback tool** (named ``{name}_feedback``) that lets the LLM invalidate
-      a stale or incorrect cached result so the next query goes fresh to Genie.
-
-    Both tools share one ``GenieServiceBase`` stack, so invalidation on the
-    feedback tool directly clears the query tool's LRU cache.
-
-    When ``max_consecutive_cache_hits`` is set, the toolkit implements a
-    **Circuit Breaker** pattern: if the same cached SQL is returned N times
-    consecutively, the cache entry is automatically invalidated and a fresh
-    query is sent to Genie. This prevents the agent from getting stuck in a
-    loop where the LLM normalizes different user phrasings into the same
-    tool call, repeatedly hitting the same stale cache entry.
-
-    Args:
-        genie_room: GenieRoomModel or dict containing Genie configuration.
-        name: Custom tool name visible to the LLM. Defaults to ``"genie_tool"``.
-        description: Custom tool description. Defaults to a generic prompt.
-        persist_conversation: Persist conversation IDs across calls for multi-turn.
-        truncate_results: Truncate large query results.
-        lru_cache_parameters: LRU cache config for fast exact-match SQL caching.
-        context_aware_cache_parameters: PostgreSQL/Lakebase context-aware cache config.
-        in_memory_context_aware_cache_parameters: In-memory context-aware cache config.
-        max_consecutive_cache_hits: Auto-invalidate after this many consecutive
-            identical cache hits (Circuit Breaker). ``None`` disables (default).
-            Suggested value: ``3``.
-
-    Returns:
-        A GenieToolkit containing the query tool and feedback tool.
-    """
+    """Build the cached toolkit variant (query + feedback, optional cache layers)."""
     logger.debug(
         "Creating Genie toolkit",
         genie_room_type=type(genie_room).__name__,
@@ -526,6 +607,8 @@ def create_genie_toolkit(
 
     # ---- Query tool ----
 
+    feedback_name: str = f"{tool_name}_feedback"
+
     @tool(name_or_callable=tool_name, description=tool_description)
     def genie_tool(
         question: Annotated[str, "The question to ask Genie about your data"],
@@ -564,7 +647,6 @@ def create_genie_toolkit(
         cache_key: str | None = cache_result.served_by
         auto_invalidated: bool = False
 
-        # Track consecutive cache hits (Circuit Breaker)
         consecutive: int = tracker.record(space_id_str, cache_hit, genie_response.query)
 
         if (
@@ -663,7 +745,6 @@ def create_genie_toolkit(
 
     # ---- Feedback tool (shares same _get_genie_service) ----
 
-    feedback_name: str = f"{tool_name}_feedback"
     feedback_desc: str = (
         f"Provide feedback on results from {tool_name}. "
         "You MUST call this tool with rating 'negative' when:\n"

--- a/tests/dao_ai/test_first_class_tool_models.py
+++ b/tests/dao_ai/test_first_class_tool_models.py
@@ -1,0 +1,243 @@
+"""Tests for first-class tool model types: Genie, VectorSearch, Search.
+
+These models are thin Pydantic wrappers around the existing factory functions
+(``dao_ai.tools.create_genie_tool``, ``create_vector_search_tool``,
+``create_search_tool``). The tests verify:
+
+- Pydantic discriminator dispatch: ``type: genie`` deserializes to
+  ``GenieToolModel``, etc.
+- ``.as_tools()`` delegates to the existing factory and returns the same
+  tool count / names as the equivalent ``type: factory`` configuration.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.tools import BaseTool
+
+from dao_ai.config import (
+    FunctionType,
+    GenieToolModel,
+    SearchToolModel,
+    ToolModel,
+    VectorSearchToolModel,
+)
+from dao_ai.tools.genie import GenieToolkit
+
+
+@pytest.fixture
+def genie_room_dict() -> dict:
+    return {
+        "space_id": "test-space-id",
+        "name": "Test Room",
+        "on_behalf_of_user": False,
+    }
+
+
+@pytest.fixture
+def vector_store_dict() -> dict:
+    return {
+        "embedding_model": {"name": "dummy-embedding"},
+        "endpoint": {"name": "test-endpoint", "type": "STANDARD"},
+        "index": {"name": "test_idx"},
+        "source_table": {"name": "test_table"},
+        "primary_key": "id",
+        "embedding_source_column": "text",
+        "columns": ["id", "text"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Discriminator dispatch — confirm the right subclass is constructed
+# ---------------------------------------------------------------------------
+
+
+class TestDiscriminatorDispatch:
+    def test_type_genie_dispatches_to_genie_tool_model(
+        self, genie_room_dict: dict
+    ) -> None:
+        m = ToolModel.model_validate(
+            {
+                "name": "sales_genie",
+                "function": {"type": "genie", "genie_room": genie_room_dict},
+            }
+        )
+        assert isinstance(m.function, GenieToolModel)
+        assert m.function.type == FunctionType.GENIE.value
+
+    def test_type_vector_search_dispatches_to_vector_search_tool_model(
+        self, vector_store_dict: dict
+    ) -> None:
+        m = ToolModel.model_validate(
+            {
+                "name": "product_search",
+                "function": {
+                    "type": "vector_search",
+                    "vector_store": vector_store_dict,
+                },
+            }
+        )
+        assert isinstance(m.function, VectorSearchToolModel)
+        assert m.function.type == FunctionType.VECTOR_SEARCH.value
+
+    def test_type_search_dispatches_to_search_tool_model(self) -> None:
+        m = ToolModel.model_validate(
+            {"name": "web_search", "function": {"type": "search"}}
+        )
+        assert isinstance(m.function, SearchToolModel)
+        assert m.function.type == FunctionType.SEARCH.value
+
+
+# ---------------------------------------------------------------------------
+# Validation rules on the new models
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_genie_requires_genie_room(self) -> None:
+        with pytest.raises(Exception):
+            ToolModel.model_validate(
+                {"name": "x", "function": {"type": "genie"}}
+            )
+
+    def test_vector_search_rejects_neither_retriever_nor_store(self) -> None:
+        with pytest.raises(Exception, match="retriever.*vector_store"):
+            ToolModel.model_validate(
+                {"name": "x", "function": {"type": "vector_search"}}
+            )
+
+    def test_vector_search_rejects_both_retriever_and_store(
+        self, vector_store_dict: dict
+    ) -> None:
+        with pytest.raises(Exception, match="retriever.*vector_store"):
+            ToolModel.model_validate(
+                {
+                    "name": "x",
+                    "function": {
+                        "type": "vector_search",
+                        "vector_store": vector_store_dict,
+                        "retriever": {"vector_store": vector_store_dict},
+                    },
+                }
+            )
+
+
+# ---------------------------------------------------------------------------
+# .as_tools() parity vs equivalent FactoryFunctionModel
+# ---------------------------------------------------------------------------
+
+
+class TestParityWithFactory:
+    def test_genie_no_cache_parity(self, genie_room_dict: dict) -> None:
+        """type: genie with no caches should produce identical tools to factory shape."""
+        new = ToolModel.model_validate(
+            {
+                "name": "g",
+                "function": {
+                    "type": "genie",
+                    "genie_room": genie_room_dict,
+                    "name": "my_genie",
+                },
+            }
+        )
+        old = ToolModel.model_validate(
+            {
+                "name": "g",
+                "function": {
+                    "type": "factory",
+                    "name": "dao_ai.tools.create_genie_tool",
+                    "args": {
+                        "genie_room": genie_room_dict,
+                        "name": "my_genie",
+                    },
+                },
+            }
+        )
+        new_tools = new.function.as_tools()
+        old_tools = old.function.as_tools()
+        assert len(new_tools) == len(old_tools) == 1
+        assert [t.name for t in new_tools] == [t.name for t in old_tools]
+
+    def test_genie_with_lru_cache_parity(self, genie_room_dict: dict) -> None:
+        """type: genie with LRU cache should produce GenieToolkit (query + feedback)."""
+        from dao_ai.config import GenieLRUCacheParametersModel, WarehouseModel
+
+        lru = GenieLRUCacheParametersModel(
+            warehouse=WarehouseModel(warehouse_id="test-warehouse"),
+            capacity=10,
+            time_to_live_seconds=60,
+        )
+        m = ToolModel.model_validate(
+            {
+                "name": "g",
+                "function": {
+                    "type": "genie",
+                    "genie_room": genie_room_dict,
+                    "name": "cached_genie",
+                    "lru_cache": lru.model_dump(),
+                },
+            }
+        )
+        tools = m.function.as_tools()
+        assert len(tools) == 2
+        names = {t.name for t in tools}
+        assert names == {"cached_genie", "cached_genie_feedback"}
+
+    def test_genie_enable_feedback_promotes_to_toolkit(
+        self, genie_room_dict: dict
+    ) -> None:
+        m = ToolModel.model_validate(
+            {
+                "name": "g",
+                "function": {
+                    "type": "genie",
+                    "genie_room": genie_room_dict,
+                    "name": "feedback_genie",
+                    "enable_feedback": True,
+                },
+            }
+        )
+        tools = m.function.as_tools()
+        assert len(tools) == 2
+        assert {t.name for t in tools} == {
+            "feedback_genie",
+            "feedback_genie_feedback",
+        }
+
+
+# ---------------------------------------------------------------------------
+# All new tool models inherit BaseFunctionModel behavior (human_in_the_loop, etc.)
+# ---------------------------------------------------------------------------
+
+
+class TestInheritedBehavior:
+    def test_genie_accepts_human_in_the_loop(self, genie_room_dict: dict) -> None:
+        m = ToolModel.model_validate(
+            {
+                "name": "g",
+                "function": {
+                    "type": "genie",
+                    "genie_room": genie_room_dict,
+                    "human_in_the_loop": {
+                        "review_prompt": "Approve this query?",
+                    },
+                },
+            }
+        )
+        assert m.function.human_in_the_loop is not None
+        assert m.function.human_in_the_loop.review_prompt == "Approve this query?"
+
+    def test_vector_search_accepts_human_in_the_loop(
+        self, vector_store_dict: dict
+    ) -> None:
+        m = ToolModel.model_validate(
+            {
+                "name": "vs",
+                "function": {
+                    "type": "vector_search",
+                    "vector_store": vector_store_dict,
+                    "human_in_the_loop": {"review_prompt": "Approve search?"},
+                },
+            }
+        )
+        assert m.function.human_in_the_loop is not None

--- a/tests/dao_ai/test_genie_provisioning.py
+++ b/tests/dao_ai/test_genie_provisioning.py
@@ -240,6 +240,36 @@ class TestBuildSerializedSpace:
         assert snippets["filters"][0]["display_name"] == "Active products"
         assert snippets["filters"][0]["synonyms"] == ["live", "available"]
 
+    def test_sql_snippets_all_carry_display_name(
+        self,
+        schema: SchemaModel,
+        warehouse: WarehouseModel,
+    ):
+        """Genie's export-proto validator requires ``display_name`` on every
+        snippet type (filters, expressions, measures). Historically the
+        emitter wrote ``alias`` for expressions+measures and ``display_name``
+        only for filters, which trips
+        ``Invalid export proto: instructions.sql_snippets.expressions[0].display_name is required but missing``
+        against the current Genie validator. Verify all three types now
+        carry ``display_name``."""
+        room = GenieRoomModel(
+            name="Snippets Genie",
+            warehouse=warehouse,
+            parent_path="/Users/me@example.com/genie",
+            sql_filters=[GenieSqlSnippet(display_name="Active", sql="status = 'A'")],
+            sql_expressions=[
+                GenieSqlSnippet(display_name="FullName", sql="first || ' ' || last")
+            ],
+            sql_measures=[GenieSqlSnippet(display_name="Revenue", sql="SUM(amount)")],
+        )
+        snippets = room._build_serialized_space()["instructions"]["sql_snippets"]
+        for kind in ("filters", "expressions", "measures"):
+            assert kind in snippets, f"missing snippet kind {kind}"
+            for entry in snippets[kind]:
+                assert "display_name" in entry and entry["display_name"], (
+                    f"snippet kind {kind!r} entry missing display_name: {entry}"
+                )
+
     def test_benchmark_round_trips(self, fully_configured_room: GenieRoomModel):
         payload = fully_configured_room._build_serialized_space()
         question = payload["benchmarks"]["questions"][0]

--- a/tests/dao_ai/test_genie_toolkit.py
+++ b/tests/dao_ai/test_genie_toolkit.py
@@ -411,6 +411,78 @@ class TestCreateGenieTool:
 
 
 # ============================================================================
+# create_genie_tool unified-factory behavior tests
+# ============================================================================
+
+
+class TestUnifiedCreateGenieTool:
+    """Tests for the collapsed create_genie_tool that dispatches based on cache/feedback."""
+
+    @pytest.fixture
+    def mock_genie_room(self) -> dict:
+        return {
+            "space_id": "test-space-id",
+            "name": "Test Room",
+            "on_behalf_of_user": False,
+        }
+
+    @pytest.fixture
+    def mock_lru_params(self) -> GenieLRUCacheParametersModel:
+        return GenieLRUCacheParametersModel(
+            warehouse=WarehouseModel(warehouse_id="test-warehouse"),
+            capacity=10,
+            time_to_live_seconds=60,
+        )
+
+    def test_no_cache_no_feedback_returns_single_tool(
+        self, mock_genie_room: dict
+    ) -> None:
+        """With no caching and enable_feedback=False, returns a single tool."""
+        result = create_genie_tool(genie_room=mock_genie_room)
+
+        assert not isinstance(result, GenieToolkit)
+        assert isinstance(result, BaseTool)
+
+    def test_lru_cache_promotes_to_toolkit(
+        self, mock_genie_room: dict, mock_lru_params: GenieLRUCacheParametersModel
+    ) -> None:
+        """Configuring any cache yields a GenieToolkit with feedback tool."""
+        result = create_genie_tool(
+            genie_room=mock_genie_room,
+            name="cached_query",
+            lru_cache_parameters=mock_lru_params,
+        )
+
+        assert isinstance(result, GenieToolkit)
+        names = {t.name for t in result.get_tools()}
+        assert names == {"cached_query", "cached_query_feedback"}
+
+    def test_enable_feedback_promotes_to_toolkit_without_caches(
+        self, mock_genie_room: dict
+    ) -> None:
+        """enable_feedback=True yields a toolkit even with no caches configured."""
+        result = create_genie_tool(
+            genie_room=mock_genie_room,
+            name="feedback_only",
+            enable_feedback=True,
+        )
+
+        assert isinstance(result, GenieToolkit)
+        names = {t.name for t in result.get_tools()}
+        assert names == {"feedback_only", "feedback_only_feedback"}
+
+    def test_create_genie_toolkit_shim_always_returns_toolkit(
+        self, mock_genie_room: dict
+    ) -> None:
+        """The backward-compat shim always returns a toolkit, even without caches."""
+        result = create_genie_toolkit(genie_room=mock_genie_room, name="shim_query")
+
+        assert isinstance(result, GenieToolkit)
+        names = {t.name for t in result.get_tools()}
+        assert names == {"shim_query", "shim_query_feedback"}
+
+
+# ============================================================================
 # Session state message_id tests
 # ============================================================================
 


### PR DESCRIPTION
## Summary

Make the highest-frequency dao-ai tool types (Genie, Vector Search, web Search) first-class members of the tool config so beginners no longer have to know factory import paths or args-dict shapes. The original ``type: factory`` shape continues to work indefinitely — no deprecation.

**Before:**
```yaml
function:
  type: factory
  name: dao_ai.tools.create_genie_toolkit
  args:
    genie_room: *room
    lru_cache_parameters: { warehouse: *wh, capacity: 100 }
```

**After:**
```yaml
function:
  type: genie
  genie_room: *room
  lru_cache: { warehouse: *wh, capacity: 100 }
```

## Commits

| Commit | What |
| --- | --- |
| ``991336a`` | **Phase 1.** Collapse ``create_genie_tool`` and ``create_genie_toolkit`` into one unified factory. Cache layers, circuit breaker, and feedback tool are all opt-in via optional kwargs. ``create_genie_toolkit`` kept as a thin shim. |
| ``b387762`` | **Phase 2.** Add ``GenieToolModel`` / ``VectorSearchToolModel`` / ``SearchToolModel`` as new ``BaseFunctionModel`` discriminated-union members. Each is a thin typed wrapper that delegates to the existing factory in ``.as_tools()`` — no new tool implementations, no changes under ``src/dao_ai/tools/``. Schema regenerated. |
| ``6cfca09`` | **Phase 3a.** Migrate 13 canonical example configs (``04_genie/*``, ``01_getting_started/minimal``, top 5 ``15_complete_applications/*``) to the new shape + add a side-by-side callout to ``config/examples/README.md``. |
| ``011ecad`` | **Phase 3b.** Extend migration to the remaining 26 example configs (37 function blocks total). Fix the Makefile ``schema`` target to use ``uv run --quiet`` so regens don't leak ``Resolved N packages…`` lines into the JSON. |
| ``3afdd8d`` | **Phase 3c.** Update ``docs/key-capabilities.md`` (tool-type table + Advanced Caching section), ``docs/mcp_server.md`` (callout that MCP adapter still keys on factory name), ``docs/genie_context_aware_cache_prompt_history.md`` (field-name note). |

## What stays the same

- Every existing ``type: factory + name: dao_ai.tools.create_*`` config continues to work — no deprecation warnings, no migration deadline.
- ``create_genie_toolkit`` continues to exist as a thin shim around the unified ``create_genie_tool``.
- ``UnityCatalogFunctionModel`` and ``McpFunctionModel`` are unchanged (they were already first-class).
- The MCP server adapter still keys on factory name (``dao_ai.tools.create_genie_toolkit``); MCP server configs continue to use the factory shape until a follow-up makes ``type: genie`` and ``type: vector_search`` MCP-aware.

## Tests

- 11 new tests in ``tests/dao_ai/test_first_class_tool_models.py`` covering discriminator dispatch, validation rules, factory-shape parity, and inherited ``human_in_the_loop`` behavior.
- 4 new tests in ``tests/dao_ai/test_genie_toolkit.py::TestUnifiedCreateGenieTool`` covering the Phase 1 dispatch matrix (no cache + no feedback → single tool; any cache → toolkit; ``enable_feedback=True`` → toolkit; ``create_genie_toolkit`` shim always returns toolkit).
- 103 tests pass across ``test_first_class_tool_models`` + ``test_genie_toolkit`` + ``tests/dao_ai/mcp`` + ``test_genie_provisioning``, no regressions.
- Pydantic round-trip on all 75 ``config/examples/**/*.yaml`` files: 190 tool entries scanned, **0 real validation errors**.

## End-to-end validation on fevm

Deployed a config exercising both new tool types to the ``dao-ai-phase2-validation`` Databricks App on ``fevm-nfleming-stable-aws``:

- ``type: genie`` + ``lru_cache:`` against the "Merchandising Analytics — Sporting Goods" Genie space
- ``type: vector_search`` + ``instructed:`` against ``retail_consumer_goods.hardware_store.products_index``

**Inference responses (real data):**
- VS query "Find me a Milwaukee cordless drill" → 5 real Milwaukee SKUs returned via the instructed retriever
- VS query "Search for a DeWalt circular saw" → real DeWalt SKUs
- Genie query "top selling categories by revenue in Q4" → Genie pipeline fired (LLM routed correctly, Genie API hit, underlying SQL permission-blocked — orthogonal to this PR)

**MLflow trace lineage (UC OTEL tables):**

``type: vector_search`` trace (34 spans):
```
LangGraph → merchandiser → ChatDatabricks → tools → product_search
  → execute_instructed_retrieval → decompose_query
    → RunnableSequence → ChatDatabricks → PydanticToolsParser
  → apply_post_processing → instruction_aware_rerank
```

``type: genie`` + ``lru_cache:`` trace (23 spans):
```
LangGraph → merchandiser → ChatDatabricks → tools → query_merchandising
  → genie_lru_cache_ask_question → genie_lru_cache_lookup
  → genie_core_ask_question → ask_question
    → start_conversation → poll_for_result → poll_result
    → genie_timeline → fetching_metadata
  → genie_lru_cache_store
```

The full cache layer (LRU lookup → core fetch → cache store) is visible, confirming the new ``type: genie`` shape composes the cached toolkit identically to the factory shape.

## Out of scope (follow-ups)

- **MCP adapter awareness of new shapes.** ``src/dao_ai/mcp/adapters/genie.py`` keys on the factory name ``dao_ai.tools.create_genie_toolkit`` as a string discriminator. Teach it to also recognize ``type: genie`` / ``type: vector_search`` so MCP server configs can use the new shapes too.
- **Workshop migration.** ``dao-ai-workshop`` labs pin ``dao-ai>=0.1.92`` — the new types aren't in any released version yet. Migrate workshop configs after the dao-ai release that ships these types.
- **Other tool factories** (``create_agent_endpoint_tool``, ``create_visualization_tool``, ``create_app_info_tool``) stay on the ``type: factory`` shape in this PR; they can be made first-class later if usage justifies it.

## Test plan

- [x] Pydantic round-trip across all 75 example configs (0 real errors)
- [x] 103 tests pass across the relevant test files
- [x] ``make schema`` produces clean JSON
- [x] CLI ``dao-ai validate`` on a ``type: genie`` config → ``tools_count=1`` uncached, ``=2`` with caching
- [x] CLI ``dao-ai generate-bundle`` produces a valid bundle from the new shape
- [x] Real deploy on fevm + inference + OTEL trace span verification

This pull request and its description were written by Isaac.