### PR TITLE
fix(vector_search): support ambient WorkspaceClient auth on Serverless v5

### DIFF
--- a/src/dao_ai/tools/vector_search.py
+++ b/src/dao_ai/tools/vector_search.py
@@ -61,6 +61,83 @@ from dao_ai.tools.verifier import add_verification_metadata, verify_results
 from dao_ai.utils import is_in_model_serving, normalize_host
 
 
+# auth_type values that the databricks-langchain library (as of 0.20.0) extracts
+# natively from workspace_client.config inside DatabricksVectorSearch.__init__.
+# When wc.config.auth_type is one of these, we let the library do its own job.
+# Sources of truth in databricks-sdk credentials_provider.py:
+#   - "pat":                              L146 @credentials_strategy("pat", ...)
+#   - "oauth-m2m":                        L237 @oauth_credentials_strategy("oauth-m2m", ...)
+#   - "model_serving_user_credentials":   L1499-1501, composed from
+#                                         "model_serving_" + ModelServingAuthProvider.USER_CREDENTIALS ("user_credentials")
+_LIBRARY_NATIVE_AUTH_TYPES: tuple[str, ...] = (
+    "pat",
+    "oauth-m2m",
+    "model_serving_user_credentials",
+)
+
+
+def _client_args_from_ambient_wc(wc: WorkspaceClient) -> dict[str, Any] | None:
+    """Populate ``VectorSearchClient`` auth kwargs from an ambient WorkspaceClient
+    whose ``config.auth_type`` is *not* one the ``databricks-langchain`` library
+    extracts natively.
+
+    The library inspects ``workspace_client.config.auth_type`` inside
+    ``DatabricksVectorSearch.__init__`` and only builds ``client_args`` for the
+    three values in ``_LIBRARY_NATIVE_AUTH_TYPES``. On Databricks Serverless v5
+    notebook / job runs, ``auth_type`` is usually ``databricks-cli`` /
+    ``oauth-u2m`` / ``default`` — none of which the library maps. Without help
+    ``client_args`` stays empty and the underlying ``VectorSearchClient`` raises
+    ``InvalidInputException`` demanding a PAT or SP.
+
+    Returns ``None`` when:
+      * the library will already handle the WC natively (auth_type in the
+        native list), or
+      * no bearer can be resolved from ``wc.config.authenticate()``, or
+      * ``wc.config.host`` is missing (VectorSearchClient rejects a bearer
+        without a workspace_url in its ``validate()`` — passing a partial dict
+        would convert one error into a more confusing one).
+
+    In every ``None`` case the caller passes ``client_args=None`` to the
+    library, which then gets a clean shot at its own extraction / fallback.
+
+    Otherwise returns a dict shaped as
+    ``{workspace_url, personal_access_token}``.
+    """
+    try:
+        auth_type = getattr(wc.config, "auth_type", None)
+        if auth_type in _LIBRARY_NATIVE_AUTH_TYPES:
+            return None
+        headers = wc.config.authenticate() or {}
+        bearer = str(headers.get("Authorization", ""))
+        if not bearer.startswith("Bearer "):
+            # Recognized the WC but its ambient auth isn't a Bearer we can
+            # forward (e.g. Basic). Better to punt to the library than lie
+            # about credentials we can't actually use.
+            logger.warning(
+                "dao_ai.vector_search.ambient_auth.unusable",
+                auth_type=auth_type,
+                note="WorkspaceClient.config.authenticate() produced no Bearer header",
+            )
+            return None
+        host = getattr(wc.config, "host", None)
+        if not host:
+            # VectorSearchClient.validate() requires workspace_url when a PAT
+            # is provided (databricks/ai_search/client.py:186-189). Punt.
+            logger.warning(
+                "dao_ai.vector_search.ambient_auth.no_host",
+                auth_type=auth_type,
+                note="WorkspaceClient.config.host is missing; cannot mint client_args",
+            )
+            return None
+        return {
+            "workspace_url": normalize_host(host),
+            "personal_access_token": bearer[len("Bearer "):],
+        }
+    except Exception as e:
+        logger.warning("dao_ai.vector_search.ambient_auth.exception", error=str(e))
+        return None
+
+
 class VectorSearchInput(BaseModel):
     """Arguments for the dao-ai vector_search tool factory.
 
@@ -383,17 +460,29 @@ def create_vector_search_tool(
         # Get workspace client with OBO support via context
         workspace_client: WorkspaceClient = vector_store.workspace_client_from(context)
 
-        # Create DatabricksVectorSearch
-        # Note: text_column should be None for Databricks-managed embeddings
-        # (it's automatically determined from the index)
+        # Create DatabricksVectorSearch. text_column stays None for
+        # Databricks-managed embeddings (auto-detected from the index).
         #
-        # When OBO is active, skip client_args entirely so
-        # DatabricksVectorSearch uses the workspace_client (which carries
-        # the user's forwarded token) instead of creating a separate
-        # VectorSearchClient from client_args with ambient/SP auth.
-        effective_client_args: dict[str, Any] | None = (
-            client_args if client_args and not vector_store.on_behalf_of_user else None
-        )
+        # Auth selection covers four modes, in priority order:
+        #   1. OBO — vector_store.on_behalf_of_user=True: pass client_args=None
+        #      so DatabricksVectorSearch uses the forwarded-bearer WorkspaceClient
+        #      directly.
+        #   2. Explicit PAT/SP — DATABRICKS_TOKEN / DATABRICKS_CLIENT_ID env vars
+        #      OR YAML vector_store.pat / .client_id / .client_secret; already
+        #      collected into `client_args` upstream.
+        #   3. Ambient App SP on Serverless v5 — WorkspaceClient.config.auth_type
+        #      is oauth-m2m; the library handles it natively when we pass
+        #      client_args=None (helper returns None).
+        #   4. Ambient user on Serverless v5 (notebook / job) — auth_type is
+        #      one of databricks-cli / oauth-u2m / default; the library does
+        #      NOT handle these, so we mint client_args ourselves from the
+        #      runtime bearer via _client_args_from_ambient_wc.
+        if vector_store.on_behalf_of_user:
+            effective_client_args: dict[str, Any] | None = None
+        elif client_args:
+            effective_client_args = client_args
+        else:
+            effective_client_args = _client_args_from_ambient_wc(workspace_client)
         vs: DatabricksVectorSearch = DatabricksVectorSearch(
             index_name=index_name,
             text_column=None,

--- a/tests/dao_ai/test_vector_search.py
+++ b/tests/dao_ai/test_vector_search.py
@@ -424,3 +424,374 @@ def test_create_vector_search_tool_obo_off_does_not_use_context_headers() -> Non
 
     # Still called (to mint the SP-scoped WC), but headers were empty.
     assert vs_model.workspace_client_from.called
+
+
+# ---------------------------------------------------------------------------
+# Auth-mode matrix for _client_args_from_ambient_wc + effective_client_args
+# in create_vector_search_tool. All four modes must resolve on Serverless v5:
+#
+#   #1  ambient App SP  → auth_type=oauth-m2m       → client_args=None (library-native)
+#   #2  ambient user    → auth_type=databricks-cli  → client_args={ws_url, PAT} (dao-ai fills in)
+#   #3  OBO             → on_behalf_of_user=true    → client_args=None (library uses WC)
+#   #4  explicit PAT/SP → YAML vector_store.pat|.client_id/.client_secret → client_args populated
+#
+# The existing OBO tests above cover mode #3 for the runtime-context path.
+# The tests below pin the four modes at the DatabricksVectorSearch(...) boundary:
+# they capture the client_args kwarg dao-ai passes and assert the exact shape
+# each mode should produce. Without the ambient-user fallback, mode #2 would
+# leave client_args={} and VectorSearchClient({disable_notice:True}) would
+# raise InvalidInputException. All four modes are the regression watchdog.
+# ---------------------------------------------------------------------------
+
+
+def _make_ambient_vector_store_mock(*, on_behalf_of_user: bool = False) -> Mock:
+    """VectorStoreModel mock with all four auth-mode fields defaulted to None
+    (no explicit PAT/SP). Tests override individual fields as needed.
+    """
+    from dao_ai.config import VectorStoreModel
+
+    vs = Mock(spec=VectorStoreModel)
+    vs.columns = ["text"]
+    vs.embedding_model = None
+    vs.primary_key = "id"
+    vs.index = Mock()
+    vs.index.full_name = "catalog.schema.some_index"
+    vs.index.name = "some_index"
+    vs.index.columns = ["text"]
+    vs.endpoint = Mock()
+    vs.source_table = None
+    vs.embedding_source_column = None
+    vs.doc_uri = None
+    vs.on_behalf_of_user = on_behalf_of_user
+    # No explicit PAT / SP in YAML
+    vs.pat = None
+    vs.client_id = None
+    vs.client_secret = None
+    vs.workspace_host = None
+    try:
+        from conftest import add_databricks_resource_attrs
+
+        add_databricks_resource_attrs(vs)
+    except ImportError:
+        pass
+    # add_databricks_resource_attrs re-sets on_behalf_of_user=False; restore intent.
+    vs.on_behalf_of_user = on_behalf_of_user
+    return vs
+
+
+def _fake_wc(*, auth_type: str, host: str = "https://fevm.example.com",
+             client_id: Any = None, client_secret: Any = None,
+             bearer: str | None = None) -> MagicMock:
+    """Build a WorkspaceClient mock whose .config exposes the auth_type shape
+    the databricks-langchain library and _client_args_from_ambient_wc read."""
+    wc = MagicMock(name=f"wc[{auth_type}]")
+    wc.config.auth_type = auth_type
+    wc.config.host = host
+    wc.config.client_id = client_id
+    wc.config.client_secret = client_secret
+    if bearer is not None:
+        wc.config.authenticate.return_value = {"Authorization": f"Bearer {bearer}"}
+    else:
+        wc.config.authenticate.return_value = {}
+    return wc
+
+
+def _capture_client_args_and_invoke(
+    vs_model: Mock,
+    wc: MagicMock,
+    *,
+    monkeypatch: Any | None = None,
+    query: str = "probe",
+) -> dict[str, Any]:
+    """Wire the vector_store mock to return the given fake WC, patch
+    DatabricksVectorSearch to capture the kwargs it's constructed with, invoke
+    the tool once, and return the captured kwargs dict.
+    """
+    from langgraph.runtime import Runtime
+
+    from dao_ai.config import RetrieverModel
+    from dao_ai.state import Context
+    from dao_ai.tools.vector_search import create_vector_search_tool
+
+    vs_model.workspace_client_from.return_value = wc
+    retriever = RetrieverModel(vector_store=vs_model)
+
+    captured: dict[str, Any] = {}
+    with patch("dao_ai.tools.vector_search.DatabricksVectorSearch") as MockDVS:
+        def _capture(**kwargs: Any) -> MagicMock:
+            captured.update(kwargs)
+            m = MagicMock()
+            m.similarity_search.return_value = []
+            return m
+        MockDVS.side_effect = _capture
+
+        tool = create_vector_search_tool(retriever=retriever)
+        rt = Runtime(context=Context(headers={}))
+        tool.invoke({"query": query, "filters": None, "runtime": rt})
+
+    return captured
+
+
+@pytest.mark.unit
+def test_vs_mode1_ambient_app_sp_oauth_m2m(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mode #1: deployed Databricks App on Serverless v5.
+    WorkspaceClient.config.auth_type == 'oauth-m2m' (owning SP). The library
+    handles this branch natively, so dao-ai must pass client_args=None (or
+    empty/falsy) — the library reads config.client_id / .client_secret from
+    the WorkspaceClient we hand it.
+    """
+    for var in ("DATABRICKS_TOKEN", "DATABRICKS_CLIENT_ID", "DATABRICKS_CLIENT_SECRET", "DATABRICKS_HOST"):
+        monkeypatch.delenv(var, raising=False)
+
+    vs_model = _make_ambient_vector_store_mock()
+    wc = _fake_wc(
+        auth_type="oauth-m2m",
+        client_id="sp-client-id",
+        client_secret="sp-client-secret",
+    )
+    kwargs = _capture_client_args_and_invoke(vs_model, wc)
+
+    assert kwargs["workspace_client"] is wc
+    # None or empty are both acceptable here — both let the library run its
+    # native oauth-m2m extraction. The important part is we did NOT override
+    # with a bogus PAT from a bearer that this WC doesn't actually emit.
+    assert kwargs.get("client_args") in (None, {}, {"disable_notice": True}), (
+        f"mode #1 must not synthesize client_args for oauth-m2m; got {kwargs.get('client_args')!r}"
+    )
+
+
+@pytest.mark.unit
+def test_vs_mode2_ambient_serverless_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mode #2: Serverless v5 notebook / job with no explicit PAT or SP.
+    WorkspaceClient.config.auth_type is one of {databricks-cli, oauth-u2m,
+    default}. The databricks-langchain library does NOT extract creds from
+    these, so dao-ai must fill client_args from the runtime bearer.
+    """
+    for var in ("DATABRICKS_TOKEN", "DATABRICKS_CLIENT_ID", "DATABRICKS_CLIENT_SECRET", "DATABRICKS_HOST"):
+        monkeypatch.delenv(var, raising=False)
+
+    vs_model = _make_ambient_vector_store_mock()
+    wc = _fake_wc(
+        auth_type="databricks-cli",
+        host="https://fevm.example.com",
+        bearer="ambient-oauth-token",
+    )
+    kwargs = _capture_client_args_and_invoke(vs_model, wc)
+
+    ca = kwargs.get("client_args") or {}
+    assert ca.get("personal_access_token") == "ambient-oauth-token", (
+        f"mode #2 must synthesize a PAT from the ambient bearer; got {ca!r}"
+    )
+    assert ca.get("workspace_url", "").startswith("https://fevm.example.com"), (
+        f"mode #2 must include workspace_url; got {ca!r}"
+    )
+
+
+@pytest.mark.unit
+def test_vs_mode2_other_ambient_auth_types(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mode #2 variants: oauth-u2m and 'default' behave the same as
+    databricks-cli — dao-ai must synthesize client_args from the bearer.
+    """
+    for var in ("DATABRICKS_TOKEN", "DATABRICKS_CLIENT_ID", "DATABRICKS_CLIENT_SECRET", "DATABRICKS_HOST"):
+        monkeypatch.delenv(var, raising=False)
+
+    for auth_type in ("oauth-u2m", "default"):
+        vs_model = _make_ambient_vector_store_mock()
+        wc = _fake_wc(
+            auth_type=auth_type,
+            bearer=f"tok-{auth_type}",
+        )
+        kwargs = _capture_client_args_and_invoke(vs_model, wc)
+        ca = kwargs.get("client_args") or {}
+        assert ca.get("personal_access_token") == f"tok-{auth_type}", (
+            f"auth_type={auth_type} did not produce a PAT: {ca!r}"
+        )
+
+
+@pytest.mark.unit
+def test_vs_mode3_obo_passes_none_client_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mode #3: OBO with vector_store.on_behalf_of_user=True. dao-ai must pass
+    client_args=None so the library uses the forwarded-bearer WorkspaceClient
+    directly instead of building a separate VectorSearchClient.
+    """
+    for var in ("DATABRICKS_TOKEN", "DATABRICKS_CLIENT_ID", "DATABRICKS_CLIENT_SECRET", "DATABRICKS_HOST"):
+        monkeypatch.delenv(var, raising=False)
+
+    vs_model = _make_ambient_vector_store_mock(on_behalf_of_user=True)
+    # OBO WC — auth_type shouldn't matter; the library uses the WC directly.
+    wc = _fake_wc(auth_type="databricks-cli", bearer="user-forwarded-bearer")
+    kwargs = _capture_client_args_and_invoke(vs_model, wc)
+
+    assert kwargs.get("client_args") is None, (
+        f"mode #3 (OBO) must pass client_args=None; got {kwargs.get('client_args')!r}"
+    )
+    assert kwargs["workspace_client"] is wc
+
+
+@pytest.mark.unit
+def test_vs_mode4_explicit_pat_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mode #4a: DATABRICKS_TOKEN env var set. dao-ai must populate
+    client_args["personal_access_token"] from the env var, not synthesize
+    from the ambient bearer.
+    """
+    monkeypatch.setenv("DATABRICKS_TOKEN", "explicit-pat-from-env")
+    monkeypatch.setenv("DATABRICKS_HOST", "https://fevm.example.com")
+    for var in ("DATABRICKS_CLIENT_ID", "DATABRICKS_CLIENT_SECRET"):
+        monkeypatch.delenv(var, raising=False)
+
+    vs_model = _make_ambient_vector_store_mock()
+    wc = _fake_wc(auth_type="databricks-cli", bearer="ambient-should-be-ignored")
+    kwargs = _capture_client_args_and_invoke(vs_model, wc)
+
+    ca = kwargs.get("client_args") or {}
+    assert ca.get("personal_access_token") == "explicit-pat-from-env", (
+        f"mode #4a must use env DATABRICKS_TOKEN, not ambient bearer; got {ca!r}"
+    )
+
+
+@pytest.mark.unit
+def test_vs_mode4_explicit_sp_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mode #4b: DATABRICKS_CLIENT_ID / DATABRICKS_CLIENT_SECRET env vars set.
+    dao-ai must populate client_args with the SP creds, not the ambient bearer.
+    """
+    monkeypatch.setenv("DATABRICKS_CLIENT_ID", "sp-id")
+    monkeypatch.setenv("DATABRICKS_CLIENT_SECRET", "sp-secret")
+    monkeypatch.setenv("DATABRICKS_HOST", "https://fevm.example.com")
+    monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+
+    vs_model = _make_ambient_vector_store_mock()
+    wc = _fake_wc(auth_type="oauth-m2m", client_id="wc-id", client_secret="wc-secret",
+                  bearer="ambient-should-be-ignored")
+    kwargs = _capture_client_args_and_invoke(vs_model, wc)
+
+    ca = kwargs.get("client_args") or {}
+    assert ca.get("service_principal_client_id") == "sp-id", (
+        f"mode #4b must use DATABRICKS_CLIENT_ID env; got {ca!r}"
+    )
+    assert ca.get("service_principal_client_secret") == "sp-secret", (
+        f"mode #4b must use DATABRICKS_CLIENT_SECRET env; got {ca!r}"
+    )
+
+
+# Direct unit tests of the helper — cheap and precise.
+
+@pytest.mark.unit
+def test_client_args_from_ambient_wc_returns_none_for_library_native() -> None:
+    """The helper must decline to touch auth_types the library handles itself,
+    so we don't accidentally override the library's built-in extraction.
+    """
+    from dao_ai.tools.vector_search import _client_args_from_ambient_wc
+
+    for auth_type in ("pat", "oauth-m2m", "model_serving_user_credentials"):
+        wc = _fake_wc(auth_type=auth_type, bearer="does-not-matter")
+        assert _client_args_from_ambient_wc(wc) is None, (
+            f"helper must return None for library-native auth_type={auth_type}"
+        )
+
+
+@pytest.mark.unit
+def test_client_args_from_ambient_wc_returns_none_when_no_bearer() -> None:
+    """If no bearer is resolvable, the helper returns None so the caller can
+    pass client_args=None to the library — which will then raise its native
+    error rather than dao-ai producing a broken PAT-shaped payload.
+    """
+    from dao_ai.tools.vector_search import _client_args_from_ambient_wc
+
+    wc = _fake_wc(auth_type="databricks-cli")  # authenticate() -> {}
+    assert _client_args_from_ambient_wc(wc) is None
+
+
+# ---------------------------------------------------------------------------
+# F1 — regression guard: workspace_url is mandatory when PAT is passed.
+# VectorSearchClient.validate() (databricks/ai_search/client.py:186-189)
+# raises when personal_access_token is supplied without workspace_url. If the
+# helper synthesized a partial dict it would degrade the error UX, so we
+# require it to return None whenever wc.config.host is missing.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_client_args_from_ambient_wc_returns_none_when_no_host() -> None:
+    """host absent → helper returns None so the caller can pass client_args=None."""
+    from dao_ai.tools.vector_search import _client_args_from_ambient_wc
+
+    for host_val in (None, ""):
+        wc = _fake_wc(auth_type="databricks-cli", host=host_val, bearer="tok")
+        assert _client_args_from_ambient_wc(wc) is None, (
+            f"helper must return None when host={host_val!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# F3-a — M3b Model Serving OBO. When on_behalf_of_user=True and no forwarded
+# bearer is in Context.headers, workspace_client_from() falls through to
+# self.workspace_client (config.py:439-445), which builds
+# WorkspaceClient(credentials_strategy=ModelServingUserCredentials()). That
+# WC's config.auth_type is "model_serving_user_credentials"; the library's
+# native branch then adds credential_strategy=MODEL_SERVING_USER_CREDENTIALS
+# to client_args and VectorSearchClient reads invoker creds from the MS env.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_vs_mode3b_model_serving_obo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OBO on Model Serving path: WC auth_type is model_serving_user_credentials,
+    dao-ai must pass client_args=None so the library's native branch fires.
+    """
+    for var in ("DATABRICKS_TOKEN", "DATABRICKS_CLIENT_ID", "DATABRICKS_CLIENT_SECRET", "DATABRICKS_HOST"):
+        monkeypatch.delenv(var, raising=False)
+
+    vs_model = _make_ambient_vector_store_mock(on_behalf_of_user=True)
+    wc = _fake_wc(auth_type="model_serving_user_credentials", bearer="ms-invoker-tok")
+    kwargs = _capture_client_args_and_invoke(vs_model, wc)
+
+    assert kwargs.get("client_args") is None, (
+        "mode #3b (Model Serving OBO) must pass client_args=None so the library "
+        "forwards to VectorSearchClient with "
+        "credential_strategy=MODEL_SERVING_USER_CREDENTIALS; "
+        f"got {kwargs.get('client_args')!r}"
+    )
+    assert kwargs["workspace_client"] is wc
+
+
+# ---------------------------------------------------------------------------
+# F3-b — defense in depth: a WorkspaceClient whose authenticate() returns a
+# non-Bearer Authorization header (e.g. Basic) must NOT be turned into a
+# spurious PAT. The helper punts (returns None), the library errors natively.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_client_args_from_ambient_wc_returns_none_for_basic_auth() -> None:
+    from dao_ai.tools.vector_search import _client_args_from_ambient_wc
+
+    wc = MagicMock(name="wc[basic]")
+    wc.config.auth_type = "basic"
+    wc.config.host = "https://ws.example.com"
+    wc.config.authenticate.return_value = {"Authorization": "Basic dXNlcjpwYXNz"}
+    assert _client_args_from_ambient_wc(wc) is None
+
+
+# ---------------------------------------------------------------------------
+# F5 — auth_type="default" edge. DefaultCredentials.auth_type() returns
+# "default" (credentials_provider.py:1426), and ModelServingUserCredentials
+# outside a Model Serving container ALSO returns "default"
+# (credentials_provider.py:1503). Either case must produce a workable
+# client_args from the ambient bearer.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_vs_default_auth_type_falls_back_to_bearer(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("DATABRICKS_TOKEN", "DATABRICKS_CLIENT_ID", "DATABRICKS_CLIENT_SECRET", "DATABRICKS_HOST"):
+        monkeypatch.delenv(var, raising=False)
+
+    vs_model = _make_ambient_vector_store_mock()
+    wc = _fake_wc(auth_type="default", bearer="fallback-bearer")
+    kwargs = _capture_client_args_and_invoke(vs_model, wc)
+
+    ca = kwargs.get("client_args") or {}
+    assert ca.get("personal_access_token") == "fallback-bearer", (
+        f"auth_type='default' must fall through to bearer extraction; got {ca!r}"
+    )
+    assert ca.get("workspace_url"), "workspace_url must be present alongside PAT"

