### PR TITLE
feat: AgentToolModel takes full InferenceEndpointModel + migrate examples

### DIFF
--- a/config/examples/10_agent_integrations/README.md
+++ b/config/examples/10_agent_integrations/README.md
@@ -42,14 +42,14 @@ flowchart TB
 
 | File | Description |
 |------|-------------|
-| [`agent_first_class.yaml`](./agent_first_class.yaml) | **First-class `type: agent`** — call a Knowledge Assistant or Model Serving endpoint with a typed shape |
-| [`a2a_first_class.yaml`](./a2a_first_class.yaml) | **First-class `type: a2a`** — call a remote Google A2A agent with a typed shape |
+| [`agent_first_class.yaml`](./agent_first_class.yaml) | **First-class `type: agent`** — minimal example calling a KA or Model Serving endpoint with a typed shape |
+| [`a2a_first_class.yaml`](./a2a_first_class.yaml) | **First-class `type: a2a`** — minimal example calling a remote Google A2A agent with a typed shape |
 | [`nested_agents.yaml`](./nested_agents.yaml) | Main agent calling specialized sub-agents |
 | [`parallel_agents.yaml`](./parallel_agents.yaml) | Parallel agent execution pattern |
-| [`agent_bricks.yaml`](./agent_bricks.yaml) | Delegate to Databricks Agent Bricks endpoints (verbose `type: factory` form) |
-| [`kasal.yaml`](./kasal.yaml) | Delegate to Kasal specialist agents |
+| [`agent_bricks.yaml`](./agent_bricks.yaml) | Delegate to Databricks Agent Bricks endpoints using `type: agent` with full `InferenceEndpointModel` (temperature / max_tokens per tool) |
+| [`kasal.yaml`](./kasal.yaml) | Delegate to Kasal specialist agents using `type: agent` |
 | [`vertex_agent_engine.yaml`](./vertex_agent_engine.yaml) | Call a Google Cloud ADK agent on Vertex AI Agent Engine |
-| [`a2a_agent.yaml`](./a2a_agent.yaml) | Call any remote agent over Google's open A2A protocol (verbose `type: factory` form) |
+| [`a2a_agent.yaml`](./a2a_agent.yaml) | Comprehensive `type: a2a` walkthrough — bearer / GCP / none auth, AppResource mode, card-path overrides |
 
 ## Vertex AI Agent Engine (Google ADK)
 

--- a/config/examples/10_agent_integrations/a2a_agent.yaml
+++ b/config/examples/10_agent_integrations/a2a_agent.yaml
@@ -74,71 +74,68 @@ prompts:
       ask the user whether they want to retry.
 
 tools:
-  # Primary A2A tool — bearer-token auth variant.
+  # Primary A2A tool — bearer-token auth variant. Uses the first-class
+  # `type: a2a` shape (dao-ai 0.1.97+). For the verbose `type: factory`
+  # form see git history before this commit; it remains fully supported.
   remote_a2a_tool: &remote_a2a_tool
     name: remote_a2a_agent
     function:
-      type: factory
-      name: dao_ai.tools.create_a2a_agent_tool
-      args:
-        name: remote_a2a_agent
-        description: |
-          Delegate a prompt to a remote agent over the Google A2A
-          (Agent-to-Agent) protocol and return the agent's reply as a
-          single string. Use this tool for any question that the remote
-          A2A specialist should answer.
-        endpoint: *a2a_endpoint
-        auth: *a2a_auth
-        auth_type: bearer
-        # Multi-turn continuity: runtime.context.thread_id is forwarded as
-        # the A2A ``Message.context_id`` automatically. runtime.context.user_id
-        # is forwarded as ``Message.metadata["dao_ai.user_id"]``.
-        streaming: true
+      type: a2a
+      name: remote_a2a_agent
+      description: |
+        Delegate a prompt to a remote agent over the Google A2A
+        (Agent-to-Agent) protocol and return the agent's reply as a
+        single string. Use this tool for any question that the remote
+        A2A specialist should answer.
+      endpoint: *a2a_endpoint
+      auth: *a2a_auth
+      auth_type: bearer
+      # Multi-turn continuity: runtime.context.thread_id is forwarded as
+      # the A2A ``Message.context_id`` automatically. runtime.context.user_id
+      # is forwarded as ``Message.metadata["dao_ai.user_id"]``.
+      streaming: true
 
