### PR TITLE
feat(config): cap IsDatabricksResource description at 200 chars

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -20,3 +20,14 @@ uv.lock:square-access-token:6189
 # credential). Introduced in the repo's initial commit; the config file
 # was later moved to config/examples/05_memory/.
 5c78b52d19d4bc63a6f7570e9ded40f551051033:config/examples/04_memory/postgres_persistence.yaml:postgres-connection-string:78
+
+# Placeholder connection-string template inside a Mermaid diagram in the
+# 05_memory README, illustrating the shape of the Unity Catalog secret
+# contents. Not a real credential. Both SHAs below carry the same line
+# (cherry-pick / rebase history).
+5977040684e41baf377581bdf6104403f7e8d4ea:config/examples/05_memory/README.md:postgres-connection-string:154
+5d33d1e95658694ec754b7cd660b71c6985961ed:config/examples/05_memory/README.md:postgres-connection-string:154
+
+# Synthetic connection-string used as a test fixture in a context-aware
+# cache test — literal `test:test@localhost/test`, not a real credential.
+cd92208c887a72e2da3e5a4fb2a86137658fe3d5:tests/dao_ai/test_context_aware_cache.py:postgres-connection-string:720

--- a/config/examples/10_agent_integrations/vertex_agent_engine.yaml
+++ b/config/examples/10_agent_integrations/vertex_agent_engine.yaml
@@ -61,12 +61,9 @@ resources:
     sales_genie_room: &sales_genie_room
       name: "Retail Customer Sales Analysis"
       description: >
-        Customer, sales, and product analytics. Use for order-level and
-        product-level analysis including top-selling products, revenue by
-        product/category, pricing, order status, payment methods, and
-        inventory snapshots. Also covers customer segmentation by
-        demographics, geography, signup date, and loyalty tier, plus
-        purchasing patterns.
+        Customer, sales, and product analytics: order- and product-level
+        analysis, revenue by category, pricing, order status, inventory
+        snapshots, and customer segmentation by demographics and loyalty.
       space_id:
         env: SALES_GENIE_SPACE_ID
         default_value: 01f139d55de31350b6195b771c24faac
@@ -75,11 +72,9 @@ resources:
     logistics_genie_room: &logistics_genie_room
       name: "Logistics Operations and Tracking"
       description: >
-        Shipments, carriers, warehouse facilities, and package tracking events.
-        Use for carrier performance, transit times, delivery timelines,
-        shipment status, delay investigation, and warehouse network
-        capacity/geography. Does not cover order items, returns, damages,
-        inventory levels, or financials beyond shipping costs.
+        Shipments, carriers, warehouses, and package tracking events. Use
+        for carrier performance, transit times, delivery timelines, shipment
+        status, delay investigation, and warehouse network capacity.
       space_id:
         env: LOGISTICS_GENIE_SPACE_ID
         default_value: 01f139cf18d2194e8aa05ffec9c27b31

--- a/config/examples/15_complete_applications/brick_store.yaml
+++ b/config/examples/15_complete_applications/brick_store.yaml
@@ -188,10 +188,9 @@ resources:
     brickstore_genie_room: &brickstore_genie_room
       name: "Brick Store Operations Genie"
       description: >
