### PR TITLE
feat(apps): add app.space for Databricks App Spaces assignment

### DIFF
--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -918,6 +918,19 @@
           "description": "Databricks budget policy ID for cost attribution.",
           "title": "Budget Policy Id"
         },
+        "space": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of an existing Databricks App Space to assign this app to. Spaces govern shared resources, user_api_scopes, and the runtime service principal across multiple apps. App Spaces is currently in Private Preview; the space must already exist in the target workspace (create via Terraform `databricks_app_space` or `WorkspaceClient.apps.create_space()`). dao-ai does not create spaces.",
+          "title": "Space"
+        },
         "workload_size": {
           "anyOf": [
             {

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -452,6 +452,9 @@ def _build_app_block(
     if user_api_scopes:
         app_def["user_api_scopes"] = user_api_scopes
 
+    if config.app.space:
+        app_def["space"] = config.app.space
+
     experiments_block: dict[str, Any] = {
         experiment_key: {
             "name": f"/Users/${{workspace.current_user.userName}}/{app_name}",

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -7603,6 +7603,17 @@ class AppModel(BaseModel):
         default=None,
         description="Databricks budget policy ID for cost attribution.",
     )
+    space: Optional[str] = Field(
+        default=None,
+        description=(
+            "Name of an existing Databricks App Space to assign this app to. "
+            "Spaces govern shared resources, user_api_scopes, and the runtime "
+            "service principal across multiple apps. App Spaces is currently in "
+            "Private Preview; the space must already exist in the target workspace "
+            "(create via Terraform `databricks_app_space` or "
+            "`WorkspaceClient.apps.create_space()`). dao-ai does not create spaces."
+        ),
+    )
     workload_size: Optional[WorkloadSize] = Field(
         default="Small",
         description="Model Serving workload size (Small, Medium, Large).",

--- a/tests/dao_ai/test_bundle_app_space.py
+++ b/tests/dao_ai/test_bundle_app_space.py
@@ -1,0 +1,57 @@
+"""Bundle emission tests for ``AppModel.space`` (Databricks App Spaces).
+
+Locks in the contract that ``_build_app_block`` emits
+``resources.apps.<name>.space`` only when ``app.space`` is set, matching the
+DABs schema (CLI v1.3.0) where ``space`` is a private-preview string field on
+the App resource.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dao_ai.apps.bundle import _build_app_block
+from dao_ai.config import (
+    AgentModel,
+    AppConfig,
+    AppModel,
+    DeploymentTarget,
+    InferenceEndpointModel,
+)
+
+
+def _config(*, space: str | None = None) -> AppConfig:
+    extra: dict = {}
+    if space is not None:
+        extra["space"] = space
+    return AppConfig(
+        app=AppModel(
+            name="dao-ai-space-test",
+            description="test agent",
+            deployment_target=DeploymentTarget.APPS,
+            enable_chat_proxy=False,
+            agents=[
+                AgentModel(
+                    name="greeter",
+                    description="test agent",
+                    model=InferenceEndpointModel(name="databricks-gpt-5-4-mini"),
+                )
+            ],
+            **extra,
+        ),
+    )
+
+
+@pytest.mark.unit
+class TestAppSpaceEmission:
+    def test_omits_space_when_unset(self) -> None:
+        _, _, apps_block = _build_app_block(_config(), "dao_ai.yaml")
+        (app_def,) = apps_block.values()
+        assert "space" not in app_def
+
+    def test_emits_space_when_set(self) -> None:
+        _, _, apps_block = _build_app_block(
+            _config(space="retail-builders"), "dao_ai.yaml"
+        )
+        (app_def,) = apps_block.values()
+        assert app_def["space"] == "retail-builders"


### PR DESCRIPTION
## Summary

- Adds optional `AppModel.space: Optional[str]` field; bundle generator forwards it to `resources.apps.<name>.space` in the emitted `resources/app.yml`, assigning the deployed app to a pre-existing Databricks App Space (Private Preview, announced at DAIS 2026).
- Assignment-only — dao-ai does not create spaces. The DABs schema (CLI v1.3.0) does not yet support `resources.app_spaces.*`, so spaces must be pre-provisioned via Terraform (`databricks_app_space`) or the Python SDK (`WorkspaceClient.apps.create_space()`).
- Field is `Optional[str]` defaulting to `None`; emission is gated by `if config.app.space:` so the YAML stays unchanged for the 99% of users not enrolled in the preview.

## Test plan

- [x] `uv run pytest tests/dao_ai/test_bundle_app_space.py` — 2/2 pass (omitted-when-unset, emitted-when-set)
- [x] `uv run pytest tests/dao_ai/test_a2a_routes.py tests/dao_ai/test_bundle_requirements_txt.py tests/dao_ai/test_config_vars.py` — 83/83 pass, no regressions
- [x] `uv run dao-ai generate-bundle --force --development --config <minimal.yaml with app.space>` — `grep space: resources/app.yml` returns `space: dao-ai-test-space`
- [x] Same without `app.space` set — no `space:` line emitted
- [x] `uv run dao-ai schema > schemas/model_config_schema.json` — regenerated; diff is exactly the new field
- [ ] End-to-end deploy against a preview-enrolled workspace: `databricks --profile fevm apps create-space ...` → `databricks bundle deploy` → `apps get` confirms `space` field matches

This pull request and its description were written by Isaac.