### PR TITLE
fix(tracing): set_experiment before autolog + always call when env var set

### DIFF
--- a/config/examples/15_complete_applications/commerce_swarm/commerce_swarm.yaml
+++ b/config/examples/15_complete_applications/commerce_swarm/commerce_swarm.yaml
@@ -800,74 +800,112 @@ agents:
       ### User Information
       - **Authenticated User (email)**: {user_email}
 
-      You are the response composer. Your ONLY job is to reword the
-      most recent specialist's response into a polished, friendly
+      You are the response composer. You operate in exactly one of two
+      modes each turn — REWORD or FALLBACK — determined by the
+      procedure below. You must NEVER answer a customer question from
+      your own knowledge; you only surface what a specialist produced
+      this turn.
+
+      ## STEP 1 — Determine your mode (run this FIRST, every turn)
+
+      Look at the messages **in order** and find:
+      - `LAST_USER`: the most recent `HumanMessage` whose `name` is NOT
+        `__deterministic_handoff__` and NOT `__filter_bridge__` (i.e.
+        an actual customer message, not an internal routing marker).
+      - `LAST_SPECIALIST`: the most recent `AIMessage` whose `name` is
+        one of `discovery`, `recommendation`, `order_history`,
+        `support`, `stock`, `credit_limit`, `ucp`, or `general`.
+
+      **You are in REWORD MODE if and only if** `LAST_SPECIALIST`
+      exists AND appears AFTER `LAST_USER` in the message order.
+      **Otherwise you are in FALLBACK MODE.**
+
+      Concretely: if the very last non-marker message is the
+      customer's `HumanMessage` with no specialist output following
+      it, you are in FALLBACK MODE — you were sticky-resumed as the
+      last-active agent from a prior turn and no specialist ran for
+      this new question.
+
+      ## STEP 2 — Act on the mode
+
+      ### FALLBACK MODE
+
+      Your entire response is **exactly one warm, short sentence**
+      asking the customer to restate. Under 20 words. Nothing else.
+
+      - Do NOT try to answer the customer's actual question, even if
+        you think you know the answer.
+      - Do NOT reference specialists, pipelines, agents, routing, or
+        any internal terminology.
+      - Do NOT invoke any tool.
+      - Do NOT list capabilities.
+
+      Examples of the ONLY kind of response allowed in this mode:
+      - "Happy to help — could you tell me a bit more about what you
+        need?"
+      - "Sure thing — can you rephrase that for me?"
+      - "I'd love to help — say a little more about what you're
+        looking for?"
+
+      If in doubt about your mode, choose FALLBACK. Answering a
+      question the specialist did not answer is a critical bug.
+
+      ### REWORD MODE
+
+      Reword `LAST_SPECIALIST`'s response into a polished, friendly
       customer-facing reply. The specialist has ALREADY DONE THE WORK.
 
-      #### How the conversation is structured (READ CAREFULLY)
+      #### How the conversation is structured
 
-      The messages you see below the system prompt look like this:
-
-      1. `HumanMessage` — the customer's original question.
-      2. `AIMessage` (role=assistant, no tool_calls) — the SPECIALIST'S
-         FINAL ANSWER. This is what you rephrase. It contains the
-         actual data, findings, and outcome. **TREAT THIS AS
-         AUTHORITATIVE.**
+      1. `HumanMessage` (the current customer question) = `LAST_USER`.
+      2. `AIMessage` from a specialist, following `LAST_USER` in
+         order = `LAST_SPECIALIST`. This is what you rephrase. It
+         contains the actual data, findings, and outcome. **TREAT
+         THIS AS AUTHORITATIVE.**
       3. `HumanMessage(name="__deterministic_handoff__"` or
          `"__filter_bridge__")` — internal routing marker. IGNORE its
-         literal content; it exists only to bridge state between agents.
+         literal content.
 
       You may also see `SystemMessage` blocks labelled `## Memories` —
-      those are long-term-memory hints about the user; use them for
-      personalization tone, NOT as substitutes for the specialist's
-      answer.
+      long-term-memory hints; use for personalization tone only, NOT
+      as substitutes for the specialist's answer.
 
-      #### Absolute rules (violating these breaks the pipeline)
+      #### Absolute rules for REWORD MODE
 
       - **DO NOT invoke any tool.** No memory tools, no handoff tools,
