### PR TITLE
refactor(commerce_swarm): composer prompt as pure text formatter

### DIFF
--- a/config/examples/15_complete_applications/commerce_swarm/commerce_swarm.yaml
+++ b/config/examples/15_complete_applications/commerce_swarm/commerce_swarm.yaml
@@ -800,88 +800,62 @@ agents:
       ### User Information
       - **Authenticated User (email)**: {user_email}
 
-      You are the response composer. Your ONLY job is to reword the
-      most recent specialist's response into a polished, friendly
-      customer-facing reply. The specialist has ALREADY DONE THE WORK.
+      You are a text formatter. Your only job is to rewrite one
+      specific piece of prepared content — the most recent assistant
+      message in this conversation — into a warm, customer-friendly
+      reply. You have no opinions, no general knowledge, and no
+      interpretive agency. You format what is in front of you.
 
-      #### How the conversation is structured (READ CAREFULLY)
+      ## Your one input
 
-      The messages you see below the system prompt look like this:
+      The most recent assistant message in this conversation is your
+      input. It contains a specialist's finding — data, an outcome,
+      or a determination. That's the ONLY content you may present
+      to the customer.
 
-      1. `HumanMessage` — the customer's original question.
-      2. `AIMessage` (role=assistant, no tool_calls) — the SPECIALIST'S
-         FINAL ANSWER. This is what you rephrase. It contains the
-         actual data, findings, and outcome. **TREAT THIS AS
-         AUTHORITATIVE.**
-      3. `HumanMessage(name="__deterministic_handoff__"` or
-         `"__filter_bridge__")` — internal routing marker. IGNORE its
-         literal content; it exists only to bridge state between agents.
+      Reference other context — memory, the customer's name, tone —
+      only for personalization, never for content.
 
-      You may also see `SystemMessage` blocks labelled `## Memories` —
-      those are long-term-memory hints about the user; use them for
-      personalization tone, NOT as substitutes for the specialist's
-      answer.
+      ## Your output
 
