### PR TITLE
feat(trace-persistence): MS agents.deploy → UC OTEL end-to-end + ExperimentModel

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -14,3 +14,9 @@
 # is a content-addressed package hash, not a secret.
 uv.lock:square-access-token:6189
 696fd4bf191df78b669375cd8586dd779e3bc6b6:uv.lock:square-access-token:6189
+
+# Commented-out example db connection string template in a config file
+# (literal placeholder like ``user`` and ``password``, not a real
+# credential). Introduced in the repo's initial commit; the config file
+# was later moved to config/examples/05_memory/.
+5c78b52d19d4bc63a6f7570e9ded40f551051033:config/examples/04_memory/postgres_persistence.yaml:postgres-connection-string:78

--- a/config/examples/15_complete_applications/commerce_supervisor/commerce_supervisor.yaml
+++ b/config/examples/15_complete_applications/commerce_supervisor/commerce_supervisor.yaml
@@ -869,6 +869,21 @@ app:
 
   endpoint_name: commerce_super_dao
 
+  # Pin the runtime identity for MLflow tracing writes — auto-populates
+  # DATABRICKS_CLIENT_ID / DATABRICKS_CLIENT_SECRET on the deployed endpoint
+  # from the referenced secrets. dao-ai auto-grants this SP CAN_EDIT on the
+  # MLflow experiment + UC OTEL table SELECT+MODIFY at deploy time (unless
+  # ``manage_permissions: false``). Independent of the bespoke
+  # RETAIL_AI_DATABRICKS_CLIENT_ID/SECRET env vars below, which the Lakebase
+  # OAuth minting code reads at request time.
+  service_principal:
+    client_id:
+      scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_ID
+    client_secret:
+      scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+
   # MLflow trace persistence on Databricks Apps requires trace_location — Apps
   # containers cannot reach the default control-plane trace storage host
   # (us-east-1.storage.cloud.databricks.com). Routing exports through a SQL

--- a/config/examples/15_complete_applications/commerce_swarm/commerce_swarm.yaml
+++ b/config/examples/15_complete_applications/commerce_swarm/commerce_swarm.yaml
@@ -891,6 +891,21 @@ app:
 
   endpoint_name: commerce_swarm_dao
 
+  # Pin the runtime identity for MLflow tracing writes — auto-populates
+  # DATABRICKS_CLIENT_ID / DATABRICKS_CLIENT_SECRET on the deployed endpoint
+  # from the referenced secrets. dao-ai auto-grants this SP CAN_EDIT on the
+  # MLflow experiment + UC OTEL table SELECT+MODIFY at deploy time (unless
+  # ``manage_permissions: false``). Independent of the bespoke
+  # RETAIL_AI_DATABRICKS_CLIENT_ID/SECRET env vars below, which the Lakebase
+  # OAuth minting code reads at request time.
+  service_principal:
+    client_id:
+      scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_ID
+    client_secret:
+      scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+
   # MLflow trace persistence on Databricks Apps requires trace_location — Apps
   # containers cannot reach the default control-plane trace storage host
   # (us-east-1.storage.cloud.databricks.com). Routing exports through a SQL

--- a/config/examples/15_complete_applications/hardware_store.yaml
+++ b/config/examples/15_complete_applications/hardware_store.yaml
@@ -11,6 +11,9 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  warehouse_id:
+    description: SQL warehouse ID for the UC OTEL trace tables' initial DDL
+    default: d1be2f7fe7faacb1
 
 # =============================================================================
 # Multi-Agent AI Orchestration Framework Configuration
@@ -704,7 +707,7 @@ agents:
 # and agent orchestration patterns for the multi-agent system
 
 app:
-  name: hardware_store_dao                      # Application name  
+  name: hardware_store_dao                      # Application name
   description: "Multi-agent system for retail customer service and product assistance"
   log_level: DEBUG                                   # Logging level for the application
   registered_model:                                 # MLflow registered model configuration
@@ -712,6 +715,37 @@ app:
                                                     # Schema where model will be registered
     name: hardware_store_dao
   endpoint_name: hardware_store_dao                    # Model serving endpoint name
+
+  # Stage-1 diagnostic (MS-trace-persistence investigation). Declaring an
+  # SP here triggers AppModel.set_databricks_env_vars to auto-populate
+  # DATABRICKS_CLIENT_ID / DATABRICKS_CLIENT_SECRET on the deployed
+  # endpoint from the referenced secrets. Combined with trace_location
+  # below, this is the exact env-var contract the official docs recommend
+  # for writing MS traces to UC (docs.databricks.com/aws/en/mlflow3/genai/
+  # tracing/trace-unity-catalog#write-traces-from-a-model-serving-endpoint).
+  service_principal:
+    client_id:
+      scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_ID
+    client_secret:
+      scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+
+  # trace_location temporarily disabled for Stage 1 — the current
+  # experiment (id=1952423719449237) has pre-existing non-UC traces
+  # from yesterday's deploys, and MLflow won't re-link a UC trace
+  # destination onto an experiment that already contains traces.
+  # Stage 1 only needs the SP-env-var round-trip, which trace_location
+  # doesn't affect.
+  # trace_location:
+  #   schema: *retail_schema
+  #   warehouse: ${var.warehouse_id}
+
+  environment_vars:
+    # Enable the in-model + post-deploy env-var reflection diagnostics
+    # (dao_ai.diagnostics.is_enabled). Toggle off after the investigation.
+    DAO_AI_TRACE_ENV_DUMP: "1"
+
   tags:                                             # Tags for resource organization
     business: rcg                                   # Business unit identifier
     streaming: true                                 # Indicates streaming capabilities

--- a/config/examples/15_complete_applications/hardware_store.yaml
+++ b/config/examples/15_complete_applications/hardware_store.yaml
@@ -716,13 +716,11 @@ app:
     name: hardware_store_dao
   endpoint_name: hardware_store_dao                    # Model serving endpoint name
 
-  # Stage-1 diagnostic (MS-trace-persistence investigation). Declaring an
-  # SP here triggers AppModel.set_databricks_env_vars to auto-populate
+  # Pin the runtime identity for MLflow tracing writes (auto-populates
   # DATABRICKS_CLIENT_ID / DATABRICKS_CLIENT_SECRET on the deployed
-  # endpoint from the referenced secrets. Combined with trace_location
-  # below, this is the exact env-var contract the official docs recommend
-  # for writing MS traces to UC (docs.databricks.com/aws/en/mlflow3/genai/
-  # tracing/trace-unity-catalog#write-traces-from-a-model-serving-endpoint).
+  # endpoint from the referenced secrets). Required for writing MS
+  # traces to UC — see docs.databricks.com/aws/en/mlflow3/genai/
+  # tracing/trace-unity-catalog#write-traces-from-a-model-serving-endpoint
   service_principal:
     client_id:
       scope: retail_consumer_goods
@@ -731,20 +729,23 @@ app:
       scope: retail_consumer_goods
       secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
 
-  # trace_location temporarily disabled for Stage 1 — the current
-  # experiment (id=1952423719449237) has pre-existing non-UC traces
-  # from yesterday's deploys, and MLflow won't re-link a UC trace
-  # destination onto an experiment that already contains traces.
-  # Stage 1 only needs the SP-env-var round-trip, which trace_location
-  # doesn't affect.
-  # trace_location:
-  #   schema: *retail_schema
-  #   warehouse: ${var.warehouse_id}
+  # Point at the existing MLflow experiment by id (admin-provisioned +
+  # UC-linked). dao-ai skips create in get_or_create_experiment and
+  # injects MLFLOW_EXPERIMENT_ID at config-load time via the validator.
+  experiment:
+    id: "1952423719449237"
 
