### PR TITLE
fix(eval-notebook): pin agent to persistent asyncio loop (Lakebase Lock fix)

### DIFF
--- a/notebooks/08_run_evaluation.py
+++ b/notebooks/08_run_evaluation.py
@@ -11,17 +11,15 @@ import os
 def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
     if not os.path.exists(base_path):
         raise FileNotFoundError(f"Base path does not exist: {base_path}")
-    
+
     if not os.path.isdir(base_path):
         raise NotADirectoryError(f"Base path is not a directory: {base_path}")
-    
-    yaml_files = []
-    
-    for root, dirs, files in os.walk(base_path):
+
+    yaml_files: list[str] = []
+    for root, _, files in os.walk(base_path):
         for file in files:
-            if file.lower().endswith(('.yaml', '.yml')):
+            if file.lower().endswith((".yaml", ".yml")):
                 yaml_files.append(os.path.join(root, file))
-    
     return sorted(yaml_files)
 
 # COMMAND ----------
@@ -31,11 +29,7 @@ dbutils.widgets.text(name="config-path", defaultValue="")
 config_files: Sequence[str] = find_yaml_files_os_walk("../config")
 dbutils.widgets.dropdown(name="config-paths", choices=config_files, defaultValue=next(iter(config_files), ""))
 
-config_path: str | None = dbutils.widgets.get("config-path") or None
-project_path: str = dbutils.widgets.get("config-paths") or None
-
-config_path: str = config_path or project_path
-
+config_path: str = dbutils.widgets.get("config-path") or dbutils.widgets.get("config-paths")
 print(config_path)
 
 # COMMAND ----------
@@ -64,70 +58,38 @@ import dao_ai.memory.databricks
 
 # COMMAND ----------
 
-# DBTITLE 1,Pin Eval Harness to a Single Event Loop
+# DBTITLE 1,Pin Eval Harness to One Thread + One Event Loop
 #
-# mlflow.genai.evaluate's harness runs each row via asyncio.run(predict_fn(...))
-# which by default creates a fresh event loop per call and closes it. The dao-ai
-# Lakebase memory checkpointer is a process-wide singleton whose internal
-# asyncio.Lock (and the underlying psycopg AsyncConnectionPool's futures) latch
-# to the event loop they're first used on. On row 2+ the cached lock points at
-# row 1's closed loop and raises `bound to a different event loop`. The trace
-# completes (the error is caught + falls back to a fresh state), but the
-# exception shows up on every eval-row trace as noise.
+# mlflow.genai.evaluate uses a 10-worker ThreadPoolExecutor by default and wraps
+# every async predict_fn call in asyncio.run(...) — fresh loop per worker thread.
+# The shared dao-ai agent's Lakebase checkpointer binds an asyncio.Lock to the
+# first loop that touches it, so cross-thread rows trip
+# "bound to a different event loop". Pin to one worker; nest_asyncio makes
+# sequential asyncio.run calls reuse that thread's single loop.
 #
-# nest_asyncio.apply() monkey-patches asyncio.run to REUSE the existing event
-# loop instead of creating a fresh one (see nest_asyncio._patch_asyncio:run —
-# `loop = asyncio.get_event_loop(); loop.run_until_complete(task)`). Net effect:
-# every eval row shares one persistent loop, the checkpointer's primitives stay
-# valid for the whole run, and the Lakebase pool is reused across rows.
-#
-# This is scoped to the eval notebook process; it has no effect on Apps or
-# Model Serving (which already use a single long-lived loop per process).
+# Verified empirically: 4 workers across 10 rows produce 4 distinct loop ids;
+# MAX_WORKERS=1 produces 1. Throughput trade-off is fine for typical eval sizes.
+# Scoped to this notebook process — no effect on Apps or Model Serving (which
+# already run on a single long-lived loop per process).
+os.environ["MLFLOW_GENAI_EVAL_MAX_WORKERS"] = "1"
 import nest_asyncio
 nest_asyncio.apply()
 
 # COMMAND ----------
 
-# DBTITLE 1,Initialize and Configure DAO AI ResponsesAgent
-#
-# Canonical mlflow.genai.evaluate setup. Three intentional non-actions here,
-# each of which broke things in prior versions of this notebook:
-#
-# 1. Do NOT call ``mlflow.langchain.autolog(...)``. The harness already
-#    enables it under its own ``configure_autologging_for_evaluation``
-#    context (mlflow/models/evaluation/utils/trace.py). Calling it here too
-#    double-patches LangChain's callback manager and produces orphan-rooted
-#    spans whose parent_span_id points outside the exported trace.
-# 2. Do NOT call ``mlflow.tracing.set_destination(...)`` or
-#    ``mlflow.set_experiment(trace_location=...)`` to bind UC tracing. The
-#    experiment is bound once at App boot — the binding is persistent in
-#    the experiment tags and re-binding here is a no-op at best and a
-#    footgun at worst (puts the experiment's trace-location list into a
-#    TRACE_LOCATION_TYPE_UNSPECIFIED state that breaks search_traces).
-# 3. Do NOT spin up a dedicated event-loop thread + ``asyncio.run_
-#    coroutine_threadsafe``. The harness wraps coroutine predict_fns with
-#    ``asyncio.run`` in the same thread (mlflow/genai/utils/trace_utils.py
-#    ``convert_predict_fn``), which keeps OpenTelemetry's contextvars-based
-#    span propagation intact so autolog spans nest under the per-row root.
-from typing import Any
-import mlflow
-from mlflow.pyfunc import ResponsesAgent
-from dao_ai.config import AppConfig
+# DBTITLE 1,Load Application Config
+from dao_ai.config import AppConfig, EvaluationModel
 from dao_ai.logging import configure_logging
 
 config: AppConfig = AppConfig.from_file(path=config_path)
 configure_logging(level=config.app.log_level)
 
-app: ResponsesAgent = config.as_responses_agent()
-
 # COMMAND ----------
 
 # DBTITLE 1,Validate Evaluation Configuration
 from typing import Any
-from dao_ai.config import EvaluationModel
 
 evaluation: EvaluationModel = config.evaluation
-
 if not evaluation:
     dbutils.notebook.exit("Missing evaluation configuration")
 
@@ -139,75 +101,75 @@ print(f"Custom inputs: {custom_inputs}")
 
 # COMMAND ----------
 
-# DBTITLE 1,Load Model Version and Define Prediction Function
-from typing import Any
-
+# DBTITLE 1,Resolve UC Model Version
 import mlflow
 from mlflow import MlflowClient
 from mlflow.entities.model_registry.model_version import ModelVersion
-from mlflow.types.responses import ResponsesAgentRequest, ResponsesAgentResponse
 from dao_ai.models import get_latest_model_version
 
 mlflow.set_registry_uri("databricks-uc")
-mlflow_client = MlflowClient()
+mlflow_client: MlflowClient = MlflowClient()
 
 registered_model_name: str = config.app.registered_model.full_name
 latest_version: int = get_latest_model_version(registered_model_name)
 model_uri: str = f"models:/{registered_model_name}/{latest_version}"
 model_version: ModelVersion = mlflow_client.get_model_version(registered_model_name, str(latest_version))
 
-_predict_counter = {"current": 0, "total": 0}
+print(f"Registered model: {registered_model_name}")
+print(f"Latest version:   {latest_version}")
+print(f"Model ID:         {model_version.model_id}")
 
+# COMMAND ----------
 
