### PR TITLE
refactor(ai-gateway): replace AIGatewayChatOpenAI with ChatUnityAIGateway

### DIFF
--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -54,7 +54,6 @@ from langchain_core.embeddings import Embeddings
 from langchain_core.language_models import LanguageModelLike
 from langchain_core.messages import BaseMessage, messages_from_dict
 from langchain_core.runnables.base import RunnableLike
-from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.store.base import BaseStore
@@ -899,38 +898,26 @@ class BestOfNConfig(BaseModel):
         return v
 
 
-class AIGatewayChatOpenAI(ChatOpenAI):
-    """ChatOpenAI variant for the Databricks AI Gateway.
+class ChatUnityAIGateway(ChatDatabricks):
+    """``ChatDatabricks`` subclass routed through the Databricks AI Gateway.
 
-    The Gateway's OpenAI-compatible validator rejects ``name`` on
-    ``user`` / ``assistant`` / ``system`` messages with::
+    Functionally identical to ``ChatDatabricks(use_ai_gateway=True)`` — exists
+    so that MLflow trace spans surface a distinct class name (LangChain's
+    MLflow autolog labels spans by ``self.__class__.__name__``) and so
+    ``_llm_type`` reports a distinct identifier, making AI-Gateway-routed
+    calls visually distinguishable from plain ``ChatDatabricks`` calls in
+    the trace UI.
 
-        400 BAD_REQUEST: messages.N.name: Extra inputs are not permitted
-
-    LangGraph's supervisor pattern attaches a ``name`` field to agent
-    AIMessages for routing (see
-    :func:`dao_ai.orchestration.core.filter_messages_for_agent`), so we
-    strip it at the request-payload boundary instead of in orchestration
-    where it carries real semantics for ChatDatabricks and other backends.
-    ``role: "tool"`` / ``role: "function"`` messages are left untouched.
+    The historical ``name``-field strip workaround is no longer needed:
+    ``ChatDatabricks._convert_message_to_dict`` already drops the ``name``
+    field at the request-payload boundary (databricks-langchain >= 0.20).
     """
 
-    def _get_request_payload(
-        self,
-        input_: Any,
-        *,
-        stop: Optional[list[str]] = None,
-        **kwargs: Any,
-    ) -> dict:
-        payload: dict = super()._get_request_payload(input_, stop=stop, **kwargs)
-        for msg in payload.get("messages", []) or []:
-            if isinstance(msg, dict) and msg.get("role") in (
-                "user",
-                "assistant",
-                "system",
-            ):
-                msg.pop("name", None)
-        return payload
+    use_ai_gateway: bool = True
+
+    @property
+    def _llm_type(self) -> str:
+        return "chat-unity-ai-gateway"
 
 
 class InferenceEndpointModel(IsDatabricksResource):
@@ -1036,38 +1023,6 @@ class InferenceEndpointModel(IsDatabricksResource):
         # OBO token, gate it here with a ValueError.
         return self
 
-    def _ai_gateway_host(self) -> str:
-        """Return the workspace host without trailing slash."""
-        from dao_ai.utils import normalize_host
-
-        return normalize_host(self.workspace_client.config.host).rstrip("/")
-
-    def _ai_gateway_token_provider(self) -> Callable[[], str]:
-        """Return a callable that resolves a fresh bearer token per call.
-
-        ``ChatOpenAI`` / the ``openai`` SDK invoke this provider on every
-        request, so PAT, service-principal (OAuth-M2M), and OBO tokens are
-        always refreshed through the SDK's auth ladder instead of being
-        captured once at construction time.
-        """
-        wc: WorkspaceClient = self.workspace_client
-
-        def _provider() -> str:
-            headers: Mapping[str, str] = wc.config.authenticate()
-            auth: str = headers.get("Authorization", "")
-            if not auth.lower().startswith("bearer "):
-                raise RuntimeError(
-                    f"Could not extract bearer token for {self.name!r}; "
-                    f"authenticate() returned keys: {list(headers)}"
-                )
-            return auth.split(" ", 1)[1]
-
-        return _provider
-
-    def _resolve_ai_gateway_credentials(self) -> tuple[str, Callable[[], str]]:
-        """Return ``(host, token_provider)`` for AI Gateway HTTP calls."""
-        return self._ai_gateway_host(), self._ai_gateway_token_provider()
-
     def chat_model_for_workspace_client(
         self,
         workspace_client: WorkspaceClient,
@@ -1080,35 +1035,12 @@ class InferenceEndpointModel(IsDatabricksResource):
         ``WorkspaceClient`` per request. Respects ``self.ai_gateway`` so OBO
         traffic still routes through the AI Gateway path when enabled.
         """
-        from dao_ai.utils import normalize_host
-
         effective_disable_streaming: bool = (
             self.disable_streaming if disable_streaming is None else disable_streaming
         )
 