-  environment_vars:
-    # Enable the in-model + post-deploy env-var reflection diagnostics
-    # (dao_ai.diagnostics.is_enabled). Toggle off after the investigation.
-    DAO_AI_TRACE_ENV_DUMP: "1"
+  # Optional: set to false when an admin has already granted the SP the
+  # required UC + experiment permissions, and the deployer lacks GRANT
+  # rights. Default true — dao-ai attempts both grants at deploy time.
+  # manage_permissions: false
+
+  # UC destination for MLflow trace persistence — materializes four OTEL
+  # Delta tables at <catalog>.<schema>.<experiment_id>_otel_{spans,logs,
+  # metrics,annotations} on first deploy.
+  trace_location:
+    schema: *retail_schema
+    warehouse: ${var.warehouse_id}
 
   tags:                                             # Tags for resource organization
     business: rcg                                   # Business unit identifier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 ]
 dependencies = [
     "a2a-sdk>=0.3.0,<1.0.0",
-    "databricks-agents>=1.9.3",
+    "databricks-agents>=1.11.0",
     "databricks-langchain[memory]>=0.20.0",
     "databricks-mcp>=0.9.0",
     "databricks-sdk[openai]>=0.108.0",

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -1142,6 +1142,24 @@
           "default": null,
           "description": "Unity Catalog location for storing MLflow traces in OTEL-format Delta tables. Accepts a schema reference or 'catalog.schema' string, with an optional ``table_prefix`` to namespace the OTEL tables. When set, ``mlflow.set_experiment(trace_location=UnityCatalog(...))`` is called at startup and at deploy time for both Model Serving and Databricks Apps deployments."
         },