-def _extract_output_text(response: ResponsesAgentResponse) -> str:
-    texts: list[str] = []
-    for output in response.output:
-        if isinstance(output, dict):
-            if output.get("type") == "message":
-                for content in output.get("content", []):
-                    if isinstance(content, dict) and content.get("type") == "output_text":
-                        texts.append(content.get("text", ""))
-                    elif isinstance(content, dict) and "text" in content:
-                        texts.append(content.get("text", ""))
-                    elif getattr(content, "type", None) == "output_text":
-                        texts.append(content.text)
-        elif getattr(output, "type", None) == "message":
-            for content in output.content:
-                if isinstance(content, dict) and "text" in content:
-                    texts.append(content.get("text", ""))
-                elif getattr(content, "type", None) == "output_text":
-                    texts.append(content.text)
-    return "".join(texts) if texts else str(response.output)
-
-
-# Async predict_fn. The harness (mlflow/genai/utils/trace_utils.py
-# ``convert_predict_fn``) detects coroutines and wraps with
-# ``asyncio.run(asyncio.wait_for(...))`` in the same thread, so contextvars
-# (which carry the autolog/trace context) propagate correctly. Returning
-# the response as a JSON-serializable dict satisfies the eval harness's
-# output contract; the eval framework auto-extracts text from the
-# ResponsesAgent output schema.
+# DBTITLE 1,Build Shared Agent — UC Registry (default) or Local Config
 #
-# The function emits exactly one trace per call (the auto-injected
-# ResponsesAgent.predict span from
-# mlflow.pyfunc.ResponsesAgent.__init_subclass__) — the harness validator
-# (``check_model_prediction``) won't add an outer ``predict`` span on top
-# because it already sees a span being produced. One root per eval row.
-async def predict_fn(messages: list[dict[str, Any]]) -> dict[str, Any]:
-    _predict_counter["current"] += 1
-    row_num = _predict_counter["current"]
-    total = _predict_counter["total"]
-    print(f"[{row_num}/{total}] Predicting...")
+# Two supported eval sources:
+#   - "registry" loads the actual UC-registered artifact via mlflow.pyfunc.load_model.
+#     Most honest eval (you test what's deployed). Requires a successful deploy first.
+#   - "config" builds in-process from the local YAML via AppConfig.as_responses_agent().
+#     Fast iteration on the YAML without redeploying.
+#
+# Both paths reach the same LanggraphResponsesAgent code with the same async
+# singletons (Lakebase checkpointer, langgraph saver), so the harness pin above
+# applies to both. One shared instance per run.
+from typing import Literal
 
-    request: ResponsesAgentRequest = ResponsesAgentRequest(
-        input=[{"role": m["role"], "content": m["content"]} for m in messages],
-        custom_inputs=custom_inputs,
-    )
-    response: ResponsesAgentResponse = await app.apredict(request)
+dbutils.widgets.dropdown(name="agent-source", defaultValue="registry", choices=["registry", "config"])
+agent_source: Literal["registry", "config"] = dbutils.widgets.get("agent-source")  # type: ignore[assignment]
 
-    output_text: str = _extract_output_text(response)
-    print(f"[{row_num}/{total}] Done ({len(output_text)} chars)")
-    return response.model_dump()
+if agent_source == "registry":
+    app: Any = mlflow.pyfunc.load_model(model_uri)
+else:
+    app = config.as_responses_agent()
+
+print(f"Agent source: {agent_source}")
+
+# COMMAND ----------
+
+# DBTITLE 1,Define predict_fn
+from mlflow.types.responses import ResponsesAgentRequest, ResponsesAgentResponse
+
+if agent_source == "registry":
+    # PyFuncModel.predict is sync; it wraps LanggraphResponsesAgent.apredict via
+    # its own asyncio.run internally. The harness pin keeps every row on one
+    # loop so the wrapped agent's async singletons stay valid.
+    def predict_fn(messages: list[dict[str, Any]]) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "input": [{"role": m["role"], "content": m["content"]} for m in messages],
+            "custom_inputs": custom_inputs,
+        }
+        return app.predict(payload)
+else:
+    # Async predict_fn against the in-process LanggraphResponsesAgent. The
+    # harness detects coroutines and wraps with asyncio.run(...) on the same
+    # thread; nest_asyncio keeps that thread's loop persistent across rows.
+    async def predict_fn(messages: list[dict[str, Any]]) -> dict[str, Any]:
+        request: ResponsesAgentRequest = ResponsesAgentRequest(
+            input=[{"role": m["role"], "content": m["content"]} for m in messages],
+            custom_inputs=custom_inputs,
+        )
+        response: ResponsesAgentResponse = await app.apredict(request)
+        return response.model_dump()
 
 # COMMAND ----------
 
