### PR TITLE
fix(obo): close type:app OBO matrix — direct httpx + strict-mode

### DIFF
--- a/src/dao_ai/auth.py
+++ b/src/dao_ai/auth.py
@@ -1,0 +1,70 @@
+"""Shared HTTP auth primitives for invoking Databricks resources from dao-ai.
+
+Two pieces ship here:
+
+- :class:`WorkspaceBearerAuth` — an :class:`httpx.Auth` subclass that
+  delegates to ``WorkspaceClient.config.authenticate``. Same pattern as
+  ``databricks_openai.utils.clients.BearerAuth``, but without the OAuth-
+  strategy gate that breaks PAT-auth workspace clients (the forwarded
+  user-token path). Use this any time dao-ai needs to POST to a
+  Databricks-hosted HTTP endpoint (Databricks App, Model Serving) and
+  wants the workspace client's auth strategy honored as-is.
+
+- :class:`OBONotAvailableError` — raised by ``IsDatabricksResource.workspace_client_from``
+  when ``strict=True`` and the resource asked for OBO but no forwarded
+  user token is present in the call context. Surfaces misconfigured OBO
+  at first-call instead of silently falling back to the service-principal
+  identity.
+"""
+
+from __future__ import annotations
+
+from typing import Generator, Optional
+
+from databricks.sdk import WorkspaceClient
+from httpx import Auth, Request, Response
+
+
+class WorkspaceBearerAuth(Auth):
+    """httpx auth that reads the Authorization header from a WorkspaceClient.
+
+    Equivalent to ``BearerAuth(workspace_client.config.authenticate)`` from
+    ``databricks_openai``, but ships in dao-ai so callers can opt out of
+    that package's OAuth-strategy gate (``_validate_oauth_for_apps``).
+    """
+
+    def __init__(self, workspace_client: WorkspaceClient) -> None:
+        self._workspace_client = workspace_client
+
+    def auth_flow(self, request: Request) -> Generator[Request, Response, None]:
+        auth_headers = self._workspace_client.config.authenticate()
+        request.headers["Authorization"] = auth_headers["Authorization"]
+        yield request
+
+
+class OBONotAvailableError(ValueError):
+    """Raised when a resource asked for OBO but no forwarded user token exists.
+
+    Carries ``resource_name`` and ``field`` so the message can pinpoint the
+    misconfiguration (e.g. ``apps.translator_app.on_behalf_of_user=true``
+    in a config whose calling agent does not have OBO enabled).
+    """
+
+    def __init__(
+        self,
+        *,
+        resource_name: Optional[str] = None,
+        field: Optional[str] = None,
+    ) -> None:
+        self.resource_name = resource_name
+        self.field = field
+        message = (
+            "Resource declared on_behalf_of_user=true but no forwarded user "
+            "token is available in the call context. The calling agent must "
+            "also run with OBO so its forwarded user identity can propagate."
+        )
+        if resource_name:
+            message += f" Offending resource: {resource_name!r}"
+        if field:
+            message += f" (field: {field})"
+        super().__init__(message)

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -513,7 +513,12 @@ class IsDatabricksResource(ABC, BaseModel):
         )
         return WorkspaceClient()
 
-    def workspace_client_from(self, context: "Context | None") -> WorkspaceClient:
+    def workspace_client_from(
+        self,
+        context: "Context | None",
+        *,
+        strict: bool = False,
+    ) -> WorkspaceClient:
         """
         Get a WorkspaceClient using headers from the provided Context.
 
@@ -524,16 +529,29 @@ class IsDatabricksResource(ABC, BaseModel):
         Args:
             context: Runtime context containing headers for OBO auth.
                      If None or no headers, falls back to workspace_client property.
+            strict: If True and ``self.on_behalf_of_user`` is set but no
+                    forwarded user token is available in the context, raise
+                    :class:`dao_ai.auth.OBONotAvailableError` instead of
+                    silently falling back to the service-principal identity.
+                    Dispatcher call sites that invoke a target on a user's
+                    behalf should pass ``strict=True`` so misconfigured OBO
+                    surfaces at first-call rather than running as the SP.
 
         Returns:
             WorkspaceClient configured with appropriate authentication.
+
+        Raises:
+            OBONotAvailableError: when ``strict=True`` and OBO was requested
+                but no forwarded user token is in the call context.
         """
+        from dao_ai.auth import OBONotAvailableError
         from dao_ai.utils import normalize_host
 
         logger.trace(
             "workspace_client_from called",
             context=context,
             on_behalf_of_user=self.on_behalf_of_user,
+            strict=strict,
         )
 
         # Check if we have headers in context for OBO
@@ -564,6 +582,17 @@ class IsDatabricksResource(ABC, BaseModel):
                     token=forwarded_token,
                     auth_type="pat",
                 )
+
+        # OBO was requested but no forwarded token reached us. Either the
+        # calling agent isn't running with OBO, or its middleware didn't
+        # propagate the headers. In strict mode this is a misconfiguration
+        # we should fail fast on; in lenient mode (current default) we fall
+        # through to the SP-identity workspace_client.
+        if strict and self.on_behalf_of_user:
+            raise OBONotAvailableError(
+                resource_name=getattr(self, "name", None),
+                field=f"{self.__class__.__name__}.on_behalf_of_user",
+            )
 
         # Fall back to existing workspace_client property
         return self.workspace_client

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -537,6 +537,15 @@ class IsDatabricksResource(ABC, BaseModel):
                     behalf should pass ``strict=True`` so misconfigured OBO
                     surfaces at first-call rather than running as the SP.
 
+                    Note on deploy target semantics: inside Databricks Apps,
+                    the proxy unconditionally forwards
+                    ``x-forwarded-access-token`` on every authenticated user
+                    request, so ``strict=True`` rarely fires there — the
+                    token is present even when other agents in the call
+                    chain didn't ask for OBO. Strict-mode is most useful in
+                    Model Serving deploys (no Apps proxy → genuine absence
+                    of the forwarded header) and in M2M-only contexts.
+
         Returns:
             WorkspaceClient configured with appropriate authentication.
 