-        if self.ai_gateway:
-            host: str = normalize_host(workspace_client.config.host).rstrip("/")
-
-            def token_provider() -> str:
-                headers: Mapping[str, str] = workspace_client.config.authenticate()
-                auth: str = headers.get("Authorization", "")
-                if not auth.lower().startswith("bearer "):
-                    raise RuntimeError(
-                        f"Could not extract bearer token for {self.name!r}; "
-                        f"authenticate() returned keys: {list(headers)}"
-                    )
-                return auth.split(" ", 1)[1]
-
-            return AIGatewayChatOpenAI(
-                model=self.name,
-                base_url=f"{host}/ai-gateway/mlflow/v1",
-                api_key=token_provider,
-                temperature=self.temperature,
-                max_tokens=self.max_tokens,
-                streaming=not effective_disable_streaming,
-            )
-
-        return ChatDatabricks(
+        cls = ChatUnityAIGateway if self.ai_gateway else ChatDatabricks
+        return cls(
             model=self.name,
             temperature=self.temperature,
             max_tokens=self.max_tokens,
@@ -1128,25 +1060,14 @@ class InferenceEndpointModel(IsDatabricksResource):
             )
             effective_disable_streaming = True
 
-        chat_client: LanguageModelLike
-        if self.ai_gateway:
-            host, token_provider = self._resolve_ai_gateway_credentials()
-            chat_client = AIGatewayChatOpenAI(
-                model=self.name,
-                base_url=f"{host}/ai-gateway/mlflow/v1",
-                api_key=token_provider,
-                temperature=self.temperature,
-                max_tokens=self.max_tokens,
-                streaming=not effective_disable_streaming,
-            )
-        else:
-            chat_client = ChatDatabricks(
-                model=self.name,
-                temperature=self.temperature,
-                max_tokens=self.max_tokens,
-                use_responses_api=self.use_responses_api,
-                disable_streaming=effective_disable_streaming,
-            )
+        cls = ChatUnityAIGateway if self.ai_gateway else ChatDatabricks
+        chat_client: LanguageModelLike = cls(
+            model=self.name,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+            use_responses_api=self.use_responses_api,
+            disable_streaming=effective_disable_streaming,
+        )
 
         fallbacks: Sequence[LanguageModelLike] = []
         for fallback in self.fallbacks:
@@ -1182,26 +1103,6 @@ class InferenceEndpointModel(IsDatabricksResource):
                 generator_temperature=self.temperature,
                 temperature_override=self.best_of_n.temperature_override,
             )
-
-        return chat_client
-
-    def as_open_ai_client(self) -> LanguageModelLike:
-        chat_client: ChatOpenAI
-        if self.ai_gateway:
-            host, token_provider = self._resolve_ai_gateway_credentials()
-            chat_client = AIGatewayChatOpenAI(
-                model=self.name,
-                base_url=f"{host}/ai-gateway/mlflow/v1",
-                api_key=token_provider,
-                temperature=self.temperature,
-                max_tokens=self.max_tokens,
-            )
-        else:
-            chat_client = self.workspace_client.serving_endpoints.get_langchain_chat_open_ai_client(
-                model=self.name
-            )
-            chat_client.temperature = self.temperature
-            chat_client.max_tokens = self.max_tokens
 
         return chat_client
 

--- a/tests/dao_ai/test_ai_gateway_routing.py
+++ b/tests/dao_ai/test_ai_gateway_routing.py
@@ -1,27 +1,37 @@
 """Unit tests for AI Gateway routing on InferenceEndpointModel.
 
-Covers the `ai_gateway: bool` flag introduced for the revamped Databricks
-AI Gateway (`/ai-gateway/mlflow/v1/chat/completions`). Verifies:
+Covers the `ai_gateway: bool` flag for routing through the Databricks AI
+Gateway via ``ChatUnityAIGateway`` (a ``ChatDatabricks`` subclass with
+``use_ai_gateway=True`` defaulted). The subclass exists so that MLflow
+trace spans surface a distinct class name; functionally it inherits the
+full ``ChatDatabricks`` behavior including the upstream name-field strip
+in ``_convert_message_to_dict``.
 
-- Pydantic validator rejects `ai_gateway` + `use_responses_api`
-- Default flag value leaves the legacy ChatDatabricks path intact
-- `ai_gateway=True` routes both `as_chat_model()` and `as_open_ai_client()`
-  through ChatOpenAI with the AI Gateway base_url
-- `_resolve_ai_gateway_credentials()` extracts bearer tokens uniformly
-  across PAT, service principal, and OBO modes via the SDK's
-  `Config.authenticate()`
+Verifies:
+
+- Pydantic validator rejects ``ai_gateway`` + ``use_responses_api``
+- Default flag value leaves the legacy ``ChatDatabricks`` path intact
+- ``ai_gateway=True`` routes ``as_chat_model()`` and
+  ``chat_model_for_workspace_client()`` through ``ChatUnityAIGateway``
+- ``ChatUnityAIGateway`` is a ``ChatDatabricks`` subclass with
+  ``use_ai_gateway=True`` defaulted (verifies the trace-observability
+  contract)
 - Heterogeneous fallback lists (AI Gateway primary + legacy fallback)
   compose without raising
+- Upstream ``ChatDatabricks`` strips the ``name`` field at the request
+  boundary (the behavior dao-ai now relies on; smoke check)
 """
 
 from __future__ import annotations
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+from databricks_langchain import ChatDatabricks
 from pydantic import ValidationError
 