+        "experiment": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ExperimentModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Reference an existing MLflow experiment by name or id. Independent of ``service_principal`` and ``trace_location`` \u2014 any combination is a valid config. When omitted, dao-ai uses ``/Users/<deployer_email>/<app.name>`` (create-if-missing). When set, ``MLFLOW_EXPERIMENT_ID`` is injected on the deployed workload \u2014 from ``experiment.id`` when explicit, or resolved via ``experiment.name`` at deploy time."
+        },
+        "manage_permissions": {
+          "default": true,
+          "description": "When True (default), dao-ai attempts UC and MLflow-experiment grants on the runtime service principal at deploy time. Set to False when an admin has already provisioned the SP + experiment + all grants and the deployer lacks GRANT rights \u2014 avoids noisy 403 warnings during deploy.",
+          "title": "Manage Permissions",
+          "type": "boolean"
+        },
         "monitoring": {
           "anyOf": [
             {
@@ -3357,6 +3375,88 @@
         "num_evals"
       ],
       "title": "EvaluationModel",
+      "type": "object"
+    },
+    "ExperimentModel": {
+      "additionalProperties": false,
+      "description": "Reference an MLflow experiment by name and/or id.\n\nMirrors the ``WarehouseModel`` idiom (`config.py:1310`): both ``name``\nand ``id`` are optional but at least one is required. Actual resolution\nis lazy \u2014 the id-from-name lookup (and optional create) happens in\n:meth:`ensure_resolved`, not at config-load time, so this model is safe\nto construct in environments without an active MLflow client.\n\nPrecedence:\n    * ``id`` wins when both are set \u2014 used directly, no MLflow lookup.\n    * ``name`` triggers ``mlflow.get_experiment_by_name(name)``; if\n      missing and ``create_if_not_exists`` is True (default), the\n      experiment is created and its id captured back into ``self.id``.\n\nIndependent of ``service_principal`` and ``trace_location`` \u2014 any\ncombination of the three is a valid config. When ``AppModel.experiment``\nis omitted entirely, dao-ai falls back to the historical default:\n``/Users/<deployer_email>/<app.name>`` (create-if-missing).",
+      "properties": {
+        "name": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CompositeVariableModel"
+            },
+            {
+              "$ref": "#/$defs/EnvironmentVariableModel"
+            },
+            {
+              "$ref": "#/$defs/SecretVariableModel"
+            },
+            {
+              "$ref": "#/$defs/PrimitiveVariableModel"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Full workspace path of the MLflow experiment (e.g. ``/Shared/team/agent_traces``). When ``id`` is unset, dao-ai resolves the id from this name at deploy time \u2014 creating the experiment if missing (see ``create_if_not_exists``).",
+          "title": "Name"
+        },
+        "id": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CompositeVariableModel"
+            },
+            {
+              "$ref": "#/$defs/EnvironmentVariableModel"
+            },
+            {
+              "$ref": "#/$defs/SecretVariableModel"
+            },
+            {
+              "$ref": "#/$defs/PrimitiveVariableModel"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Numeric MLflow experiment id. When set, takes precedence over ``name`` and is used verbatim (no MLflow lookup, no create). Use when an admin has pre-provisioned + linked the experiment and the deployer knows the id.",
+          "title": "Id"
+        },
+        "create_if_not_exists": {
+          "default": true,
+          "description": "When True (default), ``ensure_resolved()`` creates the experiment at ``name`` when ``id`` is unset and the name does not resolve. Set to False when an admin has already provisioned the experiment and the deployer lacks create rights on the parent workspace path.",
+          "title": "Create If Not Exists",
+          "type": "boolean"
+        }
+      },
+      "title": "ExperimentModel",
       "type": "object"
     },
     "FactoryFunctionModel": {

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -353,6 +353,19 @@ def _build_app_block(
         else True
     )
 
+    # The experiment is ALWAYS bound as an App resource named "experiment"
+    # (see below). ``MLFLOW_EXPERIMENT_ID`` is uniformly sourced from that
+    # binding via ``value_from: experiment`` — DABs resolves it to the
+    # bundle-declared experiment's id (auto-derived default case) or to
+    # the literal id we set on the resource (``experiment`` configured
+    # case). When ``config.app.experiment`` is set we call ``.create(w)``
+    # here to populate ``id`` from ``name`` if needed (creating the
+    # experiment via ``DatabricksProvider.create_experiment`` when
+    # permitted), then use the resolved id verbatim on the app resource.
+    _external_experiment_id: str | None = None
+    if config.app.experiment is not None:
+        config.app.experiment.create()
+        _external_experiment_id = config.app.experiment.resolved_id
     env_vars: list[dict[str, str]] = [
         {"name": "MLFLOW_TRACKING_URI", "value": "databricks"},
         {"name": "MLFLOW_REGISTRY_URI", "value": "databricks-uc"},
@@ -417,14 +430,36 @@ def _build_app_block(
             )
         )
 
+    # Always bind the experiment as an App resource so the runtime SP can
+    # read/write traces to it via auto-auth. Two variants:
+    #   * external ``experiment.id`` set → bind by literal id (admin
+    #     provisioned the experiment; nothing to declare in
+    #     ``experiments_block``). Requested permission downgrades to
+    #     CAN_READ when ``manage_permissions=false``, since the deployer
+    #     may lack GRANT rights on an admin-owned experiment.
+    #   * otherwise (``experiment.name`` or auto-derived) → declare in
+    #     ``experiments_block`` and bind via ``${resources.experiments.<key>.id}``
+    #     so DABs materializes + grants CAN_EDIT to the App SP.
     experiment_key: str = f"{app_name}-experiment"
-    experiment_app_resource: dict[str, Any] = {
-        "name": "experiment",
-        "experiment": {
-            "experiment_id": f"${{resources.experiments.{experiment_key}.id}}",
-            "permission": "CAN_EDIT",
-        },
-    }
+    if _external_experiment_id:
+        _experiment_permission: str = (
+            "CAN_EDIT" if config.app.manage_permissions else "CAN_READ"
+        )
+        experiment_app_resource: dict[str, Any] = {
+            "name": "experiment",
+            "experiment": {
+                "experiment_id": _external_experiment_id,
+                "permission": _experiment_permission,
+            },
+        }
+    else:
+        experiment_app_resource = {
+            "name": "experiment",
+            "experiment": {
+                "experiment_id": f"${{resources.experiments.{experiment_key}.id}}",
+                "permission": "CAN_EDIT",
+            },
+        }
     bundle_resources.insert(0, experiment_app_resource)
 
     user_api_scopes = generate_user_api_scopes(config)
@@ -455,11 +490,23 @@ def _build_app_block(
     if config.app.space:
         app_def["space"] = config.app.space
 
-    experiments_block: dict[str, Any] = {
-        experiment_key: {
-            "name": f"/Users/${{workspace.current_user.userName}}/{app_name}",
-        },
-    }
+    # experiments_block sourcing:
+    #   - config.app.experiment set → we already resolved the id via
+    #     ``ensure_resolved`` above (creating from name if needed). The
+    #     experiment lives outside the bundle's lifecycle, so DABs
+    #     doesn't declare it — the app resource binding (below) points
+    #     at the resolved id literally.
+    #   - config.app.experiment omitted → declare
+    #     ``/Users/${workspace.current_user.userName}/<app_name>`` in the
+    #     bundle so DABs creates + owns it.
+    if _external_experiment_id:
+        experiments_block: dict[str, Any] = {}
+    else:
+        experiments_block = {
+            experiment_key: {
+                "name": f"/Users/${{workspace.current_user.userName}}/{app_name}",
+            },
+        }
     apps_block: dict[str, Any] = {
         app_name: app_def,
     }
@@ -588,7 +635,23 @@ def write_bundle(
     When development=True, copies the local dao-ai source into the bundle
     and generates a pyproject.toml that builds from local source instead of
     pulling dao-ai from PyPI.
+
+    Refuses to write into the dao-ai source repo root — the generator emits
+    a ``pyproject.toml`` with ``name = "<app_name>"`` and would silently
+    clobber the dao-ai project descriptor if the deployer accidentally ran
+    ``generate-bundle`` from inside a dao-ai checkout (the default
+    ``--output-dir`` is the CWD).
     """
+    resolved_output = output_dir.resolve()
+    if (resolved_output / "src" / "dao_ai" / "config.py").exists():
+        raise ValueError(
+            f"Refusing to write bundle into the dao-ai source repo "
+            f"({resolved_output}). ``generate-bundle`` would clobber the "
+            "dao-ai project's ``pyproject.toml``. Pass ``-o <path>`` to "
+            "target a fresh directory, e.g. "
+            "``dao-ai generate-bundle -c <config> -o ./bundle``."
+        )
+
     output_dir.mkdir(parents=True, exist_ok=True)
     app_name: str = config.app.name.lower().replace("_", "-")
     written: list[str] = []

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -287,6 +287,62 @@ Examples:
         help="Path to the model configuration file to validate (default: ./config/model_config.yaml)",
     )
 
+    # Create-experiment command
+    create_experiment_parser: ArgumentParser = subparsers.add_parser(
+        "create-experiment",
+        help="Create (or look up) an MLflow experiment and print its id",
+        description="""
+Provision or resolve an MLflow experiment on Databricks and print the
+resulting id + metadata. Delegates to
+``DatabricksProvider.create_experiment`` — same code path used by
+``dao-ai deploy`` when it resolves ``app.experiment`` from a config.
+
+Pass ``--name`` for create-if-missing behavior (default) or ``--id``
+to verify an existing experiment. Exactly one of the two is required.
+        """,
+        epilog="""
+Examples:
+  dao-ai create-experiment --name /Shared/rcg/hardware_store_traces
+  dao-ai create-experiment --name /Shared/team/agent -p fevm
+  dao-ai create-experiment --id 1952423719449237 --output json
+  dao-ai create-experiment --name /Shared/only-if-exists --no-create
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    _create_exp_ident_group = create_experiment_parser.add_mutually_exclusive_group(
+        required=True
+    )
+    _create_exp_ident_group.add_argument(
+        "--name",
+        type=str,
+        metavar="PATH",
+        help="Workspace path (e.g. /Shared/team/traces). Created if missing unless --no-create.",
+    )
+    _create_exp_ident_group.add_argument(
+        "--id",
+        type=str,
+        metavar="ID",
+        help="Numeric experiment id. Fetched (not created).",
+    )
+    create_experiment_parser.add_argument(
+        "--no-create",
+        action="store_true",
+        help="With --name: fail instead of creating when the experiment is missing.",
+    )
+    create_experiment_parser.add_argument(
+        "-p",
+        "--profile",
+        type=str,
+        help="Databricks profile to use for authentication.",
+    )
+    create_experiment_parser.add_argument(
+        "-o",
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text).",
+    )
+
     # Graph command
     graph_parser: ArgumentParser = subparsers.add_parser(
         "graph",
@@ -1077,6 +1133,48 @@ def handle_chat_command(options: Namespace) -> None:
 def handle_schema_command(options: Namespace) -> None:
     logger.debug("Generating JSON schema...")
     print(json.dumps(AppConfig.model_json_schema(), indent=2))
+
+
+def handle_create_experiment_command(options: Namespace) -> None:
+    """Create (or resolve) an MLflow experiment and print its metadata."""
+    _apply_profile_context(options.profile)
+
+    from dao_ai.config import ExperimentModel
+    from dao_ai.providers.databricks import DatabricksProvider
+
+    kwargs: dict[str, Any] = {"create_if_not_exists": not options.no_create}
+    if options.name:
+        kwargs["name"] = options.name
+    if options.id:
+        kwargs["id"] = options.id
+
+    try:
+        experiment_model = ExperimentModel(**kwargs)
+        provider = DatabricksProvider()
+        experiment = provider.create_experiment(experiment_model)
+    except Exception as e:
+        logger.error(f"Failed to create/resolve experiment: {e}")
+        sys.exit(1)
+
+    if options.output == "json":
+        print(
+            json.dumps(
+                {
+                    "experiment_id": experiment.experiment_id,
+                    "name": experiment.name,
+                    "artifact_location": experiment.artifact_location,
+                    "lifecycle_stage": experiment.lifecycle_stage,
+                    "creation_time": experiment.creation_time,
+                    "last_update_time": experiment.last_update_time,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(f"experiment_id:     {experiment.experiment_id}")
+        print(f"name:              {experiment.name}")
+        print(f"artifact_location: {experiment.artifact_location}")
+        print(f"lifecycle_stage:   {experiment.lifecycle_stage}")
 
 
 def handle_graph_command(options: Namespace) -> None:
@@ -1967,6 +2065,8 @@ def main() -> None:
             handle_version_command(options)
         case "schema":
             handle_schema_command(options)
+        case "create-experiment":
+            handle_create_experiment_command(options)
         case "validate":
             handle_validate_command(options)
         case "graph":

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -7235,6 +7235,96 @@ class TraceLocationModel(BaseModel):
         return []
 
 
+class ExperimentModel(BaseModel):
+    """Reference an MLflow experiment by name and/or id.
+
+    Mirrors the ``WarehouseModel`` idiom (`config.py:1310`): both ``name``
+    and ``id`` are optional but at least one is required. Actual resolution
+    is lazy — the id-from-name lookup (and optional create) happens in
+    :meth:`ensure_resolved`, not at config-load time, so this model is safe
+    to construct in environments without an active MLflow client.
+
+    Precedence:
+        * ``id`` wins when both are set — used directly, no MLflow lookup.
+        * ``name`` triggers ``mlflow.get_experiment_by_name(name)``; if
+          missing and ``create_if_not_exists`` is True (default), the
+          experiment is created and its id captured back into ``self.id``.
+
+    Independent of ``service_principal`` and ``trace_location`` — any
+    combination of the three is a valid config. When ``AppModel.experiment``
+    is omitted entirely, dao-ai falls back to the historical default:
+    ``/Users/<deployer_email>/<app.name>`` (create-if-missing).
+    """
+
+    model_config = ConfigDict(use_enum_values=True, extra="forbid")
+
+    name: Optional[AnyVariable] = Field(
+        default=None,
+        description=(
+            "Full workspace path of the MLflow experiment "
+            "(e.g. ``/Shared/team/agent_traces``). When ``id`` is unset, "
+            "dao-ai resolves the id from this name at deploy time — "
+            "creating the experiment if missing (see ``create_if_not_exists``)."
+        ),
+    )
+    id: Optional[AnyVariable] = Field(
+        default=None,
+        description=(
+            "Numeric MLflow experiment id. When set, takes precedence over "
+            "``name`` and is used verbatim (no MLflow lookup, no create). "
+            "Use when an admin has pre-provisioned + linked the experiment "
+            "and the deployer knows the id."
+        ),
+    )
+    create_if_not_exists: bool = Field(
+        default=True,
+        description=(
+            "When True (default), ``ensure_resolved()`` creates the "
+            "experiment at ``name`` when ``id`` is unset and the name "
+            "does not resolve. Set to False when an admin has already "
+            "provisioned the experiment and the deployer lacks create "
+            "rights on the parent workspace path."
+        ),
+    )
+
+    _resolved: bool = PrivateAttr(default=False)
+
+    @model_validator(mode="after")
+    def require_name_or_id(self) -> Self:
+        if self.name is None and self.id is None:
+            raise ValueError(
+                "ExperimentModel: at least one of 'name' or 'id' must be set."
+            )
+        return self
+
+    @property
+    def resolved_name(self) -> Optional[str]:
+        return value_of(self.name) if self.name is not None else None
+
+    @property
+    def resolved_id(self) -> Optional[str]:
+        return str(value_of(self.id)) if self.id is not None else None
+
+    def create(self, w: WorkspaceClient | None = None) -> None:
+        """Ensure the referenced MLflow experiment exists and ``self.id``
+        is populated.
+
+        Matches the dao-ai ``Model.create(w)`` convention (see
+        ``SchemaModel.create`` / ``VolumeModel.create``): fire-and-forget
+        wrapper that delegates to the provider. Idempotent — repeated
+        calls after the first no-op.
+
+        Callers that need the resolved ``mlflow.entities.Experiment``
+        object should use :meth:`DatabricksProvider.create_experiment`
+        (or call ``mlflow.get_experiment(self.resolved_id)`` after this
+        returns).
+        """
+        from dao_ai.providers.databricks import DatabricksProvider
+
+        provider = DatabricksProvider(w=w)
+        provider.create_experiment(self)
+
+
 class BackgroundModel(BaseModel):
     """Opt-in background agent configuration.
 
@@ -7608,6 +7698,28 @@ class AppModel(BaseModel):
         "``mlflow.set_experiment(trace_location=UnityCatalog(...))`` is called at startup "
         "and at deploy time for both Model Serving and Databricks Apps deployments.",
     )
+    experiment: Optional[ExperimentModel] = Field(
+        default=None,
+        description=(
+            "Reference an existing MLflow experiment by name or id. "
+            "Independent of ``service_principal`` and ``trace_location`` — "
+            "any combination is a valid config. When omitted, dao-ai uses "
+            "``/Users/<deployer_email>/<app.name>`` (create-if-missing). "
+            "When set, ``MLFLOW_EXPERIMENT_ID`` is injected on the "
+            "deployed workload — from ``experiment.id`` when explicit, or "
+            "resolved via ``experiment.name`` at deploy time."
+        ),
+    )
+    manage_permissions: bool = Field(
+        default=True,
+        description=(
+            "When True (default), dao-ai attempts UC and MLflow-experiment "
+            "grants on the runtime service principal at deploy time. Set "
+            "to False when an admin has already provisioned the SP + "
+            "experiment + all grants and the deployer lacks GRANT rights "
+            "— avoids noisy 403 warnings during deploy."
+        ),
+    )
     monitoring: Optional[MonitoringModel] = Field(
         default=None,
         description="Production monitoring configuration. When present, scorers are "
@@ -7634,41 +7746,49 @@ class AppModel(BaseModel):
 
     @model_validator(mode="after")
     def set_databricks_env_vars(self) -> Self:
-        """Set Databricks environment variables for Model Serving.
+        """Set Databricks environment variables for Model Serving / Apps.
 
-        Sets DATABRICKS_HOST, DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET,
-        and OTEL trace destination env vars when trace_location is configured.
-        Values explicitly provided in environment_vars take precedence.
+        Each field triggers its own env-var injection independently — SP,
+        experiment, and trace_location are three separate concerns and any
+        combination is a valid config. Values already present in
+        ``environment_vars`` are preserved (setdefault semantics).
+
+        * ``service_principal`` → ``DATABRICKS_CLIENT_ID`` / ``DATABRICKS_CLIENT_SECRET``.
+        * ``experiment.id`` → ``MLFLOW_EXPERIMENT_ID`` (only when id is
+          explicit at config-load; the ``name`` and auto-derive cases are
+          resolved at deploy time in ``deploy_*_agent``).
+        * ``trace_location`` → ``MLFLOW_TRACING_DESTINATION`` /
+          ``MLFLOW_TRACING_SQL_WAREHOUSE_ID``.
         """
         from dao_ai.utils import get_default_databricks_host
 
-        # Set DATABRICKS_HOST if not already provided
         if "DATABRICKS_HOST" not in self.environment_vars:
             host: str | None = get_default_databricks_host()
             if host:
                 self.environment_vars["DATABRICKS_HOST"] = host
 
-        # Set service principal credentials if provided
         if self.service_principal is not None:
-            if "DATABRICKS_CLIENT_ID" not in self.environment_vars:
-                self.environment_vars["DATABRICKS_CLIENT_ID"] = (
-                    self.service_principal.client_id
-                )
-            if "DATABRICKS_CLIENT_SECRET" not in self.environment_vars:
-                self.environment_vars["DATABRICKS_CLIENT_SECRET"] = (
-                    self.service_principal.client_secret
-                )
+            self.environment_vars.setdefault(
+                "DATABRICKS_CLIENT_ID", self.service_principal.client_id
+            )
+            self.environment_vars.setdefault(
+                "DATABRICKS_CLIENT_SECRET", self.service_principal.client_secret
+            )
 
-        # Set OTEL trace destination env vars when trace_location is configured
+        if self.experiment is not None and self.experiment.resolved_id:
+            self.environment_vars.setdefault(
+                "MLFLOW_EXPERIMENT_ID", self.experiment.resolved_id
+            )
+
         if self.trace_location is not None:
-            if "MLFLOW_TRACING_DESTINATION" not in self.environment_vars:
-                self.environment_vars["MLFLOW_TRACING_DESTINATION"] = (
-                    f"{self.trace_location.catalog_name}.{self.trace_location.schema_name}"
-                )
-            if "MLFLOW_TRACING_SQL_WAREHOUSE_ID" not in self.environment_vars:
-                self.environment_vars["MLFLOW_TRACING_SQL_WAREHOUSE_ID"] = (
-                    self.trace_location.warehouse_id
-                )
+            self.environment_vars.setdefault(
+                "MLFLOW_TRACING_DESTINATION",
+                f"{self.trace_location.catalog_name}.{self.trace_location.schema_name}",
+            )
+            self.environment_vars.setdefault(
+                "MLFLOW_TRACING_SQL_WAREHOUSE_ID",
+                self.trace_location.warehouse_id,
+            )
         return self
 
     @model_validator(mode="after")

--- a/src/dao_ai/diagnostics.py
+++ b/src/dao_ai/diagnostics.py
@@ -1,0 +1,112 @@
+"""Runtime diagnostics for verifying dao-ai deployment plumbing.
+
+Stage-1 probes for the MS-trace-persistence investigation: capture the
+env-var surface that a deployed model actually sees, and redact anything
+that looks like a credential before it lands in logs or ``custom_outputs``.
+
+Off by default. Set ``DAO_AI_TRACE_ENV_DUMP=1`` in the endpoint's env vars
+to enable the in-model probe.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Iterable, Mapping
+
+DIAGNOSTIC_ENV_FLAG: str = "DAO_AI_TRACE_ENV_DUMP"
+
+# Keys whose *values* must be redacted. Match on the key name — value
+# heuristics (looking for JWT-looking strings, base64 blobs, etc.) are
+# too noisy to be trustworthy at boot time.
+_SECRET_KEY_PATTERN: re.Pattern[str] = re.compile(
+    r"(SECRET|TOKEN|PASSWORD|KEY|CREDENTIAL|COOKIE|SESSION)",
+    re.IGNORECASE,
+)
+
+# Keys we care about surfacing verbatim for the MS-trace investigation.
+# Everything else falls back to the redact-or-echo decision. Keeping this
+# explicit set means the probe output is scannable — the operator doesn't
+# have to grep 300 env vars to find what they came for.
+TRACE_RELEVANT_KEYS: tuple[str, ...] = (
+    "DATABRICKS_HOST",
+    "DATABRICKS_CLIENT_ID",
+    "DATABRICKS_CLIENT_SECRET",
+    "DATABRICKS_TOKEN",
+    "MLFLOW_EXPERIMENT_ID",
+    "MLFLOW_TRACING_DESTINATION",
+    "MLFLOW_TRACING_SQL_WAREHOUSE_ID",
+    "MLFLOW_TRACKING_URI",
+    "MLFLOW_REGISTRY_URI",
+    "DATABRICKS_AUTH_TYPE",
+    "DAO_AI_TRACE_ENV_DUMP",
+)
+
+
+def is_enabled() -> bool:
+    """Whether the in-model env probe is enabled for this process."""
+    return os.environ.get(DIAGNOSTIC_ENV_FLAG, "").lower() in ("1", "true", "yes")
+
+
+def redact_value(key: str, value: str) -> str:
+    """Return ``value`` unchanged, or a redacted placeholder if ``key`` looks
+    like a credential.
+
+    Preserves length + first/last two chars so the operator can eyeball
+    "did the value round-trip" without leaking the secret itself.
+    """
+    if not _SECRET_KEY_PATTERN.search(key):
+        return value
+    if not value:
+        return "<empty>"
+    if len(value) <= 6:
+        return f"<redacted len={len(value)}>"
+    return f"{value[:2]}…{value[-2:]} <redacted len={len(value)}>"
+
+
+def env_snapshot(
+    keys: Iterable[str] | None = None,
+    include_all: bool = False,
+) -> dict[str, str]:
+    """Return a redacted view of ``os.environ``.
+
+    Args:
+        keys: Iterable of env-var names to include. If ``None``,
+            defaults to :data:`TRACE_RELEVANT_KEYS`.
+        include_all: If ``True``, also include every other env var
+            present in the process (redacted per :func:`redact_value`).
+            Off by default — the trace-relevant subset is what the MS
+            investigation needs.
+
+    Absent keys are emitted as ``"<unset>"`` so the operator can
+    distinguish "stripped by platform" from "never set by dao-ai".
+    """
+    target_keys: tuple[str, ...] = (
+        tuple(keys) if keys is not None else TRACE_RELEVANT_KEYS
+    )
+    snapshot: dict[str, str] = {}
+    for k in target_keys:
+        raw: str | None = os.environ.get(k)
+        snapshot[k] = "<unset>" if raw is None else redact_value(k, raw)
+
+    if include_all:
+        for k, raw in os.environ.items():
+            if k in snapshot:
+                continue
+            snapshot[k] = redact_value(k, raw)
+
+    return snapshot
+
+
+def redacted_env_var_map(
+    env_vars: Mapping[str, str] | None,
+) -> dict[str, str]:
+    """Redact secret-shaped values in a ``{name: value}`` env-var map.
+
+    Used by the post-deploy reflection probe to log
+    ``serving_endpoints.get(...).config.served_entities[0].environment_vars``
+    without spilling secrets. Absent input returns an empty dict.
+    """
+    if not env_vars:
+        return {}
+    return {k: redact_value(k, str(v)) for k, v in env_vars.items()}

--- a/src/dao_ai/models.py
+++ b/src/dao_ai/models.py
@@ -1010,6 +1010,19 @@ class LanggraphResponsesAgent(ResponsesAgent):
         self.graph = graph
         self._prompt_versions: list = prompt_versions or []
 
+        # Stage-1 diagnostic (MS-trace-persistence investigation): log the
+        # trace-relevant env-var snapshot at endpoint boot. This is the
+        # earliest hookable point after MLflow unpickles the model in the
+        # serving container, so it captures ``os.environ`` as MLflow's
+        # tracing writer would have read it during library import.
+        from dao_ai.diagnostics import env_snapshot, is_enabled
+
+        if is_enabled():
+            logger.info(
+                "dao_ai.diagnostic.env_snapshot",
+                snapshot=env_snapshot(),
+            )
+
     @mlflow.trace(span_type=SpanType.AGENT, name="dao_ai_apredict")
     async def apredict(self, request: ResponsesAgentRequest) -> ResponsesAgentResponse:
         """
@@ -1921,10 +1934,22 @@ class LanggraphResponsesAgent(ResponsesAgent):
                     }
                 }
 
-        return {
+        outputs: dict[str, Any] = {
             "configurable": configurable,
             "session": session,
         }
+
+        # Stage-1 diagnostic (MS-trace-persistence investigation). When the
+        # endpoint's env has DAO_AI_TRACE_ENV_DUMP=1, echo the trace-relevant
+        # env-var snapshot back through custom_outputs so the operator can
+        # observe from client-side what actually reached the endpoint's
+        # runtime process. Off by default.
+        from dao_ai.diagnostics import env_snapshot, is_enabled
+
+        if is_enabled():
+            outputs["_diagnostic"] = {"env": env_snapshot()}
+
+        return outputs
 
 
 def create_agent(graph: CompiledStateGraph) -> ChatAgent:

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -331,7 +331,87 @@ def _link_experiment_trace_location(config: AppConfig, experiment_id: str) -> No
             raise
 
 
-def _grant_trace_permissions_to_principal(
+def _grant_experiment_permissions_to_principal(
+    principal: str,
+    experiment_id: str,
+) -> None:
+    """Grant a service principal ``CAN_EDIT`` on an MLflow experiment.
+
+    MLflow's tracing writer refuses ``set_experiment(experiment_id=...)``
+    — and thus any subsequent trace write — unless the calling identity
+    has at least ``CAN_READ`` on the experiment. Traces are writes, so
+    we grant ``CAN_EDIT``. Without this the boot-time
+    ``mlflow.set_experiment`` call in ``apps/model_serving.py`` crashes
+    with ``PERMISSION_DENIED: User <sp> does not have permission to
+    'View' experiment with id <id>``.
+
+    Independent of Unity Catalog — required for any tracing writes,
+    UC-backed or workspace-default alike.
+
+    Uses ``PATCH /api/2.0/permissions/experiments/<id>`` which appends
+    an ACL entry rather than replacing (verified against fevm). Prefers
+    the typed SDK ``w.experiments.update_permissions`` when available,
+    falling back to the raw REST call otherwise. Idempotent — repeated
+    calls with the same principal + permission_level are a no-op.
+
+    WARN-and-continue on failure so a deployer without ``CAN_MANAGE``
+    on the experiment can still ship — the runtime will surface the
+    misconfiguration at boot if the pre-provisioned grants are missing.
+
+    Args:
+        principal: Service principal client id (UUID) to grant.
+        experiment_id: MLflow experiment id (numeric string).
+    """
+    from databricks.sdk import WorkspaceClient
+
+    w = WorkspaceClient()
+
+    try:
+        try:
+            from databricks.sdk.service.ml import (
+                ExperimentAccessControlRequest,
+                ExperimentPermissionLevel,
+            )
+
+            w.experiments.update_permissions(
+                experiment_id=experiment_id,
+                access_control_list=[
+                    ExperimentAccessControlRequest(
+                        service_principal_name=principal,
+                        permission_level=ExperimentPermissionLevel.CAN_EDIT,
+                    )
+                ],
+            )
+        except (ImportError, AttributeError):
+            w.api_client.do(
+                "PATCH",
+                f"/api/2.0/permissions/experiments/{experiment_id}",
+                body={
+                    "access_control_list": [
+                        {
+                            "service_principal_name": principal,
+                            "permission_level": "CAN_EDIT",
+                        }
+                    ]
+                },
+            )
+        logger.debug(
+            "Granted CAN_EDIT on experiment",
+            principal=principal,
+            experiment_id=experiment_id,
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to grant experiment ACL — verify the calling identity has "
+            "CAN_MANAGE on the experiment, or set app.manage_permissions=false "
+            "when the admin has already provisioned this grant",
+            principal=principal,
+            experiment_id=experiment_id,
+            error=str(e),
+        )
+
+
+def _grant_uc_trace_table_permissions_to_principal(
     principal: str,
     catalog_name: str,
     schema_name: str,
@@ -355,6 +435,11 @@ def _grant_trace_permissions_to_principal(
     and after ``apps.create_and_wait`` (Databricks Apps), passing the
     endpoint or app service principal identifier. Idempotent — repeated
     calls with the same grants no-op on the UC side.
+
+    Complementary to :func:`_grant_experiment_permissions_to_principal`
+    — the experiment ACL grant is required for any tracing writes; this
+    UC helper is only needed when the experiment's trace destination is
+    a UC catalog.schema (``trace_location`` is set).
 
     Args:
         principal: The UC principal identifier to grant to. For a
@@ -556,11 +641,31 @@ class DatabricksProvider(ServiceProvider):
         self._dfs_initialized = True
 
     def experiment_name(self, config: AppConfig) -> str:
+        """Resolve the experiment path from ``app.experiment.name``, or
+        fall back to ``/Users/<deployer_email>/<app.name>`` when not set.
+
+        The id-based ``app.experiment.id`` branch never lands here — it
+        short-circuits ``get_or_create_experiment`` directly.
+        """
+        if config.app.experiment is not None and config.app.experiment.resolved_name:
+            return config.app.experiment.resolved_name
         current_user: User = self.w.current_user.me()
         name: str = config.app.name
         return f"/Users/{current_user.user_name}/{name}"
 
     def get_or_create_experiment(self, config: AppConfig) -> Experiment:
+        """Resolve to an MLflow ``Experiment``.
+
+        * ``app.experiment`` set → delegate to ``self.create_experiment``
+          (id takes precedence; name resolved lazily with optional create,
+          per the dao-ai ``Model.create(w)`` convention).
+        * otherwise → fall back to the historical default
+          ``/Users/<deployer_email>/<app.name>`` with restore-if-deleted,
+          create-if-missing.
+        """
+        if config.app.experiment is not None:
+            return self.create_experiment(config.app.experiment)
+
         experiment_name: str = self.experiment_name(config)
         experiment: Experiment | None = mlflow.get_experiment_by_name(experiment_name)
 
@@ -968,18 +1073,22 @@ class DatabricksProvider(ServiceProvider):
 
         tags_kw: dict[str, str] | None = None if serving_exists else tags
 
-        # Link experiment to UC trace location BEFORE agents.deploy. The
-        # logged model's auth_policy declares the OTEL trace tables as
-        # databricks_resources (via TraceLocationModel.as_resources()), and
-        # agents.deploy validates the resource list when it calls
-        # generate-temporary-credentials on the model version. If the OTEL
-        # tables don't exist yet, that lookup returns TABLE_DOES_NOT_EXIST
-        # and agents.deploy aborts. Idempotent re-link — create_agent
-        # normally handles this first, but re-deploys that skip create_agent
-        # still need the setup.
+        # Resolve the MLflow experiment ONCE — used for:
+        #   1. injecting ``MLFLOW_EXPERIMENT_ID`` into env_vars (symmetric
+        #      with ``DATABRICKS_CLIENT_ID/SECRET`` — always set at deploy
+        #      time so the boot code in apps/model_serving.py can find it)
+        #   2. linking to UC trace_location (if configured)
+        #   3. granting experiment CAN_EDIT + UC table perms to the SP
+        experiment: Experiment = self.get_or_create_experiment(config)
+        experiment_id: str = str(experiment.experiment_id)
+        environment_vars.setdefault("MLFLOW_EXPERIMENT_ID", experiment_id)
+
+        # Link experiment to UC trace location BEFORE agents.deploy — the
+        # tracing writer expects the four OTEL tables to exist at endpoint
+        # boot. Idempotent; no-op if the experiment already has a UC trace
+        # destination linked.
         if config.app.trace_location:
-            experiment: Experiment = self.get_or_create_experiment(config)
-            _link_experiment_trace_location(config, experiment.experiment_id)
+            _link_experiment_trace_location(config, experiment_id)
 
         max_attempts: int = 6
         for attempt in range(1, max_attempts + 1):
@@ -1044,23 +1153,44 @@ class DatabricksProvider(ServiceProvider):
                 error=str(e),
             )
 
-        # MS trace persistence is an unresolved Databricks platform gap
-        # (see TraceLocationModel.as_resources docstring): the endpoint's
-        # runtime system SP is not exposed by any API and is not
-        # grantable via UC, and DATABRICKS_CLIENT_ID/SECRET env vars are
-        # stripped by the platform. Surface a WARN at deploy time so
-        # users know traces will silently drop on this target — deploy
-        # to Databricks Apps instead when trace persistence is required.
-        if config.app.trace_location:
-            logger.warning(
-                "trace_location is configured, but MLflow trace persistence "
-                "from Model Serving endpoints created via agents.deploy is "
-                "an unresolved Databricks platform gap — traces will not "
-                "appear in the UC OTEL tables from this endpoint. Deploy "
-                "to Databricks Apps if trace persistence is required. See "
-                "TraceLocationModel.as_resources for details.",
-                endpoint_name=endpoint_name,
-            )
+        # Grant the runtime SP the permissions MLflow tracing needs.
+        # Same two-path pattern as deploy_apps_agent — experiment ACL
+        # is gated on SP alone (needed for any tracing writes), UC table
+        # grants are additionally gated on trace_location. Both are
+        # gated on ``manage_permissions`` so a deployer without GRANT
+        # rights can opt out and rely on admin pre-provisioning.
+        #
+        # For Model Serving the SP is the caller-declared one from
+        # ``config.app.service_principal.client_id`` (resolved into
+        # ``DATABRICKS_CLIENT_ID`` on the endpoint). Contrast with Apps,
+        # where the SP is auto-generated by the platform.
+        if config.app.manage_permissions and config.app.service_principal is not None:
+            try:
+                sp_id: str = str(value_of(config.app.service_principal.client_id))
+                _grant_experiment_permissions_to_principal(
+                    principal=sp_id,
+                    experiment_id=experiment_id,
+                )
+                if config.app.trace_location:
+                    table_prefix: str = _resolve_trace_table_prefix(
+                        config,
+                        None
+                        if config.app.trace_location.resolved_table_prefix
+                        else experiment_id,
+                    )
+                    _grant_uc_trace_table_permissions_to_principal(
+                        principal=sp_id,
+                        catalog_name=config.app.trace_location.catalog_name,
+                        schema_name=config.app.trace_location.schema_name,
+                        table_prefix=table_prefix,
+                    )
+            except Exception as e:
+                logger.warning(
+                    "Failed to grant trace-persistence privileges to Model "
+                    "Serving SP",
+                    endpoint_name=endpoint_name,
+                    error=str(e),
+                )
 
         permissions: Sequence[dict[str, Any]] = config.app.permissions
 
@@ -1661,16 +1791,17 @@ class DatabricksProvider(ServiceProvider):
             )
             raise RuntimeError(f"App deployment failed: {status_message}")
 
-        # Grant the app's SP the UC privileges MLflow tracing needs.
-        # Same rationale as deploy_model_serving_agent: ``ALL_PRIVILEGES``
-        # inherited via workspace groups is not sufficient for OTEL trace
-        # tables per the docs; ``MODIFY`` + ``SELECT`` on each table must
-        # be explicit. In the common FEVM setup this is a no-op because
-        # the App SP already inherits schema-level ``ALL_PRIVILEGES``,
-        # but customer workspaces without that inheritance previously
-        # required a manual GRANT (see the note that used to sit at
-        # ``apps/resources.py:_extract_raw_trace_location_resources``).
-        if config.app.trace_location:
+        # Grant the App's runtime SP the permissions MLflow tracing needs.
+        # Two independent grant paths, gated separately:
+        #   1. Experiment CAN_EDIT — required for any tracing writes
+        #      (workspace-default OR UC-backed). Gate: SP known.
+        #   2. UC OTEL-table SELECT+MODIFY — only needed when the
+        #      experiment's trace destination is a UC schema. Gate:
+        #      trace_location set.
+        # Both are additionally gated on ``config.app.manage_permissions``
+        # so a deployer without GRANT rights can skip the attempt when
+        # an admin has pre-provisioned everything.
+        if config.app.manage_permissions:
             try:
                 # Refresh App to pick up the assigned SP identifier.
                 fresh_app: App = self.w.apps.get(name=app_name)
@@ -1678,34 +1809,41 @@ class DatabricksProvider(ServiceProvider):
                     fresh_app.service_principal_client_id
                     or fresh_app.service_principal_id
                 )
-                if sp_id:
-                    # Resolve the trace-table prefix. Prefer the explicit
-                    # trace_location.table_prefix if set; otherwise fall
-                    # back to the linked experiment's ID (MLflow's
-                    # default when UnityCatalog is constructed without a
-                    # prefix). Only fetch the experiment when we need it.
-                    experiment_id_for_prefix: Optional[str] = (
-                        None
-                        if config.app.trace_location.resolved_table_prefix
-                        else str(self.get_or_create_experiment(config).experiment_id)
-                    )
-                    _grant_trace_permissions_to_principal(
-                        principal=str(sp_id),
-                        catalog_name=config.app.trace_location.catalog_name,
-                        schema_name=config.app.trace_location.schema_name,
-                        table_prefix=_resolve_trace_table_prefix(
-                            config, experiment_id_for_prefix
-                        ),
-                    )
-                else:
+                if not sp_id:
                     logger.warning(
                         "Could not resolve App SP identity; "
-                        "trace-persistence UC grants skipped.",
+                        "trace-persistence grants skipped.",
                         app_name=app_name,
                     )
+                else:
+                    experiment: Experiment = self.get_or_create_experiment(config)
+                    experiment_id: str = str(experiment.experiment_id)
+
+                    _grant_experiment_permissions_to_principal(
+                        principal=str(sp_id),
+                        experiment_id=experiment_id,
+                    )
+
+                    if config.app.trace_location:
+                        # Resolve the trace-table prefix — prefer explicit
+                        # ``trace_location.table_prefix``, else fall back
+                        # to experiment_id (MLflow's default when
+                        # ``UnityCatalog(table_prefix=None)``).
+                        table_prefix: str = _resolve_trace_table_prefix(
+                            config,
+                            None
+                            if config.app.trace_location.resolved_table_prefix
+                            else experiment_id,
+                        )
+                        _grant_uc_trace_table_permissions_to_principal(
+                            principal=str(sp_id),
+                            catalog_name=config.app.trace_location.catalog_name,
+                            schema_name=config.app.trace_location.schema_name,
+                            table_prefix=table_prefix,
+                        )
             except Exception as e:
                 logger.warning(
-                    "Failed to grant trace-persistence UC privileges to App SP",
+                    "Failed to grant trace-persistence privileges to App SP",
                     app_name=app_name,
                     error=str(e),
                 )
@@ -1743,6 +1881,57 @@ class DatabricksProvider(ServiceProvider):
             logger.info("Creating catalog", catalog_name=schema.catalog_name)
             catalog_info = self.w.catalogs.create(name=schema.catalog_name)
         return catalog_info
+
+    def create_experiment(
+        self, experiment: "ExperimentModel"
+    ) -> Experiment:
+        """Resolve an ``ExperimentModel`` to a live MLflow ``Experiment``,
+        creating the experiment if only ``name`` was provided and it does
+        not exist yet.
+
+        Precedence:
+
+        * ``experiment.id`` set → fetch by id via
+          ``mlflow.get_experiment(id)``. No create attempted; errors if
+          the id is invalid.
+        * ``experiment.id`` unset, ``experiment.name`` set →
+          ``get_experiment_by_name(name)``. When missing, create iff
+          ``experiment.create_if_not_exists`` is True (default), else
+          raise so the deployer knows to ask an admin.
+
+        Idempotent — caches on ``experiment._resolved``. Populates
+        ``experiment.id`` when it was inferred from ``name`` so
+        subsequent calls short-circuit through the id-branch.
+        """
+        if experiment._resolved and experiment.id is not None:
+            return mlflow.get_experiment(str(value_of(experiment.id)))
+
+        if experiment.id is not None:
+            experiment_id = str(value_of(experiment.id))
+            experiment._resolved = True
+            return mlflow.get_experiment(experiment_id)
+
+        # id is None → look up by name, optionally create
+        assert experiment.name is not None  # invariant of require_name_or_id
+        name = value_of(experiment.name)
+        exp = mlflow.get_experiment_by_name(name)
+        if exp is None:
+            if not experiment.create_if_not_exists:
+                raise ValueError(
+                    f"MLflow experiment '{name}' does not exist and "
+                    "create_if_not_exists=False. Ask an admin to provision "
+                    "the experiment, or set create_if_not_exists=True."
+                )
+            experiment_id = mlflow.create_experiment(name=name)
+            logger.info(
+                "Created MLflow experiment",
+                experiment_name=name,
+                experiment_id=experiment_id,
+            )
+            exp = mlflow.get_experiment(experiment_id)
+        experiment.id = str(exp.experiment_id)
+        experiment._resolved = True
+        return exp
 
     def create_schema(self, schema: SchemaModel) -> SchemaInfo:
         catalog_info: CatalogInfo = self.create_catalog(schema)

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -925,7 +925,17 @@ class DatabricksProvider(ServiceProvider):
             )
         registered_model_name: str = config.app.registered_model.full_name
         scale_to_zero: bool = config.app.scale_to_zero
-        environment_vars: dict[str, str] = config.app.environment_vars
+        # Model Serving expects string env-var values. SecretVariableModel
+        # instances stringify to ``{{secrets/scope/key}}`` — the platform
+        # resolves that literal at endpoint boot. PrimitiveVariable and raw
+        # strings pass through. Without this coercion, ``agents.deploy``
+        # sees Pydantic-model values and silently drops them; the ensuing
+        # empty ``DATABRICKS_CLIENT_ID/SECRET`` at runtime was one of the
+        # observations behind the "stripped by platform" claim in 1b4290c.
+        environment_vars: dict[str, str] = {
+            k: str(v) if v is not None else ""
+            for k, v in (config.app.environment_vars or {}).items()
+        }
         workload_size: str = config.app.workload_size
         tags: dict[str, str] = config.app.tags.copy() if config.app.tags else {}
 
@@ -1002,6 +1012,37 @@ class DatabricksProvider(ServiceProvider):
                     )
                     continue
                 raise
+
+        # Stage-1 diagnostic (MS-trace-persistence investigation):
+        # reflect what env vars actually landed on the endpoint's
+        # served-entity config after ``agents.deploy``. Compare with
+        # what dao-ai sent (``environment_vars`` above) to answer:
+        # did DATABRICKS_CLIENT_ID/SECRET survive, or did the platform
+        # strip them? Logs the redacted view — secret values are
+        # elided but presence + length round-trip is visible.
+        try:
+            from dao_ai.diagnostics import redacted_env_var_map
+
+            endpoint_after = self.w.serving_endpoints.get(name=endpoint_name)
+            landed_env: dict[str, str] = {}
+            if endpoint_after.config and endpoint_after.config.served_entities:
+                landed_env = (
+                    endpoint_after.config.served_entities[0].environment_vars or {}
+                )
+            logger.info(
+                "dao_ai.diagnostic.deploy_env_reflection",
+                endpoint_name=endpoint_name,
+                sent=redacted_env_var_map(environment_vars),
+                landed=redacted_env_var_map(landed_env),
+                sent_only=sorted(set(environment_vars) - set(landed_env)),
+                landed_only=sorted(set(landed_env) - set(environment_vars)),
+            )
+        except Exception as e:
+            logger.debug(
+                "Post-deploy env-var reflection failed (non-fatal diagnostic)",
+                endpoint_name=endpoint_name,
+                error=str(e),
+            )
 
         # MS trace persistence is an unresolved Databricks platform gap
         # (see TraceLocationModel.as_resources docstring): the endpoint's

--- a/uv.lock
+++ b/uv.lock
@@ -1096,7 +1096,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.3.0,<1.0.0" },
-    { name = "databricks-agents", specifier = ">=1.9.3" },
+    { name = "databricks-agents", specifier = ">=1.11.0" },
     { name = "databricks-connect", marker = "extra == 'databricks'", specifier = ">=16.0.0" },
     { name = "databricks-langchain", extras = ["memory"], specifier = ">=0.20.0" },
     { name = "databricks-mcp", specifier = ">=0.9.0" },


### PR DESCRIPTION
## Summary

- **Retires the "MS trace persistence is a platform gap" claim.** Traces from Model Serving endpoints deployed via `agents.deploy` DO persist to UC OTEL tables when the deploy-time contract is satisfied. Verified end-to-end on fevm/`hardware_store_dao` v12 (24 spans landed for a single invocation) + Apps deploy of the same config (App SP grants fired, app RUNNING).
- **New `ExperimentModel`** on `AppModel` — reference an existing MLflow experiment by `name` or `id`, or auto-derive to `/Users/<deployer>/<app.name>`. Follows the `WarehouseModel`/`SchemaModel` idiom (lazy resolution, `create(w)` matching the `Model.create(w)` convention).
- **`app.manage_permissions`** knob — admins may pre-provision the SP + experiment + grants; set `manage_permissions: false` when the deployer lacks GRANT rights so dao-ai skips the PATCHes instead of warning on 403.
- **Grant helpers split by concern** (`_grant_experiment_permissions_to_principal` + `_grant_uc_trace_table_permissions_to_principal`) and wired into `deploy_model_serving_agent` (previously only Apps). `MLFLOW_EXPERIMENT_ID` is now injected into MS env vars at deploy time symmetric with `DATABRICKS_CLIENT_ID/SECRET`.
- **New CLI subcommand: `dao-ai create-experiment`** — one-shot provisioning by name or id, `--output json` for scripting. Reuses `DatabricksProvider.create_experiment`.
- **Safety guard on `dao-ai generate-bundle`** — refuses to write into the dao-ai source repo (would silently clobber the dao-ai `pyproject.toml`, `.gitignore`, and `requirements.txt`).
- **Commerce configs** (`commerce_swarm`, `commerce_supervisor`) — added the `service_principal:` block so their canonical `DATABRICKS_CLIENT_ID/SECRET` env vars flow into MS tracing auth (the bespoke `RETAIL_AI_*` env vars remain for Lakebase OAuth minting).
- **Dropped the stale "trace persistence is an unresolved platform gap" WARN** at MS deploy time; schema regenerated to include `ExperimentModel` + new `AppModel` fields.

Root cause of the historical "MS strips DATABRICKS_CLIENT_ID/SECRET" observation was a client-side send bug — the SDK silently dropped `SecretVariableModel` Pydantic instances passed to `agents.deploy(environment_vars=...)`. The str-coerce fix landed in `0648bbb`; this PR completes the picture with grants + config knobs + verification.

## Test plan

- [x] MS deploy of `hardware_store.yaml` on fevm — invocation returned `trace_id: 050efac540bc6bfe45634b6cca5275a0`, 24 spans in `retail_consumer_goods.hardware_store.1952423719449237_otel_spans`, zero permission errors
- [x] Apps deploy of same config — App SP `e5dc2050-…` received both grants, app RUNNING
- [x] `manage_permissions: false` variant — 0 grant PATCH log lines, deploy still succeeded
- [x] `experiment.id: "<existing>"` variant — 0 create calls, grants fired against the pinned id, `MLFLOW_EXPERIMENT_ID` injected at config-load
- [x] `dao-ai create-experiment --name /Shared/... -p fevm` (create), idempotent re-run, lookup by `--id`, `--no-create` refuses missing, `--output json`
- [x] `dao-ai generate-bundle` in dao-ai repo root — aborts cleanly with actionable error
- [x] `dao-ai generate-bundle -o /tmp/…` into subdir — succeeds, dao-ai `pyproject.toml` untouched
- [ ] Deploy on a workspace that requires `manage_permissions: false` (blocked on customer availability; not tested)

This pull request and its description were written by Isaac.