### PR TITLE
fix(tracing): silence memory-extraction autolog warnings via log-record filter

### DIFF
--- a/src/dao_ai/logging.py
+++ b/src/dao_ai/logging.py
@@ -10,34 +10,84 @@ from loguru import logger
 __all__ = ["logger", "configure_logging", "suppress_autolog_context_warnings"]
 
 
-class _ContextVarWarningFilter(logging.Filter):
-    """Drops the noisy 'was created in a different Context' warnings.
+class _AutologWarningFilter(logging.Filter):
+    """Drops two classes of noisy but harmless MLflow autolog warnings.
 
-    MLflow's autologging emits these when it tries to reset a ContextVar
-    token across async boundaries (nest_asyncio). They are harmless but
-    extremely noisy in Model Serving logs.
+    1. ``was created in a different Context`` — MLflow's autologging emits
+       these when it tries to reset a ContextVar token across async
+       boundaries (nest_asyncio).
+
+    2. ``Span for run_id ... not found`` — emitted by
+       ``mlflow.langchain.langchain_tracer._get_span_by_run_id`` and
+       swallowed by MLflow's autolog safety wrapper as an
+       ``Encountered unexpected error during autologging: ...`` warning.
+       This fires on every LLM call made from the memory-extraction
+       background executor (langmem's ``LocalReflectionExecutor``): that
+       executor internally uses ``get_executor_for_config(config)`` to
+       spawn a nested thread pool for parallel ``store.search`` calls,
+       and MLflow's autolog installs its tracer via a monkey-patch of
+       ``BaseCallbackManager.__init__``. Each new callback manager on
+       those sub-threads creates a fresh ``MlflowLangchainTracer`` whose
+       instance-state ``_run_span_mapping`` doesn't have the parent
+       tracer's run_ids. Passing ``callbacks=[]`` in the RunnableConfig
+       does not silence this because autolog is injected at the callback
+       manager level, not through the caller's config. And
+       ``mlflow.utils.autologging_utils.disable_autologging`` toggles a
+       process-global flag that would race with concurrent main-pipeline
+       requests. So we filter the warning at the log-record level:
+       memory-extraction still writes to the store correctly, and main
+       pipeline traces continue to land in MLflow — the only thing this
+       change silences is the log noise.
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
-        return "was created in a different Context" not in record.getMessage()
+        msg: str = record.getMessage()
+        if "was created in a different Context" in msg:
+            return False
+        if "Span for run_id" in msg and "not found" in msg:
+            return False
+        return True
+
+
+class _SpanEntitiesFilter(logging.Filter):
+    """Drops ``mlflow.entities.span: Failed to end span`` warnings.
+
+    Same root cause as the ``Span for run_id ... not found`` filter above:
+    a memory-extraction sub-worker tries to end a span whose parent tracer
+    doesn't know about it. Non-fatal.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return "Failed to end span" not in record.getMessage()
 
 
 def suppress_autolog_context_warnings() -> None:
-    """Suppress ``mlflow.utils.autologging_utils`` ContextVar warnings.
+    """Suppress noisy MLflow autolog warnings that occur on cross-thread paths.
 
     Call this after ``mlflow.langchain.autolog()`` in entry-point modules
     (e.g., ``model_serving.py``, ``handlers.py``).
 
-    Defense-in-depth: the primary fix for these warnings is
+    Silences:
+    - ``mlflow.utils.autologging_utils``:
+      - ``was created in a different Context`` (nest_asyncio ContextVar resets)
+      - ``Span for run_id ... not found`` (memory-extraction background thread)
+    - ``mlflow.entities.span``:
+      - ``Failed to end span`` (same memory-extraction path)
+
+    Defense-in-depth: the primary MLflow-side fix for the first warning is
     ``mlflow.langchain.autolog(run_tracer_inline=True)``, which keeps
     LangChain callbacks on the main async task so the active-span
-    ``ContextVar`` doesn't get reset across thread-pool boundaries. This
-    filter remains as a safety net for code paths where autolog runs
-    without that flag.
+    ``ContextVar`` doesn't get reset across thread-pool boundaries. The
+    second/third warnings do not have a runtime fix — MLflow's autolog
+    installs itself via a monkey-patch of ``BaseCallbackManager.__init__``
+    and its tracer state is not ContextVar-based, so the memory-extraction
+    background thread will always emit them. They are harmless: memory
+    writes still succeed and main-pipeline traces are unaffected.
     """
     logging.getLogger("mlflow.utils.autologging_utils").addFilter(
-        _ContextVarWarningFilter()
+        _AutologWarningFilter()
     )
+    logging.getLogger("mlflow.entities.span").addFilter(_SpanEntitiesFilter())
 
 
 def format_extra(record: dict[str, Any]) -> str:

--- a/tests/dao_ai/test_memory_extraction_reflector.py
+++ b/tests/dao_ai/test_memory_extraction_reflector.py
@@ -1,0 +1,134 @@
+"""Regression tests for the MLflow-autolog warning suppression path.
+
+Background: ``mlflow.langchain.autolog`` installs its tracer via a
+monkey-patch of ``BaseCallbackManager.__init__``. LangChain's memory-
+extraction chain (``langmem.knowledge.extraction.MemoryStoreManager``)
+uses ``get_executor_for_config(config)`` to spawn a nested thread pool
+for parallel ``store.search`` calls, and each new callback manager on
+those sub-threads gets a fresh ``MlflowLangchainTracer`` instance whose
+per-instance ``_run_span_mapping`` cannot see the parent tracer's
+run_ids. That triggers two families of warnings on every request:
+
+- ``mlflow.utils.autologging_utils``: ``Encountered unexpected error
+  during autologging: Span for run_id X not found.``
+- ``mlflow.entities.span``: ``Failed to end span X: .``
+
+The warnings are harmless (memory writes still succeed, main-pipeline
+traces still land). They cannot be silenced at the RunnableConfig level
+because autolog injects at the callback-manager-init level. And they
+cannot be silenced by ``mlflow.utils.autologging_utils.disable_autologging``
+because that flips a process-global flag that races with concurrent
+foreground requests. So we filter them at the log-record level via
+``suppress_autolog_context_warnings`` in ``dao_ai/logging.py``.
+
+These tests pin that filter behavior.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from dao_ai.logging import suppress_autolog_context_warnings
+
+
+@pytest.fixture
+def _fresh_loggers() -> None:
+    """Reset filters on the two loggers before/after each test."""
+
+    def _clear() -> None:
+        for name in ("mlflow.utils.autologging_utils", "mlflow.entities.span"):
+            log = logging.getLogger(name)
+            for f in list(log.filters):
+                log.removeFilter(f)
+
+    _clear()
+    yield
+    _clear()
+
+
+def _emit(logger_name: str, message: str) -> logging.LogRecord:
+    """Build a synthetic warning record — same shape MLflow emits."""
+    return logging.LogRecord(
+        name=logger_name,
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=0,
+        msg=message,
+        args=None,
+        exc_info=None,
+    )
+
+
+def _passes_all_filters(logger_name: str, record: logging.LogRecord) -> bool:
+    log = logging.getLogger(logger_name)
+    return all(f.filter(record) for f in log.filters)
+
+
+@pytest.mark.unit
+def test_filter_drops_span_for_run_id_not_found(_fresh_loggers: None) -> None:
+    """Memory-extraction cross-thread callback warning is silenced."""
+    suppress_autolog_context_warnings()
+    record = _emit(
+        "mlflow.utils.autologging_utils",
+        "Encountered unexpected error during autologging: "
+        "Span for run_id 019f2d1c-9b9f-7720-a880-6036114b135e not found.",
+    )
+    assert _passes_all_filters("mlflow.utils.autologging_utils", record) is False
+
+
+@pytest.mark.unit
+def test_filter_drops_context_var_warning(_fresh_loggers: None) -> None:
+    """Pre-existing nest_asyncio ContextVar warning is silenced (backcompat)."""
+    suppress_autolog_context_warnings()
+    record = _emit(
+        "mlflow.utils.autologging_utils",
+        "Token <ContextVarToken ...> was created in a different Context "
+        "and cannot be used to reset it.",
+    )
+    assert _passes_all_filters("mlflow.utils.autologging_utils", record) is False
+
+
+@pytest.mark.unit
+def test_filter_drops_failed_to_end_span(_fresh_loggers: None) -> None:
+    """Sibling ``Failed to end span`` warning is silenced."""
+    suppress_autolog_context_warnings()
+    record = _emit(
+        "mlflow.entities.span",
+        "Failed to end span d3a1418cf6624aa8: . "
+        "For full traceback, set logging level to debug.",
+    )
+    assert _passes_all_filters("mlflow.entities.span", record) is False
+
+
+@pytest.mark.unit
+def test_filter_lets_unrelated_autolog_warnings_through(_fresh_loggers: None) -> None:
+    """Real, actionable autolog warnings still surface — filter is targeted."""
+    suppress_autolog_context_warnings()
+    record = _emit(
+        "mlflow.utils.autologging_utils",
+        "MLflow autologging encountered a warning: model registry unavailable.",
+    )
+    assert _passes_all_filters("mlflow.utils.autologging_utils", record) is True
+
+
+@pytest.mark.unit
+def test_filter_lets_unrelated_span_warnings_through(_fresh_loggers: None) -> None:
+    """Non-'Failed to end span' entries.span warnings still surface."""
+    suppress_autolog_context_warnings()
+    record = _emit("mlflow.entities.span", "Span exceeded max attribute count.")
+    assert _passes_all_filters("mlflow.entities.span", record) is True
+
+
+@pytest.mark.unit
+def test_filter_matches_partial_span_for_run_id_variants(_fresh_loggers: None) -> None:
+    """Guard against wording drift — match any 'Span for run_id ... not found'."""
+    suppress_autolog_context_warnings()
+    for msg in [
+        "Span for run_id abc not found.",
+        "Encountered unexpected error during autologging: Span for run_id X not found.",
+        "Span for run_id 019f... not found (retrying).",
+    ]:
+        record = _emit("mlflow.utils.autologging_utils", msg)
+        assert _passes_all_filters("mlflow.utils.autologging_utils", record) is False, msg


### PR DESCRIPTION
## Summary

Every dao-ai request emitted noisy but harmless MLflow autolog warnings:

```
WARNING mlflow.utils.autologging_utils: Encountered unexpected error during autologging: Span for run_id 019f2d1c-9b9f-... not found.
WARNING mlflow.entities.span: Failed to end span 74c2dac9b409fbf7: .
```

They came from memory-extraction background threads. Non-fatal, but noisy — 3–6 warnings per request.

## Root cause

MLflow autolog installs its tracer via a monkey-patch of `BaseCallbackManager.__init__` (mlflow/langchain/autolog.py). Every new callback manager gets a fresh `MlflowLangchainTracer` whose `_run_span_mapping` is per-instance state. When langmem's `LocalReflectionExecutor` runs memory extraction on its worker thread, `MemoryStoreManager.invoke` (langmem/knowledge/extraction.py:1149) spawns a NESTED thread pool via `get_executor_for_config(config)` for parallel `store.search` calls. Each sub-worker's callback manager gets a distinct tracer instance that doesn't have the parent tracer's run_ids → warning on every LLM call.

Main-pipeline traces are unaffected. Memory writes are unaffected.

## Why other approaches don't work

- **`RunnableConfig(callbacks=[])`** — MLflow injects at the callback-manager-init level, not the config's callbacks list. And clobbering the config breaks langmem's `configurable.user_id` namespace scoping (`ConfigurationError: Missing key in 'configurable'`).
- **`mlflow.utils.autologging_utils.disable_autologging`** — toggles a process-global flag; races with concurrent foreground requests.
- **`disable_discrete_autologging(["langchain"])`** — same race.

## Fix

Extend the existing `suppress_autolog_context_warnings` in `src/dao_ai/logging.py` (already suppresses the sibling `was created in a different Context` warnings from the same logger) to also drop:

- `mlflow.utils.autologging_utils`: `Span for run_id ... not found`
- `mlflow.entities.span`: `Failed to end span`

Zero-latency: single substring check per log record. All tracing preserved.

## Test plan

- [x] 6 unit tests in `tests/dao_ai/test_memory_extraction_reflector.py`
  - drops each targeted warning pattern
  - preserves unrelated warnings on the same loggers
  - guards against wording drift on the `Span for run_id` matcher
- [x] **Live-validated on FEVM `agent-commerce-swarm-dao`:**
  - Before: 3–6 `WARNING mlflow` lines per request
  - After: **0** `WARNING mlflow` lines of any kind
- [x] **Memory extraction confirmed end-to-end:**
  - Thread A: submit personal details (`"Hi, I am Nate Fleming, allergic to peanuts, love dark chocolate. Recommend a cake."`)
  - Thread B (**fresh thread**, same user): generic query (`"Recommend a dessert for a small gathering."`)
  - Response on Thread B: *"Here are some great dessert picks for your small gathering, **Nate**! I've kept your **peanut allergy** in mind and factored in your and **Sarah's** preferences: Triple Chocolate Mousse Cake — A rich **dark chocolate** dream..."*
  - Confirms memory was written to Lakebase and injected on new turns.
- [x] Main-pipeline traces still land in the target MLflow experiment.

This pull request and its description were written by Isaac.