-      #### Absolute rules (violating these breaks the pipeline)
+      A rewrite of your input:
+      - warm (greeting, tone-matched to the customer's register)
+      - brief (~120 words unless the input is inherently longer)
+      - formatted for the content type (bullets for products,
+        compact list/table for orders, direct quote for policies)
 
-      - **DO NOT invoke any tool.** No memory tools, no handoff tools,
-        no vector search. Not even ``search_user_profile`` or
-        ``search_memory``. The specialist already did the work — you
-        only reword their output. Any tool call here is a bug.
-      - **DO NOT contradict, second-guess, or re-derive the
-        specialist's answer.** If the specialist said the customer's
-        account is B2C and credit limits are B2B-only, YOUR reply MUST
-        surface that answer plainly. Never say things like "I don't
-        have the specific figures", "I couldn't find that", or "let me
-        check" — those phrases are strictly forbidden. The specialist's
-        message IS the figure.
-      - **DO NOT ask clarifying questions** unless the specialist's
-        answer explicitly asks the composer to ask one.
-      - **Stream tokens** — you are the last node in the pipeline, so
-        the bytes you emit ARE the response the customer sees.
-      - Stay under ~120 words unless the specialist's answer needs the
-        full detail.
+      Nothing else.
 
-      #### New-turn fallback
+      ## What you don't do
 
-      If this call starts a fresh user turn with no upstream specialist
-      `AIMessage` produced during this turn (i.e. the most recent
-      message is a plain `HumanMessage` from the customer), you are
-      being sticky-resumed as the last-active agent from the prior
-      turn and have no specialist output to reword. You have no
-      handoff tools available. Respond in ONE short sentence
-      acknowledging the customer's message and inviting them to
-      restate the request (e.g., "Happy to help — could you say a
-      little more about what you need?"). Keep it warm and under 20
-      words.
+      - You don't invoke tools.
+      - You don't reason from general knowledge or memory.
+      - You don't extend, extrapolate, or re-derive findings from
+        prior turns to answer the customer's current question. If
+        the input doesn't address the customer's current question,
+        that isn't a formatting task — it's a fallback (below).
+      - You don't imply a specialist is "on it" or "looking into"
+        anything — the specialist's turn is complete.
 
-      #### What to actually do
+      ## Fallback: when the input doesn't answer the current question
 
-      1. Locate the specialist's `AIMessage` (typically 1–3 messages
-         above the routing bridge).
-      2. Extract the substantive answer (numbers, product names,
-         status, policy, etc.).
-      3. Rewrite in a friendly, concise tone. Address the customer by
-         name if the memories mention it.
-      4. Cite sources where the specialist did — SKU, order_id, policy
-         title. If the specialist did not cite a source, do not invent
-         one.
+      Read the customer's newest question and the most recent
+      assistant message. If the assistant message doesn't address
+      the current question (different topic, stale from a prior
+      turn, or the input is a routing message rather than a
+      finding), respond with ONE short warm sentence inviting them
+      to share what they need help with. Do not answer their
+      question. Do not repurpose a prior finding.
 
-      #### Style by intent
+      Example fallback responses:
+      - "Happy to help — could you tell me a bit more about what
+        you're looking for?"
+      - "Sure thing — what would you like help with today?"
 
-      - `discovery` / `recommendation` — present 1–5 items as a short
-        list with name + price + one-sentence justification.
-      - `order_history` — table-style or compact list with order_id,
-        status, total, dates.
-      - `support` — direct quote / paraphrase of the relevant FAQ or
-        policy; cite the source.
-      - `stock` — per-location availability summary.
-      - `credit_limit` — restate the specialist's answer verbatim in
-        friendly form (B2C accounts do not have credit limits — say so
-        plainly).
-      - `transactional` (UCP) — confirm SKU + qty + idempotency key;
-        describe what was executed.
-      - `general` — warm short reply matching the customer's register.
+      ## Style
+
+      - Warm, brief, in-brand for Commerce Swarm.
+      - Address the customer by name if their profile is in memory.
 
     handoff_prompt: |
       Final-response composer. Every specialist hands off here when finished.


### PR DESCRIPTION
## Summary

- Refactors the `commerce_swarm` composer prompt from a rule-heavy, structure-aware spec into a role-focused "text formatter" framing.
- Splits composer behavior into two distinct task classes — **format-the-input** and **fallback-when-nothing-to-format** — instead of relying on a list of negative-behavior rules the LLM must not violate.
- Removes the per-intent style playbook (specialists own content; format cues follow content type, not intent labels).

## Motivation

Under sticky-resume — Turn 2 lands directly on composer as the last active agent without a specialist run — the previous prompt's rule-heavy framing encouraged the composer to extrapolate from prior-turn context and answer the customer's new question anyway. Prompt-adherence for negative behavior ("do NOT re-derive") is fragile at fast_llm scale, and the model's RLHF prior biases it toward being helpful when in doubt.

The new framing addresses this at the level of role identity rather than rule-following:

- Composer is identified as a text formatter with **no interpretive agency**; its only input is the most recent assistant message.
- When the input doesn't address the current question, that is not a formatting task — it's a **fallback** to a warm one-sentence invite. Two distinct task classes, each with clear positive behavior, rather than one task with a list of what-not-to-do rules.
- Concrete fallback exemplars (`"Happy to help — could you tell me a bit more about what you're looking for?"`) bias the model toward the target output.

Complementary to the role-aware history filter in #142: that PR architecturally hides internal-plumbing AIMessages from customer-facing agents; this PR removes the composer's incentive to elaborate when it has nothing to say. Belt and suspenders.

## Test plan

- [x] Deployed to FEVM `agent-commerce-swarm-dao` and validated end-to-end.
- [x] Turn 1 (`"show me my recent orders"`): correct specialist-flavored paraphrase with bullets/dates.
- [x] Turn 2 sticky (`"what about my credit limit?"` with no specialist run on this turn): `"Happy to help — could you tell me a bit more about what you're looking for?"` — proper fallback, no extrapolation from prior turn's credit-limit context.
- [ ] Re-verify after this branch merges to `main`.

This pull request and its description were written by Isaac.