### PR TITLE
fix(orchestration): prevent cross-agent context leakage via role-aware history filter

### DIFF
--- a/config/examples/15_complete_applications/commerce_swarm/commerce_swarm.yaml
+++ b/config/examples/15_complete_applications/commerce_swarm/commerce_swarm.yaml
@@ -429,6 +429,12 @@ agents:
   supervisor: &supervisor
     name: supervisor
     description: "Intent classification — extracts the customer's intent label(s) and confidence; deterministic handoff to planner."
+    # Internal / plumbing agent — its INTENT classification output is
+    # hidden from non-internal (customer-facing) agents' view of shared
+    # history. Prevents composer from pattern-matching on the
+    # `INTENT: X | CONFIDENCE: Y | NOTES: Z` format and echoing it as a
+    # customer response on sticky-resume turns.
+    internal: true
     model: *fast_llm
     tools: []
     guardrails: []
@@ -478,6 +484,10 @@ agents:
   planner: &planner
     name: planner
     description: "Orchestrator — picks the specialist handler based on supervisor's intent label."
+    # Internal / plumbing agent — its routing decision is internal
+    # plumbing and hidden from non-internal agents. Planner still sees
+    # supervisor's INTENT classification because both are internal.
+    internal: true
     model: *fast_llm
     tools: []
     guardrails: []

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -738,6 +738,12 @@
           },
           "title": "Requires",
           "type": "array"
+        },
+        "internal": {
+          "default": false,
+          "description": "Marks this agent as an internal / plumbing agent. Its ``AIMessage`` outputs are filtered out of the conversation history passed to NON-internal (customer-facing) agents' LLM context. Other internal agents still see them \u2014 e.g., a planner can still read a supervisor's intent classification. The agent itself always sees its own prior messages on re-entry.\n\nThe agent still runs, still writes to shared state, and still appears in MLflow traces \u2014 only downstream customer-facing agents' LLM view is scoped away, so internal-plumbing text (intent classifications, routing decisions, working notes) cannot leak as if it were a customer-facing response. Typical use: swarm supervisors, planners, routers; anything whose output is intended for downstream consumption rather than the customer. Composer / response-formatter agents should stay at the default ``False``.",
+          "title": "Internal",
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -6237,6 +6237,27 @@ class AgentModel(BaseModel):
             "self-reference, cycles in the requires DAG) runs at config-build time."
         ),
     )
