### PR TITLE
fix(vector_search): give LLM a structural args_schema for filters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dao-ai"
-version = "0.1.100"
+version = "0.1.102"
 description = "DAO AI: A modular, multi-agent orchestration framework for complex AI workflows. Supports agent handoff, tool integration, and dynamic configuration via YAML."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dao_ai/tools/vector_search.py
+++ b/src/dao_ai/tools/vector_search.py
@@ -72,7 +72,11 @@ class VectorSearchInput(BaseModel):
     shape (which it then commonly emits as a flat dict instead of a list).
     """
 
-    model_config = ConfigDict(extra="forbid")
+    # extra="ignore" rather than "forbid": LangChain passes the injected
+    # ToolRuntime as a kwarg when invoking a tool whose @tool decorator has
+    # args_schema=, and Pydantic must silently drop it. extra="forbid" would
+    # reject every call with `validation error … runtime: extra_forbidden`.
+    model_config = ConfigDict(extra="ignore")
 
     query: str = Field(
         description="The natural-language search query to find relevant documents.",

--- a/src/dao_ai/tools/vector_search.py
+++ b/src/dao_ai/tools/vector_search.py
@@ -22,6 +22,7 @@ from langchain_core.documents import Document
 from langchain_core.tools import StructuredTool
 from loguru import logger
 from mlflow.entities import SpanType
+from pydantic import BaseModel, ConfigDict, Field
 
 from dao_ai._tracing import in_caller_context
 from dao_ai.config import (
@@ -58,6 +59,37 @@ from dao_ai.tools.tracing import (
 )
 from dao_ai.tools.verifier import add_verification_metadata, verify_results
 from dao_ai.utils import is_in_model_serving, normalize_host
+
+
+class VectorSearchInput(BaseModel):
+    """Arguments for the dao-ai vector_search tool factory.
+
+    Co-located with the @tool decorator so the JSON schema rendered to the LLM
+    matches the factory's runtime expectations. Without an explicit args_schema,
+    LangChain's @tool decorator infers schema from Annotated[...] hints and
+    silently drops the structural type information for Optional[list[BaseModel]]
+    fields, leaving the LLM with only a description string to guide filter
+    shape (which it then commonly emits as a flat dict instead of a list).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    query: str = Field(
+        description="The natural-language search query to find relevant documents.",
+    )
+    filters: Optional[list[FilterItem]] = Field(
+        default=None,
+        description=(
+            "Optional metadata filters. Pass a JSON array of objects, each with "
+            "'key' and 'value'. Do NOT pass a flat dict. "
+            'Example: [{"key": "category", "value": "B2B"}, '
+            '{"key": "price <=", "value": 150}]. '
+            "The 'key' is a column name optionally suffixed with an operator: "
+            "(none) for equality, 'NOT' for exclusion, '< <= > >=' for numeric "
+            "comparison, 'LIKE' for token match, 'NOT LIKE' to exclude tokens. "
+            "Omit or set to null when no filter applies."
+        ),
+    )
 
 
 @mlflow.trace(name="rerank_documents", span_type=SpanType.RERANKER)