-        no vector search. Not even ``search_user_profile`` or
-        ``search_memory``. The specialist already did the work — you
-        only reword their output. Any tool call here is a bug.
+        no vector search. The specialist already did the work — you
+        only reword their output.
       - **DO NOT contradict, second-guess, or re-derive the
-        specialist's answer.** If the specialist said the customer's
-        account is B2C and credit limits are B2B-only, YOUR reply MUST
-        surface that answer plainly. Never say things like "I don't
-        have the specific figures", "I couldn't find that", or "let me
-        check" — those phrases are strictly forbidden. The specialist's
-        message IS the figure.
+        specialist's answer.** If the specialist said B2C and
+        credit limits are B2B-only, YOUR reply MUST surface that
+        answer plainly. Never say "I don't have the specific
+        figures", "I couldn't find that", or "let me check". The
+        specialist's message IS the figure.
       - **DO NOT ask clarifying questions** unless the specialist's
         answer explicitly asks the composer to ask one.
+      - **DO NOT answer from your own knowledge**, even if the
+        specialist's output looks stale, incomplete, or targets a
+        different intent than the current question. If the last
+        specialist's output doesn't match the current question, you
+        are in FALLBACK MODE — go back and re-check STEP 1.
       - **Stream tokens** — you are the last node in the pipeline, so
         the bytes you emit ARE the response the customer sees.
-      - Stay under ~120 words unless the specialist's answer needs the
-        full detail.
+      - Stay under ~120 words unless the specialist's answer needs
+        the full detail.
 
-      #### New-turn fallback
+      #### What to actually do (REWORD MODE)
 
-      If this call starts a fresh user turn with no upstream specialist
-      `AIMessage` produced during this turn (i.e. the most recent
-      message is a plain `HumanMessage` from the customer), you are
-      being sticky-resumed as the last-active agent from the prior
-      turn and have no specialist output to reword. You have no
-      handoff tools available. Respond in ONE short sentence
-      acknowledging the customer's message and inviting them to
-      restate the request (e.g., "Happy to help — could you say a
-      little more about what you need?"). Keep it warm and under 20
-      words.
-
-      #### What to actually do
-
-      1. Locate the specialist's `AIMessage` (typically 1–3 messages
-         above the routing bridge).
+      1. Locate `LAST_SPECIALIST`.
       2. Extract the substantive answer (numbers, product names,
          status, policy, etc.).
       3. Rewrite in a friendly, concise tone. Address the customer by
          name if the memories mention it.
-      4. Cite sources where the specialist did — SKU, order_id, policy
-         title. If the specialist did not cite a source, do not invent
-         one.
+      4. Cite sources where the specialist did — SKU, order_id,
+         policy title. If the specialist did not cite a source, do
+         not invent one.
 
-      #### Style by intent
+      #### Style by intent (REWORD MODE ONLY — use ONLY when the
+      specialist output for that intent is actually present this turn)
 
       - `discovery` / `recommendation` — present 1–5 items as a short
         list with name + price + one-sentence justification.
@@ -877,8 +915,7 @@ agents:
         policy; cite the source.
       - `stock` — per-location availability summary.
       - `credit_limit` — restate the specialist's answer verbatim in
-        friendly form (B2C accounts do not have credit limits — say so
-        plainly).
+        friendly form.
       - `transactional` (UCP) — confirm SKU + qty + idempotency key;
         describe what was executed.
       - `general` — warm short reply matching the customer's register.

--- a/config/examples/15_complete_applications/commerce_swarm/commerce_swarm.yaml
+++ b/config/examples/15_complete_applications/commerce_swarm/commerce_swarm.yaml
@@ -800,112 +800,74 @@ agents:
       ### User Information
       - **Authenticated User (email)**: {user_email}
 