@@ -249,28 +211,19 @@ eval_dataset = create_or_get_eval_dataset(
 experiment = mlflow.get_experiment(model_run.info.experiment_id)
 print(f"Dataset name:      {eval_dataset.name}")
 print(f"Dataset ID:        {eval_dataset.dataset_id}")
-print(f"Dataset source:    {eval_dataset.source_type}")
 print(f"Dataset records:   {len(eval_dataset.to_df())} rows")
 print(f"Experiment name:   {experiment.name}")
 print(f"Experiment ID:     {model_run.info.experiment_id}")
 
-# Intentionally NO ``mlflow.autolog(...)`` calls here either. The harness
-# enables langchain/openai/anthropic/litellm autologs internally under its
-# own snapshot. Toggling them at notebook level either no-ops (harness
-# overrides) or fights the harness's restore logic.
-
-run_tags: dict[str, str] = {
-    k: str(v) for k, v in (config.app.tags or {}).items()
-}
+run_tags: dict[str, str] = {k: str(v) for k, v in (config.app.tags or {}).items()}
 run_tags["run_type"] = "evaluation"
 run_name: str = f"{config.app.name}_evaluation_v{latest_version}_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
 
-_predict_counter["total"] = len(eval_df)
 print(f"Starting evaluation: {len(eval_df)} rows, {len(scorers)} scorers")
 
 with mlflow.start_run(run_name=run_name, tags=run_tags) as run:
     try:
-        eval_results: EvaluationResult = mlflow.genai.evaluate(
+        eval_results: EvaluationResult | None = mlflow.genai.evaluate(
             data=eval_dataset,
             predict_fn=predict_fn,
             model_id=model_version.model_id,
@@ -289,7 +242,7 @@ if eval_results is not None:
     for metric_name, metric_value in eval_results.metrics.items():
         print(f"  {metric_name}: {metric_value}")
 
-    eval_results_df = prepare_eval_results_for_display(eval_results)
+    eval_results_df: pd.DataFrame = prepare_eval_results_for_display(eval_results)
     print(f"Total evaluation results: {len(eval_results_df)} rows")
     if not eval_results_df.empty:
         display(eval_results_df.head(100))

--- a/notebooks/08_run_evaluation.py
+++ b/notebooks/08_run_evaluation.py
@@ -64,30 +64,6 @@ import dao_ai.memory.databricks
 
 # COMMAND ----------
 
-# DBTITLE 1,Pin Eval Harness to a Single Event Loop
-#
-# mlflow.genai.evaluate's harness runs each row via asyncio.run(predict_fn(...))
-# which by default creates a fresh event loop per call and closes it. The dao-ai
-# Lakebase memory checkpointer is a process-wide singleton whose internal
-# asyncio.Lock (and the underlying psycopg AsyncConnectionPool's futures) latch
-# to the event loop they're first used on. On row 2+ the cached lock points at
-# row 1's closed loop and raises `bound to a different event loop`. The trace
-# completes (the error is caught + falls back to a fresh state), but the
-# exception shows up on every eval-row trace as noise.
-#
-# nest_asyncio.apply() monkey-patches asyncio.run to REUSE the existing event
-# loop instead of creating a fresh one (see nest_asyncio._patch_asyncio:run —
-# `loop = asyncio.get_event_loop(); loop.run_until_complete(task)`). Net effect:
-# every eval row shares one persistent loop, the checkpointer's primitives stay
-# valid for the whole run, and the Lakebase pool is reused across rows.
-#
-# This is scoped to the eval notebook process; it has no effect on Apps or
-# Model Serving (which already use a single long-lived loop per process).
-import nest_asyncio
-nest_asyncio.apply()
-
-# COMMAND ----------
-
 # DBTITLE 1,Initialize and Configure DAO AI ResponsesAgent
 #
 # Canonical mlflow.genai.evaluate setup. Three intentional non-actions here,

--- a/notebooks/08_run_evaluation.py
+++ b/notebooks/08_run_evaluation.py
@@ -64,6 +64,30 @@ import dao_ai.memory.databricks
 
 # COMMAND ----------
 
+# DBTITLE 1,Pin Eval Harness to a Single Event Loop
+#
+# mlflow.genai.evaluate's harness runs each row via asyncio.run(predict_fn(...))
+# which by default creates a fresh event loop per call and closes it. The dao-ai
+# Lakebase memory checkpointer is a process-wide singleton whose internal
+# asyncio.Lock (and the underlying psycopg AsyncConnectionPool's futures) latch
+# to the event loop they're first used on. On row 2+ the cached lock points at
+# row 1's closed loop and raises `bound to a different event loop`. The trace
+# completes (the error is caught + falls back to a fresh state), but the
+# exception shows up on every eval-row trace as noise.
+#
+# nest_asyncio.apply() monkey-patches asyncio.run to REUSE the existing event
+# loop instead of creating a fresh one (see nest_asyncio._patch_asyncio:run —
+# `loop = asyncio.get_event_loop(); loop.run_until_complete(task)`). Net effect:
+# every eval row shares one persistent loop, the checkpointer's primitives stay
+# valid for the whole run, and the Lakebase pool is reused across rows.
+#
+# This is scoped to the eval notebook process; it has no effect on Apps or
+# Model Serving (which already use a single long-lived loop per process).
+import nest_asyncio
+nest_asyncio.apply()
+
+# COMMAND ----------
+
 # DBTITLE 1,Initialize and Configure DAO AI ResponsesAgent
 #
 # Canonical mlflow.genai.evaluate setup. Three intentional non-actions here,

--- a/notebooks/08_run_evaluation.py
+++ b/notebooks/08_run_evaluation.py
@@ -58,25 +58,6 @@ import dao_ai.memory.databricks
 
 # COMMAND ----------
 
-# DBTITLE 1,Pin Eval Harness to One Thread + One Event Loop
-#
-# mlflow.genai.evaluate uses a 10-worker ThreadPoolExecutor by default and wraps
-# every async predict_fn call in asyncio.run(...) — fresh loop per worker thread.
-# The shared dao-ai agent's Lakebase checkpointer binds an asyncio.Lock to the
-# first loop that touches it, so cross-thread rows trip
-# "bound to a different event loop". Pin to one worker; nest_asyncio makes
-# sequential asyncio.run calls reuse that thread's single loop.
-#
-# Verified empirically: 4 workers across 10 rows produce 4 distinct loop ids;
-# MAX_WORKERS=1 produces 1. Throughput trade-off is fine for typical eval sizes.
-# Scoped to this notebook process — no effect on Apps or Model Serving (which
-# already run on a single long-lived loop per process).
-os.environ["MLFLOW_GENAI_EVAL_MAX_WORKERS"] = "1"
-import nest_asyncio
-nest_asyncio.apply()
-
-# COMMAND ----------
-
 # DBTITLE 1,Load Application Config
 from dao_ai.config import AppConfig, EvaluationModel
 from dao_ai.logging import configure_logging
@@ -94,10 +75,24 @@ if not evaluation:
     dbutils.notebook.exit("Missing evaluation configuration")
 
 payload_table: str = evaluation.table.full_name
-custom_inputs: dict[str, Any] = evaluation.custom_inputs
+# Fall back to app.input_example.custom_inputs when evaluation.custom_inputs is
+# empty. Required for configs that wire validation middleware (e.g.
+# store_validation in sporting_goods_store*) but omit evaluation.custom_inputs;
+# without this the middleware raises on every row. app.input_example is a
+# ChatPayload Pydantic model (config.py:7547) with a Dict custom_inputs field.
+_eval_custom_inputs: dict[str, Any] = evaluation.custom_inputs or {}
+_input_example_custom_inputs: dict[str, Any] = (
+    getattr(config.app.input_example, "custom_inputs", None) or {}
+)
+custom_inputs: dict[str, Any] = _eval_custom_inputs or _input_example_custom_inputs or {}
+_custom_inputs_source: str = (
+    "evaluation" if _eval_custom_inputs
+    else "input_example" if _input_example_custom_inputs
+    else "empty"
+)
 
-print(f"Evaluation table: {payload_table}")
-print(f"Custom inputs: {custom_inputs}")
+print(f"Evaluation table:        {payload_table}")
+print(f"Custom inputs (source={_custom_inputs_source}): {custom_inputs}")
 
 # COMMAND ----------
 
@@ -108,6 +103,10 @@ from mlflow.entities.model_registry.model_version import ModelVersion
 from dao_ai.models import get_latest_model_version
 
 mlflow.set_registry_uri("databricks-uc")
+# Match the Apps handler (src/dao_ai/apps/handlers.py:52) so config-mode runs
+# produce complete child spans (LLM, tool, retriever). Idempotent for the
+# registry path where pyfunc-load already wires it.
+mlflow.langchain.autolog(run_tracer_inline=True)
 mlflow_client: MlflowClient = MlflowClient()
 
 registered_model_name: str = config.app.registered_model.full_name
@@ -130,8 +129,8 @@ print(f"Model ID:         {model_version.model_id}")
 #     Fast iteration on the YAML without redeploying.
 #
 # Both paths reach the same LanggraphResponsesAgent code with the same async
-# singletons (Lakebase checkpointer, langgraph saver), so the harness pin above
-# applies to both. One shared instance per run.
+# singletons (Lakebase checkpointer, langgraph saver). The persistent-loop
+# predict_fn below pins those singletons to a single loop for the whole run.
 from typing import Literal
 
 dbutils.widgets.dropdown(name="agent-source", defaultValue="registry", choices=["registry", "config"])
@@ -146,30 +145,63 @@ print(f"Agent source: {agent_source}")
 
 # COMMAND ----------
 
-# DBTITLE 1,Define predict_fn
+# DBTITLE 1,Define predict_fn — sync wrapper over a persistent asyncio loop
+#
+# mlflow.genai.evaluate calls predict_fn per row. Both available paths to the
+# agent create a fresh event loop per row:
+#   - registry mode: pyfunc.load_model.predict -> LanggraphResponsesAgent.predict
+#     -> asyncio.run(self.apredict(...)) at src/dao_ai/models.py:1599
+#   - config mode (async predict_fn): the harness wraps each row in asyncio.run
+#
+# The shared agent's Lakebase checkpointer binds an asyncio.Lock to the loop
+# that touches it first. Row 2's fresh loop then trips
+#   RuntimeError: <asyncio.locks.Lock> is bound to a different event loop
+# at langgraph/pregel/_loop.py:1888 (await checkpointer.aget_tuple(...)).
+# Reproduced live on trace tr-c06b0a1c8d3147aded17809bd20207d3
+# (experiment 2481319859454651).
+#
+# Fix: pin every apredict to ONE long-lived loop running in a daemon thread,
+# and submit row coroutines via asyncio.run_coroutine_threadsafe. The Lock
+# binds to this loop once and stays valid for the whole eval run.
+# Vault memory feedback_no_eval_accommodation_in_runtime.md mandates we fix
+# this in the harness, never in dao-ai runtime.
+import asyncio
+import threading
+
 from mlflow.types.responses import ResponsesAgentRequest, ResponsesAgentResponse
 
+# Idempotent across interactive cell re-runs: if the loop already exists and is
+# alive, reuse it so the agent's Lakebase Lock binding stays valid. Re-running
+# this cell with a fresh loop while the previous agent still binds the Lock to
+# the old loop would re-introduce the very bug we're fixing.
+if "_eval_loop" not in globals() or _eval_loop.is_closed():  # type: ignore[name-defined]
+    _eval_loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
+    _eval_loop_thread: threading.Thread = threading.Thread(
+        target=_eval_loop.run_forever, name="dao-ai-eval-loop", daemon=True
+    )
+    _eval_loop_thread.start()
+
+# Unwrap pyfunc to drive LanggraphResponsesAgent.apredict directly and skip the
+# sync .predict() wrapper at src/dao_ai/models.py:1599. ResponsesAgent-flavored
+# pyfunc models use _ResponsesAgentPyfuncWrapper (mlflow/pyfunc/loaders/
+# responses_agent.py) which exposes the underlying agent via get_raw_model();
+# unwrap_python_model() does NOT work here (that returns _model_impl.python_model
+# which only exists on the generic PythonModel wrapper).
 if agent_source == "registry":
-    # PyFuncModel.predict is sync; it wraps LanggraphResponsesAgent.apredict via
-    # its own asyncio.run internally. The harness pin keeps every row on one
-    # loop so the wrapped agent's async singletons stay valid.
-    def predict_fn(messages: list[dict[str, Any]]) -> dict[str, Any]:
-        payload: dict[str, Any] = {
-            "input": [{"role": m["role"], "content": m["content"]} for m in messages],
-            "custom_inputs": custom_inputs,
-        }
-        return app.predict(payload)
+    agent: Any = app._model_impl.get_raw_model()
 else:
-    # Async predict_fn against the in-process LanggraphResponsesAgent. The
-    # harness detects coroutines and wraps with asyncio.run(...) on the same
-    # thread; nest_asyncio keeps that thread's loop persistent across rows.
-    async def predict_fn(messages: list[dict[str, Any]]) -> dict[str, Any]:
-        request: ResponsesAgentRequest = ResponsesAgentRequest(
-            input=[{"role": m["role"], "content": m["content"]} for m in messages],
-            custom_inputs=custom_inputs,
-        )
-        response: ResponsesAgentResponse = await app.apredict(request)
-        return response.model_dump()
+    agent = app
+
+
+def predict_fn(messages: list[dict[str, Any]]) -> dict[str, Any]:
+    """Sync predict_fn so mlflow.genai.evaluate does NOT wrap in asyncio.run."""
+    request: ResponsesAgentRequest = ResponsesAgentRequest(
+        input=[{"role": m["role"], "content": m["content"]} for m in messages],
+        custom_inputs=custom_inputs,
+    )
+    future = asyncio.run_coroutine_threadsafe(agent.apredict(request), _eval_loop)
+    response: ResponsesAgentResponse = future.result(timeout=300)
+    return response.model_dump()
 
 # COMMAND ----------
 

--- a/notebooks/08_run_evaluation.py
+++ b/notebooks/08_run_evaluation.py
@@ -64,47 +64,35 @@ import dao_ai.memory.databricks
 
 # COMMAND ----------
 
-# DBTITLE 1,Set Up Dedicated Async Event Loop Thread
-import asyncio
-import threading
-
-_eval_loop = asyncio.new_event_loop()
-_eval_thread = threading.Thread(target=_eval_loop.run_forever, daemon=True)
-_eval_thread.start()
-
-def run_async(coro):
-    """Run an async coroutine on the dedicated event loop thread.
-    
-    All async operations (agent predictions) must run on the same event loop
-    to avoid asyncio.Lock cross-loop errors with nest_asyncio.
-    """
-    return asyncio.run_coroutine_threadsafe(coro, _eval_loop).result()
-
-# COMMAND ----------
-
 # DBTITLE 1,Initialize and Configure DAO AI ResponsesAgent
+#
+# Canonical mlflow.genai.evaluate setup. Three intentional non-actions here,
+# each of which broke things in prior versions of this notebook:
+#
+# 1. Do NOT call ``mlflow.langchain.autolog(...)``. The harness already
+#    enables it under its own ``configure_autologging_for_evaluation``
+#    context (mlflow/models/evaluation/utils/trace.py). Calling it here too
+#    double-patches LangChain's callback manager and produces orphan-rooted
+#    spans whose parent_span_id points outside the exported trace.
+# 2. Do NOT call ``mlflow.tracing.set_destination(...)`` or
+#    ``mlflow.set_experiment(trace_location=...)`` to bind UC tracing. The
+#    experiment is bound once at App boot — the binding is persistent in
+#    the experiment tags and re-binding here is a no-op at best and a
+#    footgun at worst (puts the experiment's trace-location list into a
+#    TRACE_LOCATION_TYPE_UNSPECIFIED state that breaks search_traces).
+# 3. Do NOT spin up a dedicated event-loop thread + ``asyncio.run_
+#    coroutine_threadsafe``. The harness wraps coroutine predict_fns with
+#    ``asyncio.run`` in the same thread (mlflow/genai/utils/trace_utils.py
+#    ``convert_predict_fn``), which keeps OpenTelemetry's contextvars-based
+#    span propagation intact so autolog spans nest under the per-row root.
+from typing import Any
 import mlflow
 from mlflow.pyfunc import ResponsesAgent
 from dao_ai.config import AppConfig
 from dao_ai.logging import configure_logging
 
-mlflow.langchain.autolog(run_tracer_inline=True)
-
 config: AppConfig = AppConfig.from_file(path=config_path)
 configure_logging(level=config.app.log_level)
-
-if config.app and config.app.trace_location:
-    os.environ.setdefault("MLFLOW_TRACING_SQL_WAREHOUSE_ID", config.app.trace_location.warehouse_id)
-
-    from mlflow.entities import UCSchemaLocation
-
-    _loc = config.app.trace_location
-    mlflow.tracing.set_destination(
-        destination=UCSchemaLocation(
-            catalog_name=_loc.catalog_name,
-            schema_name=_loc.schema_name,
-        )
-    )
 
 app: ResponsesAgent = config.as_responses_agent()
 
@@ -168,33 +156,34 @@ def _extract_output_text(response: ResponsesAgentResponse) -> str:
     return "".join(texts) if texts else str(response.output)
 
 
-_predict_lock = threading.Lock()
-
-def _run_prediction(messages: list[dict[str, Any]], custom_inputs: dict[str, Any] | None) -> str:
-    with _predict_lock:
-        request = ResponsesAgentRequest(
-            input=[{"role": m["role"], "content": m["content"]} for m in messages],
-            custom_inputs=custom_inputs,
-        )
-        response: ResponsesAgentResponse = run_async(app.apredict(request))
-        return _extract_output_text(response)
-
-
-@mlflow.trace(name="evaluation", span_type="CHAIN")
-def predict_fn(messages: list[dict[str, Any]]) -> str:
+# Async predict_fn. The harness (mlflow/genai/utils/trace_utils.py
+# ``convert_predict_fn``) detects coroutines and wraps with
+# ``asyncio.run(asyncio.wait_for(...))`` in the same thread, so contextvars
+# (which carry the autolog/trace context) propagate correctly. Returning
+# the response as a JSON-serializable dict satisfies the eval harness's
+# output contract; the eval framework auto-extracts text from the
+# ResponsesAgent output schema.
+#
+# The function emits exactly one trace per call (the auto-injected
+# ResponsesAgent.predict span from
+# mlflow.pyfunc.ResponsesAgent.__init_subclass__) — the harness validator
+# (``check_model_prediction``) won't add an outer ``predict`` span on top
+# because it already sees a span being produced. One root per eval row.
+async def predict_fn(messages: list[dict[str, Any]]) -> dict[str, Any]:
     _predict_counter["current"] += 1
     row_num = _predict_counter["current"]
     total = _predict_counter["total"]
     print(f"[{row_num}/{total}] Predicting...")
 
-    try:
-        response_content = _run_prediction(messages, custom_inputs)
-    except Exception as e:
-        print(f"[{row_num}/{total}] ERROR: {e}")
-        response_content = f"[ERROR] {e}"
+    request: ResponsesAgentRequest = ResponsesAgentRequest(
+        input=[{"role": m["role"], "content": m["content"]} for m in messages],
+        custom_inputs=custom_inputs,
+    )
+    response: ResponsesAgentResponse = await app.apredict(request)
 
-    print(f"[{row_num}/{total}] Done ({len(response_content)} chars)")
-    return response_content
+    output_text: str = _extract_output_text(response)
+    print(f"[{row_num}/{total}] Done ({len(output_text)} chars)")
+    return response.model_dump()
 
 # COMMAND ----------
 
@@ -241,8 +230,10 @@ print(f"Dataset records:   {len(eval_dataset.to_df())} rows")
 print(f"Experiment name:   {experiment.name}")
 print(f"Experiment ID:     {model_run.info.experiment_id}")
 
-mlflow.autolog(disable=True)
-mlflow.langchain.autolog(run_tracer_inline=True)
+# Intentionally NO ``mlflow.autolog(...)`` calls here either. The harness
+# enables langchain/openai/anthropic/litellm autologs internally under its
+# own snapshot. Toggling them at notebook level either no-ops (harness
+# overrides) or fights the harness's restore logic.
 
 run_tags: dict[str, str] = {
     k: str(v) for k, v in (config.app.tags or {}).items()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dao-ai"
-version = "0.1.102"
+version = "0.1.100"
 description = "DAO AI: A modular, multi-agent orchestration framework for complex AI workflows. Supports agent handoff, tool integration, and dynamic configuration via YAML."
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dao-ai"
-version = "0.1.102"
+version = "0.1.103"
 description = "DAO AI: A modular, multi-agent orchestration framework for complex AI workflows. Supports agent handoff, tool integration, and dynamic configuration via YAML."
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dao-ai"
-version = "0.1.103"
+version = "0.1.102"
 description = "DAO AI: A modular, multi-agent orchestration framework for complex AI workflows. Supports agent handoff, tool integration, and dynamic configuration via YAML."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dao_ai/memory/databricks.py
+++ b/src/dao_ai/memory/databricks.py
@@ -28,6 +28,7 @@ deferred imports to avoid pulling ``databricks_ai_bridge`` at module-load time.
 """
 
 import asyncio
+import threading
 from typing import Any, AsyncIterator, Iterable, Literal, Sequence
 
 from databricks_langchain import DatabricksEmbeddings
@@ -117,45 +118,61 @@ class _LazyLakebaseCheckpointer(BaseCheckpointSaver):
     (Databricks Apps, Model Serving), that's fine: the loop persists for
     the process lifetime.
 
-    The ``mlflow.genai.evaluate`` harness, by contrast, runs each row from
-    a ``ThreadPoolExecutor`` worker via ``asyncio.run(predict_fn(...))``.
-    Each worker thread has its own event loop; ``asyncio.run`` also
-    creates a fresh loop per call. The cached saver's lock breaks any time
-    the running loop changes — every eval-row trace ends up tagged
-    ``ERROR`` with a ``RuntimeError: ... is bound to a different event
-    loop`` traceback.
+    The ``mlflow.genai.evaluate`` harness, by contrast, dispatches each
+    eval row to a ``ThreadPoolExecutor`` worker and runs it via
+    ``asyncio.run(predict_fn(...))``. Each worker thread has its own
+    event loop; ``asyncio.run`` also creates a fresh loop per call within
+    a thread. A shared singleton's asyncio primitives would break the
+    moment a different thread or a fresh loop touched them — every
+    eval-row trace would be tagged ``ERROR`` with a ``RuntimeError: ...
+    is bound to a different event loop`` traceback.
 
-    We tag the cached saver with the ``id()`` of the loop it was opened
-    on. On a different loop we drop the reference and rebuild. Closing
-    the stale pool from a different loop would itself trip the cross-loop
-    error, so we just let the dead pool be GC'd along with its closed
-    loop. For the eval workflow that's a few pool re-opens (~10-50ms
-    each); for Apps/Model Serving the loop never changes, so the
-    rebuild branch is dead code at runtime.
+    We resolve this with **per-thread, loop-aware caching**:
+
+    - Per-thread state via :class:`threading.local`. Each worker thread
+      has its own ``saver``/``init_lock``/``loop_id`` slots, so
+      concurrent threads can't corrupt each other's references.
+    - Loop-id check within a thread. Sequential ``asyncio.run`` calls in
+      the same thread create different event loops; when we detect the
+      ``id()`` of the running loop has changed, we drop the cached saver
+      and rebuild on the new loop.
+
+    Closing the stale pool from a different loop would itself trip the
+    cross-loop error, so we just let the dead pool be GC'd along with
+    its closed loop. For the eval workflow that's a few pool re-opens
+    (~10-50ms each, bounded by ``ThreadPoolExecutor`` size); for
+    Apps/Model Serving the thread + loop never change, so the rebuild
+    branch is dead code at runtime.
     """
 
     def __init__(self, saver_kwargs: dict[str, Any], log_extra: dict[str, Any]):
         super().__init__()
         self._saver_kwargs = saver_kwargs
         self._log_extra = log_extra
-        self._saver: BaseCheckpointSaver | None = None
-        self._saver_loop_id: int | None = None
-        self._init_lock: asyncio.Lock | None = None
+        # Per-thread storage: each thread gets its own saver, init_lock, and
+        # loop_id. Avoids the cross-thread race that occurs when the
+        # mlflow.genai.evaluate harness dispatches rows to a thread pool.
+        self._local = threading.local()
 
     async def _ensure(self) -> BaseCheckpointSaver:
         current_loop_id: int = id(asyncio.get_running_loop())
-        if self._saver is not None and self._saver_loop_id != current_loop_id:
-            # Stale: the loop the saver was opened on has been closed (eval
-            # harness pattern). Drop the reference; rebuild below.
-            self._saver = None
-            self._init_lock = None
-        if self._saver is not None:
-            return self._saver
-        # Bind the init lock to the active loop on first use.
-        if self._init_lock is None:
-            self._init_lock = asyncio.Lock()
-        async with self._init_lock:
-            if self._saver is None:
+        cached_saver = getattr(self._local, "saver", None)
+        cached_loop_id = getattr(self._local, "loop_id", None)
+        if cached_saver is not None and cached_loop_id == current_loop_id:
+            return cached_saver
+
+        # Stale or no saver for this (thread, loop) pair. Need to rebuild.
+        # asyncio.Lock binds to the active loop on construction, so build a
+        # fresh init lock keyed to the current loop too.
+        if cached_loop_id != current_loop_id:
+            self._local.init_lock = asyncio.Lock()
+            self._local.saver = None
+        init_lock = self._local.init_lock
+
+        async with init_lock:
+            cached_saver = getattr(self._local, "saver", None)
+            cached_loop_id = getattr(self._local, "loop_id", None)
+            if cached_saver is None or cached_loop_id != current_loop_id:
                 from databricks_langchain import AsyncCheckpointSaver
 
                 saver = AsyncCheckpointSaver(**self._saver_kwargs)
@@ -165,9 +182,9 @@ class _LazyLakebaseCheckpointer(BaseCheckpointSaver):
                     "Lakebase checkpointer initialized (lazy)",
                     **self._log_extra,
                 )
-                self._saver = saver
-                self._saver_loop_id = current_loop_id
-        return self._saver
+                self._local.saver = saver
+                self._local.loop_id = current_loop_id
+        return self._local.saver
 
     async def aget(self, config: RunnableConfig) -> Checkpoint | None:
         return await (await self._ensure()).aget(config)
@@ -232,8 +249,8 @@ class _LazyLakebaseStore(BaseStore):
     """Lazily opens the wrapped ``AsyncDatabricksStore`` on first await call.
 
     See :class:`_LazyLakebaseCheckpointer` for the rationale behind the
-    loop-id rebind dance — same asyncio-primitive-on-stale-loop problem,
-    same fix.
+    per-thread + loop-id caching — same asyncio-primitive-on-stale-loop
+    problem, same fix.
     """
 
     def __init__(self, store_kwargs: dict[str, Any], log_extra: dict[str, Any]):
@@ -241,21 +258,24 @@ class _LazyLakebaseStore(BaseStore):
         # ``batch`` / ``abatch`` — we satisfy those via overrides below.
         self._store_kwargs = store_kwargs
         self._log_extra = log_extra
-        self._store: BaseStore | None = None
-        self._store_loop_id: int | None = None
-        self._init_lock: asyncio.Lock | None = None
+        self._local = threading.local()
 
     async def _ensure(self) -> BaseStore:
         current_loop_id: int = id(asyncio.get_running_loop())
-        if self._store is not None and self._store_loop_id != current_loop_id:
-            self._store = None
-            self._init_lock = None
-        if self._store is not None:
-            return self._store
-        if self._init_lock is None:
-            self._init_lock = asyncio.Lock()
-        async with self._init_lock:
-            if self._store is None:
+        cached_store = getattr(self._local, "store", None)
+        cached_loop_id = getattr(self._local, "loop_id", None)
+        if cached_store is not None and cached_loop_id == current_loop_id:
+            return cached_store
+
+        if cached_loop_id != current_loop_id:
+            self._local.init_lock = asyncio.Lock()
+            self._local.store = None
+        init_lock = self._local.init_lock
+
+        async with init_lock:
+            cached_store = getattr(self._local, "store", None)
+            cached_loop_id = getattr(self._local, "loop_id", None)
+            if cached_store is None or cached_loop_id != current_loop_id:
                 from databricks_langchain import AsyncDatabricksStore
 
                 store = AsyncDatabricksStore(**self._store_kwargs)
@@ -265,9 +285,9 @@ class _LazyLakebaseStore(BaseStore):
                     "Lakebase store initialized (lazy)",
                     **self._log_extra,
                 )
-                self._store = store
-                self._store_loop_id = current_loop_id
-        return self._store
+                self._local.store = store
+                self._local.loop_id = current_loop_id
+        return self._local.store
 
     async def abatch(self, ops: Iterable[Op]) -> list[Result]:
         return await (await self._ensure()).abatch(ops)

--- a/src/dao_ai/memory/databricks.py
+++ b/src/dao_ai/memory/databricks.py
@@ -107,19 +107,51 @@ async def _create_async_lakebase_pool(database: DatabaseModel, **extra: Any):
 
 
 class _LazyLakebaseCheckpointer(BaseCheckpointSaver):
-    """Lazily opens the wrapped ``AsyncCheckpointSaver`` on first await call."""
+    """Lazily opens the wrapped ``AsyncCheckpointSaver`` on first await call.
+
+    The checkpointer is a process-wide singleton (one per ``MemoryModel``
+    config, cached by :class:`CheckpointManager`). Its internal asyncio
+    primitives — the langgraph ``AsyncPostgresSaver.lock`` and the
+    underlying ``psycopg_pool.AsyncConnectionPool`` futures — latch to the
+    event loop they're first used on. For long-lived single-loop callers
+    (Databricks Apps, Model Serving), that's fine: the loop persists for
+    the process lifetime.
+
+    The ``mlflow.genai.evaluate`` harness, by contrast, runs each row from
+    a ``ThreadPoolExecutor`` worker via ``asyncio.run(predict_fn(...))``.
+    Each worker thread has its own event loop; ``asyncio.run`` also
+    creates a fresh loop per call. The cached saver's lock breaks any time
+    the running loop changes — every eval-row trace ends up tagged
+    ``ERROR`` with a ``RuntimeError: ... is bound to a different event
+    loop`` traceback.
+
+    We tag the cached saver with the ``id()`` of the loop it was opened
+    on. On a different loop we drop the reference and rebuild. Closing
+    the stale pool from a different loop would itself trip the cross-loop
+    error, so we just let the dead pool be GC'd along with its closed
+    loop. For the eval workflow that's a few pool re-opens (~10-50ms
+    each); for Apps/Model Serving the loop never changes, so the
+    rebuild branch is dead code at runtime.
+    """
 
     def __init__(self, saver_kwargs: dict[str, Any], log_extra: dict[str, Any]):
         super().__init__()
         self._saver_kwargs = saver_kwargs
         self._log_extra = log_extra
         self._saver: BaseCheckpointSaver | None = None
+        self._saver_loop_id: int | None = None
         self._init_lock: asyncio.Lock | None = None
 
     async def _ensure(self) -> BaseCheckpointSaver:
+        current_loop_id: int = id(asyncio.get_running_loop())
+        if self._saver is not None and self._saver_loop_id != current_loop_id:
+            # Stale: the loop the saver was opened on has been closed (eval
+            # harness pattern). Drop the reference; rebuild below.
+            self._saver = None
+            self._init_lock = None
         if self._saver is not None:
             return self._saver
-        # Bind the lock to the active loop on first use.
+        # Bind the init lock to the active loop on first use.
         if self._init_lock is None:
             self._init_lock = asyncio.Lock()
         async with self._init_lock:
@@ -134,6 +166,7 @@ class _LazyLakebaseCheckpointer(BaseCheckpointSaver):
                     **self._log_extra,
                 )
                 self._saver = saver
+                self._saver_loop_id = current_loop_id
         return self._saver
 
     async def aget(self, config: RunnableConfig) -> Checkpoint | None:
@@ -196,7 +229,12 @@ class _LazyLakebaseCheckpointer(BaseCheckpointSaver):
 
 
 class _LazyLakebaseStore(BaseStore):
-    """Lazily opens the wrapped ``AsyncDatabricksStore`` on first await call."""
+    """Lazily opens the wrapped ``AsyncDatabricksStore`` on first await call.
+
+    See :class:`_LazyLakebaseCheckpointer` for the rationale behind the
+    loop-id rebind dance — same asyncio-primitive-on-stale-loop problem,
+    same fix.
+    """
 
     def __init__(self, store_kwargs: dict[str, Any], log_extra: dict[str, Any]):
         # Don't call super().__init__() because BaseStore is abstract on
@@ -204,9 +242,14 @@ class _LazyLakebaseStore(BaseStore):
         self._store_kwargs = store_kwargs
         self._log_extra = log_extra
         self._store: BaseStore | None = None
+        self._store_loop_id: int | None = None
         self._init_lock: asyncio.Lock | None = None
 
     async def _ensure(self) -> BaseStore:
+        current_loop_id: int = id(asyncio.get_running_loop())
+        if self._store is not None and self._store_loop_id != current_loop_id:
+            self._store = None
+            self._init_lock = None
         if self._store is not None:
             return self._store
         if self._init_lock is None:
@@ -223,6 +266,7 @@ class _LazyLakebaseStore(BaseStore):
                     **self._log_extra,
                 )
                 self._store = store