@@ -617,18 +649,19 @@ def create_vector_search_tool(
 
         return documents
 
-    # Use @tool decorator for proper ToolRuntime injection
-    @tool(name_or_callable=tool_name, description=tool_description)
+    # Use @tool decorator for proper ToolRuntime injection. args_schema=
+    # gives the LLM a structural JSON schema for `filters` (type=array,
+    # items={key,value}) — without it, Annotated[Optional[list[FilterItem]]]
+    # is serialised to just a description string and the LLM commonly emits
+    # filters as a flat dict.
+    @tool(
+        name_or_callable=tool_name,
+        description=tool_description,
+        args_schema=VectorSearchInput,
+    )
     def _vector_search_tool(
-        query: Annotated[str, "The search query to find relevant documents"],
-        filters: Annotated[
-            Optional[list[FilterItem]],
-            "Optional filters as key-value pairs. "
-            "Key operators: 'column' (equality), 'column NOT' (exclusion), "
-            "'column <', '<=', '>', '>=' (comparison), "
-            "'column LIKE' (token match), 'column NOT LIKE' (exclude token). "
-            f"Valid columns: {', '.join(columns) if columns else 'none'}.",
-        ] = None,
+        query: str,
+        filters: Optional[list[FilterItem]] = None,
         runtime: ToolRuntime[Context] = None,
     ) -> str:
         """Search for relevant documents using vector similarity."""

--- a/tests/dao_ai/test_vector_search.py
+++ b/tests/dao_ai/test_vector_search.py
@@ -1,7 +1,11 @@
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
+from langchain.tools import ToolRuntime, tool
 
+from dao_ai.config import FilterItem
+from dao_ai.tools.vector_search import VectorSearchInput
 from dao_ai.vector_search import endpoint_exists, index_exists
 
 
@@ -169,3 +173,135 @@ def test_index_exists_get_index_failure() -> None:
 
     with pytest.raises(Exception, match="ENDPOINT_NOT_FOUND: Endpoint doesn't exist"):
         index_exists(mock_vsc, "missing_endpoint", "catalog.schema.table")
+
+
+# ---------------------------------------------------------------------------
+# VectorSearchInput — the args_schema we attach to the vector_search @tool
+# so the LLM receives a structural JSON schema (type=array, items=FilterItem)
+# for `filters` instead of a bare description string.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_vector_search_input_accepts_list_of_filter_items() -> None:
+    """Canonical happy path — LLM emits a list of {key, value} filter objects."""
+    payload = {
+        "query": "B2B return policy",
+        "filters": [
+            {"key": "category", "value": "B2B"},
+            {"key": "price <=", "value": 150},
+        ],
+    }
+    validated = VectorSearchInput.model_validate(payload)
+    assert validated.query == "B2B return policy"
+    assert validated.filters is not None and len(validated.filters) == 2
+    assert all(isinstance(f, FilterItem) for f in validated.filters)
+    assert validated.filters[0].key == "category"
+    assert validated.filters[0].value == "B2B"
+
+
+@pytest.mark.unit
+def test_vector_search_input_accepts_null_filters() -> None:
+    """LLM may omit filters or pass null when no constraint applies."""
+    assert VectorSearchInput.model_validate({"query": "no filters"}).filters is None
+    assert (
+        VectorSearchInput.model_validate({"query": "explicit null", "filters": None}).filters
+        is None
+    )
+
+
+@pytest.mark.unit
+def test_vector_search_input_rejects_flat_dict_for_filters() -> None:
+    """The pre-fix LLM-mistake shape (flat dict instead of list of objects)
+    must be rejected by Pydantic so the tool returns a clear error rather
+    than silently semi-running on a broken filter."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError) as exc:
+        VectorSearchInput.model_validate({"query": "x", "filters": {"category": "B2B"}})
+    assert "filters" in str(exc.value).lower()
+
+
+@pytest.mark.unit
+def test_vector_search_input_ignores_injected_runtime_kwarg() -> None:
+    """LangGraph's ToolNode injects `runtime` as a kwarg AFTER args_schema
+    validation runs, so VectorSearchInput must tolerate the extra. Without
+    this (ConfigDict(extra='forbid')) every tool call fails with
+    `validation error … runtime: Extra inputs are not permitted`."""
+    sentinel = object()
+    payload = {
+        "query": "x",
+        "filters": None,
+        "runtime": sentinel,  # impersonates the injected ToolRuntime
+        "state": sentinel,  # impersonates injected graph state
+    }
+    validated = VectorSearchInput.model_validate(payload)
+    # extras are silently dropped from the validated model …
+    assert not hasattr(validated, "runtime")
+    assert not hasattr(validated, "state")
+    # … but model_dump only contains the LLM-facing fields, so downstream
+    # callers can't accidentally pass forged injection through.
+    assert set(validated.model_dump().keys()) == {"query", "filters"}
+
+
+@pytest.mark.unit
+def test_vector_search_input_json_schema_is_structural() -> None:
+    """The whole point of args_schema= is that the LLM sees a *structural*
+    type for `filters` (not just a description string). Pin the shape so
+    a future refactor that drops the schema, or downgrades it back to an
+    Annotated hint, fails this test loudly."""
+    schema: dict[str, Any] = VectorSearchInput.model_json_schema()
+    filters_schema = schema["properties"]["filters"]
+    # anyOf with [array-of-FilterItem, null] — i.e. the LLM must pass a
+    # JSON array, not a flat dict.
+    any_of = filters_schema.get("anyOf") or []
+    array_variant = next((v for v in any_of if v.get("type") == "array"), None)
+    assert array_variant is not None, f"filters not declared as array: {filters_schema}"
+    assert array_variant["items"].get("$ref", "").endswith("/FilterItem"), array_variant
+    # FilterItem itself is a proper sub-schema with key+value, not free-form.
+    filter_item = schema["$defs"]["FilterItem"]
+    assert set(filter_item["required"]) == {"key", "value"}
+
+
+@pytest.mark.unit
+def test_vector_search_tool_decorator_passes_runtime_through() -> None:
+    """End-to-end of the args_schema integration: a @tool-decorated function
+    using VectorSearchInput as args_schema must still receive `runtime` at
+    call time (LangGraph injects it; Pydantic validation tolerates it)."""
+    received: dict[str, Any] = {}
+
+    @tool(
+        name_or_callable="probe_search",
+        description="probe",
+        args_schema=VectorSearchInput,
+    )
+    def probe(
+        query: str,
+        filters: list[FilterItem] | None = None,
+        # Annotation must be the bare ToolRuntime (not Optional[ToolRuntime])
+        # so LangChain's _is_injected_arg_type recognises it. = None is just
+        # a default; the annotation is what gates injection.
+        runtime: ToolRuntime = None,  # type: ignore[assignment]
+    ) -> str:
+        received["query"] = query
+        received["filters"] = filters
+        received["runtime"] = runtime
+        return "ok"
+
+    # LangGraph's ToolNode strips LLM-supplied injected keys and adds back the
+    # trusted runtime. We simulate the final tool-call shape it produces.
+    sentinel_runtime = Mock(name="ToolRuntime")
+    result = probe.invoke(
+        {
+            "query": "test",
+            "filters": [{"key": "k", "value": "v"}],
+            "runtime": sentinel_runtime,
+        }
+    )
+
+    assert result == "ok"
+    assert received["query"] == "test"
+    assert received["filters"] and received["filters"][0].key == "k"
+    assert received["runtime"] is sentinel_runtime, (
+        "runtime injection did not reach the function — extra='ignore' may be wrong"
+    )

--- a/tests/dao_ai/test_vector_search.py
+++ b/tests/dao_ai/test_vector_search.py
@@ -1,5 +1,5 @@
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from langchain.tools import ToolRuntime, tool
@@ -305,3 +305,122 @@ def test_vector_search_tool_decorator_passes_runtime_through() -> None:
     assert received["runtime"] is sentinel_runtime, (
         "runtime injection did not reach the function — extra='ignore' may be wrong"
     )
+
+
+# ---------------------------------------------------------------------------
+# OBO end-to-end through the args_schema + ToolRuntime chain:
+#
+# runtime.context.headers -> _get_vector_search(context) ->
+# vector_store.workspace_client_from(context) -> DatabricksVectorSearch
+# (workspace_client=user-scoped WC)
+#
+# These tests pin that the args_schema fix does NOT regress OBO: the LLM-facing
+# schema only exposes {query, filters}, but the function still receives
+# `runtime` and uses `runtime.context` to build an OBO-scoped vector search
+# client. If LangChain ever stops re-injecting runtime after args_schema
+# validation, OBO would silently degrade to SP auth — that's the future
+# regression these tests protect against.
+# ---------------------------------------------------------------------------
+
+
+def _make_obo_vector_store_mock() -> Mock:
+    """Build a minimal VectorStoreModel mock with on_behalf_of_user=True."""
+    from dao_ai.config import VectorStoreModel
+
+    vs = Mock(spec=VectorStoreModel)
+    vs.columns = ["text"]
+    vs.embedding_model = None
+    vs.primary_key = "id"
+    vs.index = Mock()
+    vs.index.full_name = "catalog.schema.obo_index"
+    vs.index.name = "obo_index"
+    vs.index.columns = ["text"]
+    vs.endpoint = Mock()
+    vs.source_table = None
+    vs.embedding_source_column = None
+    vs.doc_uri = None
+    vs.on_behalf_of_user = True
+    # workspace_client_from must return a mock WC; we capture the context
+    # it's called with via .call_args
+    vs.workspace_client_from.return_value = MagicMock(name="obo_wc")
+    # databricks-resource attrs needed by the factory
+    try:
+        from conftest import add_databricks_resource_attrs
+
+        add_databricks_resource_attrs(vs)
+    except ImportError:
+        pass
+    return vs
+
+
+@pytest.mark.unit
+def test_create_vector_search_tool_obo_passes_context_to_workspace_client_from() -> None:
+    """When on_behalf_of_user=True and the tool is invoked with a ToolRuntime
+    carrying user headers, the factory must call
+    vector_store.workspace_client_from(context) with THAT same Context — so
+    the user's x-forwarded-access-token flows through to the VS query."""
+    from langgraph.runtime import Runtime
+
+    from dao_ai.config import RetrieverModel
+    from dao_ai.state import Context
+    from dao_ai.tools.vector_search import create_vector_search_tool
+
+    vs_model = _make_obo_vector_store_mock()
+    retriever = RetrieverModel(vector_store=vs_model)
+
+    with patch("dao_ai.tools.vector_search.DatabricksVectorSearch") as MockDVS:
+        mock_vs_client = MagicMock()
+        mock_vs_client.similarity_search.return_value = []
+        MockDVS.return_value = mock_vs_client
+
+        tool = create_vector_search_tool(retriever=retriever)
+
+        # Simulate the exact shape LangGraph's ToolNode produces: it strips
+        # any LLM-supplied 'runtime' and re-adds the trusted ToolRuntime.
+        user_headers = {"x-forwarded-access-token": "user-dapi-token-abc"}
+        ctx = Context(headers=user_headers)
+        # ToolRuntime is normally constructed by ToolNode; for a unit test
+        # langgraph.runtime.Runtime is the concrete carrier of `.context`.
+        rt = Runtime(context=ctx)
+
+        tool.invoke({"query": "obo probe", "filters": None, "runtime": rt})
+
+    # The OBO branch in _get_vector_search must have asked the model for an
+    # OBO-scoped WC by passing the runtime's Context through verbatim.
+    assert vs_model.workspace_client_from.called, (
+        "OBO regressed: workspace_client_from was never called — runtime did "
+        "not reach the function or _get_vector_search was bypassed."
+    )
+    received_ctx = vs_model.workspace_client_from.call_args.args[0]
+    assert received_ctx is ctx, (
+        f"OBO context not forwarded verbatim: got {received_ctx!r}, expected {ctx!r}"
+    )
+    assert received_ctx.headers == user_headers, (
+        f"OBO headers lost in transit: got {received_ctx.headers!r}"
+    )
+
+
+@pytest.mark.unit
+def test_create_vector_search_tool_obo_off_does_not_use_context_headers() -> None:
+    """Symmetric guard: with on_behalf_of_user=False, workspace_client_from is
+    still called (to build a non-OBO WC), but the runtime injection path must
+    not crash even when headers are absent."""
+    from langgraph.runtime import Runtime
+
+    from dao_ai.config import RetrieverModel
+    from dao_ai.state import Context
+    from dao_ai.tools.vector_search import create_vector_search_tool
+
+    vs_model = _make_obo_vector_store_mock()
+    vs_model.on_behalf_of_user = False  # OBO off
+    retriever = RetrieverModel(vector_store=vs_model)
+
+    with patch("dao_ai.tools.vector_search.DatabricksVectorSearch") as MockDVS:
+        MockDVS.return_value.similarity_search.return_value = []
+        tool = create_vector_search_tool(retriever=retriever)
+        rt = Runtime(context=Context(headers={}))
+        # Must not raise
+        tool.invoke({"query": "non-obo probe", "filters": None, "runtime": rt})
+
+    # Still called (to mint the SP-scoped WC), but headers were empty.
+    assert vs_model.workspace_client_from.called


### PR DESCRIPTION
## Summary

- Add a co-located `VectorSearchInput` Pydantic schema and pass it to the `@tool` decorator on `create_vector_search_tool` so the LLM gets a **structural** JSON schema for `filters` (array of `FilterItem`) instead of just a free-form description string.
- Use `ConfigDict(extra="ignore")` so LangGraph's injected `ToolRuntime` (and any future `_DirectlyInjectedToolArg` kwarg) passes through validation cleanly. The function signature still declares `runtime: ToolRuntime[Context] = None` so LangGraph re-adds it after validation — confirmed by a new unit test.
- 8 new unit tests pin (a) the schema shape, (b) the @tool decorator integration, and (c) the OBO chain that depends on `runtime.context` reaching `vector_store.workspace_client_from`.
- Bumps version `0.1.100 → 0.1.102` to force pip-reinstall on Databricks Apps containers (pip caches by name+version).

## Why

Eval traces against `commerce_swarm` on fevm consistently hit ~34 Pydantic validation errors per 15-row run on `faq_search` / `product_search` / `policy_search`: the LLM passed `filters: {dict}`; the schema demanded `filters: list[FilterItem]`. Root cause was in the rendered tool schema the LLM saw — the `filters` property had **no `type` field, no `items` sub-schema, only a `description` string** because LangChain's `@tool` decorator drops the structural type information when the parameter is `Annotated[Optional[list[BaseModel]], "desc"]`. The fix is the canonical LangChain pattern: pass `args_schema=` explicitly.

Diagnostic trace: `mlflow.chat.tools[*]` on `a46d9219806ca5443b730531ddcacfd5` (fevm `retail_consumer_goods.commerce_swarm.3023366674399020` OTEL).

## End-to-end verification (fevm commerce_swarm, 15-row eval)

|                                | Before | After  |
| ------------------------------ | ------ | ------ |
| Total ERROR spans              | 66 (5.1%) | 30 (3.0%) |
| Pydantic validation errors on `filters` | 34 | **0** |
| `product_search` OK / ERR      | 0 / 10 | **14 / 0** |
| `faq_search` OK / ERR          | 0 / 40 | **12 / 0** |
| `policy_search` OK / ERR       | 0 / 3  | **9 / 0** |

Remaining ERROR spans are all LangGraph swarm `Command(...)` handoffs (intentional control flow, separate upstream MLflow ↔ LangGraph integration issue).

## OBO verification

After landing the fix, flipped `on_behalf_of_user: true` on all 3 commerce_swarm vector stores (products / faqs / policies), redeployed via `deploy-agents`, and called `/invocations` with the calling user's bearer. Response:

```
HTTP 500
databricks.ai_search.exceptions.PermissionDenied:
  Invalid scope, required scopes: vector-search
```

That error is itself proof OBO is honored end-to-end: the user's forwarded `x-forwarded-access-token` reached the VectorSearch endpoint, which rejected because the calling user's OAuth client lacks the `vector-search` scope. With `on_behalf_of_user=false` (default), the call uses the App's SP token, which has the scope. So OBO is wired correctly — flip the flag on per-store when you want user-scoped reads.

Two unit tests (`test_create_vector_search_tool_obo_*`) pin this chain in isolation so a future LangChain/LangGraph upgrade can't silently degrade OBO to SP auth.

## Test plan

- [x] `uv run pytest tests/dao_ai/test_vector_search.py` — 19 pass (11 pre-existing + 6 args_schema + 2 OBO)
- [x] `DATABRICKS_CONFIG_PROFILE=fevm make unit` — 1351 pass, 15 skipped (4 errors are pre-existing MLflow file-store maintenance-mode rejection on autolog/background-trace/memory-context tests — confirmed identical on `origin/main`)
- [x] `DATABRICKS_CONFIG_PROFILE=fevm make integration` — passes for the suite that doesn't require the Azure CI workspace
- [x] Live inference on the deployed commerce_swarm Databricks App returns 200 with the new wheel; rendered tool schema verified structural via OTEL span attributes
- [x] Full 15-row commerce_swarm eval succeeds with 0 filter-shape validation errors and full child-span coverage on every trace
- [x] OBO end-to-end: `on_behalf_of_user=true` honored — user's bearer reached the VS endpoint (verified by the `Invalid scope` server response)

This pull request and its description were written by Isaac.