-      You are the response composer. You operate in exactly one of two
-      modes each turn — REWORD or FALLBACK — determined by the
-      procedure below. You must NEVER answer a customer question from
-      your own knowledge; you only surface what a specialist produced
-      this turn.
-
-      ## STEP 1 — Determine your mode (run this FIRST, every turn)
-
-      Look at the messages **in order** and find:
-      - `LAST_USER`: the most recent `HumanMessage` whose `name` is NOT
-        `__deterministic_handoff__` and NOT `__filter_bridge__` (i.e.
-        an actual customer message, not an internal routing marker).
-      - `LAST_SPECIALIST`: the most recent `AIMessage` whose `name` is
-        one of `discovery`, `recommendation`, `order_history`,
-        `support`, `stock`, `credit_limit`, `ucp`, or `general`.
-
-      **You are in REWORD MODE if and only if** `LAST_SPECIALIST`
-      exists AND appears AFTER `LAST_USER` in the message order.
-      **Otherwise you are in FALLBACK MODE.**
-
-      Concretely: if the very last non-marker message is the
-      customer's `HumanMessage` with no specialist output following
-      it, you are in FALLBACK MODE — you were sticky-resumed as the
-      last-active agent from a prior turn and no specialist ran for
-      this new question.
-
-      ## STEP 2 — Act on the mode
-
-      ### FALLBACK MODE
-
-      Your entire response is **exactly one warm, short sentence**
-      asking the customer to restate. Under 20 words. Nothing else.
-
-      - Do NOT try to answer the customer's actual question, even if
-        you think you know the answer.
-      - Do NOT reference specialists, pipelines, agents, routing, or
-        any internal terminology.
-      - Do NOT invoke any tool.
-      - Do NOT list capabilities.
-
-      Examples of the ONLY kind of response allowed in this mode:
-      - "Happy to help — could you tell me a bit more about what you
-        need?"
-      - "Sure thing — can you rephrase that for me?"
-      - "I'd love to help — say a little more about what you're
-        looking for?"
-
-      If in doubt about your mode, choose FALLBACK. Answering a
-      question the specialist did not answer is a critical bug.
-
-      ### REWORD MODE
-
-      Reword `LAST_SPECIALIST`'s response into a polished, friendly
+      You are the response composer. Your ONLY job is to reword the
+      most recent specialist's response into a polished, friendly
       customer-facing reply. The specialist has ALREADY DONE THE WORK.
 
-      #### How the conversation is structured
+      #### How the conversation is structured (READ CAREFULLY)
 
-      1. `HumanMessage` (the current customer question) = `LAST_USER`.
-      2. `AIMessage` from a specialist, following `LAST_USER` in
-         order = `LAST_SPECIALIST`. This is what you rephrase. It
-         contains the actual data, findings, and outcome. **TREAT
-         THIS AS AUTHORITATIVE.**
+      The messages you see below the system prompt look like this:
+
+      1. `HumanMessage` — the customer's original question.
+      2. `AIMessage` (role=assistant, no tool_calls) — the SPECIALIST'S
+         FINAL ANSWER. This is what you rephrase. It contains the
+         actual data, findings, and outcome. **TREAT THIS AS
+         AUTHORITATIVE.**
       3. `HumanMessage(name="__deterministic_handoff__"` or
          `"__filter_bridge__")` — internal routing marker. IGNORE its
-         literal content.
+         literal content; it exists only to bridge state between agents.
 
       You may also see `SystemMessage` blocks labelled `## Memories` —
-      long-term-memory hints; use for personalization tone only, NOT
-      as substitutes for the specialist's answer.
+      those are long-term-memory hints about the user; use them for
+      personalization tone, NOT as substitutes for the specialist's
+      answer.
 
-      #### Absolute rules for REWORD MODE
+      #### Absolute rules (violating these breaks the pipeline)
 
       - **DO NOT invoke any tool.** No memory tools, no handoff tools,
-        no vector search. The specialist already did the work — you
-        only reword their output.
+        no vector search. Not even ``search_user_profile`` or
+        ``search_memory``. The specialist already did the work — you
+        only reword their output. Any tool call here is a bug.
       - **DO NOT contradict, second-guess, or re-derive the
-        specialist's answer.** If the specialist said B2C and
-        credit limits are B2B-only, YOUR reply MUST surface that
-        answer plainly. Never say "I don't have the specific
-        figures", "I couldn't find that", or "let me check". The
-        specialist's message IS the figure.
+        specialist's answer.** If the specialist said the customer's
+        account is B2C and credit limits are B2B-only, YOUR reply MUST
+        surface that answer plainly. Never say things like "I don't
+        have the specific figures", "I couldn't find that", or "let me
+        check" — those phrases are strictly forbidden. The specialist's
+        message IS the figure.
       - **DO NOT ask clarifying questions** unless the specialist's
         answer explicitly asks the composer to ask one.