+    internal: bool = Field(
+        default=False,
+        description=(
+            "Marks this agent as an internal / plumbing agent. Its "
+            "``AIMessage`` outputs are filtered out of the conversation "
+            "history passed to NON-internal (customer-facing) agents' LLM "
+            "context. Other internal agents still see them — e.g., a "
+            "planner can still read a supervisor's intent classification. "
+            "The agent itself always sees its own prior messages on "
+            "re-entry.\n\n"
+            "The agent still runs, still writes to shared state, and still "
+            "appears in MLflow traces — only downstream customer-facing "
+            "agents' LLM view is scoped away, so internal-plumbing text "
+            "(intent classifications, routing decisions, working notes) "
+            "cannot leak as if it were a customer-facing response. "
+            "Typical use: swarm supervisors, planners, routers; anything "
+            "whose output is intended for downstream consumption rather "
+            "than the customer. Composer / response-formatter agents "
+            "should stay at the default ``False``."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_requires_no_self_reference(self) -> Self:

--- a/src/dao_ai/orchestration/core.py
+++ b/src/dao_ai/orchestration/core.py
@@ -13,7 +13,13 @@ from typing import Any, Awaitable, Callable, Literal
 
 from langchain.tools import ToolRuntime, tool
 from langchain_core.language_models import LanguageModelLike
-from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
 from langchain_core.tools import BaseTool
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.config import get_config
@@ -83,14 +89,17 @@ def create_checkpointer(
 def filter_messages_for_agent(
     messages: list[BaseMessage],
     current_agent_name: str | None = None,
+    internal_agents: frozenset[str] | None = None,
 ) -> list[BaseMessage]:
     """
-    Filter messages for a worker agent to avoid tool_use/tool_result pairing errors.
+    Filter messages for a worker agent to avoid tool_use/tool_result pairing
+    errors AND prevent cross-agent context leakage.
 
     When agents share parent-graph state, each agent should only see:
     - HumanMessage (user queries)
     - AIMessage with content from any agent (peer responses, with tool_calls
-      stripped so the model doesn't see orphaned tool_use blocks)
+      stripped so the model doesn't see orphaned tool_use blocks) — with the
+      exception below for internal agents
     - Its own AIMessage(tool_calls=...) and the matching ToolMessage(s), so a
       multi-turn agent can see its own prior tool results
 
@@ -103,11 +112,34 @@ def filter_messages_for_agent(
       ToolMessage to an agent, we pair it via ``tool_call_id`` against the
       surrounding ``AIMessage(tool_calls=…)`` we already decided to keep.
 
+    Context-leakage rules (applied by default):
+    - ``SystemMessage`` in shared history is DROPPED. Every agent's system
+      prompt and memory-context injection is applied fresh per invocation by
+      middleware / the prompt template — a ``SystemMessage`` sitting in
+      shared state from a prior agent's turn is context noise, not signal.
+    - Peer ``AIMessage`` from an agent named in ``internal_agents`` is
+      DROPPED when the current agent is NOT itself internal. Internal
+      agents (supervisors, planners, routers) emit plumbing text (intent
+      classifications, routing decisions) that would otherwise pollute
+      customer-facing agents' LLM context and get pattern-matched as
+      user-facing output. This mirrors the Anthropic "distilled handoffs"
+      pattern and LangGraph's documented swarm private-history recipe:
+      internal reasoning must be architecturally invisible to downstream
+      customer-facing agents, not merely prompt-instructed to be ignored.
+    - Internal agents STILL see each other (planner reads supervisor's
+      intent), and every agent STILL sees its own prior messages on
+      re-entry.
+
     Args:
         messages: The full message history from parent state
         current_agent_name: The name of the agent receiving the filtered
             history. When set, the agent's own tool exchanges are preserved.
             When ``None`` (legacy callers), all tool exchanges are stripped.
+        internal_agents: Set of agent names marked ``internal: true`` in
+            their ``AgentModel`` config. Peer AIMessages from these agents
+            are hidden from non-internal agents' view. Empty / ``None``
+            preserves pre-change filter behavior byte-for-byte for peer
+            AIMessages.
 
     Returns:
         Filtered messages safe for the agent to process
@@ -117,11 +149,30 @@ def filter_messages_for_agent(
     # Track which own tool_call_ids we've seen a matching ToolMessage for,
     # so we can synthesize placeholders for any orphans at the end.
     matched_tool_call_ids: set[str] = set()
+    _internal: frozenset[str] = internal_agents or frozenset()
+    _current_is_internal: bool = (
+        current_agent_name is not None and current_agent_name in _internal
+    )
     for msg in messages:
+        if isinstance(msg, SystemMessage):
+            # Prior-turn / prior-agent system prompts and memory-context
+            # injections are re-applied fresh per invocation. Drop from
+            # shared history to prevent cross-agent context accumulation.
+            continue
         if isinstance(msg, HumanMessage):
             filtered.append(msg)
         elif isinstance(msg, AIMessage):
             is_own = current_agent_name is not None and msg.name == current_agent_name
+            # Context-leakage guard: hide peer internal agents from
+            # non-internal (customer-facing) agents. Internal agents can
+            # still see each other's outputs — a planner needs to read a
+            # supervisor's intent classification to route.
+            if (
+                not is_own
+                and msg.name in _internal
+                and not _current_is_internal
+            ):
+                continue
             if msg.tool_calls:
                 if is_own:
                     filtered.append(msg)
@@ -279,12 +330,16 @@ def create_agent_node_handler(
     output_mode: OutputMode = "last_message",
     reflection_executor: Any | None = None,
     recursion_limit: int | None = None,
+    internal_agents: frozenset[str] = frozenset(),
 ) -> Callable[[AgentState, Runtime[Context]], Awaitable[AgentState]]:
     """
     Create a handler that wraps an agent subgraph with message filtering.
 
     This filters messages before passing to the agent and extracts only
-    the relevant response, avoiding tool_use/tool_result pairing errors.
+    the relevant response, avoiding tool_use/tool_result pairing errors AND
+    preventing cross-agent context leakage (internal-plumbing text like
+    intent classifications or routing decisions leaking into a
+    customer-facing agent's LLM context).
 
     Used by both supervisor and swarm patterns to ensure consistent
     message handling when agents are CompiledStateGraphs.
@@ -297,18 +352,25 @@ def create_agent_node_handler(
         output_mode: How to extract response ("last_message" or "full_history")
         reflection_executor: Optional background reflection executor for
             automatic memory extraction after each agent turn.
+        internal_agents: Set of agent names marked ``internal: true`` in
+            their ``AgentModel`` config. Their AIMessages are hidden from
+            non-internal (customer-facing) agents' views. Default empty
+            preserves pre-change behavior for callers that don't opt in.
 
     Returns:
         An async handler function for the workflow node
     """
 
     async def handler(state: AgentState, runtime: Runtime[Context]) -> AgentState:
-        # Filter messages to avoid tool_use/tool_result pairing errors.
+        # Filter messages to avoid tool_use/tool_result pairing errors AND
+        # scope internal-plumbing content away from non-internal agents.
         # Passing agent_name preserves the agent's own tool exchanges from
         # prior turns while still hiding peers' tool exchanges.
         original_messages = state.get("messages", [])
         filtered_messages = filter_messages_for_agent(
-            original_messages, current_agent_name=agent_name
+            original_messages,
+            current_agent_name=agent_name,
+            internal_agents=internal_agents,
         )
 
         logger.trace(

--- a/src/dao_ai/orchestration/supervisor.py
+++ b/src/dao_ai/orchestration/supervisor.py
@@ -341,6 +341,17 @@ def create_supervisor_graph(config: AppConfig) -> CompiledStateGraph:
     # Each worker gets a handoff_to_supervisor tool to return control
     agent_subgraphs: dict[str, CompiledStateGraph] = {}
     agent_recursion_limits: dict[str, int | None] = {}
+    # Agents marked ``internal: true`` in config. Their AIMessage outputs
+    # are hidden from non-internal (customer-facing) agents' view of
+    # shared history (context-leakage prevention).
+    internal_agents: frozenset[str] = frozenset(
+        a.name for a in config.app.agents if a.internal
+    )
+    if internal_agents:
+        logger.debug(
+            "Supervisor pattern internal agents (outputs hidden from non-internal peers)",
+            internal_agents=sorted(internal_agents),
+        )
     for registered_agent in config.app.agents:
         # Create handoff back to supervisor tool
         supervisor_handoff: BaseTool = _create_handoff_back_to_supervisor_tool()
@@ -379,6 +390,7 @@ def create_supervisor_graph(config: AppConfig) -> CompiledStateGraph:
             output_mode=orchestration.output_mode,
             reflection_executor=reflection_executor,
             recursion_limit=agent_recursion_limits.get(agent_name),
+            internal_agents=internal_agents,
         )
         workflow.add_node(agent_name, handler)
 

--- a/src/dao_ai/orchestration/swarm.py
+++ b/src/dao_ai/orchestration/swarm.py
@@ -403,6 +403,19 @@ def create_swarm_graph(config: AppConfig) -> CompiledStateGraph:
     agent_subgraphs: dict[str, CompiledStateGraph] = {}
     agent_recursion_limits: dict[str, int | None] = {}
     deterministic_targets: dict[str, str] = {}
+    # Agents marked ``internal: true`` in config. Their AIMessage outputs
+    # are filtered out of the history view passed to non-internal agents to
+    # prevent cross-agent context leakage (Anthropic distilled-handoff
+    # pattern; LangGraph swarm private-history recipe). Internal agents
+    # can still see each other's outputs.
+    internal_agents: frozenset[str] = frozenset(
+        a.name for a in config.app.agents if a.internal
+    )
+    if internal_agents:
+        logger.debug(
+            "Swarm internal agents (outputs hidden from non-internal peers)",
+            internal_agents=sorted(internal_agents),
+        )
     memory: MemoryModel | None = orchestration.memory
 
     # Set up memory store early so we can pass it to agents for auto-injection
@@ -502,6 +515,7 @@ def create_swarm_graph(config: AppConfig) -> CompiledStateGraph:
             output_mode=orchestration.output_mode,
             reflection_executor=reflection_executor,
             recursion_limit=agent_recursion_limits.get(agent_name),
+            internal_agents=internal_agents,
         )
 
         # Wrap the handler for deterministic routing:

--- a/tests/dao_ai/test_context_leakage_filter.py
+++ b/tests/dao_ai/test_context_leakage_filter.py
@@ -1,0 +1,250 @@
+"""Regression tests for context-leakage prevention in ``filter_messages_for_agent``.
+
+Two orthogonal policies added to the filter:
+
+1. ``SystemMessage`` in shared history is dropped by default. Every agent's
+   system prompt / memory-context injection is applied fresh per invocation
+   by middleware / the prompt template, so a ``SystemMessage`` from a prior
+   agent's turn is context noise.
+
+2. Peer ``AIMessage`` from an agent named in ``internal_agents`` is dropped
+   when the current agent is NOT itself internal. Internal agents can still
+   see each other's outputs (a planner needs to read a supervisor's intent
+   classification to route).
+
+Together these mirror Anthropic's "distilled handoffs" pattern and
+LangGraph's documented swarm private-history recipe: internal reasoning is
+architecturally invisible to downstream customer-facing agents.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+
+from dao_ai.orchestration.core import filter_messages_for_agent
+
+
+def _names(messages: list[BaseMessage]) -> list[tuple[str, str | None]]:
+    """Compact repr: (type, name) tuples for readable assertions."""
+    return [(type(m).__name__, getattr(m, "name", None)) for m in messages]
+
+
+@pytest.mark.unit
+def test_system_messages_are_dropped_by_default() -> None:
+    """``SystemMessage`` in shared history is always dropped from the view."""
+    msgs: list[BaseMessage] = [
+        SystemMessage(content="You are a helpful supervisor."),
+        HumanMessage(content="hello"),
+        AIMessage(content="hi there", name="general"),
+        SystemMessage(content="## Memories\n- user is Nate"),
+    ]
+    out = filter_messages_for_agent(msgs, current_agent_name="general")
+    assert not any(isinstance(m, SystemMessage) for m in out), (
+        f"SystemMessages should be filtered out; got {_names(out)}"
+    )
+    # Non-system messages are preserved in order.
+    non_bridge = [m for m in out if getattr(m, "name", None) != "__filter_bridge__"]
+    assert _names(non_bridge) == [("HumanMessage", None), ("AIMessage", "general")]
+
+
+@pytest.mark.unit
+def test_peer_internal_ai_message_dropped_for_non_internal_current() -> None:
+    """Non-internal agent (composer) must not see internal agent (supervisor) output."""
+    msgs: list[BaseMessage] = [
+        HumanMessage(content="show me my orders"),
+        AIMessage(
+            content="INTENT: order_history | CONFIDENCE: 0.95 | NOTES: …",
+            name="supervisor",
+        ),
+        AIMessage(content="No orders found.", name="order_history"),
+    ]
+    out = filter_messages_for_agent(
+        msgs,
+        current_agent_name="composer",
+        internal_agents=frozenset({"supervisor", "planner"}),
+    )
+    # Supervisor's INTENT line is filtered — composer literally cannot
+    # pattern-match on a string it never receives.
+    assert not any(getattr(m, "name", None) == "supervisor" for m in out), (
+        f"supervisor's AIMessage should have been filtered; got {_names(out)}"
+    )
+    # Order history (non-internal) still visible.
+    assert any(getattr(m, "name", None) == "order_history" for m in out)
+
+
+@pytest.mark.unit
+def test_peer_internal_ai_message_kept_for_internal_current() -> None:
+    """Internal agent (planner) MUST see other internal agent (supervisor) output.
+
+    Without this rule, planner couldn't read supervisor's intent classification
+    to make its routing decision.
+    """
+    msgs: list[BaseMessage] = [
+        HumanMessage(content="show me my orders"),
+        AIMessage(
+            content="INTENT: order_history | CONFIDENCE: 0.95 | NOTES: …",
+            name="supervisor",
+        ),
+    ]
+    out = filter_messages_for_agent(
+        msgs,
+        current_agent_name="planner",
+        internal_agents=frozenset({"supervisor", "planner"}),
+    )
+    assert any(getattr(m, "name", None) == "supervisor" for m in out), (
+        f"planner should see supervisor's output; got {_names(out)}"
+    )
+
+
+@pytest.mark.unit
+def test_own_ai_message_preserved_for_internal_agent() -> None:
+    """Any agent (internal or not) always sees its own prior AIMessages."""
+    msgs: list[BaseMessage] = [
+        HumanMessage(content="q"),
+        AIMessage(content="prior supervisor output", name="supervisor"),
+    ]
+    out = filter_messages_for_agent(
+        msgs,
+        current_agent_name="supervisor",
+        internal_agents=frozenset({"supervisor"}),
+    )
+    # Own output survives even though supervisor is in internal_agents.
+    assert any(getattr(m, "name", None) == "supervisor" for m in out)
+
+
+@pytest.mark.unit
+def test_peer_non_internal_ai_message_preserved_with_tool_calls_stripped() -> None:
+    """Existing behavior for non-internal peers is unchanged."""
+    peer_msg = AIMessage(
+        content="Here is the answer.",
+        name="order_history",
+        tool_calls=[{"id": "tc1", "name": "search_orders", "args": {}}],
+    )
+    msgs: list[BaseMessage] = [HumanMessage(content="q"), peer_msg]
+    out = filter_messages_for_agent(
+        msgs,
+        current_agent_name="composer",
+        internal_agents=frozenset({"supervisor"}),
+    )
+    ai_out = [m for m in out if isinstance(m, AIMessage)]
+    assert len(ai_out) == 1
+    assert ai_out[0].name == "order_history"
+    # tool_calls stripped for peer content
+    assert not ai_out[0].tool_calls
+
+
+@pytest.mark.unit
+def test_backward_compat_no_internal_agents_no_system_messages() -> None:
+    """With ``internal_agents=None`` and no SystemMessages, output is unchanged.
+
+    Pins the existing behavior for configs that don't set ``internal: true``
+    on any agent. Note: the existing filter appends a ``__filter_bridge__``
+    HumanMessage when the tail is a content-only AIMessage (strict-mode
+    provider workaround) — that behavior is preserved.
+    """
+    msgs: list[BaseMessage] = [
+        HumanMessage(content="q"),
+        AIMessage(content="a1", name="planner"),
+        AIMessage(content="a2", name="composer"),
+    ]
+    out_new = filter_messages_for_agent(msgs, current_agent_name="composer")
+    # Non-bridge portion matches the prior filter behavior.
+    non_bridge = [m for m in out_new if getattr(m, "name", None) != "__filter_bridge__"]
+    assert _names(non_bridge) == [
+        ("HumanMessage", None),
+        ("AIMessage", "planner"),
+        ("AIMessage", "composer"),
+    ]
+
+
+@pytest.mark.unit
+def test_own_tool_exchange_pairs_correctly_for_internal_agent() -> None:
+    """Internal agents' own tool exchanges still pair via tool_call_id."""
+    own_ai = AIMessage(
+        content="",
+        name="supervisor",
+        tool_calls=[{"id": "tc_1", "name": "some_tool", "args": {}}],
+    )
+    tool_result = ToolMessage(content="tool ok", tool_call_id="tc_1")
+    msgs: list[BaseMessage] = [HumanMessage(content="q"), own_ai, tool_result]
+    out = filter_messages_for_agent(
+        msgs,
+        current_agent_name="supervisor",
+        internal_agents=frozenset({"supervisor"}),
+    )
+    # Own AIMessage(tool_calls) + paired ToolMessage both preserved.
+    tool_ids_seen: list[str] = [
+        m.tool_call_id for m in out if isinstance(m, ToolMessage)
+    ]
+    assert "tc_1" in tool_ids_seen
+
+
+@pytest.mark.unit
+def test_dropped_internal_peer_does_not_leave_orphan_tool_pairings() -> None:
+    """Filtering out an internal peer's AIMessage doesn't create orphan ToolMessages.
+
+    A peer agent's ToolMessages are never associated with the current agent's
+    ``own_tool_call_ids`` set, so they were being dropped by the tool-pairing
+    rule already. Verify the new internal-agent filter doesn't accidentally
+    keep them.
+    """
+    peer_ai = AIMessage(
+        content="",
+        name="supervisor",
+        tool_calls=[{"id": "tc_peer", "name": "peer_tool", "args": {}}],
+    )
+    peer_tool_result = ToolMessage(content="peer tool ok", tool_call_id="tc_peer")
+    msgs: list[BaseMessage] = [
+        HumanMessage(content="q"),
+        peer_ai,
+        peer_tool_result,
+    ]
+    out = filter_messages_for_agent(
+        msgs,
+        current_agent_name="composer",
+        internal_agents=frozenset({"supervisor"}),
+    )
+    # No orphan ToolMessage from the filtered-out peer.
+    assert not any(isinstance(m, ToolMessage) for m in out), _names(out)
+    # No supervisor AIMessage either.
+    assert not any(getattr(m, "name", None) == "supervisor" for m in out)
+
+
+@pytest.mark.unit
+def test_empty_internal_agents_still_drops_system_messages() -> None:
+    """The SystemMessage-drop rule is unconditional; not gated on internal_agents."""
+    msgs: list[BaseMessage] = [
+        SystemMessage(content="stale prompt from prior turn"),
+        HumanMessage(content="q"),
+    ]
+    out = filter_messages_for_agent(msgs, current_agent_name="composer")
+    assert not any(isinstance(m, SystemMessage) for m in out)
+
+
+@pytest.mark.unit
+def test_untagged_peer_ai_message_not_filtered() -> None:
+    """AIMessages without a ``name`` field are treated as peers with content-visible.
+
+    Guards against future writers that forget to tag their AIMessage — they
+    should still appear (not silently vanish) so any leak would still be
+    visible for observation rather than silently dropped.
+    """
+    msgs: list[BaseMessage] = [
+        HumanMessage(content="q"),
+        AIMessage(content="untagged content"),  # no name
+    ]
+    out = filter_messages_for_agent(
+        msgs,
+        current_agent_name="composer",
+        internal_agents=frozenset({"supervisor"}),
+    )
+    ai_seen = [m for m in out if isinstance(m, AIMessage)]
+    assert len(ai_seen) == 1
+    assert ai_seen[0].content == "untagged content"


### PR DESCRIPTION
## Summary

Multi-agent dao-ai apps share `state["messages"]` across every agent in the graph. That shared list accumulates internal plumbing — intent classifications, routing decisions, memory-context `SystemMessage` injections, agent working notes. Downstream agents' LLMs can pattern-match on that content and emit it as customer responses.

Concretely observed in `commerce_swarm`: on Turn 2 sticky-resume the composer echoed supervisor's raw output — `` `INTENT: credit_limit | CONFIDENCE: 0.95 | NOTES: user requesting credit limit information` ``. Never seen in the supervisor pattern (which rebuilds from the entry node every turn), but the failure mode is **framework-general**: any dao-ai config that mixes an internal-plumbing agent with a downstream reader of shared history is vulnerable.

## Vendor foundation

- **Anthropic — [Effective context engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents):** internal reasoning must be *"architecturally invisible"* to downstream agents, not merely prompt-instructed to be ignored.
- **[LangGraph swarm README](https://github.com/langchain-ai/langgraph-swarm-py):** documents the private-history pattern for exactly this scenario.

## Fix — role-aware filter at the existing choke point

Extends `filter_messages_for_agent` (`src/dao_ai/orchestration/core.py:83`, already called on every agent invocation via `create_agent_node_handler`) with two rules:

1. **`SystemMessage` in shared history is dropped by default.** Every agent's system prompt / memory-context injection is applied fresh per invocation — a `SystemMessage` sitting in shared state from a prior turn is context noise.
2. **Peer `AIMessage` from an internal agent is dropped for non-internal current agents.** Internal agents (declared via new `AgentModel.internal: bool = False`) whose outputs are internal plumbing rather than customer-facing text get scoped away from downstream customer-facing agents' LLM views. Internal agents **still see each other** — a planner needs to read a supervisor's intent classification.

State and MLflow traces are unchanged: internal AIMessages still land in `state["messages"]` and still appear in traces. Only the downstream LLM view is scoped.

## Strategies considered (see plan for full grading)

|              | Correctness | Maintainability | Scalability | Edge cases |
|--------------|-------------|-----------------|-------------|------------|
| **A: Role-aware filter at existing choke point (chosen)** | ★★★★☆ | ★★★★★ | ★★★★★ | ★★★★☆ |
| B: Two-channel `AgentState` | ★★★★★ | ★★★☆☆ | ★★★★☆ | ★★★☆☆ |
| C: Per-agent subgraph state schemas | ★★★★★ | ★★☆☆☆ | ★★★☆☆ | ★★☆☆☆ |

A wins: same functional outcome as B/C with ~10% of the blast radius. Escalate to B if A ever proves insufficient.

## Edge cases handled

- **Internal-to-internal chatter** (planner reads supervisor) — kept.
- **Own AIMessages** on re-entry — always preserved.
- **Orphan `ToolMessage`s** from filtered-out peers — filtered too (no broken tool pairings).
- **Empty `internal_agents`** — byte-for-byte compat pinned by regression test.
- **Concurrent invocations** — filter is stateless.
- **Checkpoint restore from before this change** — old `SystemMessage`s in state are dropped from views (no-op).
- **Command(goto=…) handoffs** — filter runs per handler invocation regardless of routing mechanism.
- **A2A external callers** — same protection via standard handler path.

## Test plan

- [x] 10 unit tests in `tests/dao_ai/test_context_leakage_filter.py` — all pass.
- [x] Surrounding suites (deterministic handoffs, handoff constraints, swarm sticky, memory extraction, config vars) — 159/159 pass, no regressions.
- [x] `make schema` — schema diff is exactly one new `internal` field on `AgentModel`.
- [x] **Live-validated on FEVM `agent-commerce-swarm-dao`:**
  - Turn 1 (`"show me my recent orders"`): full pipeline runs, composer produces contextual account-not-found response.
  - Turn 2 sticky composer (`"what about my credit limit?"`): response is *"Since your account couldn't be located in our system, Nate, we're unable to retrieve credit limit information at this time..."* — carries forward Turn 1's context, no `INTENT:` / `CONFIDENCE:` / `NOTES:` leak.

## Latency

Zero delta — the filter is same O(n) it already was, plus one set-membership check per AIMessage.

This pull request and its description were written by Isaac.