+                self._store_loop_id = current_loop_id
         return self._store
 
     async def abatch(self, ops: Iterable[Op]) -> list[Result]:

--- a/src/dao_ai/memory/databricks.py
+++ b/src/dao_ai/memory/databricks.py
@@ -28,7 +28,6 @@ deferred imports to avoid pulling ``databricks_ai_bridge`` at module-load time.
 """
 
 import asyncio
-import threading
 from typing import Any, AsyncIterator, Iterable, Literal, Sequence
 
 from databricks_langchain import DatabricksEmbeddings
@@ -118,61 +117,45 @@ class _LazyLakebaseCheckpointer(BaseCheckpointSaver):
     (Databricks Apps, Model Serving), that's fine: the loop persists for
     the process lifetime.
 
-    The ``mlflow.genai.evaluate`` harness, by contrast, dispatches each
-    eval row to a ``ThreadPoolExecutor`` worker and runs it via
-    ``asyncio.run(predict_fn(...))``. Each worker thread has its own
-    event loop; ``asyncio.run`` also creates a fresh loop per call within
-    a thread. A shared singleton's asyncio primitives would break the
-    moment a different thread or a fresh loop touched them — every
-    eval-row trace would be tagged ``ERROR`` with a ``RuntimeError: ...
-    is bound to a different event loop`` traceback.
+    The ``mlflow.genai.evaluate`` harness, by contrast, runs each row from
+    a ``ThreadPoolExecutor`` worker via ``asyncio.run(predict_fn(...))``.
+    Each worker thread has its own event loop; ``asyncio.run`` also
+    creates a fresh loop per call. The cached saver's lock breaks any time
+    the running loop changes — every eval-row trace ends up tagged
+    ``ERROR`` with a ``RuntimeError: ... is bound to a different event
+    loop`` traceback.
 
-    We resolve this with **per-thread, loop-aware caching**:
-
-    - Per-thread state via :class:`threading.local`. Each worker thread
-      has its own ``saver``/``init_lock``/``loop_id`` slots, so
-      concurrent threads can't corrupt each other's references.
-    - Loop-id check within a thread. Sequential ``asyncio.run`` calls in
-      the same thread create different event loops; when we detect the
-      ``id()`` of the running loop has changed, we drop the cached saver
-      and rebuild on the new loop.
-
-    Closing the stale pool from a different loop would itself trip the
-    cross-loop error, so we just let the dead pool be GC'd along with
-    its closed loop. For the eval workflow that's a few pool re-opens
-    (~10-50ms each, bounded by ``ThreadPoolExecutor`` size); for
-    Apps/Model Serving the thread + loop never change, so the rebuild
-    branch is dead code at runtime.
+    We tag the cached saver with the ``id()`` of the loop it was opened
+    on. On a different loop we drop the reference and rebuild. Closing
+    the stale pool from a different loop would itself trip the cross-loop
+    error, so we just let the dead pool be GC'd along with its closed
+    loop. For the eval workflow that's a few pool re-opens (~10-50ms
+    each); for Apps/Model Serving the loop never changes, so the
+    rebuild branch is dead code at runtime.
     """
 
     def __init__(self, saver_kwargs: dict[str, Any], log_extra: dict[str, Any]):
         super().__init__()
         self._saver_kwargs = saver_kwargs
         self._log_extra = log_extra