-from dao_ai.config import InferenceEndpointModel
+from dao_ai.config import ChatUnityAIGateway, InferenceEndpointModel
 
 # ---------------------------------------------------------------------------
 # Validator
@@ -44,7 +54,7 @@ def test_ai_gateway_true_with_responses_api_rejected() -> None:
 
 
 def test_ai_gateway_true_with_obo_currently_allowed() -> None:
-    """OBO + ai_gateway is permitted in v1 pending live verification."""
+    """OBO + ai_gateway is permitted pending live verification."""
     model = InferenceEndpointModel(
         name="databricks-claude-opus-4-6",
         ai_gateway=True,
@@ -55,61 +65,34 @@ def test_ai_gateway_true_with_obo_currently_allowed() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Credential resolver
+# ChatUnityAIGateway subclass contract
 # ---------------------------------------------------------------------------
 
 
-def _stub_workspace_client(host: str, token: str) -> MagicMock:
-    wc = MagicMock()
-    wc.config.host = host
-    wc.config.authenticate.return_value = {"Authorization": f"Bearer {token}"}
-    return wc
+def test_chat_unity_ai_gateway_is_chat_databricks_subclass() -> None:
+    assert issubclass(ChatUnityAIGateway, ChatDatabricks)
 
 
-def test_resolve_credentials_returns_host_and_provider() -> None:
-    model = InferenceEndpointModel(name="x", ai_gateway=True)
-    wc = _stub_workspace_client(
-        host="https://adb-984752964297111.11.azuredatabricks.net/",
-        token="dapi-test-token",
-    )
-    with patch.object(
-        type(model), "workspace_client", new_callable=lambda: property(lambda self: wc)
-    ):
-        host, provider = model._resolve_ai_gateway_credentials()
-    assert host == "https://adb-984752964297111.11.azuredatabricks.net"
-    assert callable(provider)
-    assert provider() == "dapi-test-token"
+def test_chat_unity_ai_gateway_defaults_use_ai_gateway_true() -> None:
+    instance = ChatUnityAIGateway.model_construct(model="databricks-claude-opus-4-6")
+    assert instance.use_ai_gateway is True
 
 
-def test_token_provider_refreshes_per_call() -> None:
-    """Token provider must call authenticate() each time so rotated/refreshed
-    OBO and OAuth-M2M tokens are picked up without re-instantiating the client."""
-    model = InferenceEndpointModel(name="x", ai_gateway=True)
-    wc = MagicMock()
-    wc.config.host = "https://example.databricks.com"
-    wc.config.authenticate.side_effect = [
-        {"Authorization": "Bearer token-v1"},
-        {"Authorization": "Bearer token-v2"},
-    ]
-    with patch.object(
-        type(model), "workspace_client", new_callable=lambda: property(lambda self: wc)
-    ):
-        provider = model._ai_gateway_token_provider()
-        assert provider() == "token-v1"
-        assert provider() == "token-v2"
+def test_chat_databricks_parent_default_is_false() -> None:
+    """Parent class default stays False; only the subclass flips it."""
+    instance = ChatDatabricks.model_construct(model="databricks-claude-opus-4-6")
+    assert instance.use_ai_gateway is False
 
 
-def test_resolve_credentials_raises_when_no_bearer() -> None:
-    model = InferenceEndpointModel(name="x", ai_gateway=True)
-    wc = MagicMock()
-    wc.config.host = "https://example.databricks.com"
-    wc.config.authenticate.return_value = {"X-Custom": "nope"}
-    with patch.object(
-        type(model), "workspace_client", new_callable=lambda: property(lambda self: wc)
-    ):
-        _, provider = model._resolve_ai_gateway_credentials()
-        with pytest.raises(RuntimeError, match="bearer token"):
-            provider()
+def test_chat_unity_ai_gateway_llm_type_is_distinct() -> None:
+    """_llm_type surfaces in MLflow traces and LangSmith — must be distinct
+    from the parent ``chat-databricks`` so AI-Gateway-routed calls are
+    visually distinguishable in observability tooling."""
+    instance = ChatUnityAIGateway.model_construct(model="databricks-claude-opus-4-6")
+    assert instance._llm_type == "chat-unity-ai-gateway"
+    parent = ChatDatabricks.model_construct(model="databricks-claude-opus-4-6")
+    assert parent._llm_type == "chat-databricks"
+    assert instance._llm_type != parent._llm_type
 
 
 # ---------------------------------------------------------------------------
@@ -125,12 +108,12 @@ def test_as_chat_model_default_uses_chat_databricks() -> None:
     )
     with (
         patch("dao_ai.config.ChatDatabricks") as mock_chat_databricks,
-        patch("dao_ai.config.AIGatewayChatOpenAI") as mock_chat_openai,
+        patch("dao_ai.config.ChatUnityAIGateway") as mock_unity,
     ):
         mock_chat_databricks.return_value = MagicMock(name="chat_databricks_instance")
         result = model.as_chat_model()
     mock_chat_databricks.assert_called_once()