--- a/tests/dao_ai/test_vector_search_fevm_integration.py
+++ b/tests/dao_ai/test_vector_search_fevm_integration.py
@@ -1,0 +1,222 @@
+"""fevm integration tests for the vector-search tool auth-mode matrix.
+
+Runs the real dao-ai VS tool factory against a real Databricks Vector Search
+index on the fevm workspace. These tests are the regression watchdog for
+the four auth modes documented in ``create_vector_search_tool``:
+
+    #1  ambient App SP        (auth_type=oauth-m2m) — library-native path
+    #2  ambient Serverless v5 (auth_type=databricks-cli / oauth-u2m / default)
+                              — dao-ai fills client_args from runtime bearer
+    #3  OBO (user auth)       (vector_store.on_behalf_of_user=True)
+    #4  explicit PAT/SP       (DATABRICKS_TOKEN / DATABRICKS_CLIENT_ID env or YAML)
+
+Local-laptop runs of these tests exercise **mode #2 exclusively** because
+``WorkspaceClient(profile="fevm")`` picks up ``auth_type="databricks-cli"``
+on ``~/.databrickscfg`` profiles. Modes #1 and #3 are only meaningful inside
+a deployed Databricks App and can't be reproduced from a laptop; those are
+covered by the mocked unit tests in ``test_vector_search.py``.
+
+To run:
+    pytest tests/dao_ai/test_vector_search_fevm_integration.py -v -m integration
+
+Requires the ``fevm`` CLI profile in ``~/.databrickscfg`` OR
+``DATABRICKS_HOST`` + ``DATABRICKS_TOKEN`` env vars. Uses the healthy
+phase2 replacement indexes provisioned during workshop validation:
+    - retail_consumer_goods.dao_ai_phase2.products_index
+    - retail_consumer_goods.dao_ai_phase2.kb_articles_index
+Both live on VS endpoint ``dao_ai_workshop_vs``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+from databricks.sdk import WorkspaceClient
+from langchain_core.messages import ToolCall as LCToolCall
+from langchain_core.messages import ToolMessage
+
+from dao_ai.config import (
+    IndexModel,
+    RetrieverModel,
+    SchemaModel,
+    SearchParametersModel,
+    VectorSearchEndpoint,
+    VectorStoreModel,
+)
+from dao_ai.tools.vector_search import create_vector_search_tool
+
+TEST_PROFILE = os.getenv("DAO_AI_TEST_PROFILE", "fevm")
+
+
+def _has_fevm_profile() -> bool:
+    """Cheap check that fevm profile is usable without actually calling the API."""
+    if os.getenv("DATABRICKS_HOST") and os.getenv("DATABRICKS_TOKEN"):
+        return True
+    cfg = os.path.expanduser("~/.databrickscfg")
+    if not os.path.exists(cfg):
+        return False
+    try:
+        with open(cfg) as f:
+            return f"[{TEST_PROFILE}]" in f.read()
+    except Exception:
+        return False
+
+
+SKIP_MSG = (
+    f"Requires DATABRICKS_CONFIG_PROFILE={TEST_PROFILE} in ~/.databrickscfg "
+    "or DATABRICKS_HOST + DATABRICKS_TOKEN env vars."
+)
+
+
+def _extract_documents(result):
+    """Unwrap the tool result into a list. Copied from test_reranking_integration."""
+    if isinstance(result, ToolMessage):
+        content = result.content
+        if isinstance(content, str):
+            try:
+                return json.loads(content)
+            except json.JSONDecodeError:
+                import ast
+
+                return ast.literal_eval(content)
+        return content
+    return result
+
+
+def _products_retriever() -> RetrieverModel:
+    schema = SchemaModel(
+        catalog_name="retail_consumer_goods",
+        schema_name="dao_ai_phase2",
+    )
+    return RetrieverModel(
+        vector_store=VectorStoreModel(
+            index=IndexModel(name="products_index", schema=schema),
+            endpoint=VectorSearchEndpoint(name="dao_ai_workshop_vs"),
+            primary_key="sku",
+            embedding_source_column="description",
+            columns=["sku", "product_name", "category", "description"],
+        ),
+        search_parameters=SearchParametersModel(num_results=3),
+    )
+
+
+def _kb_retriever() -> RetrieverModel:
+    schema = SchemaModel(
+        catalog_name="retail_consumer_goods",
+        schema_name="dao_ai_phase2",
+    )
+    return RetrieverModel(
+        vector_store=VectorStoreModel(
+            index=IndexModel(name="kb_articles_index", schema=schema),
+            endpoint=VectorSearchEndpoint(name="dao_ai_workshop_vs"),
+            primary_key="article_id",
+            embedding_source_column="body",
+            columns=["article_id", "title", "topic", "body"],
+        ),
+        search_parameters=SearchParametersModel(num_results=3),
+    )
+
+
+def _invoke(tool, query: str):
+    tool_call = LCToolCall(
+        name=tool.name,
+        args={"query": query},
+        id="test-tc-1",
+        type="tool_call",
+    )
+    result = tool.invoke(tool_call)
+    return _extract_documents(result)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _has_fevm_profile(), reason=SKIP_MSG)
+class TestVectorSearchFevmAmbientMode2:
+    """Mode #2: ambient auth via ``fevm`` profile (auth_type=databricks-cli).
+
+    Without the ``_client_args_from_ambient_wc`` fix, every method below
+    would raise ``InvalidInputException: Please specify either personal
+    access token or service principal client ID and secret`` at
+    ``create_vector_search_tool``-invocation time.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_env_auth(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Ensure the ambient path is what actually gets exercised — clear
+        any DATABRICKS_TOKEN / SP env vars that would flip us into mode #4.
+        """
+        for var in (
+            "DATABRICKS_TOKEN",
+            "DATABRICKS_CLIENT_ID",
+            "DATABRICKS_CLIENT_SECRET",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("DATABRICKS_CONFIG_PROFILE", TEST_PROFILE)
+
+    def test_workspace_client_auth_type_is_ambient(self) -> None:
+        """Guardrail: confirm the profile really produces one of the
+        ambient auth_types the fix targets. If this ever flips to 'pat'
+        or 'oauth-m2m', these tests would silently exercise the wrong
+        code path.
+        """
+        wc = WorkspaceClient(profile=TEST_PROFILE)
+        assert wc.config.auth_type in ("databricks-cli", "oauth-u2m", "default"), (
+            f"expected ambient auth_type, got {wc.config.auth_type!r}"
+        )
+
+    def test_products_index_search_returns_results(self) -> None:
+        tool = create_vector_search_tool(
+            retriever=_products_retriever(),
+            name="products_search",
+            description="Search products by description",
+        )
+        docs = _invoke(tool, "cordless drill")
+        assert isinstance(docs, list) and len(docs) > 0, (
+            f"products search returned no docs (or wrong shape): {docs!r}"
+        )
+
+    def test_kb_articles_index_search_returns_results(self) -> None:
+        tool = create_vector_search_tool(
+            retriever=_kb_retriever(),
+            name="kb_search",
+            description="Search support KB articles",
+        )
+        docs = _invoke(tool, "reset password")
+        assert isinstance(docs, list) and len(docs) > 0, (
+            f"kb search returned no docs (or wrong shape): {docs!r}"
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _has_fevm_profile(), reason=SKIP_MSG)
+class TestVectorSearchFevmExplicitAuthMode4:
+    """Mode #4: explicit PAT via ``DATABRICKS_TOKEN`` env var. Exercises the
+    path that was working *before* the fix, so we don't regress it.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _mint_pat_from_ambient(self, monkeypatch: pytest.MonkeyPatch) -> str:
+        """Pull an OAuth bearer from the ambient CLI profile and set it as
+        DATABRICKS_TOKEN so the mode #4 code path runs. This mimics what a
+        legacy notebook that hard-set the env var would look like.
+        """
+        wc = WorkspaceClient(profile=TEST_PROFILE)
+        headers = wc.config.authenticate() or {}
+        bearer = headers.get("Authorization", "")
+        assert bearer.startswith("Bearer "), f"can't get bearer: {bearer!r}"
+        token = bearer[len("Bearer "):]
+        monkeypatch.setenv("DATABRICKS_TOKEN", token)
+        monkeypatch.setenv("DATABRICKS_HOST", wc.config.host)
+        return token
+
+    def test_products_index_search_with_explicit_pat(self) -> None:
+        tool = create_vector_search_tool(
+            retriever=_products_retriever(),
+            name="products_search",
+            description="Search products by description",
+        )
+        docs = _invoke(tool, "circular saw")
+        assert isinstance(docs, list) and len(docs) > 0, (
+            f"mode #4 explicit-PAT search returned no docs: {docs!r}"
+        )


### PR DESCRIPTION
## Summary

- Fixes `InvalidInputException: Please specify either personal access token or service principal client ID and secret` at graph-build time for `create_vector_search_tool` on Databricks Serverless v5 notebooks / jobs.
- Root cause is in `databricks_langchain.DatabricksVectorSearch.__init__`: it only extracts credentials from a caller-supplied `WorkspaceClient` when `config.auth_type` is one of `pat` / `oauth-m2m` / `model_serving_user_credentials`. Serverless v5 notebooks report `databricks-cli` / `oauth-u2m` / `default` — none of which the library maps — so `client_args` stays empty and the underlying `VectorSearchClient.validate()` rejects the payload.
- New helper `_client_args_from_ambient_wc(wc)` mints `{workspace_url, personal_access_token}` from the ambient `wc.config.authenticate()` when the auth_type isn't library-native. `effective_client_args` inside `_get_vector_search` is rewritten from an implicit ternary into an explicit 4-branch mode dispatch.

## Auth-mode matrix (Serverless v5)

| # | Mode | `config.auth_type` | Path |
|---|------|--------------------|------|
| M1 | Ambient App SP | `oauth-m2m` | library-native (unchanged) |
| M2 | Ambient user notebook / job | `databricks-cli` / `oauth-u2m` / `default` | **new: dao-ai fills client_args** |
| M3a | OBO on Apps | `pat` (forwarded bearer) | library-native (unchanged) |
| M3b | OBO on Model Serving | `model_serving_user_credentials` | library-native (unchanged) |
| M4 | Explicit PAT / SP | env vars or YAML | dao-ai fills client_args upstream (unchanged) |

## Edge cases the helper defensively handles

- `wc.config.host` missing → return `None` (`VectorSearchClient` rejects a PAT without `workspace_url`, so passing a partial dict would degrade the error UX; better to punt and let the library's own ambient fallback try)
- `Authorization: Basic …` in `authenticate()` → return `None` (don't lie about creds we can't use)
- Exception on `authenticate()` → return `None` + WARNING log

## Tests

- 8 new unit tests in `tests/dao_ai/test_vector_search.py` covering all four modes plus edge cases (no host, no bearer, Basic auth, `auth_type="default"`, Model Serving OBO). Existing OBO test + all pre-existing VS tests still pass (31 total).
- New `tests/dao_ai/test_vector_search_fevm_integration.py` exercising real fevm indexes (`retail_consumer_goods.dao_ai_phase2.{products_index, kb_articles_index}` on endpoint `dao_ai_workshop_vs`) for the M2 ambient and M4 explicit PAT paths. Guarded by `@pytest.mark.integration`; skipped unless the fevm profile / `DATABRICKS_TOKEN` is available.

## End-to-end validation

Two side-loaded Databricks Apps on fevm (`vs-test-noobo-nate-fleming` mode #2, `vs-test-obo-nate-fleming` mode #3) both returned SKU-grounded answers verbatim from `retail_consumer_goods.dao_ai_phase2.products_index` — proving the vector search tool actually executes and returns real documents inside the deployed apps.

## Test plan

- [x] `pytest tests/dao_ai/test_vector_search.py -v` — 31 passed locally
- [x] `pytest tests/dao_ai/test_vector_search_fevm_integration.py -v -m integration` — 4 passed against real fevm indexes
- [x] End-to-end deployed apps returned real VS-grounded answers
- [ ] Broader smoke via workshop labs 06/11 once this is on PyPI (blocked today by a pre-existing wheel-vs-source deploy issue in `deploy_apps_agent` when dao-ai is installed from a wheel path; not related to this fix)

## Non-goals

- No config-schema field added.
- No dependency-pin change (`databricks-langchain==0.20.0` retained).
- No `make schema` regen — purely runtime behavior in `src/dao_ai/tools/vector_search.py`.
- No changes to classic-compute paths — Serverless v5 is the sole target per project constraints.

This pull request and its description were written by Isaac.