-        # Per-thread storage: each thread gets its own saver, init_lock, and
-        # loop_id. Avoids the cross-thread race that occurs when the
-        # mlflow.genai.evaluate harness dispatches rows to a thread pool.
-        self._local = threading.local()
+        self._saver: BaseCheckpointSaver | None = None
+        self._saver_loop_id: int | None = None
+        self._init_lock: asyncio.Lock | None = None
 
     async def _ensure(self) -> BaseCheckpointSaver:
         current_loop_id: int = id(asyncio.get_running_loop())
-        cached_saver = getattr(self._local, "saver", None)
-        cached_loop_id = getattr(self._local, "loop_id", None)
-        if cached_saver is not None and cached_loop_id == current_loop_id:
-            return cached_saver
-
-        # Stale or no saver for this (thread, loop) pair. Need to rebuild.
-        # asyncio.Lock binds to the active loop on construction, so build a
-        # fresh init lock keyed to the current loop too.
-        if cached_loop_id != current_loop_id:
-            self._local.init_lock = asyncio.Lock()
-            self._local.saver = None
-        init_lock = self._local.init_lock
-
-        async with init_lock:
-            cached_saver = getattr(self._local, "saver", None)
-            cached_loop_id = getattr(self._local, "loop_id", None)
-            if cached_saver is None or cached_loop_id != current_loop_id:
+        if self._saver is not None and self._saver_loop_id != current_loop_id:
+            # Stale: the loop the saver was opened on has been closed (eval
+            # harness pattern). Drop the reference; rebuild below.
+            self._saver = None
+            self._init_lock = None
+        if self._saver is not None:
+            return self._saver
+        # Bind the init lock to the active loop on first use.
+        if self._init_lock is None:
+            self._init_lock = asyncio.Lock()
+        async with self._init_lock:
+            if self._saver is None:
                 from databricks_langchain import AsyncCheckpointSaver
 
                 saver = AsyncCheckpointSaver(**self._saver_kwargs)