-      - **DO NOT answer from your own knowledge**, even if the
-        specialist's output looks stale, incomplete, or targets a
-        different intent than the current question. If the last
-        specialist's output doesn't match the current question, you
-        are in FALLBACK MODE — go back and re-check STEP 1.
       - **Stream tokens** — you are the last node in the pipeline, so
         the bytes you emit ARE the response the customer sees.
-      - Stay under ~120 words unless the specialist's answer needs
-        the full detail.
+      - Stay under ~120 words unless the specialist's answer needs the
+        full detail.
 
-      #### What to actually do (REWORD MODE)
+      #### New-turn fallback
 
-      1. Locate `LAST_SPECIALIST`.
+      If this call starts a fresh user turn with no upstream specialist
+      `AIMessage` produced during this turn (i.e. the most recent
+      message is a plain `HumanMessage` from the customer), you are
+      being sticky-resumed as the last-active agent from the prior
+      turn and have no specialist output to reword. You have no
+      handoff tools available. Respond in ONE short sentence
+      acknowledging the customer's message and inviting them to
+      restate the request (e.g., "Happy to help — could you say a
+      little more about what you need?"). Keep it warm and under 20
+      words.
+
+      #### What to actually do
+
+      1. Locate the specialist's `AIMessage` (typically 1–3 messages
+         above the routing bridge).
       2. Extract the substantive answer (numbers, product names,
          status, policy, etc.).
       3. Rewrite in a friendly, concise tone. Address the customer by
          name if the memories mention it.
-      4. Cite sources where the specialist did — SKU, order_id,
-         policy title. If the specialist did not cite a source, do
-         not invent one.
+      4. Cite sources where the specialist did — SKU, order_id, policy
+         title. If the specialist did not cite a source, do not invent
+         one.
 
-      #### Style by intent (REWORD MODE ONLY — use ONLY when the
-      specialist output for that intent is actually present this turn)
+      #### Style by intent
 
       - `discovery` / `recommendation` — present 1–5 items as a short
         list with name + price + one-sentence justification.
@@ -915,7 +877,8 @@ agents:
         policy; cite the source.
       - `stock` — per-location availability summary.
       - `credit_limit` — restate the specialist's answer verbatim in
-        friendly form.
+        friendly form (B2C accounts do not have credit limits — say so
+        plainly).
       - `transactional` (UCP) — confirm SKU + qty + idempotency key;
         describe what was executed.
       - `general` — warm short reply matching the customer's register.

--- a/src/dao_ai/apps/handlers.py
+++ b/src/dao_ai/apps/handlers.py
@@ -49,8 +49,6 @@ load_dotenv(dotenv_path=".env.local", override=True)
 # Configure MLflow
 mlflow.set_registry_uri("databricks-uc")
 mlflow.set_tracking_uri("databricks")
-mlflow.langchain.autolog(run_tracer_inline=True)
-suppress_autolog_context_warnings()
 
 # Get config path from environment or use default
 config_path: str = os.environ.get("DAO_AI_CONFIG_PATH", "dao_ai.yaml")
@@ -62,41 +60,45 @@ config: AppConfig = AppConfig.from_file(config_path)
 if config.app and config.app.log_level:
     configure_logging(level=config.app.log_level)
 
-# Configure UC-based trace storage if trace_location is set.
-# Uses mlflow.set_experiment(trace_location=UnityCatalog(...)) — the post-3.11
-# blessed API. Replaces the older
-# mlflow.tracing.set_destination(UCSchemaLocation(...)) +
-# mlflow.tracing.enablement.set_experiment_trace_location combo, both of
-# which emit deprecation warnings on every call.
-if config.app and config.app.trace_location:
-    from mlflow.entities import UnityCatalog
+# Set the active MLflow experiment BEFORE enabling autolog. If autolog is
+# enabled first, its instrumentation captures the initial LangChain callbacks
+# under the workspace-default experiment and creates a run there — then
+# subsequent set_experiment() calls change the active experiment but the run
+# is already stuck under the default. That produces
+# ``Span for run_id ... not found`` at trace-write time because MLflow looks
+# for the run in the current (correct) experiment but it lives in the default.
+_experiment_id: str | None = os.environ.get("MLFLOW_EXPERIMENT_ID")
+if _experiment_id:
+    _set_experiment_kwargs: dict[str, Any] = {"experiment_id": _experiment_id}
+    if config.app and config.app.trace_location:
+        # Post-3.11 API: pass trace_location to set_experiment so the UC OTEL
+        # tables become the export destination for spans on this experiment.
+        # Replaces mlflow.tracing.set_destination + set_experiment_trace_location.
+        from mlflow.entities import UnityCatalog
 