-        # --- Alternate auth configurations -------------------------------
-        #
-        # For Vertex-AI-hosted A2A agents, swap bearer for gcp_service_account:
-        #   auth_type: gcp_service_account
-        #   auth: *a2a_gcp_credentials
-        #
-        # For public / unauthenticated A2A agents:
-        #   auth_type: none
-        #   (omit the ``auth`` arg)
-        #
-        # --- Calling another dao-ai Databricks App (AppResource mode) ----
-        #
-        # If the remote agent is itself a dao-ai app deployed on Databricks
-        # Apps, declare it under ``resources.apps`` and reference it via
-        # the ``app`` arg instead of ``endpoint`` / ``auth`` / ``auth_type``.
-        # The factory resolves the URL from ``DatabricksAppModel.url`` and
-        # picks the auth mode from ``app.on_behalf_of_user``:
-        #
-        #     resources:
-        #       apps:
-        #         remote_dao_ai_app: &remote_dao_ai_app
-        #           name: dao-ai-some-other-app
-        #           on_behalf_of_user: true   # -> forwarded_user_token
-        #                                     # false / unset -> databricks_app_sp
-        #
-        #     tools:
-        #       remote_a2a_tool:
-        #         function:
-        #           type: factory
-        #           name: dao_ai.tools.create_a2a_agent_tool
-        #           args:
-        #             app: *remote_dao_ai_app
-        #             # ``endpoint``, ``auth``, ``auth_type`` all auto-derived.
-        #
-        # See ``config/examples/15_complete_applications/procurement_supplier_a2a/``
-        # for a full procurement <-> supplier walkthrough.
-        #
-        # --- Card path overrides -----------------------------------------
-        #
-        # Some deployments expose the agent card at a non-standard path. Both
-        # paths accept AnyVariable so they can be sourced from env / secrets:
-        #
-        #   card_path: "/.well-known/agent-card.json"
-        #   card_fallback_path: "/.well-known/agent.json"
+      # --- Alternate auth configurations -------------------------------
+      #
+      # For Vertex-AI-hosted A2A agents, swap bearer for gcp_service_account:
+      #   auth_type: gcp_service_account
+      #   auth: *a2a_gcp_credentials
+      #
+      # For public / unauthenticated A2A agents:
+      #   auth_type: none
+      #   (omit the ``auth`` arg)
+      #
+      # --- Calling another dao-ai Databricks App (AppResource mode) ----
+      #
+      # If the remote agent is itself a dao-ai app deployed on Databricks
+      # Apps, declare it under ``resources.apps`` and reference it via
+      # the ``app`` field instead of ``endpoint`` / ``auth`` / ``auth_type``.
+      # The factory resolves the URL from ``DatabricksAppModel.url`` and
+      # picks the auth mode from ``app.on_behalf_of_user``:
+      #
+      #     resources:
+      #       apps:
+      #         remote_dao_ai_app: &remote_dao_ai_app
+      #           name: dao-ai-some-other-app
+      #           on_behalf_of_user: true   # -> forwarded_user_token
+      #                                     # false / unset -> databricks_app_sp
+      #
+      #     tools:
+      #       remote_a2a_tool:
+      #         function:
+      #           type: a2a
+      #           app: *remote_dao_ai_app
+      #           # ``endpoint``, ``auth``, ``auth_type`` all auto-derived.
+      #
+      # See ``config/examples/15_complete_applications/procurement_supplier_a2a/``
+      # for a full procurement <-> supplier walkthrough.
+      #
+      # --- Card path overrides -----------------------------------------
+      #
+      # Some deployments expose the agent card at a non-standard path:
+      #
+      #   card_path: "/.well-known/agent-card.json"
+      #   card_fallback_path: "/.well-known/agent.json"
 
 agents:
   a2a_delegate_agent: &a2a_delegate_agent

--- a/config/examples/10_agent_integrations/agent_bricks.yaml
+++ b/config/examples/10_agent_integrations/agent_bricks.yaml
@@ -48,45 +48,43 @@ resources:
       max_tokens: 800
 
 tools:
-  # Agent Bricks Customer Support Tool
+  # Agent Bricks Customer Support Tool — first-class `type: agent` (dao-ai
+  # 0.1.97+). `endpoint:` accepts the full InferenceEndpointModel anchor so
+  # temperature / max_tokens / ai_gateway from the resource flow through.
   customer_support_tool: &customer_support_tool
     name: customer_support_agent
     function:
-      type: factory
-      name: dao_ai.tools.create_agent_endpoint_tool
-      args:
-        llm: *agent_bricks_customer_support
-        name: customer_support_specialist
-        description: |
-          Delegate customer support queries to a specialized Agent Bricks customer support agent.
-          Use this tool for:
-          - Handling customer complaints and issues
-          - Processing returns and refunds
-          - Managing customer satisfaction concerns
-          - Escalation handling
+      type: agent
+      endpoint: *agent_bricks_customer_support
+      name: customer_support_specialist
+      description: |
+        Delegate customer support queries to a specialized Agent Bricks customer support agent.
+        Use this tool for:
+        - Handling customer complaints and issues
+        - Processing returns and refunds
+        - Managing customer satisfaction concerns
+        - Escalation handling
 
-          The agent is trained on customer support best practices and your company's policies.
-          Pass the customer's question or issue as the prompt.
+        The agent is trained on customer support best practices and your company's policies.
+        Pass the customer's question or issue as the prompt.
 
   # Agent Bricks Product Expert Tool
   product_expert_tool: &product_expert_tool
     name: product_expert_agent
     function:
-      type: factory
-      name: dao_ai.tools.create_agent_endpoint_tool
-      args:
-        llm: *agent_bricks_product_expert
-        name: product_knowledge_expert
-        description: |
-          Consult with a specialized Agent Bricks product expert for detailed product information.
-          Use this tool for:
-          - Technical product specifications
-          - Product comparisons and recommendations
-          - Compatibility questions
-          - Usage instructions and best practices
+      type: agent
+      endpoint: *agent_bricks_product_expert
+      name: product_knowledge_expert
+      description: |
+        Consult with a specialized Agent Bricks product expert for detailed product information.
+        Use this tool for:
+        - Technical product specifications
+        - Product comparisons and recommendations
+        - Compatibility questions
+        - Usage instructions and best practices
 
-          This agent has deep knowledge of your product catalog and can provide
-          expert-level guidance on product selection and usage.
+        This agent has deep knowledge of your product catalog and can provide
+        expert-level guidance on product selection and usage.
 
 agents:
   # Main orchestrator agent that delegates to Agent Bricks specialists

--- a/config/examples/10_agent_integrations/kasal.yaml
+++ b/config/examples/10_agent_integrations/kasal.yaml
@@ -54,71 +54,67 @@ resources:
       max_tokens: 800
 
 tools:
-  # Kasal Financial Analysis Tool
+  # Kasal Financial Analysis Tool — first-class `type: agent` (dao-ai
+  # 0.1.97+). `endpoint:` accepts the full InferenceEndpointModel anchor so
+  # temperature / max_tokens flow through from the resource definition.
   financial_analyst_tool: &financial_analyst_tool
     name: financial_analyst
     function:
-      type: factory
-      name: dao_ai.tools.create_agent_endpoint_tool
-      args:
-        llm: *kasal_financial_agent
-        name: kasal_financial_expert
-        description: |
-          Access a Kasal financial analyst agent for financial queries and analysis.
+      type: agent
+      endpoint: *kasal_financial_agent
+      name: kasal_financial_expert
+      description: |
+        Access a Kasal financial analyst agent for financial queries and analysis.
 
-          Capabilities:
-          - Revenue and profit analysis
-          - Financial forecasting and projections
-          - Budget planning and variance analysis
-          - Cost optimization recommendations
-          - Financial report generation
+        Capabilities:
+        - Revenue and profit analysis
+        - Financial forecasting and projections
+        - Budget planning and variance analysis
+        - Cost optimization recommendations
+        - Financial report generation
 
