### PR TITLE
fix(apps): deploy_agent must also ship requirements.txt

### DIFF
--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -1108,18 +1108,24 @@ class DatabricksProvider(ServiceProvider):
             "dao_ai.apps.start_app" if enable_chat_proxy else "dao_ai.apps.server"
         )
         if is_published():
-            # Upload a pyproject.toml pinning dao-ai to the version that
-            # generated the bundle. Databricks Apps' native uv support runs
-            # ``uv sync --locked --no-dev`` at BUILD phase based on this file
-            # and puts ``.venv/bin`` on PATH for runtime, so the deployed app
-            # always runs the dao-ai version the bundle declares. Without
-            # this, the runtime ``uv pip install dao-ai`` only audits the
-            # cached venv from prior deploys to the same app slot — letting
-            # the venv silently drift behind the local dao-ai. (See issue
-            # surfaced by the workshop verification on 2026-06-23: Lab 15
-            # introduced ``app.background:``, but the cached venv was a
-            # pre-rename dao-ai that rejected the new field as
-            # ``extra_forbidden`` and crashed the app at startup.)
+            # Ship a ``requirements.txt`` (pinned) + ``pyproject.toml``
+            # (pinned) so Databricks Apps' build phase installs the dao-ai
+            # version the bundle declares. Apps' build step recognizes
+            # ``requirements.txt`` directly (``pip install -r requirements.txt``)
+            # and emits ``Updated file: python/source_code/requirements.txt``
+            # in the deployment log; ``pyproject.toml`` alone (without
+            # ``uv.lock``) is NOT recognized — the build step logs ``No
+            # dependencies file found. Skipping installation.`` and the
+            # venv persists from prior deploys to the same app slot.
+            #
+            # Without this pin, the previous default startup command
+            # (``uv pip install dao-ai`` with no ``--upgrade``) only audited
+            # the cached venv and never upgraded — meaning the deployed app
+            # silently drifted behind the local dao-ai. Surfaced by the
+            # workshop verification on 2026-06-23: Lab 15 introduced
+            # ``app.background:``, but the cached venv was a pre-rename
+            # dao-ai that rejected the new field as ``extra_forbidden`` and
+            # crashed the app at startup.
             from dao_ai.apps.bundle import _PYPROJECT_TEMPLATE
 
             app_name_normalized = raw_name.lower().replace("_", "-")
@@ -1132,6 +1138,14 @@ class DatabricksProvider(ServiceProvider):
             self.w.workspace.upload(
                 path=f"{source_path}/pyproject.toml",
                 content=io.BytesIO(pyproject_content.encode("utf-8")),
+                format=ImportFormat.AUTO,
+                overwrite=True,
+            )
+
+            requirements_content = f"dao-ai>={dao_ai_version()}\n"
+            self.w.workspace.upload(
+                path=f"{source_path}/requirements.txt",
+                content=io.BytesIO(requirements_content.encode("utf-8")),
                 format=ImportFormat.AUTO,
                 overwrite=True,
             )

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -2438,24 +2438,41 @@ def test_deploy_apps_agent_uploads_pyproject_with_dao_ai_version_pin(tmp_path):
 
             provider.deploy_apps_agent(mock_config)
 
-    # pyproject.toml must be uploaded with a hard dao-ai version pin
+    # requirements.txt is the file Apps' build phase recognizes directly
+    # (``pyproject.toml`` alone, without ``uv.lock``, is logged as ``No
+    # dependencies file found``). Both files are uploaded so Apps installs
+    # the right dao-ai version on every deploy.
+    requirements_uploads = [
+        c
+        for c in provider.w.workspace.upload.call_args_list
+        if c.kwargs.get("path", "").endswith("/requirements.txt")
+    ]
+    assert requirements_uploads, (
+        "Published deploy_apps_agent must upload a requirements.txt so Apps' "
+        "build phase recognizes the bundle's pinned dao-ai version (rather "
+        "than the runtime command silently reusing a cached venv from a "
+        "prior deploy)."
+    )
+    requirements_text = (
+        requirements_uploads[0].kwargs["content"].getvalue().decode("utf-8")
+    )
+    assert f"dao-ai>={dao_ai_version()}" in requirements_text, (
+        f"requirements.txt must pin dao-ai>={dao_ai_version()}; got: {requirements_text!r}"
+    )
+
+    # pyproject.toml is also uploaded with the same pin (for uv-native
+    # builds + IDE awareness) but isn't the file Apps' build phase keys on.
     pyproject_uploads = [
         c
         for c in provider.w.workspace.upload.call_args_list
         if c.kwargs.get("path", "").endswith("/pyproject.toml")
     ]
-    assert pyproject_uploads, (
-        "Published deploy_apps_agent must upload a pyproject.toml so Apps' "
-        "native uv build phase installs dao-ai (rather than the runtime "
-        "command silently reusing a cached venv from a prior deploy)."
-    )
+    assert pyproject_uploads
     pyproject_text = pyproject_uploads[0].kwargs["content"].getvalue().decode("utf-8")