-    mock_chat_openai.assert_not_called()
+    mock_unity.assert_not_called()
     kwargs = mock_chat_databricks.call_args.kwargs
     assert kwargs["model"] == "databricks-gpt-5-4-mini"
     assert kwargs["temperature"] == 0.2
@@ -138,44 +121,27 @@ def test_as_chat_model_default_uses_chat_databricks() -> None:
     assert result is mock_chat_databricks.return_value
 
 
-def test_as_chat_model_ai_gateway_uses_chat_openai() -> None:
+def test_as_chat_model_ai_gateway_uses_chat_unity_ai_gateway() -> None:
     model = InferenceEndpointModel(
         name="databricks-claude-opus-4-6",
         ai_gateway=True,
         temperature=0.1,
         max_tokens=1024,
     )
-    fake_provider = lambda: "dapi-test-token"  # noqa: E731
     with (
-        patch.object(
-            InferenceEndpointModel,
-            "_resolve_ai_gateway_credentials",
-            return_value=(
-                "https://adb-984752964297111.11.azuredatabricks.net",
-                fake_provider,
-            ),
-        ),
-        patch("dao_ai.config.AIGatewayChatOpenAI") as mock_chat_openai,
+        patch("dao_ai.config.ChatUnityAIGateway") as mock_unity,
         patch("dao_ai.config.ChatDatabricks") as mock_chat_databricks,
     ):
-        mock_chat_openai.return_value = MagicMock(name="chat_openai_instance")
+        mock_unity.return_value = MagicMock(name="chat_unity_instance")
         result = model.as_chat_model()
     mock_chat_databricks.assert_not_called()
-    mock_chat_openai.assert_called_once()
-    kwargs = mock_chat_openai.call_args.kwargs
+    mock_unity.assert_called_once()
+    kwargs = mock_unity.call_args.kwargs
     assert kwargs["model"] == "databricks-claude-opus-4-6"
-    assert (
-        kwargs["base_url"]
-        == "https://adb-984752964297111.11.azuredatabricks.net/ai-gateway/mlflow/v1"
-    )
-    # api_key must be the callable provider — captured strings can't refresh
-    # OBO / OAuth-M2M tokens. The openai SDK invokes the callable per request.
-    assert kwargs["api_key"] is fake_provider
-    assert kwargs["api_key"]() == "dapi-test-token"
     assert kwargs["temperature"] == 0.1
     assert kwargs["max_tokens"] == 1024
-    assert kwargs["streaming"] is True  # disable_streaming defaults False
-    assert result is mock_chat_openai.return_value
+    assert kwargs["disable_streaming"] is False
+    assert result is mock_unity.return_value
 
 
 def test_as_chat_model_ai_gateway_disables_streaming_when_requested() -> None:
@@ -184,64 +150,20 @@ def test_as_chat_model_ai_gateway_disables_streaming_when_requested() -> None:
         ai_gateway=True,
         disable_streaming=True,
     )
-    with (
-        patch.object(
-            InferenceEndpointModel,
-            "_resolve_ai_gateway_credentials",
-            return_value=("https://x", lambda: "tok"),
-        ),
-        patch("dao_ai.config.AIGatewayChatOpenAI") as mock_chat_openai,
-    ):
+    with patch("dao_ai.config.ChatUnityAIGateway") as mock_unity:
         model.as_chat_model()
-    assert mock_chat_openai.call_args.kwargs["streaming"] is False
+    assert mock_unity.call_args.kwargs["disable_streaming"] is True
 
 
 # ---------------------------------------------------------------------------