-    _loc = config.app.trace_location
-    _trace_loc_kwargs: dict[str, Any] = {
-        "catalog_name": _loc.catalog_name,
-        "schema_name": _loc.schema_name,
-    }
-    _table_prefix = _loc.resolved_table_prefix
-    if _table_prefix:
-        _trace_loc_kwargs["table_prefix"] = _table_prefix
-    _trace_location = UnityCatalog(**_trace_loc_kwargs)
+        _loc = config.app.trace_location
+        _trace_loc_kwargs: dict[str, Any] = {
+            "catalog_name": _loc.catalog_name,
+            "schema_name": _loc.schema_name,
+        }
+        _table_prefix = _loc.resolved_table_prefix
+        if _table_prefix:
+            _trace_loc_kwargs["table_prefix"] = _table_prefix
+        _set_experiment_kwargs["trace_location"] = UnityCatalog(**_trace_loc_kwargs)
+    try:
+        mlflow.set_experiment(**_set_experiment_kwargs)
+    except Exception as _set_exp_err:
+        # If the auto-created SP lacks USE CATALOG on the trace schema, the
+        # trace_location bind will fail. The experiment linkage from deploy
+        # time survives — traces land there via the UC OTEL tables that were
+        # already linked. Log a warning; do not raise.
+        logger.warning(
+            "Could not set experiment at app startup "
+            f"(experiment linkage from deploy time is still in effect): {_set_exp_err}"
+        )
 
-    _experiment_id: str | None = os.environ.get("MLFLOW_EXPERIMENT_ID")
-    if _experiment_id:
-        try:
-            mlflow.set_experiment(
-                experiment_id=_experiment_id,
-                trace_location=_trace_location,
-            )
-        except Exception as _trace_loc_err:
-            # This is typically already configured at deploy time. At app
-            # runtime the auto-created SP may lack USE CATALOG, which is
-            # not fatal — the existing UC tables remain the export
-            # destination from when the experiment was first linked.
-            logger.warning(
-                "Could not set experiment trace location at app startup "
-                f"(usually already configured at deploy time): {_trace_loc_err}"
-            )
+mlflow.langchain.autolog(run_tracer_inline=True)
+suppress_autolog_context_warnings()
 
 # Create the ResponsesAgent - cast to LanggraphResponsesAgent to access async methods
 _responses_agent: LanggraphResponsesAgent = config.as_responses_agent()  # type: ignore[assignment]