-          The agent has access to financial data and follows GAAP standards.
-          Provide your financial question or analysis request as the prompt.
+        The agent has access to financial data and follows GAAP standards.
+        Provide your financial question or analysis request as the prompt.
 
   # Kasal Compliance Tool
   compliance_checker_tool: &compliance_checker_tool
     name: compliance_checker
     function:
-      type: factory
-      name: dao_ai.tools.create_agent_endpoint_tool
-      args:
-        llm: *kasal_compliance_agent
-        name: kasal_compliance_validator
-        description: |
-          Consult with a Kasal compliance agent to validate regulatory adherence.
+      type: agent
+      endpoint: *kasal_compliance_agent
+      name: kasal_compliance_validator
+      description: |
+        Consult with a Kasal compliance agent to validate regulatory adherence.
 
-          Use this for:
-          - Regulatory requirement validation
-          - Policy compliance checks
-          - Audit trail generation
-          - Risk assessment
-          - Industry standards verification (SOC2, HIPAA, GDPR, etc.)
+        Use this for:
+        - Regulatory requirement validation
+        - Policy compliance checks
+        - Audit trail generation
+        - Risk assessment
+        - Industry standards verification (SOC2, HIPAA, GDPR, etc.)
 
-          This agent ensures all recommendations and decisions meet regulatory requirements.
-          Describe the action or decision you need validated.
+        This agent ensures all recommendations and decisions meet regulatory requirements.
+        Describe the action or decision you need validated.
 
   # Kasal Data Privacy Tool
   privacy_specialist_tool: &privacy_specialist_tool
     name: privacy_specialist
     function:
-      type: factory
-      name: dao_ai.tools.create_agent_endpoint_tool
-      args:
-        llm: *kasal_privacy_agent
-        name: kasal_privacy_expert
-        description: |
-          Engage with a Kasal data privacy specialist for PII and data handling guidance.
+      type: agent
+      endpoint: *kasal_privacy_agent
+      name: kasal_privacy_expert
+      description: |
+        Engage with a Kasal data privacy specialist for PII and data handling guidance.
 
-          Capabilities:
-          - PII detection and classification
-          - Data retention policy guidance
-          - Privacy impact assessments
-          - GDPR/CCPA compliance validation
-          - Data anonymization strategies
+        Capabilities:
+        - PII detection and classification
+        - Data retention policy guidance
+        - Privacy impact assessments
+        - GDPR/CCPA compliance validation
+        - Data anonymization strategies
 
-          The agent helps ensure data privacy best practices are followed.
-          Ask your data privacy or PII-related question.
+        The agent helps ensure data privacy best practices are followed.
+        Ask your data privacy or PII-related question.
 
 agents:
   # Enterprise coordinator agent with Kasal specialist agents

--- a/config/examples/15_complete_applications/procurement_supplier_a2a/README.md
+++ b/config/examples/15_complete_applications/procurement_supplier_a2a/README.md
@@ -10,7 +10,7 @@ End-to-end demo of two dao-ai apps speaking the
 | App | YAML | Role |
 |-----|------|------|
 | `dao-ai-supplier-a2a` | `supplier.yaml` | Wholesale-supplier specialist. Answers SKU, pricing, lead-time, MOQ, and stock questions from an embedded catalog. Exposes A2A by default. |
-| `dao-ai-procurement-a2a` | `procurement.yaml` | Procurement-officer agent. Holds one tool — `query_supplier` — built from `dao_ai.tools.create_a2a_agent_tool` in **AppResource mode**: the supplier app is passed in directly via `app: *supplier_app`, and the tool resolves both the endpoint and the auth mode from it. |
+| `dao-ai-procurement-a2a` | `procurement.yaml` | Procurement-officer agent. Holds one tool — `query_supplier` — declared as a first-class `type: a2a` tool in **AppResource mode**: the supplier app is passed in directly via `app: *supplier_app`, and the tool resolves both the endpoint and the auth mode from it. |
 
 Both apps run on Foundation Model API only — no Unity Catalog tables,
 Vector Search indexes, or Genie rooms required.
@@ -32,10 +32,8 @@ resources:
 tools:
   query_supplier:
     function:
-      type: factory
-      name: dao_ai.tools.create_a2a_agent_tool
-      args:
-        app: *supplier_app
+      type: a2a
+      app: *supplier_app
 ```
 
 The factory then:

--- a/config/examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml
+++ b/config/examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml
@@ -101,27 +101,25 @@ tools:
   query_supplier: &query_supplier
     name: query_supplier
     function:
-      type: factory
-      name: dao_ai.tools.create_a2a_agent_tool
-      args:
-        name: query_supplier
-        description: |
-          Delegate a question to the Acme Industrial Supply wholesale
-          supplier agent over the Google A2A (Agent-to-Agent) protocol.
-          Use for any supplier-domain question: SKU lookups, unit and
-          bulk pricing, lead times, MOQs, and live stock. Pass the
-          procurement officer's question through as the ``prompt``
-          argument.
-        # Mode 2 — AppResource. Resolves the supplier endpoint from
-        # ``supplier_app.url`` and the auth mode from
-        # ``supplier_app.on_behalf_of_user``. To pin a specific mode
-        # (e.g. force App-SP M2M even though the app is OBO-tagged),
-        # add ``auth_type: databricks_app_sp`` below.
-        app: *supplier_app
-        # Multi-turn continuity: runtime.context.thread_id is forwarded
-        # as A2A ``Message.context_id`` automatically, and user_id is
-        # forwarded as ``Message.metadata["dao_ai.user_id"]``.
-        streaming: true
+      type: a2a
+      name: query_supplier
+      description: |
+        Delegate a question to the Acme Industrial Supply wholesale
+        supplier agent over the Google A2A (Agent-to-Agent) protocol.
+        Use for any supplier-domain question: SKU lookups, unit and
+        bulk pricing, lead times, MOQs, and live stock. Pass the
+        procurement officer's question through as the ``prompt``
+        argument.
+      # Mode 2 — AppResource. Resolves the supplier endpoint from
+      # ``supplier_app.url`` and the auth mode from
+      # ``supplier_app.on_behalf_of_user``. To pin a specific mode
+      # (e.g. force App-SP M2M even though the app is OBO-tagged),
+      # add ``auth_type: databricks_app_sp`` below.
+      app: *supplier_app
+      # Multi-turn continuity: runtime.context.thread_id is forwarded
+      # as A2A ``Message.context_id`` automatically, and user_id is
+      # forwarded as ``Message.metadata["dao_ai.user_id"]``.
+      streaming: true
 
 agents:
   procurement_agent: &procurement_agent

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -749,7 +749,7 @@
     },
     "AgentToolModel": {
       "additionalProperties": false,
-      "description": "First-class tool that calls a deployed chat-shape agent endpoint.\n\nCovers the Supervisor API ``knowledge_assistant`` and ``serving_endpoint``\ntool types: any Model Serving endpoint that speaks chat completions or\nChatAgent (including Knowledge Assistants, which deploy as serving\nendpoints with a known prefix).\n\nFor Databricks Apps:\n\n- MCP apps (``mcp-`` prefix): use ``type: mcp`` with ``app:``.\n- A2A apps: use ``type: a2a`` with ``app:``.\n\nEquivalent to ``type: factory + name: dao_ai.tools.create_agent_endpoint_tool``,\nbut with typed fields so beginners get IDE autocomplete and JSON-schema\nvalidation. OBO is opt-in via ``on_behalf_of_user``.",
+      "description": "First-class tool that calls a deployed chat-shape agent endpoint.\n\nCovers the Supervisor API ``knowledge_assistant`` and ``serving_endpoint``\ntool types: any Model Serving endpoint that speaks chat completions or\nChatAgent (including Knowledge Assistants, which deploy as serving\nendpoints with a known prefix).\n\nFor Databricks Apps:\n\n- MCP apps (``mcp-`` prefix): use ``type: mcp`` with ``app:``.\n- A2A apps: use ``type: a2a`` with ``app:``.\n\nEquivalent to ``type: factory + name: dao_ai.tools.create_agent_endpoint_tool``,\nbut with typed fields so beginners get IDE autocomplete and JSON-schema\nvalidation.\n\n``endpoint`` accepts two shapes:\n\n- **String / variable** (the sugar form) \u2014 just the endpoint name. dao-ai\n  promotes it to a minimal ``InferenceEndpointModel`` internally. Use\n  this when you only need the endpoint name and OBO toggle.\n- **Full ``InferenceEndpointModel``** \u2014 when you need ``temperature``,\n  ``max_tokens``, ``ai_gateway``, or any other endpoint-level\n  configuration. Mirrors how ``GenieToolModel`` takes a full\n  ``GenieRoomModel`` and ``VectorSearchToolModel`` takes a\n  ``RetrieverModel`` / ``VectorStoreModel``. The model's\n  ``on_behalf_of_user`` overrides this tool's ``on_behalf_of_user``\n  when both are set.",
       "properties": {
         "type": {
           "const": "agent",
@@ -772,6 +772,9 @@
         },
         "endpoint": {
           "anyOf": [
+            {
+              "$ref": "#/$defs/InferenceEndpointModel"
+            },
             {
               "$ref": "#/$defs/CompositeVariableModel"
             },
@@ -797,7 +800,7 @@
               "type": "boolean"
             }
           ],
-          "description": "Model Serving endpoint name. For a Knowledge Assistant this is the KA endpoint name (e.g., 'ka-customer-reviews').",
+          "description": "Model Serving endpoint to call. Accepts either an endpoint name string (sugar) or a full InferenceEndpointModel with temperature / max_tokens / ai_gateway / on_behalf_of_user. For a Knowledge Assistant this is the KA endpoint name (e.g., 'ka-customer-reviews').",
           "title": "Endpoint"
         },
         "name": {
@@ -836,7 +839,7 @@
             }
           ],
           "default": null,
-          "description": "If True, call the endpoint on behalf of the calling user by forwarding their bearer token. If False or None, the agent's service principal calls the endpoint.",
+          "description": "If True, call the endpoint on behalf of the calling user by forwarding their bearer token. If False or None, the agent's service principal calls the endpoint. Ignored when ``endpoint`` is a full InferenceEndpointModel that sets on_behalf_of_user itself.",
           "title": "On Behalf Of User"
         }
       },

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -5306,7 +5306,20 @@ class AgentToolModel(BaseFunctionModel):
 
     Equivalent to ``type: factory + name: dao_ai.tools.create_agent_endpoint_tool``,
     but with typed fields so beginners get IDE autocomplete and JSON-schema
-    validation. OBO is opt-in via ``on_behalf_of_user``.
+    validation.
+
+    ``endpoint`` accepts two shapes:
+
+    - **String / variable** (the sugar form) — just the endpoint name. dao-ai
+      promotes it to a minimal ``InferenceEndpointModel`` internally. Use
+      this when you only need the endpoint name and OBO toggle.
+    - **Full ``InferenceEndpointModel``** — when you need ``temperature``,
+      ``max_tokens``, ``ai_gateway``, or any other endpoint-level
+      configuration. Mirrors how ``GenieToolModel`` takes a full
+      ``GenieRoomModel`` and ``VectorSearchToolModel`` takes a
+      ``RetrieverModel`` / ``VectorStoreModel``. The model's
+      ``on_behalf_of_user`` overrides this tool's ``on_behalf_of_user``
+      when both are set.
     """
 
     model_config = ConfigDict(use_enum_values=True, extra="forbid")
@@ -5314,10 +5327,13 @@ class AgentToolModel(BaseFunctionModel):
         default=FunctionType.AGENT,
         description="Function type discriminator. Must be 'agent'.",
     )
-    endpoint: AnyVariable = Field(
+    endpoint: Union[InferenceEndpointModel, AnyVariable] = Field(
         description=(
-            "Model Serving endpoint name. For a Knowledge Assistant this is the "
-            "KA endpoint name (e.g., 'ka-customer-reviews')."
+            "Model Serving endpoint to call. Accepts either an endpoint "
+            "name string (sugar) or a full InferenceEndpointModel with "
+            "temperature / max_tokens / ai_gateway / on_behalf_of_user. "
+            "For a Knowledge Assistant this is the KA endpoint name "
+            "(e.g., 'ka-customer-reviews')."
         ),
     )
     name: Optional[str] = Field(
@@ -5333,24 +5349,32 @@ class AgentToolModel(BaseFunctionModel):
         description=(
             "If True, call the endpoint on behalf of the calling user by "
             "forwarding their bearer token. If False or None, the agent's "
-            "service principal calls the endpoint."
+            "service principal calls the endpoint. Ignored when ``endpoint`` "
+            "is a full InferenceEndpointModel that sets on_behalf_of_user "
+            "itself."
         ),
     )
 
-    def as_tools(self, **kwargs: Any) -> Sequence[RunnableLike]:
-        from dao_ai.tools import create_agent_endpoint_tool
-
+    def _resolved_llm(self) -> "InferenceEndpointModel":
+        """Normalize the endpoint field to an InferenceEndpointModel."""
+        if isinstance(self.endpoint, InferenceEndpointModel):
+            return self.endpoint
         endpoint_name: str = str(value_of(self.endpoint))
-        llm = InferenceEndpointModel(
+        return InferenceEndpointModel(
             name=endpoint_name,
             on_behalf_of_user=bool(self.on_behalf_of_user)
             if self.on_behalf_of_user is not None
             else None,
         )
+
+    def as_tools(self, **kwargs: Any) -> Sequence[RunnableLike]:
+        from dao_ai.tools import create_agent_endpoint_tool
+
+        llm: InferenceEndpointModel = self._resolved_llm()
         return [
             create_agent_endpoint_tool(
                 llm=llm,
-                name=self.name or endpoint_name,
+                name=self.name or llm.name,
                 description=self.description,
             )
         ]

--- a/tests/dao_ai/test_first_class_tool_models.py
+++ b/tests/dao_ai/test_first_class_tool_models.py
@@ -304,6 +304,53 @@ class TestAgentToolModel:
         assert len(tools) == 1
         assert tools[0].name == "my_agent_tool"
 
+    def test_agent_endpoint_accepts_full_inference_endpoint_model(self) -> None:
+        """endpoint: can be a full InferenceEndpointModel (with temp / max_tokens / ai_gateway)."""
+        from dao_ai.config import InferenceEndpointModel
+
+        m = ToolModel.model_validate(
+            {
+                "name": "ka",
+                "function": {
+                    "type": "agent",
+                    "endpoint": {
+                        "name": "ka-customer-reviews",
+                        "temperature": 0.7,
+                        "max_tokens": 1000,
+                    },
+                    "name": "ka_tool",
+                },
+            }
+        )
+        assert isinstance(m.function, AgentToolModel)
+        assert isinstance(m.function.endpoint, InferenceEndpointModel)
+        assert m.function.endpoint.name == "ka-customer-reviews"
+        assert m.function.endpoint.temperature == 0.7
+        assert m.function.endpoint.max_tokens == 1000
+
+        llm = m.function._resolved_llm()
+        assert isinstance(llm, InferenceEndpointModel)
+        assert llm.temperature == 0.7
+        assert llm.max_tokens == 1000
+
+        tools = m.function.as_tools()
+        assert len(tools) == 1
+        assert tools[0].name == "ka_tool"
+
+    def test_agent_endpoint_string_promoted_to_inference_endpoint_model(self) -> None:
+        """String endpoint: gets promoted to InferenceEndpointModel(name=...) internally."""
+        from dao_ai.config import InferenceEndpointModel
+
+        m = AgentToolModel(
+            type=FunctionType.AGENT,
+            endpoint="my-endpoint",
+            on_behalf_of_user=True,
+        )
+        llm = m._resolved_llm()
+        assert isinstance(llm, InferenceEndpointModel)
+        assert llm.name == "my-endpoint"
+        assert llm.on_behalf_of_user is True
+
     def test_agent_parity_with_factory(self) -> None:
         new = ToolModel.model_validate(
             {
@@ -324,6 +371,41 @@ class TestAgentToolModel:
                     "args": {
                         "llm": {"name": "my-agent"},
                         "name": "my_agent_tool",
+                    },
+                },
+            }
+        )
+        new_tools = new.function.as_tools()
+        old_tools = old.function.as_tools()
+        assert len(new_tools) == len(old_tools) == 1
+        assert [t.name for t in new_tools] == [t.name for t in old_tools]
+
+    def test_agent_parity_with_factory_full_model(self) -> None:
+        """type: agent with full InferenceEndpointModel matches the original factory shape."""
+        llm = {
+            "name": "agent-bricks-customer-support-endpoint",
+            "temperature": 0.7,
+            "max_tokens": 1000,
+        }
+        new = ToolModel.model_validate(
+            {
+                "name": "a",
+                "function": {
+                    "type": "agent",
+                    "endpoint": llm,
+                    "name": "customer_support_specialist",
+                },
+            }
+        )
+        old = ToolModel.model_validate(
+            {
+                "name": "a",
+                "function": {
+                    "type": "factory",
+                    "name": "dao_ai.tools.create_agent_endpoint_tool",
+                    "args": {
+                        "llm": llm,
+                        "name": "customer_support_specialist",
                     },
                 },
             }


### PR DESCRIPTION
## Summary

Follow-up to #123. Closes a shape gap in \`AgentToolModel\`, then completes the example migration that #123 left half-done.

### The gap

#123 shipped \`AgentToolModel.endpoint\` as a string-only field. That broke migration of \`config/examples/10_agent_integrations/agent_bricks.yaml\` and \`kasal.yaml\` — both configure \`InferenceEndpointModel\` resources with \`temperature\` / \`max_tokens\` and pass the full model to \`create_agent_endpoint_tool(llm=*resource)\`. A string-only \`endpoint:\` would silently drop those fields.

### The fix

\`AgentToolModel.endpoint\` now accepts either:

- **Sugar form** — a string / variable endpoint name (promoted to a minimal \`InferenceEndpointModel\` internally). Unchanged from #123.
- **Full \`InferenceEndpointModel\`** — when you need \`temperature\` / \`max_tokens\` / \`ai_gateway\` / \`on_behalf_of_user\`.

Matches the dao-ai first-class pattern from #121: \`GenieToolModel\` takes a full \`GenieRoomModel\`, \`VectorSearchToolModel\` takes a full \`RetrieverModel\` / \`VectorStoreModel\`.

### Examples migrated

| File | Old shape | New shape |
|---|---|---|
| \`10_agent_integrations/agent_bricks.yaml\` | \`type: factory + create_agent_endpoint_tool\` (2 tools) | \`type: agent\` with full \`InferenceEndpointModel\` |
| \`10_agent_integrations/kasal.yaml\` | \`type: factory + create_agent_endpoint_tool\` (3 tools) | \`type: agent\` with full \`InferenceEndpointModel\` |
| \`10_agent_integrations/a2a_agent.yaml\` | \`type: factory + create_a2a_agent_tool\` | \`type: a2a\` |
| \`15_complete_applications/procurement_supplier_a2a/procurement.yaml\` | \`type: factory + create_a2a_agent_tool\` | \`type: a2a\` (Mode 2 / AppResource) |

README descriptions and the procurement walkthrough doc snippet refreshed to match.

## Files

| Path | Change |
|---|---|
| \`src/dao_ai/config.py\` | \`AgentToolModel.endpoint: Union[InferenceEndpointModel, AnyVariable]\` + \`_resolved_llm()\` helper |
| \`schemas/model_config_schema.json\` | Regenerated via \`make schema\` |
| \`tests/dao_ai/test_first_class_tool_models.py\` | +3 tests (full-model dispatch, string-promotion, full-model parity vs factory) |
| 4 example YAMLs | Factory → first-class migration |
| 2 example READMEs | Updated descriptions / snippets |

## Test plan

- [x] \`uv run pytest tests/dao_ai/test_first_class_tool_models.py tests/dao_ai/test_a2a_tool.py\` → 54 pass (27 first-class + 27 A2A)
- [x] All 7 example YAMLs (\`agent_first_class\`, \`a2a_first_class\`, \`a2a_agent\`, \`agent_bricks\`, \`kasal\`, \`procurement\`, \`supplier\`) validate against \`AppConfig\`
- [x] Round-trip: full \`InferenceEndpointModel\` shape preserves \`temperature\` / \`max_tokens\` through \`_resolved_llm()\` (covered by new test)

This pull request and its description were written by Isaac.