-# as_open_ai_client routing
-# ---------------------------------------------------------------------------
-
-
-def test_as_open_ai_client_ai_gateway_uses_direct_chat_openai() -> None:
-    model = InferenceEndpointModel(
-        name="databricks-claude-opus-4-6",
-        ai_gateway=True,
-        temperature=0.1,
-        max_tokens=2048,
-    )
-    fake_provider = lambda: "tok"  # noqa: E731
-    with (
-        patch.object(
-            InferenceEndpointModel,
-            "_resolve_ai_gateway_credentials",
-            return_value=("https://host", fake_provider),
-        ),
-        patch("dao_ai.config.AIGatewayChatOpenAI") as mock_chat_openai,
-    ):
-        mock_chat_openai.return_value = MagicMock()
-        model.as_open_ai_client()
-    mock_chat_openai.assert_called_once_with(
-        model="databricks-claude-opus-4-6",
-        base_url="https://host/ai-gateway/mlflow/v1",
-        api_key=fake_provider,
-        temperature=0.1,
-        max_tokens=2048,
-    )
-
-
-# ---------------------------------------------------------------------------
-# Heterogeneous fallbacks compose
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
-# OBO simulation
+# OBO factory routing
 # ---------------------------------------------------------------------------
 
 
 def test_chat_model_for_workspace_client_uses_ai_gateway_when_flag_set() -> None:
     """OBO-style construction (per-request workspace_client) must route through
-    AI Gateway when ai_gateway=True on the config — not silently fall back to
-    ChatDatabricks. This is the bug that motivated the shared factory."""
+    ChatUnityAIGateway when ai_gateway=True on the config — not silently fall
+    back to ChatDatabricks. This is the bug that motivated the shared factory."""
     model = InferenceEndpointModel(
         name="databricks-claude-opus-4-6",
         ai_gateway=True,
@@ -250,25 +172,19 @@ def test_chat_model_for_workspace_client_uses_ai_gateway_when_flag_set() -> None
         max_tokens=128,
     )
     obo_wc = MagicMock()
-    obo_wc.config.host = "https://obo-host.databricks.com"
-    obo_wc.config.authenticate.return_value = {"Authorization": "Bearer obo-user-token"}
 
     with (
-        patch("dao_ai.config.AIGatewayChatOpenAI") as mock_chat_openai,
+        patch("dao_ai.config.ChatUnityAIGateway") as mock_unity,
         patch("dao_ai.config.ChatDatabricks") as mock_chat_databricks,
     ):
-        mock_chat_openai.return_value = MagicMock()
+        mock_unity.return_value = MagicMock()
         model.chat_model_for_workspace_client(obo_wc)
 
     mock_chat_databricks.assert_not_called()
-    mock_chat_openai.assert_called_once()
-    kwargs = mock_chat_openai.call_args.kwargs
-    assert kwargs["base_url"] == "https://obo-host.databricks.com/ai-gateway/mlflow/v1"
+    mock_unity.assert_called_once()
+    kwargs = mock_unity.call_args.kwargs
+    assert kwargs["workspace_client"] is obo_wc
     assert kwargs["model"] == "databricks-claude-opus-4-6"
-    # Token provider must close over the OBO workspace_client — not the
-    # config-level one — so OBO-scoped requests carry the user's token.
-    assert callable(kwargs["api_key"])
-    assert kwargs["api_key"]() == "obo-user-token"
 
 
 def test_chat_model_for_workspace_client_legacy_path_passes_workspace_client() -> None:
@@ -284,12 +200,12 @@ def test_chat_model_for_workspace_client_legacy_path_passes_workspace_client() -
 
     with (
         patch("dao_ai.config.ChatDatabricks") as mock_chat_databricks,
-        patch("dao_ai.config.AIGatewayChatOpenAI") as mock_chat_openai,
+        patch("dao_ai.config.ChatUnityAIGateway") as mock_unity,
     ):
         mock_chat_databricks.return_value = MagicMock()
         model.chat_model_for_workspace_client(obo_wc)
 
-    mock_chat_openai.assert_not_called()
+    mock_unity.assert_not_called()
     mock_chat_databricks.assert_called_once()
     kwargs = mock_chat_databricks.call_args.kwargs
     assert kwargs["workspace_client"] is obo_wc
@@ -306,12 +222,7 @@ def test_as_chat_model_returns_runnable_with_bind_tools() -> None:
     (which always call .bind_tools(tools)) work transparently against the
     AI Gateway path."""
     model = InferenceEndpointModel(name="databricks-claude-opus-4-6", ai_gateway=True)
-    with patch.object(
-        InferenceEndpointModel,
-        "_resolve_ai_gateway_credentials",
-        return_value=("https://x", lambda: "t"),
-    ):
-        client = model.as_chat_model()
+    client = model.as_chat_model()
     assert hasattr(client, "bind_tools"), (
         "as_chat_model() must return a client with bind_tools() — agent loops "
         "depend on this. Got: " + type(client).__name__
@@ -326,176 +237,93 @@ def test_heterogeneous_fallbacks_compose() -> None:
         fallbacks=["databricks-gpt-5-4-mini"],
     )
 
-    chat_openai_instance = MagicMock(name="ChatOpenAI-instance")
+    unity_instance = MagicMock(name="ChatUnityAIGateway-instance")
     chat_databricks_instance = MagicMock(name="ChatDatabricks-instance")
     chained = MagicMock(name="with_fallbacks-result")