@@ -182,9 +165,9 @@ class _LazyLakebaseCheckpointer(BaseCheckpointSaver):
                     "Lakebase checkpointer initialized (lazy)",
                     **self._log_extra,
                 )
-                self._local.saver = saver
-                self._local.loop_id = current_loop_id
-        return self._local.saver
+                self._saver = saver
+                self._saver_loop_id = current_loop_id
+        return self._saver
 
     async def aget(self, config: RunnableConfig) -> Checkpoint | None:
         return await (await self._ensure()).aget(config)
@@ -249,8 +232,8 @@ class _LazyLakebaseStore(BaseStore):
     """Lazily opens the wrapped ``AsyncDatabricksStore`` on first await call.
 
     See :class:`_LazyLakebaseCheckpointer` for the rationale behind the
-    per-thread + loop-id caching — same asyncio-primitive-on-stale-loop
-    problem, same fix.
+    loop-id rebind dance — same asyncio-primitive-on-stale-loop problem,
+    same fix.
     """
 
     def __init__(self, store_kwargs: dict[str, Any], log_extra: dict[str, Any]):
@@ -258,24 +241,21 @@ class _LazyLakebaseStore(BaseStore):
         # ``batch`` / ``abatch`` — we satisfy those via overrides below.
         self._store_kwargs = store_kwargs
         self._log_extra = log_extra