-        Natural-language analytics over the brick_store catalog (products,
-        inventory, sales, appointments, employee performance, customer
-        feedback) for ad-hoc questions that don't map to a single SKU or
-        UPC lookup.
+        Natural-language analytics over the brick_store catalog for ad-hoc
+        questions across products, inventory, sales, appointments, employee
+        performance, and customer feedback.
       # space_id is populated by GenieRoomModel.create() during initial
       # provisioning. With it set, subsequent deploys reference the existing
       # space (update mode) instead of creating a new one.

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -2295,6 +2295,7 @@
         "description": {
           "anyOf": [
             {
+              "maxLength": 200,
               "type": "string"
             },
             {
@@ -4571,6 +4572,7 @@
         "description": {
           "anyOf": [
             {
+              "maxLength": 200,
               "type": "string"
             },
             {
@@ -5790,6 +5792,7 @@
         "description": {
           "anyOf": [
             {
+              "maxLength": 200,
               "type": "string"
             },
             {
@@ -9805,6 +9808,7 @@
         "description": {
           "anyOf": [
             {
+              "maxLength": 200,
               "type": "string"
             },
             {

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -11,6 +11,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Final,
     Iterator,
     Literal,
     Mapping,
@@ -291,6 +292,12 @@ AnyVariable: TypeAlias = (
     | float
     | bool
 )
+
+
+APP_RESOURCE_DESCRIPTION_MAX_LENGTH: Final[int] = 200
+"""Max length for descriptions on IsDatabricksResource subclasses. Matches the
+Databricks Apps platform limit on ``AppResource.description``; overlong values
+are rejected at deploy time, so we reject at config-load time instead."""
 
 
 class ServicePrincipalModel(BaseModel):
@@ -948,6 +955,7 @@ class InferenceEndpointModel(IsDatabricksResource):
     )
     description: Optional[str] = Field(
         default=None,
+        max_length=APP_RESOURCE_DESCRIPTION_MAX_LENGTH,
         description="Human-readable description of this model configuration.",
     )
     temperature: Optional[float] = Field(
@@ -1316,6 +1324,7 @@ class WarehouseModel(IsDatabricksResource):
     )
     description: Optional[str] = Field(
         default=None,
+        max_length=APP_RESOURCE_DESCRIPTION_MAX_LENGTH,
         description="Human-readable description of this warehouse.",
     )
     warehouse_id: Optional[AnyVariable] = Field(
@@ -1659,6 +1668,7 @@ class GenieRoomModel(IsDatabricksResource, ManagedResource):
     )
     description: Optional[str] = Field(
         default=None,
+        max_length=APP_RESOURCE_DESCRIPTION_MAX_LENGTH,
         description="Description of the Genie room. Auto-populated from the space if omitted.",
     )
     space_id: Optional[AnyVariable] = Field(
@@ -3374,6 +3384,7 @@ class DatabaseModel(IsDatabricksResource):
     )
     description: Optional[str] = Field(
         default=None,
+        max_length=APP_RESOURCE_DESCRIPTION_MAX_LENGTH,
         description="Human-readable description of this database connection.",
     )
     host: Optional[AnyVariable] = Field(

--- a/tests/dao_ai/test_description_length.py
+++ b/tests/dao_ai/test_description_length.py
@@ -1,0 +1,44 @@
+"""Verify the 200-char cap on IsDatabricksResource description fields.
+
+The cap matches the Databricks Apps platform limit on ``AppResource.description``;
+overlong values would otherwise fail only at deploy time.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from dao_ai.config import (
+    APP_RESOURCE_DESCRIPTION_MAX_LENGTH,
+    DatabaseModel,
+    GenieRoomModel,
+    InferenceEndpointModel,
+    WarehouseModel,
+)
+
+_MAX = APP_RESOURCE_DESCRIPTION_MAX_LENGTH
+
+
+@pytest.mark.unit
+def test_max_length_constant_is_200() -> None:
+    assert _MAX == 200
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda desc: InferenceEndpointModel(name="ep", description=desc),
+        lambda desc: WarehouseModel(name="wh", description=desc),
+        lambda desc: GenieRoomModel(name="g", space_id="s", description=desc),
+        lambda desc: DatabaseModel(name="db", project="p", description=desc),
+    ],
+    ids=["inference_endpoint", "warehouse", "genie_room", "database"],
+)
+def test_description_length_limit(factory) -> None:
+    assert factory(None).description is None
+    assert factory("").description == ""
+    assert factory("a" * _MAX).description == "a" * _MAX
+
+    with pytest.raises(ValidationError) as exc_info:
+        factory("a" * (_MAX + 1))
+    assert "description" in str(exc_info.value)


### PR DESCRIPTION
## Summary

- Enforces the Databricks Apps `AppResource.description` 200-char limit at the Pydantic layer via `max_length=200` on `InferenceEndpointModel`, `WarehouseModel`, `GenieRoomModel`, and `DatabaseModel` — overlong descriptions now fail at config-load time with a clear error rather than at deploy time.
- Adds a shared `APP_RESOURCE_DESCRIPTION_MAX_LENGTH: Final[int] = 200` constant so the value is defined once.
- Shortens three in-tree example descriptions (brick_store, vertex_agent_engine ×2) that exceeded the new cap.
- Regenerates `schemas/model_config_schema.json` — diff is exactly four `"maxLength": 200` additions.
- Adds unit coverage in `tests/dao_ai/test_description_length.py` — parametrized across all four models, covering `None` / empty / 200-char / 201-char.

Context: a customer hit a deploy failure pushing a dao-ai config to Databricks Apps because a Genie room description exceeded the platform's 200-char limit on `resources[].description`. The same limit applies to every AppResource kind, so this cap is applied at the base-resource layer.

An auto-fetch fallback (null → SDK GET to populate from the source Databricks resource) was investigated during planning and tabled — feasible only for a subset (Genie, Serving Endpoint, UC types) and out of scope for this PR.

**Also:** one chore commit adds two `.gitleaksignore` entries for pre-existing false-positive `postgres-connection-string` findings on `main` (a Mermaid diagram placeholder `user:pass@host/db` and a test fixture `test:test@localhost/test`) that were blocking pre-push. Both are literal placeholders, not real credentials.

## Test plan

- [x] `uv run pytest tests/dao_ai/test_description_length.py -v` — 5/5 pass
- [x] `uv run pytest tests/dao_ai/test_config.py tests/dao_ai/test_resources_model_genie_integration.py tests/dao_ai/test_mcp_function_model.py -m unit` — 47/47 pass, no regressions
- [x] `make schema > schemas/model_config_schema.json` — diff is exactly the four `maxLength: 200` additions
- [x] Repo-wide YAML scan confirms no in-scope resource descriptions exceed 200 chars post-fix
- [ ] Reviewer sanity check: try assigning a 201-char description to any of the four models in a REPL and confirm `ValidationError`

This pull request and its description were written by Isaac.