-    chat_openai_instance.with_fallbacks.return_value = chained
+    unity_instance.with_fallbacks.return_value = chained
 
     with (
-        patch.object(
-            InferenceEndpointModel,
-            "_resolve_ai_gateway_credentials",
-            return_value=("https://h", lambda: "t"),
-        ),
-        patch("dao_ai.config.AIGatewayChatOpenAI", return_value=chat_openai_instance),
+        patch("dao_ai.config.ChatUnityAIGateway", return_value=unity_instance),
         patch("dao_ai.config.ChatDatabricks", return_value=chat_databricks_instance),
     ):
         result = primary.as_chat_model()
 
-    chat_openai_instance.with_fallbacks.assert_called_once()
-    (fallback_list,) = chat_openai_instance.with_fallbacks.call_args.args
+    unity_instance.with_fallbacks.assert_called_once()
+    (fallback_list,) = unity_instance.with_fallbacks.call_args.args
     assert fallback_list == [chat_databricks_instance]
     assert result is chained
 
 
 # ---------------------------------------------------------------------------
-# AIGatewayChatOpenAI — name-field stripping
-#
-# Background: the AI Gateway's OpenAI-compatible validator rejects ``name``
-# on user/assistant/system messages with 400 BAD_REQUEST. LangGraph's
-# supervisor pattern attaches ``name`` to AIMessages for routing, so the
-# subclass strips it on the request-payload boundary.
+# Subclass identity — the observability contract
 # ---------------------------------------------------------------------------
 
 
-def _build_ai_gateway_chat():
-    from dao_ai.config import AIGatewayChatOpenAI
-
-    return AIGatewayChatOpenAI(
-        model="databricks-claude-opus-4-6",
-        base_url="https://example.databricks.com/ai-gateway/mlflow/v1",
-        api_key="dapi-test-token",
-    )
-
-
-def test_ai_gateway_chat_strips_name_from_user_messages() -> None:
-    from langchain_core.messages import HumanMessage
-
-    chat = _build_ai_gateway_chat()
-    payload = chat._get_request_payload([HumanMessage(content="hi", name="alice")])
-    user_msgs = [m for m in payload["messages"] if m.get("role") == "user"]
-    assert user_msgs, "expected a user message in the payload"
-    assert all("name" not in m for m in user_msgs)
-
-
-def test_ai_gateway_chat_strips_name_from_assistant_messages() -> None:
-    from langchain_core.messages import AIMessage
-
-    chat = _build_ai_gateway_chat()
-    payload = chat._get_request_payload(
-        [AIMessage(content="hello there", name="agent_a")]
-    )
-    assistant_msgs = [m for m in payload["messages"] if m.get("role") == "assistant"]
-    assert assistant_msgs
-    assert all("name" not in m for m in assistant_msgs)
-
-
-def test_ai_gateway_chat_strips_name_from_system_messages() -> None:
-    from langchain_core.messages import SystemMessage
-
-    chat = _build_ai_gateway_chat()
-    payload = chat._get_request_payload(
-        [SystemMessage(content="you are helpful", name="sys")]
-    )
-    system_msgs = [m for m in payload["messages"] if m.get("role") == "system"]
-    assert system_msgs
-    assert all("name" not in m for m in system_msgs)
-
-
-def test_ai_gateway_chat_leaves_tool_messages_alone() -> None:
-    """Tool messages may legitimately carry ``name`` (function name); leave them
-    untouched — OpenAI's tool message schema is the upstream contract."""
-    from langchain_core.messages import (
-        AIMessage,
-        HumanMessage,
-        ToolMessage,
-    )
-
-    chat = _build_ai_gateway_chat()
-    payload = chat._get_request_payload(
-        [
-            HumanMessage(content="run my_tool", name="user"),
-            AIMessage(
-                content="",
-                name="agent_a",
-                tool_calls=[
-                    {"id": "t1", "name": "my_tool", "args": {}, "type": "tool_call"}
-                ],
-            ),
-            ToolMessage(content="ok", tool_call_id="t1", name="my_tool"),
-        ]
-    )
-    tool_msgs = [m for m in payload["messages"] if m.get("role") == "tool"]
-    assert tool_msgs, "expected a tool message in the payload"
-    # We didn't strip from role=tool. Whatever LangChain put there (likely
-    # tool_call_id only — no top-level name) is what we send to the gateway.
-    # The assertion is just "we didn't crash and we didn't reach into tool".
-
-
-def test_as_chat_model_ai_gateway_returns_subclass_instance() -> None:
-    """When ai_gateway=True, as_chat_model() must return the name-stripping
-    subclass — not a vanilla ChatOpenAI."""
-    from dao_ai.config import AIGatewayChatOpenAI
-
+def test_as_chat_model_ai_gateway_returns_chat_unity_ai_gateway() -> None:
+    """When ai_gateway=True, as_chat_model() must return ChatUnityAIGateway —
+    the named subclass that surfaces in MLflow trace spans."""
     model = InferenceEndpointModel(name="databricks-claude-opus-4-6", ai_gateway=True)