--- a/src/dao_ai/tools/agent.py
+++ b/src/dao_ai/tools/agent.py
@@ -81,7 +81,9 @@ def create_agent_endpoint_tool(
         if llm.on_behalf_of_user:
             from databricks.sdk import WorkspaceClient
 
-            workspace_client: WorkspaceClient = llm.workspace_client_from(context)
+            workspace_client: WorkspaceClient = llm.workspace_client_from(
+                context, strict=True
+            )
             logger.debug(
                 "Creating OBO chat client for agent endpoint tool",
                 model=llm.name,

--- a/src/dao_ai/tools/app_agent_dispatcher.py
+++ b/src/dao_ai/tools/app_agent_dispatcher.py
@@ -10,10 +10,20 @@ Resolution precedence (via :func:`resolve_api`):
    :func:`discover_app_agent_api`.
 3. Per-type default (``"responses"`` for ``type: app``).
 
-The HTTP call to the App is inlined here rather than delegated to the
+HTTP transport: POSTs to ``<app.url>/invocations`` using
+:class:`httpx.AsyncClient` with :class:`dao_ai.auth.WorkspaceBearerAuth`.
+The calling agent's workspace-client auth strategy is honored as-is —
+critically, PAT-auth WCs (built from forwarded user tokens for OBO) are
+accepted without the ``databricks_openai._validate_oauth_for_apps`` gate
+that would otherwise raise. OBO is auto-derived from
+:attr:`DatabricksAppModel.on_behalf_of_user` via
+:meth:`DatabricksAppModel.workspace_client_from`. Strict mode surfaces
+:class:`dao_ai.auth.OBONotAvailableError` when a target asked for OBO but
+no forwarded user token reached the dispatcher.
+
+The HTTP call is inlined here rather than delegated to
 ``create_responses_agent_tool`` / ``create_chat_completions_agent_tool``
-factories — those factories still ship for direct ``type: factory`` use,
-but inter-tool delegation would have required threading
+because inter-tool delegation would have required threading
 LangChain-injected runtime args through two ``ainvoke`` calls. Inline is
 simpler.
 """
@@ -23,13 +33,14 @@ from __future__ import annotations
 from textwrap import dedent
 from typing import Annotated, Any, Optional
 
+import httpx
 import mlflow
 from databricks.sdk import WorkspaceClient
-from databricks_openai import DatabricksOpenAI
 from langchain.tools import ToolRuntime
 from langchain_core.tools import InjectedToolArg, StructuredTool
 from loguru import logger
 
+from dao_ai.auth import WorkspaceBearerAuth
 from dao_ai.config import DatabricksAppModel
 from dao_ai.state import Context
 from dao_ai.tools._api_discovery import (
@@ -66,6 +77,24 @@ def _coerce_app(value: DatabricksAppModel | dict[str, Any]) -> DatabricksAppMode
         f"create_app_dispatcher: 'app' must be a DatabricksAppModel or "
         f"dict, got {type(value).__name__}."
     )
+
+
+def _extract_output_text(envelope: dict[str, Any], api: ApiContract) -> str:
+    """Pull the assistant's reply text from a ResponsesAgentResponse or
+    Chat Completions envelope."""
+    if api == "responses":
+        for item in envelope.get("output") or []:
+            for block in item.get("content") or []:
+                text = block.get("text")
+                if text:
+                    return text
+        return ""
+    # Chat Completions
+    choices = envelope.get("choices") or []
+    if not choices:
+        return ""
+    message = (choices[0] or {}).get("message") or {}
+    return message.get("content") or ""
 
 
 def create_app_dispatcher(
@@ -140,7 +169,11 @@ def create_app_dispatcher(
         runtime: Annotated[ToolRuntime[Context], InjectedToolArg] = None,
     ) -> str:
         context: Context | None = runtime.context if runtime else None
-        ws: WorkspaceClient = coerced_app.workspace_client_from(context)
+        # strict=True so a calling-agent that should be running with OBO but
+        # didn't propagate the forwarded user token surfaces the
+        # misconfiguration here rather than silently calling the target with
+        # the calling app's service-principal identity.
+        ws: WorkspaceClient = coerced_app.workspace_client_from(context, strict=True)
 
         # Resolve api once per tool instance and cache the result. Probe
         # is invoked only if api was unset at config time.
@@ -178,20 +211,26 @@ def create_app_dispatcher(
             )
             tool_span.set_attribute(ATTR_APP_AGENT_PROMPT_CHARS, len(prompt))
 
-        client: DatabricksOpenAI = DatabricksOpenAI(workspace_client=ws)
-        output_text: str
+        # POST directly to <app.url>/invocations using the workspace
+        # client's own auth strategy. Bypasses DatabricksOpenAI's
+        # _validate_oauth_for_apps gate which rejects PAT-auth WCs built
+        # from forwarded user tokens (the OBO path).
+        app_url: str = coerced_app.url.rstrip("/")
+        invocations_url: str = f"{app_url}/invocations"
+        body: dict[str, Any]
         if resolved == "responses":
-            response = client.responses.create(
-                model=model_id,
-                input=[{"role": "user", "content": prompt}],
-            )
-            output_text = response.output_text
+            body = {"input": [{"role": "user", "content": prompt}]}
         else:
-            response = client.chat.completions.create(
-                model=model_id,
-                messages=[{"role": "user", "content": prompt}],
-            )
-            output_text = response.choices[0].message.content or ""
+            body = {"messages": [{"role": "user", "content": prompt}]}
+
+        async with httpx.AsyncClient(
+            auth=WorkspaceBearerAuth(ws), timeout=120
+        ) as client:
+            response = await client.post(invocations_url, json=body)
+            response.raise_for_status()
+            envelope: dict[str, Any] = response.json()
+
+        output_text: str = _extract_output_text(envelope, resolved)
 
         if tool_span is not None:
             tool_span.set_attribute(ATTR_APP_AGENT_RESPONSE_CHARS, len(output_text))

--- a/src/dao_ai/tools/chat_completions_agent.py
+++ b/src/dao_ai/tools/chat_completions_agent.py
@@ -1,14 +1,15 @@
 """Tool factory for calling a Databricks App via OpenAI Chat Completions.
 
-Mirrors :mod:`dao_ai.tools.responses_agent` but uses the OpenAI Chat
-Completions API (``POST /v1/chat/completions``) instead of the Responses
-API. Reachable via ``type: factory`` today; the first-class ``type: agent``
-shape uses the Responses factory by default.
+Mirrors :mod:`dao_ai.tools.responses_agent` but POSTs a Chat Completions
+body shape (``{"messages": [...]}``) to ``<app.url>/invocations`` instead
+of the Responses-API ``{"input": [...]}`` shape. Reachable via
+``type: factory`` today; the first-class ``type: app`` covers the same
+ground with the unified
+:func:`dao_ai.tools.app_agent_dispatcher.create_app_dispatcher`.
 
-The factory wraps :class:`databricks_openai.DatabricksOpenAI` — the official
-OpenAI client subclass that pulls auth from a
-:class:`databricks.sdk.WorkspaceClient`. Routing to the App happens via the
-``model='apps/<name>'`` prefix.
+Uses :class:`dao_ai.auth.WorkspaceBearerAuth` over :class:`httpx.AsyncClient`
+so the calling agent's workspace-client auth strategy (PAT, OAuth M2M /
+U2M, runtime) is honored as-is — no DatabricksOpenAI OAuth gate.
 """
 
 from __future__ import annotations
@@ -16,13 +17,14 @@ from __future__ import annotations
 from textwrap import dedent
 from typing import Annotated, Any, Optional
 
+import httpx
 import mlflow
 from databricks.sdk import WorkspaceClient
-from databricks_openai import DatabricksOpenAI
 from langchain.tools import ToolRuntime
 from langchain_core.tools import InjectedToolArg, StructuredTool
 from loguru import logger
 
+from dao_ai.auth import WorkspaceBearerAuth
 from dao_ai.config import DatabricksAppModel
 from dao_ai.state import Context
 from dao_ai.tools.tracing import (
@@ -134,13 +136,23 @@ def create_chat_completions_agent_tool(
             on_behalf_of_user=coerced_app.on_behalf_of_user,
         )
 
-        ws: WorkspaceClient = coerced_app.workspace_client_from(context)
-        client: DatabricksOpenAI = DatabricksOpenAI(workspace_client=ws)
-        response = client.chat.completions.create(
-            model=model_id,
-            messages=[{"role": "user", "content": prompt}],
-        )
-        content: str = response.choices[0].message.content or ""
+        ws: WorkspaceClient = coerced_app.workspace_client_from(context, strict=True)
+        app_url: str = coerced_app.url.rstrip("/")
+        invocations_url: str = f"{app_url}/invocations"
+        body: dict[str, Any] = {"messages": [{"role": "user", "content": prompt}]}
+
+        async with httpx.AsyncClient(
+            auth=WorkspaceBearerAuth(ws), timeout=120
+        ) as client:
+            response = await client.post(invocations_url, json=body)
+            response.raise_for_status()
+            envelope: dict[str, Any] = response.json()
+
+        choices = envelope.get("choices") or []
+        content: str = ""
+        if choices:
+            message = (choices[0] or {}).get("message") or {}
+            content = message.get("content") or ""
 
         if tool_span is not None:
             tool_span.set_attribute(ATTR_APP_AGENT_RESPONSE_CHARS, len(content))

--- a/src/dao_ai/tools/responses_agent.py
+++ b/src/dao_ai/tools/responses_agent.py
@@ -1,13 +1,15 @@
 """Tool factory for calling a Databricks App via the MLflow Responses API.
 
-The factory wraps :class:`databricks_openai.DatabricksOpenAI` — the official
-OpenAI client subclass that pulls auth from a
-:class:`databricks.sdk.WorkspaceClient`. Routing to the App happens via the
-``model='apps/<name>'`` prefix (the workspace's serving-endpoint proxy
-forwards to the App's ``POST /v1/responses`` route). OBO is auto-derived
-from :attr:`DatabricksAppModel.on_behalf_of_user` via
-:meth:`DatabricksAppModel.workspace_client_from` — no manual header minting,
-no bespoke ``httpx`` code.
+POSTs to ``<app.url>/invocations`` using :class:`httpx.AsyncClient` with
+:class:`dao_ai.auth.WorkspaceBearerAuth`. Auth follows the calling agent's
+workspace-client strategy (PAT, OAuth M2M, OAuth U2M, runtime) without
+extra validation gates — so OBO works whether the calling agent runs as a
+user (forwarded user token) or as the App service principal.
+
+OBO is auto-derived from :attr:`DatabricksAppModel.on_behalf_of_user` via
+:meth:`DatabricksAppModel.workspace_client_from` — strict-mode raises
+:class:`dao_ai.auth.OBONotAvailableError` when the resource asked for OBO
+but no forwarded user token is present in the call context.
 
 For external (non-Databricks) targets or explicit A2A protocol use, see
 :mod:`dao_ai.tools.a2a_agent`. For Model Serving endpoints, see
@@ -19,13 +21,14 @@ from __future__ import annotations
 from textwrap import dedent
 from typing import Annotated, Any, Optional
 
+import httpx
 import mlflow
 from databricks.sdk import WorkspaceClient
-from databricks_openai import DatabricksOpenAI
 from langchain.tools import ToolRuntime
 from langchain_core.tools import InjectedToolArg, StructuredTool
 from loguru import logger
 
+from dao_ai.auth import WorkspaceBearerAuth
 from dao_ai.config import DatabricksAppModel
 from dao_ai.state import Context
 from dao_ai.tools.tracing import (
@@ -154,13 +157,27 @@ def create_responses_agent_tool(
             on_behalf_of_user=coerced_app.on_behalf_of_user,
         )
 
-        ws: WorkspaceClient = coerced_app.workspace_client_from(context)
-        client: DatabricksOpenAI = DatabricksOpenAI(workspace_client=ws)
-        response = client.responses.create(
-            model=model_id,
-            input=[{"role": "user", "content": prompt}],
-        )
-        output_text: str = response.output_text
+        ws: WorkspaceClient = coerced_app.workspace_client_from(context, strict=True)
+        app_url: str = coerced_app.url.rstrip("/")
+        invocations_url: str = f"{app_url}/invocations"
+        body: dict[str, Any] = {"input": [{"role": "user", "content": prompt}]}
+
+        async with httpx.AsyncClient(
+            auth=WorkspaceBearerAuth(ws), timeout=120
+        ) as client:
+            response = await client.post(invocations_url, json=body)
+            response.raise_for_status()
+            envelope: dict[str, Any] = response.json()
+
+        output_text: str = ""
+        for item in envelope.get("output") or []:
+            for block in item.get("content") or []:
+                text = block.get("text")
+                if text:
+                    output_text = text
+                    break
+            if output_text:
+                break
 
         if tool_span is not None:
             tool_span.set_attribute(ATTR_APP_AGENT_RESPONSE_CHARS, len(output_text))

--- a/src/dao_ai/tools/serving_endpoint_dispatcher.py
+++ b/src/dao_ai/tools/serving_endpoint_dispatcher.py
@@ -110,9 +110,12 @@ def create_serving_endpoint_dispatcher(
 
         # Build the WorkspaceClient once per call using the model's own
         # OBO-aware resolver. Used for both discovery and inference.
+        # strict=True so a calling agent that should be running with OBO but
+        # didn't forward the user token raises OBONotAvailableError instead
+        # of silently calling the endpoint as the service principal.
         ws: WorkspaceClient
         if llm.on_behalf_of_user:
-            ws = llm.workspace_client_from(context)
+            ws = llm.workspace_client_from(context, strict=True)
         else:
             ws = WorkspaceClient()
 

--- a/tests/dao_ai/test_app_agent_dispatcher.py
+++ b/tests/dao_ai/test_app_agent_dispatcher.py
@@ -1,13 +1,16 @@
 """Unit tests for :func:`dao_ai.tools.create_app_dispatcher`.
 
-The dispatcher does three things:
+The dispatcher does four things:
 1. Lazily resolves the OpenAI API contract on first invocation.
 2. Caches the resolution for subsequent invocations.
-3. Calls DatabricksOpenAI.responses.create OR
-   DatabricksOpenAI.chat.completions.create based on the resolved api.
+3. POSTs to ``<app.url>/invocations`` using ``httpx.AsyncClient`` with
+   :class:`WorkspaceBearerAuth`, bypassing the ``databricks_openai`` OAuth
+   gate that breaks PAT-auth WCs.
+4. Surfaces ``OBONotAvailableError`` when the calling agent should be in
+   OBO mode but didn't propagate the forwarded user token.
 
-Tests monkeypatch DatabricksOpenAI + discover_app_agent_api +
-DatabricksAppModel.workspace_client_from so no network is needed.
+Tests monkeypatch ``httpx.AsyncClient`` + ``discover_app_agent_api`` +
+``DatabricksAppModel.workspace_client_from`` so no network is needed.
 """
 
 from __future__ import annotations
@@ -18,7 +21,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from dao_ai.auth import OBONotAvailableError
 from dao_ai.config import DatabricksAppModel
+from dao_ai.state import Context
 from dao_ai.tools._api_discovery import ApiContract
 from dao_ai.tools.app_agent_dispatcher import create_app_dispatcher
 
@@ -28,79 +33,82 @@ from dao_ai.tools.app_agent_dispatcher import create_app_dispatcher
 
 
 class _StubResponse:
-    def __init__(self, output_text: str = "stub-response") -> None:
-        self.output_text: str = output_text
+    """httpx.Response stub."""
+
+    def __init__(self, json_payload: dict[str, Any], status_code: int = 200) -> None:
+        self._json = json_payload
+        self.status_code = status_code
+
+    def json(self) -> dict[str, Any]:
+        return self._json
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
 
 
-class _StubResponses:
-    def __init__(self) -> None:
-        self.calls: list[dict[str, Any]] = []
+class _StubAsyncClient:
+    """httpx.AsyncClient stub. Records every .post call."""
 
-    def create(self, **kwargs: Any) -> _StubResponse:
-        self.calls.append(kwargs)
-        return _StubResponse(f"resp:{kwargs.get('input')[0]['content']}")
+    instances: list["_StubAsyncClient"] = []
 
+    def __init__(self, **kwargs: Any) -> None:
+        self.init_kwargs: dict[str, Any] = kwargs
+        self.posts: list[dict[str, Any]] = []
+        # Pre-configured envelope; tests may override via instance.envelope_for
+        self.envelope_for: dict[str, dict[str, Any]] = {}
+        _StubAsyncClient.instances.append(self)
 
-class _StubMessage:
-    def __init__(self, content: str) -> None:
-        self.content: str = content
+    async def __aenter__(self) -> "_StubAsyncClient":
+        return self
 
+    async def __aexit__(self, *_exc: Any) -> None:
+        return None
 
-class _StubChoice:
-    def __init__(self, content: str) -> None:
-        self.message: _StubMessage = _StubMessage(content)
-
-
-class _StubChatCompletion:
-    def __init__(self, content: str) -> None:
-        self.choices: list[_StubChoice] = [_StubChoice(content)]
-
-
-class _StubChatCompletions:
-    def __init__(self) -> None:
-        self.calls: list[dict[str, Any]] = []
-
-    def create(self, **kwargs: Any) -> _StubChatCompletion:
-        self.calls.append(kwargs)
-        return _StubChatCompletion(f"chat:{kwargs.get('messages')[0]['content']}")
-
-
-class _StubChat:
-    def __init__(self) -> None:
-        self.completions: _StubChatCompletions = _StubChatCompletions()
-
-
-class _StubDatabricksOpenAI:
-    """Stub that records calls; both `.responses` and `.chat.completions`."""
-
-    instances: list["_StubDatabricksOpenAI"] = []
-
-    def __init__(self, **_kwargs: Any) -> None:
-        self.responses: _StubResponses = _StubResponses()
-        self.chat: _StubChat = _StubChat()
-        _StubDatabricksOpenAI.instances.append(self)
+    async def post(self, url: str, *, json: dict[str, Any], **_kw: Any) -> _StubResponse:
+        self.posts.append({"url": url, "json": json})
+        # If a test pre-loaded a response, use it. Otherwise echo the prompt
+        # in a Responses-API-shaped envelope.
+        if url in self.envelope_for:
+            return _StubResponse(self.envelope_for[url])
+        prompt: str = ""
+        if json.get("input"):
+            prompt = json["input"][0].get("content", "")
+        elif json.get("messages"):
+            prompt = json["messages"][0].get("content", "")
+        # Echo back a Responses-shaped envelope by default.
+        if "messages" in json:
+            envelope = {
+                "choices": [{"message": {"content": f"chat:{prompt}"}}]
+            }
+        else:
+            envelope = {
+                "output": [{"content": [{"text": f"resp:{prompt}"}]}]
+            }
+        return _StubResponse(envelope)
 
 
 @pytest.fixture(autouse=True)
 def reset_stub_instances() -> None:
-    _StubDatabricksOpenAI.instances.clear()
+    _StubAsyncClient.instances.clear()
 
 
 @pytest.fixture
-def stub_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+def stub_httpx(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        "dao_ai.tools.app_agent_dispatcher.DatabricksOpenAI",
-        _StubDatabricksOpenAI,
+        "dao_ai.tools.app_agent_dispatcher.httpx.AsyncClient",
+        _StubAsyncClient,
     )
 
 
 @pytest.fixture
 def stub_workspace_client(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     fake_ws: MagicMock = MagicMock(name="WorkspaceClient")
+    fake_ws.config.authenticate.return_value = {"Authorization": "Bearer stub-token"}
     monkeypatch.setattr(
         DatabricksAppModel,
         "workspace_client_from",
-        lambda self, context: fake_ws,
+        lambda self, context, *, strict=False: fake_ws,
     )
     # Also stub the .url property so the dispatcher's probe-lambda
     # doesn't trigger a real `apps.get()` SDK call on first invoke.
@@ -155,9 +163,9 @@ class TestFactoryOutput:
 
 
 class TestExplicitApiSkipsProbe:
-    def test_explicit_responses_calls_responses_create_and_skips_probe(
+    def test_explicit_responses_posts_input_body_and_skips_probe(
         self,
-        stub_openai: None,
+        stub_httpx: None,
         stub_workspace_client: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -174,15 +182,16 @@ class TestExplicitApiSkipsProbe:
 
         assert result == "resp:hi"
         assert probe_calls == []  # CRITICAL: no probe when explicit
-        # responses.create was called; chat.completions.create was NOT
-        instance = _StubDatabricksOpenAI.instances[0]
-        assert len(instance.responses.calls) == 1
-        assert instance.responses.calls[0]["model"] == "apps/explicit-resp"
-        assert len(instance.chat.completions.calls) == 0
+        instance = _StubAsyncClient.instances[0]
+        assert len(instance.posts) == 1
+        assert instance.posts[0]["url"] == "https://explicit-resp.test/invocations"
+        # Responses API uses {"input": [...]} body shape.
+        assert "input" in instance.posts[0]["json"]
+        assert "messages" not in instance.posts[0]["json"]
 
-    def test_explicit_completions_calls_chat_completions_create_and_skips_probe(
+    def test_explicit_completions_posts_messages_body_and_skips_probe(
         self,
-        stub_openai: None,
+        stub_httpx: None,
         stub_workspace_client: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -199,10 +208,10 @@ class TestExplicitApiSkipsProbe:
 
         assert result == "chat:hi"
         assert probe_calls == []
-        instance = _StubDatabricksOpenAI.instances[0]
-        assert len(instance.chat.completions.calls) == 1
-        assert instance.chat.completions.calls[0]["model"] == "apps/explicit-cc"
-        assert len(instance.responses.calls) == 0
+        instance = _StubAsyncClient.instances[0]
+        # Chat Completions uses {"messages": [...]} body shape.
+        assert "messages" in instance.posts[0]["json"]
+        assert "input" not in instance.posts[0]["json"]
 
 
 # ---------------------------------------------------------------------------
@@ -213,18 +222,19 @@ class TestExplicitApiSkipsProbe:
 class TestDiscoveryResolvesApi:
     def test_probe_returns_responses_routes_to_responses(
         self,
-        stub_openai: None,
+        stub_httpx: None,
         stub_workspace_client: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         _set_probe(monkeypatch, "responses")
         tool = create_app_dispatcher(DatabricksAppModel(name="probed-app"))
         asyncio.run(tool.ainvoke({"prompt": "hi"}))
-        assert len(_StubDatabricksOpenAI.instances[0].responses.calls) == 1
+        instance = _StubAsyncClient.instances[0]
+        assert "input" in instance.posts[0]["json"]
 
     def test_probe_returns_none_falls_back_to_default_responses(
         self,
-        stub_openai: None,
+        stub_httpx: None,
         stub_workspace_client: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -234,11 +244,12 @@ class TestDiscoveryResolvesApi:
             default_api="responses",
         )
         asyncio.run(tool.ainvoke({"prompt": "hi"}))
-        assert len(_StubDatabricksOpenAI.instances[0].responses.calls) == 1
+        instance = _StubAsyncClient.instances[0]
+        assert "input" in instance.posts[0]["json"]
 
     def test_probe_returns_none_default_completions_routes_to_chat(
         self,
-        stub_openai: None,
+        stub_httpx: None,
         stub_workspace_client: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -248,7 +259,8 @@ class TestDiscoveryResolvesApi:
             default_api="completions",
         )
         asyncio.run(tool.ainvoke({"prompt": "hi"}))
-        assert len(_StubDatabricksOpenAI.instances[0].chat.completions.calls) == 1
+        instance = _StubAsyncClient.instances[0]
+        assert "messages" in instance.posts[0]["json"]
 
 
 # ---------------------------------------------------------------------------
@@ -259,7 +271,7 @@ class TestDiscoveryResolvesApi:
 class TestProbeCaching:
     def test_probe_runs_only_once_across_invocations(
         self,
-        stub_openai: None,
+        stub_httpx: None,
         stub_workspace_client: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -276,5 +288,104 @@ class TestProbeCaching:
         asyncio.run(tool.ainvoke({"prompt": "first"}))
         asyncio.run(tool.ainvoke({"prompt": "second"}))
         asyncio.run(tool.ainvoke({"prompt": "third"}))
-
         assert len(probe_count) == 1  # probe cached after first call
+
+
+# ---------------------------------------------------------------------------
+# Strict-mode OBO surfacing (matrix cell #10 close-out)
+# ---------------------------------------------------------------------------
+
+
+class TestStrictModeOBO:
+    def test_obo_target_no_forwarded_token_raises(
+        self,
+        stub_httpx: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Cell #10: target.on_behalf_of_user=true + no forwarded token in context."""
+
+        _set_probe(monkeypatch, "responses")
+        # Stub the URL so the (never-reached) discovery branch wouldn't crash.
+        monkeypatch.setattr(
+            DatabricksAppModel,
+            "url",
+            property(lambda self: f"https://{self.name}.test"),
+        )
+        # DO NOT stub workspace_client_from — let the real implementation
+        # raise OBONotAvailableError when strict=True + on_behalf_of_user=true
+        # + no headers in context.
+        app_model = DatabricksAppModel(name="obo-app", on_behalf_of_user=True)
+        tool = create_app_dispatcher(app_model)
+
+        # ToolRuntime.context.headers is None when the caller didn't propagate.
+        # The dispatcher itself extracts context via runtime.context, so the
+        # cleanest way to assert is via tool.coroutine directly with an empty
+        # runtime stub.
+        runtime = MagicMock()
+        runtime.context = Context(headers=None)
+
+        with pytest.raises(OBONotAvailableError) as exc_info:
+            asyncio.run(tool.coroutine(prompt="hi", runtime=runtime))
+        assert "obo-app" in str(exc_info.value) or exc_info.value.resource_name == "obo-app"
+
+    def test_obo_target_with_forwarded_token_succeeds(
+        self,
+        stub_httpx: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Cell #1 happy path: target OBO + forwarded token present → tool runs."""
+
+        _set_probe(monkeypatch, "responses")
+        monkeypatch.setattr(
+            DatabricksAppModel,
+            "url",
+            property(lambda self: f"https://{self.name}.test"),
+        )
+        # Stub workspace_client_from to behave as the real implementation
+        # would with valid headers: return a WC instance.
+        fake_ws = MagicMock()
+        fake_ws.config.authenticate.return_value = {"Authorization": "Bearer u-token"}
+
+        def _ws_from(self, context, *, strict=False) -> Any:
+            # If strict and OBO and no token, raise — same shape as real impl
+            if strict and self.on_behalf_of_user:
+                headers = (context.headers if context else None) or {}
+                if not headers.get("x-forwarded-access-token"):
+                    raise OBONotAvailableError(resource_name=self.name)
+            return fake_ws
+
+        monkeypatch.setattr(DatabricksAppModel, "workspace_client_from", _ws_from)
+
+        app_model = DatabricksAppModel(name="obo-ok", on_behalf_of_user=True)
+        tool = create_app_dispatcher(app_model)
+        runtime = MagicMock()
+        runtime.context = Context(
+            headers={"x-forwarded-access-token": "u-token"}
+        )
+
+        result = asyncio.run(tool.coroutine(prompt="hola", runtime=runtime))
+        assert result == "resp:hola"
+
+
+# ---------------------------------------------------------------------------
+# Auth header propagation
+# ---------------------------------------------------------------------------
+
+
+class TestAuthHeaderPropagation:
+    def test_workspace_bearer_auth_is_used(
+        self,
+        stub_httpx: None,
+        stub_workspace_client: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Confirm the httpx.AsyncClient was constructed with WorkspaceBearerAuth."""
+
+        _set_probe(monkeypatch, "responses")
+        tool = create_app_dispatcher(DatabricksAppModel(name="auth-app"))
+        asyncio.run(tool.ainvoke({"prompt": "hi"}))
+        instance = _StubAsyncClient.instances[0]
+        auth = instance.init_kwargs.get("auth")
+        assert auth is not None
+        # WorkspaceBearerAuth holds the workspace_client by attribute.
+        assert hasattr(auth, "_workspace_client")

--- a/tests/dao_ai/test_auth_workspace_bearer.py
+++ b/tests/dao_ai/test_auth_workspace_bearer.py
@@ -1,0 +1,74 @@
+"""Unit tests for :mod:`dao_ai.auth`."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from dao_ai.auth import OBONotAvailableError, WorkspaceBearerAuth
+
+
+class TestWorkspaceBearerAuth:
+    def test_injects_authorization_header_from_workspace_client(self) -> None:
+        ws = MagicMock()
+        ws.config.authenticate.return_value = {"Authorization": "Bearer token-x"}
+        auth = WorkspaceBearerAuth(ws)
+
+        request = httpx.Request("POST", "https://example.test/invocations")
+        flow = auth.auth_flow(request)
+        prepared = next(flow)
+        assert prepared.headers["Authorization"] == "Bearer token-x"
+
+    def test_calls_authenticate_on_every_request(self) -> None:
+        """Token refresh: the callable is invoked per request, not cached."""
+        ws = MagicMock()
+        ws.config.authenticate.return_value = {"Authorization": "Bearer t1"}
+        auth = WorkspaceBearerAuth(ws)
+
+        r1 = httpx.Request("GET", "https://e.test/a")
+        r2 = httpx.Request("GET", "https://e.test/b")
+        next(auth.auth_flow(r1))
+        next(auth.auth_flow(r2))
+        assert ws.config.authenticate.call_count == 2
+
+    def test_works_for_oauth_m2m_strategy(self) -> None:
+        """The auth class doesn't care about auth_type — just reads the header."""
+        ws = MagicMock()
+        ws.config.authenticate.return_value = {"Authorization": "Bearer m2m-oauth"}
+        ws.config.auth_type = "oauth-m2m"
+        auth = WorkspaceBearerAuth(ws)
+        prepared = next(auth.auth_flow(httpx.Request("POST", "https://e.test/")))
+        assert prepared.headers["Authorization"] == "Bearer m2m-oauth"
+
+    def test_works_for_pat_strategy(self) -> None:
+        """The auth class also accepts PAT-auth WCs — the original databricks_openai
+        BearerAuth gate is NOT applied here, by design."""
+        ws = MagicMock()
+        ws.config.authenticate.return_value = {"Authorization": "Bearer pat-token"}
+        ws.config.auth_type = "pat"
+        auth = WorkspaceBearerAuth(ws)
+        prepared = next(auth.auth_flow(httpx.Request("POST", "https://e.test/")))
+        assert prepared.headers["Authorization"] == "Bearer pat-token"
+
+
+class TestOBONotAvailableError:
+    def test_message_includes_resource_name_when_supplied(self) -> None:
+        err = OBONotAvailableError(resource_name="my-app")
+        assert "my-app" in str(err)
+        assert err.resource_name == "my-app"
+
+    def test_message_includes_field_when_supplied(self) -> None:
+        err = OBONotAvailableError(field="DatabricksAppModel.on_behalf_of_user")
+        assert "DatabricksAppModel.on_behalf_of_user" in str(err)
+        assert err.field == "DatabricksAppModel.on_behalf_of_user"
+
+    def test_message_works_without_optional_args(self) -> None:
+        err = OBONotAvailableError()
+        assert "on_behalf_of_user" in str(err)
+
+    def test_is_a_value_error(self) -> None:
+        """Subclasses ValueError so callers can catch broadly if they want."""
+        with pytest.raises(ValueError):
+            raise OBONotAvailableError(resource_name="r")

--- a/tests/dao_ai/test_workspace_client_from_strict_mode.py
+++ b/tests/dao_ai/test_workspace_client_from_strict_mode.py
@@ -1,0 +1,102 @@
+"""Unit tests for the ``strict`` kwarg on ``IsDatabricksResource.workspace_client_from``."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dao_ai.auth import OBONotAvailableError
+from dao_ai.config import DatabricksAppModel, LLMModel
+from dao_ai.state import Context
+
+
+def _ws_with_authenticate(token: str = "Bearer ambient") -> MagicMock:
+    ws = MagicMock(name="WorkspaceClient")
+    ws.config.authenticate.return_value = {"Authorization": token}
+    return ws
+
+
+class TestStrictModeOBO:
+    def test_strict_true_raises_when_obo_set_and_no_context(self) -> None:
+        """`strict=True` + on_behalf_of_user + context=None → raise."""
+        model = DatabricksAppModel(name="r1", on_behalf_of_user=True)
+        with patch.object(
+            DatabricksAppModel,
+            "workspace_client",
+            new=_ws_with_authenticate(),
+        ), pytest.raises(OBONotAvailableError) as exc:
+            model.workspace_client_from(None, strict=True)
+        assert exc.value.resource_name == "r1"
+
+    def test_strict_true_raises_when_obo_set_and_context_has_no_headers(self) -> None:
+        model = DatabricksAppModel(name="r2", on_behalf_of_user=True)
+        ctx = Context(headers=None)
+        with patch.object(
+            DatabricksAppModel,
+            "workspace_client",
+            new=_ws_with_authenticate(),
+        ), pytest.raises(OBONotAvailableError):
+            model.workspace_client_from(ctx, strict=True)
+
+    def test_strict_true_raises_when_headers_missing_forwarded_token(self) -> None:
+        model = DatabricksAppModel(name="r3", on_behalf_of_user=True)
+        ctx = Context(headers={"unrelated-header": "value"})
+        with patch.object(
+            DatabricksAppModel,
+            "workspace_client",
+            new=_ws_with_authenticate(),
+        ), pytest.raises(OBONotAvailableError):
+            model.workspace_client_from(ctx, strict=True)
+
+    def test_strict_true_succeeds_when_forwarded_token_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Happy path: strict=True + OBO + token → builds a PAT-auth WC.
+
+        Patches WorkspaceClient construction so the SDK doesn't try DNS
+        host-metadata resolution against a fake hostname.
+        """
+        model = DatabricksAppModel(name="r4", on_behalf_of_user=True)
+        ctx = Context(headers={"x-forwarded-access-token": "user-token-xyz"})
+
+        captured_kwargs: dict = {}
+
+        def fake_ws_init(**kwargs):
+            captured_kwargs.update(kwargs)
+            return MagicMock(name="OBO-WC")
+
+        monkeypatch.setattr("dao_ai.config.WorkspaceClient", fake_ws_init)
+
+        ws = model.workspace_client_from(ctx, strict=True)
+        assert ws is not None
+        # Confirm the right auth shape was passed to WorkspaceClient(...)
+        assert captured_kwargs["token"] == "user-token-xyz"
+        assert captured_kwargs["auth_type"] == "pat"
+
+    def test_strict_true_with_obo_false_falls_back(self) -> None:
+        """When the resource doesn't ask for OBO, strict has no effect."""
+        model = DatabricksAppModel(name="r5", on_behalf_of_user=False)
+        fake_ws = _ws_with_authenticate()
+        with patch.object(DatabricksAppModel, "workspace_client", new=fake_ws):
+            ws = model.workspace_client_from(None, strict=True)
+        assert ws is fake_ws
+
+    def test_strict_false_silently_falls_back_when_obo_set_no_token(self) -> None:
+        """Default lenient behavior preserved when strict=False (the default)."""
+        model = DatabricksAppModel(name="r6", on_behalf_of_user=True)
+        fake_ws = _ws_with_authenticate()
+        with patch.object(DatabricksAppModel, "workspace_client", new=fake_ws):
+            # Note: no strict kwarg → defaults to False
+            ws = model.workspace_client_from(None)
+        # Falls back silently — historical behavior preserved
+        assert ws is fake_ws
+
+
+class TestStrictModeAppliesAcrossResources:
+    """The strict kwarg is on IsDatabricksResource so every resource subclass inherits it."""
+
+    def test_llm_model_inherits_strict_mode(self) -> None:
+        llm = LLMModel(name="endpoint-x", on_behalf_of_user=True)
+        with pytest.raises(OBONotAvailableError):
+            llm.workspace_client_from(None, strict=True)


### PR DESCRIPTION
## Summary

Fixes the `type: app` + OBO regression surfaced by `dao-ai-workshop/L300-advanced/lab-25-agent-as-tool/` (workshop PR #11). The user-facing bug: every `type: app` tool call from one Databricks App to another raised `ValueError: Querying Databricks Apps requires OAuth authentication` because `app_agent_dispatcher.py:181` wrapped the workspace client in `DatabricksOpenAI`, whose `_validate_oauth_for_apps` gate (`databricks_openai/utils/clients.py:150`) rejects PAT-auth WCs — and PAT-auth is exactly what `IsDatabricksResource.workspace_client_from` builds from the forwarded user token.

Approach:

- **New `src/dao_ai/auth.py`** ships `WorkspaceBearerAuth(httpx.Auth)` — same pattern as `databricks_openai.BearerAuth` (clients.py:27-34) but without the OAuth-strategy gate that breaks PAT-auth WCs — plus `OBONotAvailableError(ValueError)`.
- **`config.py`** — `workspace_client_from` gains a `strict: bool = False` kwarg. When `strict=True` and the resource asks for OBO but no forwarded token is in context, raises `OBONotAvailableError(resource_name=..., field=...)`. Default stays `False` for backwards-compat at the existing call sites.
- **`app_agent_dispatcher.py`, `responses_agent.py`, `chat_completions_agent.py`** — drop `DatabricksOpenAI`. POST directly to `<app.url>/invocations` using `httpx.AsyncClient(auth=WorkspaceBearerAuth(ws))`. Same `resolve_api` + lazy `/agent/info` discovery + tracing attributes preserved. All three pass `strict=True`.
- **`serving_endpoint_dispatcher.py`, `agent.py`** — keep `ChatDatabricks` (no gate, gives streaming + callbacks for free); just add `strict=True`.

## Live verification on fevm

Deployed both apps via `dao-ai generate-bundle --development --force` (bundles the local patched wheel) and exercised four (caller-OBO × target-OBO) combinations against `type: app`:

| Cell | Caller `default_llm.on_behalf_of_user` | Target `apps.<name>.on_behalf_of_user` | Pre-fix | Post-fix |
|---|---|---|---|---|
| #1 | true | true | ❌ OAuth gate raised | ✅ 200 OK |
| #2 | true | false | ⚠️ untested platform grant | ✅ 200 OK |
| #10 | false | true | "silent footgun" | ✅ 200 OK |
| #11 | false | false | ⚠️ untested platform grant | ✅ 200 OK |

Apps deployed for the verification (still running on fevm):
`translator-nf-obofix`, `greeter-nf-obofix`, `greeter-nf-obofix-c2`, `greeter-nf-obofix-c10b`, `greeter-nf-obofix-c11`. Zero `OAuth authentication` errors in any greeter's logs. The original error from unpatched dao-ai 0.1.98 is gone.

### One mental-model correction (and the docstring update)

I initially asserted that cell #10 (caller `on_behalf_of_user: false` + target `on_behalf_of_user: true`) would raise `OBONotAvailableError`. Live testing showed it returns 200 OK — the **Databricks Apps proxy forwards `x-forwarded-access-token` unconditionally on every authenticated user request, regardless of the calling agent's `default_llm.on_behalf_of_user` flag**. So the dispatcher sees the token, strict-mode doesn't fire, and the user identity reaches the Translator. The calling agent's OBO flag controls which identity the LLM call inside that agent runs as (via `OBOModelMiddleware`), not the headers the dispatcher sees.

`workspace_client_from`'s docstring now spells this out: strict-mode raises in Model Serving deploys (no Apps proxy → genuine absence of the forwarded header) and in M2M-only contexts; it's effectively a no-op inside Apps. Unit tests cover the strict-mode raise path correctly (they construct `Context(headers=None)` directly).

## Tests

- `tests/dao_ai/test_auth_workspace_bearer.py` (NEW, 8 tests) — `WorkspaceBearerAuth` honors every auth strategy (PAT, OAuth-M2M); `OBONotAvailableError` carries `resource_name`/`field` and subclasses `ValueError`.
- `tests/dao_ai/test_workspace_client_from_strict_mode.py` (NEW, 7 tests) — `strict=True` raises in every "OBO requested but no token" branch; happy path produces a PAT-auth WC; default (`strict=False`) preserves historical lenient behavior; inherits across `IsDatabricksResource` subclasses.
- `tests/dao_ai/test_app_agent_dispatcher.py` (REWRITTEN, 12 tests) — stubs switched from mocked `DatabricksOpenAI` to mocked `httpx.AsyncClient`. Factory output, explicit-api precedence, discovery, caching coverage preserved; added strict-mode cell-#10 raise + happy-path cell-#1 with forwarded token + auth-header propagation.
- 116 OBO-related tests across the new + existing suites all pass.

## Test plan
- [x] `uv run pytest tests/dao_ai/test_auth_workspace_bearer.py tests/dao_ai/test_workspace_client_from_strict_mode.py tests/dao_ai/test_app_agent_dispatcher.py tests/dao_ai/test_agent_endpoint_tool.py tests/dao_ai/test_rest_api_tool.py tests/dao_ai/test_serving_endpoint_dispatcher.py tests/test_mcp_app_auth.py tests/dao_ai/test_a2a_tool.py tests/dao_ai/test_a2a_agent_card.py` → 116/116 pass
- [x] `uv run pytest tests/ --ignore=tests/dao_ai/test_apps_obo_partition.py` → green (5 env-dependent errors in `test_apps_obo_partition.py::TestSportingGoodsSdk*` and `::TestSportingGoodsConfigPartition*` are pre-existing on main; need a workspace auth context to substitute `${workspace.*}`)
- [x] Live verification on fevm with `--development` bundle: 4-cell matrix all 200 OK; greeter app logs free of `OAuth authentication` errors
- [x] Greeter logs show the dispatcher reaches `POST /invocations 200 OK` against the Translator (replaces the previous `Error in graph invocation | error=Querying Databricks Apps requires OAuth authentication`)

## Follow-ups (NOT in this PR)

- **Workshop lab graduation.** Once a dao-ai release with this fix is cut, drop the regression-test banner from `dao-ai-workshop/L300-advanced/lab-25-agent-as-tool/README.md`.
- **Strict-mode sweep for non-agent tools.** UC functions, Genie, Vector Search, REST, Slack, MS Teams, MCP, SQL warehouse, instructed retriever still call `workspace_client_from(context)` without `strict=True`. Same silent-footgun pattern, scoped out of this PR per the agreed matrix.
- **Cross-app SP grant propagation** (cells #2 / #11) — turned out to work fine on fevm. Original concern resolved by this verification.

This pull request and its description were written by Isaac.