-        self._local = threading.local()
+        self._store: BaseStore | None = None
+        self._store_loop_id: int | None = None
+        self._init_lock: asyncio.Lock | None = None
 
     async def _ensure(self) -> BaseStore:
         current_loop_id: int = id(asyncio.get_running_loop())
-        cached_store = getattr(self._local, "store", None)
-        cached_loop_id = getattr(self._local, "loop_id", None)
-        if cached_store is not None and cached_loop_id == current_loop_id:
-            return cached_store
-
-        if cached_loop_id != current_loop_id:
-            self._local.init_lock = asyncio.Lock()
-            self._local.store = None
-        init_lock = self._local.init_lock
-
-        async with init_lock:
-            cached_store = getattr(self._local, "store", None)
-            cached_loop_id = getattr(self._local, "loop_id", None)
-            if cached_store is None or cached_loop_id != current_loop_id:
+        if self._store is not None and self._store_loop_id != current_loop_id:
+            self._store = None
+            self._init_lock = None
+        if self._store is not None:
+            return self._store
+        if self._init_lock is None:
+            self._init_lock = asyncio.Lock()
+        async with self._init_lock:
+            if self._store is None:
                 from databricks_langchain import AsyncDatabricksStore
 
                 store = AsyncDatabricksStore(**self._store_kwargs)
@@ -285,9 +265,9 @@ class _LazyLakebaseStore(BaseStore):
                     "Lakebase store initialized (lazy)",
                     **self._log_extra,
                 )
-                self._local.store = store
-                self._local.loop_id = current_loop_id
-        return self._local.store
+                self._store = store
+                self._store_loop_id = current_loop_id
+        return self._store
 
     async def abatch(self, ops: Iterable[Op]) -> list[Result]:
         return await (await self._ensure()).abatch(ops)

--- a/src/dao_ai/memory/databricks.py
+++ b/src/dao_ai/memory/databricks.py
@@ -107,51 +107,19 @@ async def _create_async_lakebase_pool(database: DatabaseModel, **extra: Any):
 
 
 class _LazyLakebaseCheckpointer(BaseCheckpointSaver):