-    with patch.object(
-        InferenceEndpointModel,
-        "_resolve_ai_gateway_credentials",
-        return_value=("https://x", lambda: "t"),
-    ):
-        client = model.as_chat_model()
-    assert isinstance(client, AIGatewayChatOpenAI)
+    client = model.as_chat_model()
+    assert isinstance(client, ChatUnityAIGateway)
+    assert isinstance(client, ChatDatabricks)  # subclass relationship
 
 
-def test_as_chat_model_legacy_path_is_not_subclass() -> None:
-    """Regression: ai_gateway=False returns ChatDatabricks (no subclass involvement)."""
-    from dao_ai.config import AIGatewayChatOpenAI
-
+def test_as_chat_model_legacy_path_is_not_unity_subclass() -> None:
+    """Regression: ai_gateway=False returns plain ChatDatabricks."""
     model = InferenceEndpointModel(name="databricks-gpt-5-4-mini")
-    with patch("dao_ai.config.ChatDatabricks") as mock_chat_databricks:
-        mock_chat_databricks.return_value = MagicMock(spec=[])
-        client = model.as_chat_model()
-    assert not isinstance(client, AIGatewayChatOpenAI)
+    client = model.as_chat_model()
+    assert isinstance(client, ChatDatabricks)
+    assert not isinstance(client, ChatUnityAIGateway)
 
 
-def test_chat_model_for_workspace_client_ai_gateway_returns_subclass() -> None:
-    """OBO factory must also return the subclass when ai_gateway=True."""
-    from dao_ai.config import AIGatewayChatOpenAI
+def test_chat_model_for_workspace_client_ai_gateway_returns_unity_subclass() -> None:
+    """OBO factory must also return ChatUnityAIGateway when ai_gateway=True."""
+    from databricks.sdk import WorkspaceClient
 
     model = InferenceEndpointModel(
         name="databricks-claude-opus-4-6",
         ai_gateway=True,
         on_behalf_of_user=True,
     )
-    obo_wc = MagicMock()
-    obo_wc.config.host = "https://obo-host.databricks.com"
-    obo_wc.config.authenticate.return_value = {"Authorization": "Bearer obo-tok"}
+    obo_wc = MagicMock(spec=WorkspaceClient)
 
     client = model.chat_model_for_workspace_client(obo_wc)
-    assert isinstance(client, AIGatewayChatOpenAI)
+    assert isinstance(client, ChatUnityAIGateway)
 
 
-def test_as_open_ai_client_ai_gateway_returns_subclass() -> None:
-    """as_open_ai_client (raw client factory) must also return the subclass
-    when ai_gateway=True."""
-    from dao_ai.config import AIGatewayChatOpenAI
+# ---------------------------------------------------------------------------
+# Upstream name-strip smoke check
+#
+# dao-ai used to ship a custom subclass that stripped the `name` field at the
+# request-payload boundary because the AI Gateway 400s on `messages.N.name`.
+# That behavior now lives upstream in
+# ChatDatabricks._convert_message_to_dict; we verify it survives so that the
+# subclass collapse is safe.
+# ---------------------------------------------------------------------------
 
-    model = InferenceEndpointModel(name="databricks-claude-opus-4-6", ai_gateway=True)
-    with patch.object(
-        InferenceEndpointModel,
-        "_resolve_ai_gateway_credentials",
-        return_value=("https://h", lambda: "t"),
-    ):
-        client = model.as_open_ai_client()
-    assert isinstance(client, AIGatewayChatOpenAI)
+
+def test_chat_databricks_drops_name_field_on_message_conversion() -> None:
+    """Upstream ChatDatabricks already strips the ``name`` field at the
+    request-payload boundary — this is the behavior dao-ai relies on now
+    that the custom AIGatewayChatOpenAI workaround is gone."""
+    from databricks_langchain.chat_models import _convert_message_to_dict
+    from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+    for msg in [
+        HumanMessage(content="hi", name="alice"),
+        AIMessage(content="hello there", name="agent_a"),
+        SystemMessage(content="you are helpful", name="sys"),
+    ]:
+        as_dict = _convert_message_to_dict(msg)
+        assert "name" not in as_dict, (
+            f"upstream regression: ChatDatabricks now propagates 'name' on "
+            f"{type(msg).__name__}; revisit the AIGatewayChatOpenAI workaround"
+        )
 
 
 # ---------------------------------------------------------------------------
 # Live AI Gateway smoke (integration)
 # ---------------------------------------------------------------------------
-
-
-import os  # noqa: E402
 
 
 @pytest.mark.integration