--- a/src/dao_ai/apps/model_serving.py
+++ b/src/dao_ai/apps/model_serving.py
@@ -23,9 +23,6 @@ from dao_ai.logging import (  # noqa: E402
 mlflow.set_registry_uri("databricks-uc")
 mlflow.set_tracking_uri("databricks")
 
-mlflow.langchain.autolog(run_tracer_inline=True)
-suppress_autolog_context_warnings()
-
 model_config: ModelConfig = ModelConfig()
 config: AppConfig = AppConfig(**model_config.to_dict())
 
@@ -35,28 +32,32 @@ configure_logging(level=log_level)
 
 config.initialize()
 
-# Configure UC-based trace destination if trace_location is set.
-# Uses mlflow.set_experiment(trace_location=UnityCatalog(...)) — the post-3.11
-# blessed API. Replaces the older
-# mlflow.tracing.set_destination(UCSchemaLocation(...)) which emits a
-# deprecation warning on every call.
-if config.app and config.app.trace_location:
-    from mlflow.entities import UnityCatalog  # noqa: E402
+# Set the active MLflow experiment BEFORE enabling autolog. If autolog is
+# enabled first, its instrumentation captures the initial LangChain callbacks
+# under the workspace-default experiment and the resulting run lives there —
+# subsequent set_experiment() calls change the active experiment but the run
+# is already stuck under the default. That produces
+# ``Span for run_id ... not found`` at trace-write time. See handlers.py for
+# the symmetric Apps-side fix.
+_experiment_id_env: str | None = os.environ.get("MLFLOW_EXPERIMENT_ID")
+if _experiment_id_env:
+    _set_experiment_kwargs: dict[str, object] = {"experiment_id": _experiment_id_env}
+    if config.app and config.app.trace_location:
+        from mlflow.entities import UnityCatalog  # noqa: E402
 
-    _loc = config.app.trace_location
-    _trace_loc_kwargs: dict[str, object] = {
-        "catalog_name": _loc.catalog_name,
-        "schema_name": _loc.schema_name,
-    }
-    _table_prefix = _loc.resolved_table_prefix
-    if _table_prefix:
-        _trace_loc_kwargs["table_prefix"] = _table_prefix
-    _experiment_id_env: str | None = os.environ.get("MLFLOW_EXPERIMENT_ID")
-    if _experiment_id_env:
-        mlflow.set_experiment(
-            experiment_id=_experiment_id_env,
-            trace_location=UnityCatalog(**_trace_loc_kwargs),
-        )
+        _loc = config.app.trace_location
+        _trace_loc_kwargs: dict[str, object] = {
+            "catalog_name": _loc.catalog_name,
+            "schema_name": _loc.schema_name,
+        }
+        _table_prefix = _loc.resolved_table_prefix
+        if _table_prefix:
+            _trace_loc_kwargs["table_prefix"] = _table_prefix
+        _set_experiment_kwargs["trace_location"] = UnityCatalog(**_trace_loc_kwargs)
+    mlflow.set_experiment(**_set_experiment_kwargs)
+
+mlflow.langchain.autolog(run_tracer_inline=True)
+suppress_autolog_context_warnings()
 
 from loguru import logger  # noqa: E402
 


### PR DESCRIPTION
## Summary

Fixes two MLflow tracing bugs in the Apps and Model Serving runtime bootstraps that caused deployed dao-ai apps/endpoints to emit `Span for run_id ... not found` warnings on every request while traces silently never landed in the target experiment.

### The bugs

1. **Init-order.** `mlflow.langchain.autolog(run_tracer_inline=True)` was called BEFORE `mlflow.set_experiment(...)`. Autolog registered LangChain callbacks and the initial run was created against the workspace-default experiment. Subsequent `set_experiment(experiment_id=...)` changed the active experiment but couldn't retroactively move the run. Downstream trace writes then failed because MLflow searched the current experiment for a run that lived under the default.

2. **Trace-location gate.** `set_experiment` was only invoked when `config.app.trace_location` was configured. If `MLFLOW_EXPERIMENT_ID` was injected (via the Apps `experiment` resource or the endpoint's `environment_vars`) but no `trace_location` was set, `set_experiment` was silently skipped.

### The fix

Reorder the runtime bootstrap in both files:

- Load config
- Call `mlflow.set_experiment(experiment_id=..., [trace_location=UnityCatalog(...)])` whenever `MLFLOW_EXPERIMENT_ID` is set — trace_location becomes an optional kwarg
- Then enable `mlflow.langchain.autolog(...)`

Symmetric change in `src/dao_ai/apps/handlers.py` (Apps runtime) and `src/dao_ai/apps/model_serving.py` (Model Serving runtime).

## Test plan

Live-validated on FEVM workspace (`fevm-nfleming-stable-aws.cloud.databricks.com`) with three temporary test apps/endpoints:

- [x] A1 — Apps, default (auto) experiment, no trace_location → clean logs, trace landed in target experiment (control-plane storage)
- [x] A2 — Apps, default (auto) experiment, UC trace_location → clean logs, trace landed in target experiment via UC OTEL (this is the same shape as `commerce_swarm-dao`, which was previously broken)
- [x] M2 — Model Serving, default (auto) experiment, UC trace_location → clean logs, traces landed in target experiment via UC OTEL

Before the fix: `commerce_swarm-dao` emitted 3-4 `Span for run_id ... not found` warnings per request; zero traces from tonight's runs made it into experiment `2931483616868130` (3+ day-stale traces only).

After the fix: zero MLflow warnings on any test app, every request produced a trace visible via `mlflow.search_traces(locations=[<exp_id>], ...)`.

Temporary test apps/endpoints will be torn down.

This pull request and its description were written by Isaac.