-    """Lazily opens the wrapped ``AsyncCheckpointSaver`` on first await call.
-
-    The checkpointer is a process-wide singleton (one per ``MemoryModel``
-    config, cached by :class:`CheckpointManager`). Its internal asyncio
-    primitives — the langgraph ``AsyncPostgresSaver.lock`` and the
-    underlying ``psycopg_pool.AsyncConnectionPool`` futures — latch to the
-    event loop they're first used on. For long-lived single-loop callers
-    (Databricks Apps, Model Serving), that's fine: the loop persists for
-    the process lifetime.
-
-    The ``mlflow.genai.evaluate`` harness, by contrast, runs each row from
-    a ``ThreadPoolExecutor`` worker via ``asyncio.run(predict_fn(...))``.
-    Each worker thread has its own event loop; ``asyncio.run`` also
-    creates a fresh loop per call. The cached saver's lock breaks any time
-    the running loop changes — every eval-row trace ends up tagged
-    ``ERROR`` with a ``RuntimeError: ... is bound to a different event
-    loop`` traceback.
-
-    We tag the cached saver with the ``id()`` of the loop it was opened
-    on. On a different loop we drop the reference and rebuild. Closing
-    the stale pool from a different loop would itself trip the cross-loop
-    error, so we just let the dead pool be GC'd along with its closed
-    loop. For the eval workflow that's a few pool re-opens (~10-50ms
-    each); for Apps/Model Serving the loop never changes, so the
-    rebuild branch is dead code at runtime.
-    """
+    """Lazily opens the wrapped ``AsyncCheckpointSaver`` on first await call."""
 
     def __init__(self, saver_kwargs: dict[str, Any], log_extra: dict[str, Any]):
         super().__init__()
         self._saver_kwargs = saver_kwargs
         self._log_extra = log_extra
         self._saver: BaseCheckpointSaver | None = None
-        self._saver_loop_id: int | None = None
         self._init_lock: asyncio.Lock | None = None
 
     async def _ensure(self) -> BaseCheckpointSaver:
-        current_loop_id: int = id(asyncio.get_running_loop())
-        if self._saver is not None and self._saver_loop_id != current_loop_id:
-            # Stale: the loop the saver was opened on has been closed (eval
-            # harness pattern). Drop the reference; rebuild below.
-            self._saver = None
-            self._init_lock = None
         if self._saver is not None:
             return self._saver
-        # Bind the init lock to the active loop on first use.
+        # Bind the lock to the active loop on first use.
         if self._init_lock is None:
             self._init_lock = asyncio.Lock()
         async with self._init_lock:
@@ -166,7 +134,6 @@ class _LazyLakebaseCheckpointer(BaseCheckpointSaver):
                     **self._log_extra,
                 )
                 self._saver = saver
-                self._saver_loop_id = current_loop_id
         return self._saver
 
     async def aget(self, config: RunnableConfig) -> Checkpoint | None:
@@ -229,12 +196,7 @@ class _LazyLakebaseCheckpointer(BaseCheckpointSaver):
 
 
 class _LazyLakebaseStore(BaseStore):
-    """Lazily opens the wrapped ``AsyncDatabricksStore`` on first await call.
-
-    See :class:`_LazyLakebaseCheckpointer` for the rationale behind the
-    loop-id rebind dance — same asyncio-primitive-on-stale-loop problem,
-    same fix.
-    """
+    """Lazily opens the wrapped ``AsyncDatabricksStore`` on first await call."""
 
     def __init__(self, store_kwargs: dict[str, Any], log_extra: dict[str, Any]):
         # Don't call super().__init__() because BaseStore is abstract on
@@ -242,14 +204,9 @@ class _LazyLakebaseStore(BaseStore):
         self._store_kwargs = store_kwargs
         self._log_extra = log_extra
         self._store: BaseStore | None = None
-        self._store_loop_id: int | None = None
         self._init_lock: asyncio.Lock | None = None
 
     async def _ensure(self) -> BaseStore:
-        current_loop_id: int = id(asyncio.get_running_loop())
-        if self._store is not None and self._store_loop_id != current_loop_id:
-            self._store = None
-            self._init_lock = None
         if self._store is not None:
             return self._store
         if self._init_lock is None:
@@ -266,7 +223,6 @@ class _LazyLakebaseStore(BaseStore):
                     **self._log_extra,
                 )
                 self._store = store
-                self._store_loop_id = current_loop_id
         return self._store
 
     async def abatch(self, ops: Iterable[Op]) -> list[Result]:


### PR DESCRIPTION
## Summary

Fixes the Lakebase asyncio.Lock cross-loop binding bug that made `mlflow.genai.evaluate` against dao-ai agents produce traces where every row's root span was `state=ERROR`.

- Persistent asyncio event loop in a daemon thread, started once at notebook init
- Sync `predict_fn` submits every row's coroutine via `asyncio.run_coroutine_threadsafe(...).result(timeout=300)` — the loop is the same across rows, so the Lakebase checkpointer's `asyncio.Lock` stays bound to a single loop
- For `agent-source=registry`, unwrap the underlying ResponsesAgent via `app._model_impl.get_raw_model()` and drive its `apredict` directly (skipping the sync `predict()` wrapper that would call its own `asyncio.run` per row)
- `mlflow.langchain.autolog(run_tracer_inline=True)` added explicitly so config-mode runs produce complete child spans (LLM, tool, retriever)
- `evaluation.custom_inputs` falls back to `app.input_example.custom_inputs` when empty so configs that wire validation middleware (e.g. `store_validation`) don't trip on every row
- Idempotency guard: re-running the predict_fn cell reuses the existing loop so the agent's Lock binding stays valid
- Drops the broken `MLFLOW_GENAI_EVAL_MAX_WORKERS=1 + nest_asyncio.apply()` mitigation (nest_asyncio doesn't unify independent `asyncio.run` calls from outside a loop)

## Why

`mlflow.genai.evaluate` calls `predict_fn` per row. Both available paths create a **fresh event loop per row**:

- registry mode → `pyfunc.predict()` → `LanggraphResponsesAgent.predict()` at `src/dao_ai/models.py:1599` → `asyncio.run(self.apredict(...))`. Fresh loop per row.
- config mode (async `predict_fn`) → the harness wraps each row in `asyncio.run(predict_fn(...))`. Fresh loop per row.

Row 1's loop owns the Lakebase checkpointer's `asyncio.Lock`. Row 2's fresh loop trips at `langgraph/pregel/_loop.py:1888 await self.checkpointer.aget_tuple(...)`:

```
RuntimeError: <asyncio.locks.Lock object at 0x...> is bound to a different event loop
```

The fix pins all `apredict` coroutines to one long-lived loop running in a daemon thread, so the Lock binds once and stays valid for the whole eval run.

Honors `feedback_no_eval_accommodation_in_runtime` — zero dao-ai source changes for the loop fix. The two earlier dao-ai-side attempts to fix this at the checkpointer level (commits `45b6693`, `1b0f400`) are explicitly reverted in this branch (commits `6de3157`, `3a5bf84`) so the runtime stays clean.

## End-to-end verification (fevm commerce_swarm, 15-row eval)

- **0** `asyncio.Lock` cross-loop errors across 1091 spans / 18 traces
- **0** filter-shape validation errors (the args_schema fix from #132 also lives here via merge from main)
- `product_search`: **21 OK / 0 ERR**
- `faq_search`: **11 OK / 0 ERR**
- `policy_search`: **5 OK / 0 ERR**
- 32 remaining ERROR spans are all LangGraph swarm `Command(...)` handoffs (intentional control flow)
- Sample trace span tree (44 spans, fully nested): `non_streaming → dao_ai_apredict → LangGraph → supervisor → CustomFieldValidationMiddleware → MemoryContextMiddleware → memory_context_search → model → ChatUnityAIGateway → handoff → pricing/general agents → tool spans` — no orphan spans

## Tests

- `tests/dao_ai/test_vector_search.py` — 19/19 pass (the 8 args_schema + OBO chain tests from #132 still green here)
- `DATABRICKS_CONFIG_PROFILE=fevm make unit` — 1351 pass / 15 skip (4 unrelated pre-existing MLflow file-store maintenance-mode errors)

## Supersedes

This PR supersedes #131. Mine takes the opposite direction (keep the persistent loop; reject the in-thread asyncio.run revert) because the in-thread approach re-introduces this exact Lakebase Lock cross-loop bug. Apps-only deploy support from #131 is a real feature gap and should land in a follow-up PR on top of this branch.

This pull request and its description were written by Isaac.