@@ -506,8 +334,9 @@ import os  # noqa: E402
 def test_ai_gateway_chat_handles_supervisor_named_messages_live() -> None:
     """Live AI Gateway round-trip with supervisor-tagged AIMessage(name=...).
 
-    Pre-fix this would 400 with ``messages.N.name: Extra inputs are not permitted``.
-    Post-fix the name is stripped on the request boundary and the call succeeds.
+    Pre-refactor the gateway 400'd on ``messages.N.name``; the dao-ai custom
+    subclass stripped it. Post-refactor upstream ``ChatDatabricks`` strips it
+    natively, so this call must still succeed.
     """
     from langchain_core.messages import AIMessage, HumanMessage
 
@@ -517,6 +346,7 @@ def test_ai_gateway_chat_handles_supervisor_named_messages_live() -> None:
         max_tokens=64,
     )
     chat = endpoint.as_chat_model()
+    assert isinstance(chat, ChatUnityAIGateway)
     out = chat.invoke(
         [
             HumanMessage(content="Say a one-word greeting.", name="user_alice"),


### PR DESCRIPTION
## Summary

- Replace the custom `AIGatewayChatOpenAI(ChatOpenAI)` subclass with `ChatUnityAIGateway(ChatDatabricks)` — a thin named subclass that defaults `use_ai_gateway=True` and overrides `_llm_type` to `"chat-unity-ai-gateway"`, surfacing a distinct class name in MLflow trace spans for AI-Gateway-routed calls.
- Collapse the AI Gateway routing branches in `InferenceEndpointModel.chat_model_for_workspace_client` and `as_chat_model` onto a single class selector. The `name`-field strip workaround is no longer needed — `ChatDatabricks._convert_message_to_dict` already drops it at the request-payload boundary (`databricks-langchain >= 0.20`).
- Drop the now-unused `_ai_gateway_host`, `_ai_gateway_token_provider`, `_resolve_ai_gateway_credentials` helpers and the dead `as_open_ai_client` method (zero non-test callers).
- Net diff: `-415 / +146 lines` across `src/dao_ai/config.py` and `tests/dao_ai/test_ai_gateway_routing.py`.

## Why

The custom `ChatOpenAI` subclass existed only to strip the `name` field from chat messages because the AI Gateway's OpenAI-compatible validator rejects `messages.N.name`. Upstream `databricks-langchain` (v0.20+) now handles this natively (`_convert_message_to_dict` lines 1413–1421 — comment explicitly explains the FMAPI name-strip). The workaround is redundant.

A direct collapse onto `ChatDatabricks(use_ai_gateway=True)` would lose the distinct class label in MLflow trace spans — `ChatUnityAIGateway` is purely an observability subclass so AI-Gateway-routed calls are visually distinguishable from plain `ChatDatabricks` calls in the trace UI.

## Test plan

- [x] Unit tests pass: `uv run pytest tests/dao_ai/test_ai_gateway_routing.py tests/dao_ai/test_config.py tests/dao_ai/test_inference.py tests/dao_ai/test_inference_endpoint_alias.py tests/dao_ai/test_summarization_inference.py tests/dao_ai/test_autolog_config.py` → **75 passed, 5 skipped**
- [x] Subclass identity asserted in tests: `isinstance(client, ChatUnityAIGateway)` AND `isinstance(client, ChatDatabricks)`, `use_ai_gateway is True`, `_llm_type == "chat-unity-ai-gateway"`
- [x] Upstream behavior smoke-checked: `ChatDatabricks._convert_message_to_dict` confirmed to drop `name` on `HumanMessage`, `AIMessage`, `SystemMessage` (replaces the deleted dao-ai per-role strip tests)
- [x] Bundle generates cleanly: `uv run dao-ai generate-bundle --force --development -c <verify-config> -o <tmp>` + `databricks bundle validate -p fevm` → Validation OK
- [x] Live fevm deploy: App + experiment + warehouse provisioned; `compute: ACTIVE / app: RUNNING`
- [x] Live inference round-trips (4× total) — agent correctly invoked the `current_time` tool through the AI Gateway path, returned tool-driven responses with microsecond-precision timestamps that could only come from the tool, and correctly chose **not** to invoke the tool for non-time prompts (`"What is 7 times 8?"`).

### Known orthogonal issue (not blocking this PR)

UC OTEL trace export from the verification App hit `PERMISSION_DENIED: USE CATALOG on retail_consumer_goods` + `TABLE_DOES_NOT_EXIST: mlflow_experiment_trace_otel_spans`. The dao-ai bundle generator declares the experiment + warehouse as App resources but does not auto-grant the App SP `USE CATALOG / USE SCHEMA / CREATE TABLE` on the trace_location target. Inference itself is unaffected — only the trace sink fails. Worth a follow-up issue against the bundle generator.

## Rollback

Single PR, no migrations or data shape changes. Revert the two commits and `AIGatewayChatOpenAI` returns. Note: the workaround it implemented (name-strip) is no longer required at the application layer regardless — upstream handles it.

---

This pull request and its description were written by Isaac.