-    assert f"dao-ai>={dao_ai_version()}" in pyproject_text, (
-        f"pyproject.toml must pin dao-ai>={dao_ai_version()}; got:\n{pyproject_text}"
-    )
+    assert f"dao-ai>={dao_ai_version()}" in pyproject_text
 
     # app.yaml's command must be a bare ``python -m ...`` (no runtime pip
-    # install) so Apps' build-phase ``uv sync`` is the sole installer.
+    # install) so Apps' build-phase install is the sole installer.
     app_yaml_uploads = [
         c
         for c in provider.w.workspace.upload.call_args_list
@@ -2465,6 +2482,6 @@ def test_deploy_apps_agent_uploads_pyproject_with_dao_ai_version_pin(tmp_path):
     app_yaml_text = app_yaml_uploads[0].kwargs["content"].getvalue().decode("utf-8")
     assert "uv pip install dao-ai" not in app_yaml_text, (
         "app.yaml must NOT issue a runtime ``uv pip install dao-ai`` — that "
-        "command audits the cached venv and never upgrades. The new path uses "
-        "the bundle's pyproject.toml + Apps' build-phase uv sync."
+        "command audits the cached venv and never upgrades. The new path "
+        "relies on Apps' build-phase install of requirements.txt."
     )


### PR DESCRIPTION
## Summary

dao-ai 0.1.94's ``config.deploy_agent(target=DeploymentTarget.APPS)`` uploads ``pyproject.toml`` to the App source path, but Databricks Apps' BUILD phase **only recognizes ``requirements.txt`` (or ``pyproject.toml`` + ``uv.lock``)** as a dependency-installation trigger. With just ``pyproject.toml``, BUILD logs ``No dependencies file found. Skipping installation.`` and the App's runtime uses the cached venv from prior deploys — silently drifting behind the local dao-ai.

Cherry-pick of stranded commit `bb7fa00` (originally on `feature/apps-deploy-ship-requirements-txt`, never merged) that adds a parallel ``requirements.txt`` upload alongside the existing ``pyproject.toml``.

## Reproducer (just hit it)

Workshop validation against fevm on 2026-06-23:

1. Updated workshop Lab 12 to use the new ``type: genie`` first-class shape (shipped in dao-ai 0.1.94 via PR #121)
2. Notebook runs ``%pip install dao-ai>=0.1.94`` → succeeds in the notebook env
3. Notebook calls ``config.deploy_agent(target=DeploymentTarget.APPS)`` → succeeds
4. App's BUILD log: ``[BUILD] [INFO] No dependencies file found. Skipping installation.``
5. App's runtime crashes on startup with Pydantic validation errors because the cached venv has an older dao-ai that doesn't recognize ``type: genie``:

```
app.agents.0.tools.0.function.UnityCatalogFunctionModel.type
  Input should be <FunctionType.UNITY_CATALOG: 'unity_catalog'>
  [type=literal_error, input_value='genie', input_type=str]
```

The union of FunctionModel candidates in the App's cached venv is ``python | factory | inline | unity_catalog | mcp`` — missing ``GenieToolModel``/``VectorSearchToolModel``/``SearchToolModel`` added in PR #121.

## Fix

Add a second upload after the existing ``pyproject.toml`` upload in ``DatabricksProvider.deploy_apps_agent``:

```python
requirements_content = f"dao-ai>={dao_ai_version()}\n"
self.w.workspace.upload(
    path=f"{source_path}/requirements.txt",
    content=io.BytesIO(requirements_content.encode("utf-8")),
    format=ImportFormat.AUTO,
    overwrite=True,
)
```

Apps' BUILD step now sees ``requirements.txt`` and runs ``pip install -r requirements.txt``, installing the pinned dao-ai version on every deploy.

The existing ``pyproject.toml`` stays alongside — when a future code path produces a ``uv.lock``, Apps will switch to ``uv sync --locked --no-dev`` automatically without needing a code change here.

## Tests

Existing ``test_deploy_apps_agent_uploads_pyproject_with_dao_ai_version_pin`` updated to also assert ``requirements.txt`` is uploaded with the same pin. Passes.

## Release

Needs a 0.1.95 release to ship the fix. After release:
- Bump ``dao-ai>=0.1.95`` pins in the workshop labs
- Redeploy will rebuild the App venv against the new dao-ai and ``type: genie`` will load

## Test plan

- [x] ``test_deploy_apps_agent_uploads_pyproject_with_dao_ai_version_pin`` passes
- [ ] Live redeploy of workshop Lab 12 on fevm post-release → BUILD log shows ``pip install -r requirements.txt`` and App starts cleanly with ``type: genie`` recognized

This pull request and its description were written by Isaac.