### PR TITLE
feat(vector_search): dynamic tool schema — auto-discover columns, Literal-narrow filter keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ agents:
     name: product_expert
     model: *claude_sonnet
     tools:
-      - *vector_search_tool
+      - *ai_search_tool
       - *genie_tool
     prompt: |
       You are a product expert. Answer questions about inventory and pricing.
@@ -50,7 +50,7 @@ DAO AI Builder generates valid YAML configurations that work seamlessly with thi
 - **[Configuration Reference](docs/configuration-reference.md)** - Complete YAML configuration guide
 - **[Examples](docs/examples.md)** - Ready-to-use example configurations
 - **[A2A Protocol](docs/a2a_protocol.md)** - Google Agent2Agent endpoints on every Apps deployment
-- **[MCP Server](docs/mcp_server.md)** - Expose dao-ai Genie + Vector Search tools as MCP via `dao-ai generate-mcp`
+- **[MCP Server](docs/mcp_server.md)** - Expose dao-ai Genie + AI Search tools as MCP via `dao-ai generate-mcp`
 - **[Background Agents](docs/background_agents.md)** - kickoff/poll/cancel for multi-minute graph runs
 
 ### Reference
@@ -73,7 +73,7 @@ Before you begin, you'll need:
 - **A Databricks workspace** (ask your IT team or see [Databricks docs](https://docs.databricks.com/))
   - Access to **Unity Catalog** (your organization's data catalog)
   - **Model Serving** or **Databricks Apps** enabled (for deploying AI agents)
-  - *Optional*: Vector Search, Genie (for advanced features)
+  - *Optional*: AI Search (formerly Vector Search), Genie (for advanced features)
 
 **Not sure if you have access?** Your Databricks administrator can grant you permissions.
 
@@ -317,7 +317,7 @@ DAO provides powerful capabilities for building production-ready AI agents:
 | **Orchestration Patterns** | Supervisor, Swarm, **Deep Agent** (langgraph deepagents — todo, filesystem, shell, sub-agents, skills, AGENTS.md memory) |
 | **On-Behalf-Of User** | Per-user permissions and governance |
 | **Advanced Caching** | Two-tier (LRU + Semantic) caching for cost optimization |
-| **Vector Search Reranking** | Improve RAG quality with FlashRank |
+| **AI Search Reranking** | Improve RAG quality with FlashRank |
 | **Human-in-the-Loop** | Approval workflows for sensitive operations |
 | **Memory & Persistence** | Long-term memory with structured schemas, background extraction, auto-injection; PostgreSQL, Lakebase, or in-memory backends |
 | **Prompt Registry** | Version and manage prompts in MLflow |

--- a/docs/a2a_protocol.md
+++ b/docs/a2a_protocol.md
@@ -206,7 +206,7 @@ Databricks Apps forwards the caller's bearer token via the
 `x-forwarded-access-token` header. dao-ai's A2A executor reads it from
 the FastAPI request (via a2a-sdk's `DefaultCallContextBuilder`) and
 injects it into `configurable.headers`, exactly mirroring the
-Responses-path handler. Downstream tools (UC functions, Vector Search,
+Responses-path handler. Downstream tools (UC functions, AI Search,
 Genie, model invocations) that have `on_behalf_of_user: true` see the
 end-user's token unchanged.
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -160,12 +160,12 @@ tools:
       functions: *my_schema     # Use UC Functions MCP
       genie_room: *genie        # Use Genie MCP for a single space (per-space URL)
       genie: bool               # Use workspace-wide Genie MCP (all spaces, no space_id)
-      vector_search: *store     # Use Vector Search MCP
+      vector_search: *store     # Use AI Search MCP (field name kept for backwards compat)
       include_tools: [string]   # Tools to load (allowlist, supports glob)
       exclude_tools: [string]   # Tools to exclude (denylist, supports glob)
       meta:                     # _meta sent on every tool call (MCP spec, public preview on Databricks)
         warehouse_id: string    # DBSQL: pin a specific warehouse
-        num_results: int        # Vector Search: cap result count
+        num_results: int        # AI Search: cap result count
         # ... any other server-specific keys (see Databricks managed MCP docs)
       # type: app — call a Databricks App as a tool
       app: *app_resource        # DatabricksAppModel ref (required for type: app)
@@ -499,16 +499,18 @@ resources:
       - databricks-claude-sonnet-4   # legacy Model Serving fallback
 ```
 
-### Vector Search endpoint capacity (`target_qps`)
+### AI Search endpoint capacity (`target_qps`)
 
 **`vector_stores.<name>.endpoint.target_qps`** *(int, optional, Public Preview)* —
-Target queries-per-second for the Vector Search endpoint. **STANDARD endpoints only**;
-setting this on an `OPTIMIZED_STORAGE` endpoint raises a config-validation error.
-Endpoint compute scales linearly with `target_qps`, so cost scales linearly too.
-**Honored at endpoint-creation time only** — if the endpoint already exists, this
-value is ignored (a debug log entry records the configured value but no API call
-is made). To change capacity on a live endpoint, use the Databricks UI, REST API,
-or SDK directly. See the [Databricks Vector Search QPS scaling docs](https://docs.databricks.com/aws/en/generative-ai/vector-search) for the underlying capability.
+Target queries-per-second for the AI Search endpoint (formerly Vector Search).
+**STANDARD endpoints only**; setting this on an `OPTIMIZED_STORAGE` endpoint raises
+a config-validation error. Endpoint compute scales linearly with `target_qps`, so
+cost scales linearly too. **Honored at endpoint-creation time only** — if the
+endpoint already exists, this value is ignored (a debug log entry records the
+configured value but no API call is made). To change capacity on a live endpoint,
+use the Databricks UI, REST API, or SDK directly. See the
+[Databricks AI Search QPS scaling docs](https://docs.databricks.com/aws/en/generative-ai/vector-search)
+for the underlying capability.
 
 ### Skills (`resources.skills`)
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -273,7 +273,7 @@ pytest --cov=dao_ai --cov-report=html tests/
 
 1. Choose the appropriate category in `config/examples/` based on **primary feature** demonstrated:
    - `01_getting_started/` - Foundation concepts for beginners
-   - `02_tools/` - Tool integrations (Genie, Vector Search, Slack, MCP, etc.)
+   - `02_tools/` - Tool integrations (Genie, AI Search, Slack, MCP, etc.)
    - `04_genie/` - Performance optimization strategies
    - `05_memory/` - State management and persistence
    - `06_on_behalf_of_user/` - User-level authentication and access control

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -415,7 +415,7 @@ Full-featured, production-ready agent applications.
 | `executive_assistant.yaml` | Comprehensive assistant with email, calendar, Slack |
 | `deep_research.yaml` | Multi-step research agent with web search |
 | `reservations_system.yaml` | Restaurant reservation management system |
-| `genie_vector_search_hybrid.yaml` | Combined SQL and vector search capabilities |
+| `genie_vector_search_hybrid.yaml` | Combined SQL and AI Search capabilities |
 | `genie_and_genie_mcp.yaml` | Multiple Genie instances via MCP (experimental) |
 
 **Prerequisites:** All concepts from previous categories  

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -34,7 +34,7 @@
 - [How do I orchestrate a parallel fan-out pattern?](#how-do-i-orchestrate-a-parallel-fan-out-pattern)
 - [How do I add guardrails to my agent?](#how-do-i-add-guardrails-to-my-agent)
 - [How do I add tools to my agent (UC functions, REST, MCP)?](#how-do-i-add-tools-to-my-agent-uc-functions-rest-mcp)
-- [How do I do RAG / vector search with reranking?](#how-do-i-do-rag-vector-search-with-reranking)
+- [How do I do RAG / AI Search with reranking?](#how-do-i-do-rag--ai-search-with-reranking)
 - [How do I run long-running tasks?](#how-do-i-run-long-running-tasks)
 
 **MLflow Tracing & Monitoring**
@@ -212,7 +212,7 @@ databricks bundle run <app-name>
 ### How do I optimize agent performance?
 
 1. **Enable caching** for Genie queries (LRU + Context-Aware cache) — see [Lab 12 — Genie Context-Aware Caching](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-12-genie-caching)
-2. **Use reranking** for vector search to improve result quality — see [Lab 6 — Vector Search + FlashRank](https://github.com/natefleming/dao-ai-workshop/tree/main/L200-real-agents/lab-06-vector-search) and [Lab 11 — Instructed Retrieval + LLM Rerank](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-11-instructed-retrieval)
+2. **Use reranking** on AI Search to improve result quality — see [Lab 6 — AI Search + FlashRank](https://github.com/natefleming/dao-ai-workshop/tree/main/L200-real-agents/lab-06-vector-search) and [Lab 11 — Instructed Retrieval + LLM Rerank](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-11-instructed-retrieval)
 3. **Tune similarity thresholds** to balance cache hit rate vs. accuracy
 4. **Monitor MLflow traces** to identify bottlenecks — see [Lab 24 — UC OTEL Trace Tables](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-24-uc-trace-location) for durable trace storage
 5. **Use appropriate model sizes** (larger models = slower but more accurate)
@@ -224,7 +224,7 @@ databricks bundle run <app-name>
 Latency depends on your configuration:
 
 - **Simple query with cache hit**: 50-200ms
-- **Vector search with reranking**: 200-500ms
+- **AI Search with reranking**: 200-500ms
 - **Genie NL-to-SQL (no cache)**: 2-5 seconds
 - **Multi-agent orchestration**: 1-10 seconds (depends on complexity)
 
@@ -287,7 +287,7 @@ This lets the same config target different secret scopes per environment. See [B
 
 Set `on_behalf_of_user: true` on any Databricks resource you want the deployed agent to reach *as the calling user* rather than as the agent's own service principal. The Apps runtime forwards the caller's `x-forwarded-access-token` through to that resource for every request.
 
-The flag is accepted by any Databricks resource — most commonly LLMs (`resources.models.*`), downstream Apps (`resources.apps.*`), UC tables (`resources.tables.*`), warehouses, and Vector Search indexes.
+The flag is accepted by any Databricks resource — most commonly LLMs (`resources.models.*`), downstream Apps (`resources.apps.*`), UC tables (`resources.tables.*`), warehouses, and AI Search indexes.
 
 ```yaml
 resources:
@@ -629,9 +629,9 @@ See the workshop's tool-grounding progression: [Lab 2 — Grounding with Unity C
 
 **Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`docs/mcp_server.md`](mcp_server.md) · [`config/examples/14_basic_tools/`](../config/examples/14_basic_tools/) (REST, Slack) · [`config/examples/02_mcp/`](../config/examples/02_mcp/) (custom / external / filtered MCP)
 
-### How do I do RAG / vector search with reranking?
+### How do I do RAG / AI Search with reranking?
 
-Declare a `vector_stores:` resource pointing at a Databricks Vector Search index over a Delta table with Change Data Feed enabled, then wire it into a `retrievers:` block that composes ANN search with a rerank stage.
+Declare a `vector_stores:` resource pointing at a Databricks AI Search index (formerly Vector Search) over a Delta table with Change Data Feed enabled, then wire it into a `retrievers:` block that composes ANN search with a rerank stage.
 
 ```yaml
 resources:
@@ -657,7 +657,7 @@ retrievers:
 
 Reference the retriever from an `agents:` block (`agents.<name>.retrievers: [*kb_retriever]`) — the agent grounds each turn on the top-`top_n` reranked results.
 
-For filter-heavy queries (*"Milwaukee power tools under $100"*), layer an **instructed retriever** on top: query decomposition into structured filters + a residual semantic query, then LLM-based rerank with natural-language instructions. See [Lab 6 — Knowledge-base Retrieval with Vector Search](https://github.com/natefleming/dao-ai-workshop/tree/main/L200-real-agents/lab-06-vector-search) for the base pattern and [Lab 11 — Instructed Retrieval](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-11-instructed-retrieval) for the filter-decomposition variant.
+For filter-heavy queries (*"Milwaukee power tools under $100"*), layer an **instructed retriever** on top: query decomposition into structured filters + a residual semantic query, then LLM-based rerank with natural-language instructions. See [Lab 6 — Knowledge-base Retrieval with AI Search](https://github.com/natefleming/dao-ai-workshop/tree/main/L200-real-agents/lab-06-vector-search) for the base pattern and [Lab 11 — Instructed Retrieval](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-11-instructed-retrieval) for the filter-decomposition variant.
 
 **Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`config/examples/03_reranking/`](../config/examples/03_reranking/) · [`config/examples/16_instructed_retriever/`](../config/examples/16_instructed_retriever/)
 

--- a/docs/key-capabilities.md
+++ b/docs/key-capabilities.md
@@ -66,7 +66,7 @@ DAO supports several first-class tool types plus an escape hatch for arbitrary f
 | Tool Type | Use Case | Example |
 |-----------|----------|---------|
 | **Genie** | Natural-language SQL via a Genie space, with optional caching | `type: genie` + `genie_room: *room` |
-| **Vector Search** | Semantic / hybrid search over a vector index, with optional instructed retrieval | `type: vector_search` + `retriever: *retriever` |
+| **AI Search** | Semantic / hybrid search over a Databricks AI Search index (formerly Vector Search), with optional instructed retrieval | `type: ai_search` (or legacy `vector_search`) + `retriever: *retriever` |
 | **Search** | Web search (DuckDuckGo) | `type: search` |
 | **Unity Catalog** | Governed SQL functions | `type: unity_catalog` + `resource: *fn` |
 | **MCP** | External services via Model Context Protocol | `type: mcp` + `connection: *mcp_conn` |
@@ -90,11 +90,11 @@ tools:
         capacity: 100
         time_to_live_seconds: 3600
 
-  # Vector Search - first-class, supports instructed retriever
+  # AI Search (formerly Vector Search) - first-class, supports instructed retriever
   product_search:
     name: product_search
     function:
-      type: vector_search
+      type: ai_search   # legacy alias: vector_search
       retriever: *products_retriever     # or: vector_store: *products_vs
       name: product_search
       description: "Search the product catalog by description / brand / category."
@@ -166,7 +166,7 @@ The old `type: factory + name: dao_ai.tools.create_*` shape continues to work in
 | --- | --- |
 | `type: factory`, `name: dao_ai.tools.create_genie_tool`, `args: { genie_room: ..., lru_cache_parameters: ... }` | `type: genie`, `genie_room: ...`, `lru_cache: ...` |
 | `type: factory`, `name: dao_ai.tools.create_genie_toolkit`, `args: { genie_room: ..., lru_cache_parameters: ..., context_aware_cache_parameters: ... }` | `type: genie`, `genie_room: ...`, `lru_cache: ...`, `context_aware_cache: ...` (any cache promotes to toolkit) |
-| `type: factory`, `name: dao_ai.tools.create_vector_search_tool`, `args: { retriever: ... }` | `type: vector_search`, `retriever: ...` |
+| `type: factory`, `name: dao_ai.tools.create_ai_search_tool`, `args: { retriever: ... }` | `type: ai_search`, `retriever: ...` |
 | `type: factory`, `name: dao_ai.tools.create_search_tool` | `type: search` |
 | `type: factory`, `name: dao_ai.tools.create_agent_endpoint_tool`, `args: { llm: <endpoint>, ... }` | `type: serving_endpoint`, `endpoint: <name-or-model>` (FMAPI + UC ResponsesAgent endpoints; lazy `task` discovery) |
 | `type: factory`, `name: dao_ai.tools.create_responses_agent_tool` / `create_chat_completions_agent_tool`, `args: { app: ..., ... }` | `type: app`, `app: <app>` (lazy `/agent/info` discovery; set `api:` to skip) |
@@ -428,9 +428,11 @@ genie_tool:
 - `consecutive_cache_hits`: How many times the same cached SQL has been returned consecutively (when > 1)
 - `auto_invalidated`: Set to `true` when the circuit breaker triggered auto-invalidation
 
-## 5. Vector Search Reranking & Instructed Retrieval
+## 5. AI Search Reranking & Instructed Retrieval
 
-**The problem:** Vector search (semantic similarity) is fast but sometimes returns loosely related results. It's like a librarian who quickly grabs 50 books that *might* be relevant.
+*(AI Search is the current Databricks name; older docs and configs may still call it Vector Search — dao-ai accepts both.)*
+
+**The problem:** AI Search (semantic similarity) is fast but sometimes returns loosely related results. It's like a librarian who quickly grabs 50 books that *might* be relevant.
 
 **The solution:** Reranking is like having an expert review those 50 books and pick the best 5 that *actually* answer your question.
 
@@ -462,7 +464,7 @@ retrievers:
 
 | Approach | Pros | Cons |
 |----------|------|------|
-| **Vector Search Only** | Fast, scalable | Embedding similarity ≠ relevance |
+| **AI Search Only** | Fast, scalable | Embedding similarity ≠ relevance |
 | **Reranking** | More accurate relevance | Slightly higher latency |
 | **Both (Two-Stage)** | Best of both worlds | Optimal quality/speed tradeoff |
 
@@ -495,7 +497,7 @@ rerank:
 
 ### Instructed Retrieval
 
-**The problem:** Standard vector search ignores metadata constraints entirely. When a user asks "Milwaukee power drills under $200 from last month", vector search only matches on semantic similarity — it can't enforce brand, price, or recency constraints. Queries with multiple intents or exclusions ("cordless tools excluding DeWalt") fare even worse.
+**The problem:** Standard AI Search ignores metadata constraints entirely. When a user asks "Milwaukee power drills under $200 from last month", semantic similarity alone can't enforce brand, price, or recency constraints. Queries with multiple intents or exclusions ("cordless tools excluding DeWalt") fare even worse.
 
 **The solution:** Instructed Retrieval extends basic RAG by automatically translating natural language constraints into executable metadata filters. An LLM decomposes complex queries into focused subqueries with filters, executes them in parallel, and merges results using Reciprocal Rank Fusion (RRF).
 
@@ -507,7 +509,7 @@ rerank:
 
 ### How Instructed Retrieval Works
 
-![Instructed retrieval pipeline: LLM decomposes the query into filters and subqueries, fans out to parallel vector searches, merges via Reciprocal Rank Fusion, then reranks with constraint awareness](images/instructed-retrieval-pipeline.png)
+![Instructed retrieval pipeline: LLM decomposes the query into filters and subqueries, fans out to parallel AI Search calls, merges via Reciprocal Rank Fusion, then reranks with constraint awareness](images/instructed-retrieval-pipeline.png)
 
 ### Instructed Retrieval Configuration
 

--- a/docs/mcp_server.md
+++ b/docs/mcp_server.md
@@ -1,6 +1,6 @@
 # MCP Server for dao-ai
 
-The `dao_ai.mcp` package turns any dao-ai config defining `create_genie_toolkit` or `create_vector_search_tool` factories into a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server hosted on Databricks Apps. Any MCP client — Claude Desktop, Cursor, agent platforms, dao-ai itself — can connect to a deployed app and call those tools natively over [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports).
+The `dao_ai.mcp` package turns any dao-ai config defining `create_genie_toolkit` or `create_ai_search_tool` (formerly `create_vector_search_tool`, still supported) factories into a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server hosted on Databricks Apps. Any MCP client — Claude Desktop, Cursor, agent platforms, dao-ai itself — can connect to a deployed app and call those tools natively over [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports).
 
 This is the **server** side. dao-ai's existing `dao_ai.apps.mcp` module is the client side (primitives for *consuming* external MCP servers from a dao-ai agent). The two are independent.
 
@@ -10,8 +10,8 @@ This is the **server** side. dao-ai's existing `dao_ai.apps.mcp` module is the c
 
 You already have:
 
-- a dao-ai config that wires Genie spaces, vector-search retrievers, the cache chain, and OBO/SP auth via Pydantic models;
-- factories like `dao_ai.tools.create_genie_toolkit` and `dao_ai.tools.create_vector_search_tool` that produce battle-tested tool implementations (LRU + pg_vector semantic cache, query decomposition + RRF + FlashRank + instruction-aware reranking + verifier).
+- a dao-ai config that wires Genie spaces, AI Search retrievers, the cache chain, and OBO/SP auth via Pydantic models;
+- factories like `dao_ai.tools.create_genie_toolkit` and `dao_ai.tools.create_ai_search_tool` (legacy alias `create_vector_search_tool`) that produce battle-tested tool implementations (LRU + pg_vector semantic cache, query decomposition + RRF + FlashRank + instruction-aware reranking + verifier).
 
 `dao-ai generate-mcp` lets you ship those exact tools as an MCP endpoint without writing or maintaining a parallel server. One command, one app, all the dao-ai retrieval features at the other end of an MCP client.
 
@@ -76,7 +76,9 @@ The server boots, reads its config via `dao_ai.config.AppConfig.from_file(initia
               │                       → LRUCacheService
               │     registers: ask_<name> + <name>_feedback (MCP tools)
               │
-              ├─► Vector Search adapter ── dao_ai.tools.create_vector_search_tool
+              ├─► AI Search adapter ── dao_ai.tools.create_ai_search_tool
+              │     (accepts the legacy dao_ai.tools.create_vector_search_tool
+              │      factory name too — both resolve to the same function)
               │     invokes the factory, wraps the returned StructuredTool
               │     registers: <name>
               │
@@ -100,7 +102,7 @@ register_adapter(McpAdapter(
 ))
 ```
 
-Add the import to `dao_ai/mcp/service.py` (alongside the shipped `genie` and `vector_search` imports), and your factory is now exposed as an MCP tool whenever a config references it.
+Add the import to `dao_ai/mcp/service.py` (alongside the shipped `genie` and `vector_search` / AI Search imports), and your factory is now exposed as an MCP tool whenever a config references it.
 
 ### Names and descriptions
 
@@ -132,9 +134,9 @@ Every tool response includes a structured `_meta` block in the JSON payload — 
 { "_meta": { "tool_name": "...", "conversation_id": "...", "message_id": "...", "rating": "NEGATIVE", "was_cache_hit": true } }
 ```
 
-**Vector search:**
+**AI Search:**
 ```json
-{ "_meta": { "tool_name": "product_vector_search", "result_count": 20, "latency_ms": 4557, "trace_id": null } }
+{ "_meta": { "tool_name": "product_ai_search", "result_count": 20, "latency_ms": 4557, "trace_id": null } }
 ```
 
 The client honors these `_meta` fields on inbound `tools/call`:
@@ -150,14 +152,14 @@ The MCP server's YAML is a (subset of a) dao-ai `AppConfig`. It needs:
 
 - `parameters:` — declared `${var.NAME}` references (CLI overrides, env-var fallback, defaults).
 - `resources.genie_rooms`, `resources.warehouses`, `resources.databases`, `resources.vector_stores` — the dao-ai resource models, identical to what the agent runtime consumes.
-- `retrievers:` — only needed for vector-search tools.
-- `tools:` — one entry per MCP tool to expose. Each `tools.<name>.function` must be a `factory` whose `name` matches a registered adapter (`dao_ai.tools.create_genie_toolkit` or `dao_ai.tools.create_vector_search_tool`).
+- `retrievers:` — only needed for AI Search tools.
+- `tools:` — one entry per MCP tool to expose. Each `tools.<name>.function` must be a `factory` whose `name` matches a registered adapter (`dao_ai.tools.create_genie_toolkit` or `dao_ai.tools.create_ai_search_tool` / legacy `create_vector_search_tool`).
 
 The `app:` and `agents:` blocks are **intentionally omitted** — the MCP server has no agent runtime to configure. Server name and log level come from env vars `DAO_AI_MCP_SERVER_NAME` (default `mcp-dao-ai` — chosen so Databricks Multi-Agent Supervisor's `mcp-` discovery prefix matches) and `DAO_AI_MCP_LOG_LEVEL` (default `INFO`).
 
 See `config/examples/15_complete_applications/sporting_goods_store_mcp.yaml` for a worked example.
 
-> **Note on tool types in MCP configs.** The MCP server adapter currently matches on the factory **name** (`dao_ai.tools.create_genie_toolkit` / `dao_ai.tools.create_vector_search_tool`) as its discriminator. For MCP server configs you must use the `type: factory` shape shown below — the first-class `type: genie` / `type: vector_search` shapes are supported by agent runtimes but not yet by the MCP adapter. (Agent-runtime configs can mix both shapes freely; only the MCP server is the constraint here.)
+> **Note on tool types in MCP configs.** The MCP server adapter currently matches on the factory **name** (`dao_ai.tools.create_genie_toolkit` / `dao_ai.tools.create_ai_search_tool` / legacy `create_vector_search_tool`) as its discriminator. For MCP server configs you must use the `type: factory` shape shown below — the first-class `type: genie` / `type: ai_search` (or `vector_search`) shapes are supported by agent runtimes but not yet by the MCP adapter. (Agent-runtime configs can mix both shapes freely; only the MCP server is the constraint here.)
 
 ### Cache parameters
 
@@ -190,9 +192,9 @@ The chain composes outer-to-inner: `LRUCacheService → PostgresContextAwareGeni
 
 The Postgres semantic cache needs `CREATE` privilege on its target schema in the Lakebase database. Most Apps deployments require an explicit grant in your Lakebase project; the cache will gracefully fall back to the underlying `GenieService` on permission errors but won't memoize.
 
-### Vector-search retriever
+### AI Search retriever
 
-The vector-search adapter passes the entire `args.retriever` block straight through to `create_vector_search_tool`. Anything that factory supports — query decomposition, FlashRank, instruction-aware reranking, query routing, result verification, metadata filters — works without code changes.
+The AI Search adapter passes the entire `args.retriever` block straight through to `create_ai_search_tool` (legacy alias: `create_vector_search_tool`). Anything that factory supports — query decomposition, FlashRank, instruction-aware reranking, query routing, result verification, metadata filters — works without code changes.
 
 ---
 
@@ -227,7 +229,7 @@ After `generate-mcp`, run `uv sync` in the output directory to produce `uv.lock`
 `generate-mcp` derives App resource bindings via `dao_ai.apps.resources.generate_app_resources` and converts them with `dao_ai.apps.bundle._convert_to_bundle_resources`. The resulting `databricks.yml` declares:
 
 - `genie_space` (CAN_RUN) — one per `create_genie_toolkit` entry.
-- `uc_securable` (TABLE / SELECT) — one per VS index. Vector-search indexes use the `TABLE` securable type since Databricks Apps' resource schema doesn't have a native `VECTOR_SEARCH_INDEX` type.
+- `uc_securable` (TABLE / SELECT) — one per AI Search index. AI Search / vector-search indexes use the `TABLE` securable type since Databricks Apps' resource schema doesn't have a native `VECTOR_SEARCH_INDEX` type.
 - `sql_warehouse` (CAN_USE) — for Genie SQL execution and cached-SQL re-execution.
 - `postgres` (CAN_CONNECT_AND_CREATE) — for the Lakebase autoscaling project backing the semantic cache.
 - `serving_endpoint` (CAN_QUERY) — for embedding and decomposition LLM endpoints.
@@ -237,7 +239,7 @@ Lakebase `database_instances` are **not** auto-provisioned. The MCP bundle assum
 
 ### Auth
 
-Defaults to **App SP** auth via Databricks Apps' auto-injected `DATABRICKS_CLIENT_ID` / `DATABRICKS_CLIENT_SECRET`. To use **OBO** (the requesting user's identity), set `on_behalf_of_user: true` on the relevant resource model (`GenieRoomModel`, `WarehouseModel`, `VectorStoreModel`, `DatabaseModel`). The MCP server captures `x-forwarded-access-token` per-request and dao-ai's existing `IsDatabricksResource.workspace_client_from(context)` machinery uses it when the flag is set.
+Defaults to **App SP** auth via Databricks Apps' auto-injected `DATABRICKS_CLIENT_ID` / `DATABRICKS_CLIENT_SECRET`. To use **OBO** (the requesting user's identity), set `on_behalf_of_user: true` on the relevant resource model (`GenieRoomModel`, `WarehouseModel`, `AiSearchIndexModel` / `VectorStoreModel`, `DatabaseModel`). The MCP server captures `x-forwarded-access-token` per-request and dao-ai's existing `IsDatabricksResource.workspace_client_from(context)` machinery uses it when the flag is set.
 
 The request-context middleware tags every log line with `obo_present=<true|false>` so you can confirm header propagation at a glance.
 
@@ -339,5 +341,5 @@ The Apps logs (`databricks apps logs <app-name> -p <profile>`) include structure
 ## Related modules
 
 - `dao_ai.apps.mcp` — **client** primitives for consuming external MCP servers from a dao-ai agent (security helpers, etc.). Independent of `dao_ai.mcp`.
-- `dao_ai.tools.create_genie_toolkit`, `dao_ai.tools.create_vector_search_tool` — the underlying factories the MCP server delegates to.
+- `dao_ai.tools.create_genie_toolkit`, `dao_ai.tools.create_ai_search_tool` (legacy alias: `create_vector_search_tool`) — the underlying factories the MCP server delegates to.
 - `dao_ai.apps.bundle.write_bundle` — the corresponding `dao-ai generate-bundle` entry point for agent deployments. `write_mcp_bundle` mirrors its shape.

--- a/docs/why-dao.md
+++ b/docs/why-dao.md
@@ -29,7 +29,7 @@ Databricks is a cloud platform where companies store and analyze their data. Thi
 Databricks provides several tools that DAO integrates with:
 - **Unity Catalog**: Your organization's data catalog with security and permissions
 - **Model Serving**: Turns AI models into APIs that applications can call
-- **Vector Search**: Finds relevant information using semantic similarity (understanding meaning, not just keywords)
+- **AI Search** (formerly Vector Search): Finds relevant information using semantic similarity (understanding meaning, not just keywords)
 - **Genie**: Lets people ask questions in plain English and automatically generates SQL queries
 - **MLflow**: Tracks experiments, versions models, and manages deployments
 

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -2791,8 +2791,42 @@
             }
           ],
           "default": "databricks_postgres",
-          "description": "Database name within the PostgreSQL server.",
+          "description": "PostgreSQL-level database name (used in connection strings / ``PGDATABASE`` at runtime). Distinct from ``database_id``, which is the Databricks resource id used in Apps resource paths. Convention for auto-provisioned Lakebase projects is underscored (``databricks_postgres``); for custom projects the pg-level name can be anything (e.g. ``vllm_analytics``). As an escape hatch, if this value is set to a full resource path (starting with ``projects/``), it takes precedence over ``database_id`` when constructing the Apps resource binding.",
           "title": "Database"
+        },
+        "database_id": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CompositeVariableModel"
+            },
+            {
+              "$ref": "#/$defs/EnvironmentVariableModel"
+            },
+            {
+              "$ref": "#/$defs/SecretVariableModel"
+            },
+            {
+              "$ref": "#/$defs/PrimitiveVariableModel"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "databricks-postgres",
+          "description": "Databricks Lakebase resource id \u2014 the hyphenated identifier at the end of the resource path ``projects/<project>/branches/<branch>/databases/<database_id>``. Distinct from ``database`` (the pg-level DB name). The default ``databricks-postgres`` matches the resource id Databricks auto-provisions with every new Lakebase project \u2014 so leaving this at default works for the common case. Override when your project has a custom-provisioned database (its resource id is whatever appears in ``databricks api get /api/2.0/postgres/projects/<p>/branches/<b>/databases``).",
+          "title": "Database Id"
         },
         "port": {
           "anyOf": [

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -753,6 +753,425 @@
       "title": "AgentModel",
       "type": "object"
     },
+    "AiSearchEndpoint": {
+      "additionalProperties": false,
+      "description": "AI Search endpoint that hosts one or more indexes.\n\n(Formerly ``VectorSearchEndpoint``. See :class:`AiSearchEndpointType`.)",
+      "properties": {
+        "name": {
+          "description": "AI Search endpoint name in the workspace.",
+          "title": "Name",
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/$defs/AiSearchEndpointType",
+          "default": "STANDARD",
+          "description": "Endpoint type: STANDARD or OPTIMIZED_STORAGE."
+        },
+        "target_qps": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Target queries-per-second for the endpoint. STANDARD only. Scales endpoint compute linearly; capacity changes take effect the next time an index on this endpoint is created or synced. Public Preview. Honored at endpoint-creation time only \u2014 if the endpoint already exists, this value is ignored.",
+          "title": "Target Qps"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "AiSearchEndpoint",
+      "type": "object"
+    },
+    "AiSearchEndpointType": {
+      "description": "AI Search endpoint compute profile.\n\n(Formerly ``VectorSearchEndpointType`` \u2014 Databricks rebranded Vector\nSearch to AI Search. The old name remains as an alias for backwards\ncompatibility; it will eventually be deprecated.)",
+      "enum": [
+        "STANDARD",
+        "OPTIMIZED_STORAGE"
+      ],
+      "title": "AiSearchEndpointType",
+      "type": "string"
+    },
+    "AiSearchIndexModel": {
+      "additionalProperties": false,
+      "description": "Configuration model for a Databricks AI Search index.\n\n(Formerly ``VectorStoreModel``. Databricks rebranded Vector Search to\nAI Search; the old class name remains as an alias defined at the end\nof the class body for backwards compatibility.)\n\nSupports two modes:\n1. **Use Existing Index**: Provide only `index` (fully qualified name).\n   Used for querying an existing vector search index at runtime.\n2. **Provisioning Mode**: Provide `source_table` + `embedding_source_column`.\n   Used for creating a new vector search index.\n\nExamples:\n    Minimal configuration (use existing index):\n    ```yaml\n    vector_stores:\n      products_search:\n        index:\n          name: catalog.schema.my_index\n    ```\n\n    Full provisioning configuration:\n    ```yaml\n    vector_stores:\n      products_search:\n        source_table:\n          schema: *my_schema\n          name: products\n        embedding_source_column: description\n        endpoint:\n          name: my_endpoint\n    ```",
+      "properties": {
+        "on_behalf_of_user": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "description": "Use the calling user's identity (OBO). Works in Model Serving and Databricks Apps.",
+          "title": "On Behalf Of User"
+        },
+        "service_principal": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ServicePrincipalModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Service principal for OAuth M2M authentication. Expands to client_id and client_secret."
+        },
+        "client_id": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CompositeVariableModel"
+            },
+            {
+              "$ref": "#/$defs/EnvironmentVariableModel"
+            },
+            {
+              "$ref": "#/$defs/SecretVariableModel"
+            },
+            {
+              "$ref": "#/$defs/PrimitiveVariableModel"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "OAuth client ID for service principal authentication.",
+          "title": "Client Id"
+        },
+        "client_secret": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CompositeVariableModel"
+            },
+            {
+              "$ref": "#/$defs/EnvironmentVariableModel"
+            },
+            {
+              "$ref": "#/$defs/SecretVariableModel"
+            },
+            {
+              "$ref": "#/$defs/PrimitiveVariableModel"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "OAuth client secret for service principal authentication.",
+          "title": "Client Secret"
+        },
+        "workspace_host": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CompositeVariableModel"
+            },
+            {
+              "$ref": "#/$defs/EnvironmentVariableModel"
+            },
+            {
+              "$ref": "#/$defs/SecretVariableModel"
+            },
+            {
+              "$ref": "#/$defs/PrimitiveVariableModel"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Databricks workspace URL (e.g., 'https://my-workspace.cloud.databricks.com').",
+          "title": "Workspace Host"
+        },
+        "pat": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CompositeVariableModel"
+            },
+            {
+              "$ref": "#/$defs/EnvironmentVariableModel"
+            },
+            {
+              "$ref": "#/$defs/SecretVariableModel"
+            },
+            {
+              "$ref": "#/$defs/PrimitiveVariableModel"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Personal access token for PAT-based authentication.",
+          "title": "Pat"
+        },
+        "index": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IndexModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Vector search index to query. Required for runtime; auto-generated in provisioning mode."
+        },
+        "source_table": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TableModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Source table for provisioning a new vector search index. Omit when using an existing index."
+        },
+        "embedding_source_column": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Column in the source table containing text to embed. Required in provisioning mode.",
+          "title": "Embedding Source Column"
+        },
+        "embedding_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InferenceEndpointModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Embedding model endpoint. Defaults to 'databricks-gte-large-en' in provisioning mode."
+        },
+        "endpoint": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AiSearchEndpoint"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Vector search endpoint hosting the index. Auto-detected in provisioning mode."
+        },
+        "source_path": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VolumePathModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Volume path for source data files (alternative to source_table)."
+        },
+        "checkpoint_path": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VolumePathModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Volume path for sync checkpoint storage."
+        },
+        "primary_key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Primary key column in the source table. Auto-detected if omitted.",
+          "title": "Primary Key"
+        },
+        "columns": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Columns to include in search results.",
+          "title": "Columns"
+        },
+        "doc_uri": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Column name containing document URIs for provenance tracking.",
+          "title": "Doc Uri"
+        }
+      },
+      "title": "AiSearchIndexModel",
+      "type": "object"
+    },
+    "AiSearchToolModel": {
+      "additionalProperties": false,
+      "description": "First-class AI Search tool that delegates to ``dao_ai.tools.create_ai_search_tool``.\n\n(Formerly ``VectorSearchToolModel``. Databricks rebranded Vector Search\nto AI Search; the old class name remains as an alias.)\n\nEquivalent to ``type: factory + name: dao_ai.tools.create_ai_search_tool``,\nbut with typed fields. Exactly one of ``retriever`` or ``vector_store`` is\nrequired. Accepts either ``type: ai_search`` (new) or ``type: vector_search``\n(legacy) in YAML.",
+      "properties": {
+        "type": {
+          "default": "ai_search",
+          "description": "Function type discriminator. Accepts 'ai_search' (preferred) or 'vector_search' (legacy alias).",
+          "enum": [
+            "vector_search",
+            "ai_search"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "human_in_the_loop": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HumanInTheLoopModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Human-in-the-loop approval configuration for this tool."
+        },
+        "retriever": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RetrieverModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Full retriever configuration with search parameters and reranking. Mutually exclusive with vector_store."
+        },
+        "vector_store": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AiSearchIndexModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Direct AI Search index reference (uses default search parameters). Mutually exclusive with retriever."
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Tool name visible to the LLM.",
+          "title": "Name"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Tool description shown to the LLM during function calling.",
+          "title": "Description"
+        }
+      },
+      "title": "AiSearchToolModel",
+      "type": "object"
+    },
     "AppModel": {
       "additionalProperties": false,
       "description": "Application-level configuration for deployment, model registration, and orchestration.",
@@ -6466,7 +6885,7 @@
         "vector_search": {
           "anyOf": [
             {
-              "$ref": "#/$defs/VectorStoreModel"
+              "$ref": "#/$defs/AiSearchIndexModel"
             },
             {
               "type": "null"
@@ -7533,7 +7952,7 @@
         },
         "vector_stores": {
           "additionalProperties": {
-            "$ref": "#/$defs/VectorStoreModel"
+            "$ref": "#/$defs/AiSearchIndexModel"
           },
           "description": "Vector search index configurations for semantic retrieval.",
           "title": "Vector Stores",
@@ -7654,7 +8073,7 @@
       "description": "Retriever combining a vector store with search parameters, reranking, and instructed retrieval.",
       "properties": {
         "vector_store": {
-          "$ref": "#/$defs/VectorStoreModel",
+          "$ref": "#/$defs/AiSearchIndexModel",
           "description": "Vector search index configuration used for similarity search."
         },
         "columns": {
@@ -8738,7 +9157,7 @@
               "$ref": "#/$defs/GenieToolModel"
             },
             {
-              "$ref": "#/$defs/VectorSearchToolModel"
+              "$ref": "#/$defs/AiSearchToolModel"
             },
             {
               "$ref": "#/$defs/SearchToolModel"
@@ -8998,422 +9417,6 @@
         }
       },
       "title": "UnityCatalogFunctionSqlTestModel",
-      "type": "object"
-    },
-    "VectorSearchEndpoint": {
-      "additionalProperties": false,
-      "description": "Vector search endpoint that hosts one or more vector search indexes.",
-      "properties": {
-        "name": {
-          "description": "Vector search endpoint name in the workspace.",
-          "title": "Name",
-          "type": "string"
-        },
-        "type": {
-          "$ref": "#/$defs/VectorSearchEndpointType",
-          "default": "STANDARD",
-          "description": "Endpoint type: STANDARD or OPTIMIZED_STORAGE."
-        },
-        "target_qps": {
-          "anyOf": [
-            {
-              "exclusiveMinimum": 0,
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Target queries-per-second for the endpoint. STANDARD only. Scales endpoint compute linearly; capacity changes take effect the next time an index on this endpoint is created or synced. Public Preview. Honored at endpoint-creation time only \u2014 if the endpoint already exists, this value is ignored.",
-          "title": "Target Qps"
-        }
-      },
-      "required": [
-        "name"
-      ],
-      "title": "VectorSearchEndpoint",
-      "type": "object"
-    },
-    "VectorSearchEndpointType": {
-      "description": "Vector search endpoint compute profile.",
-      "enum": [
-        "STANDARD",
-        "OPTIMIZED_STORAGE"
-      ],
-      "title": "VectorSearchEndpointType",
-      "type": "string"
-    },
-    "VectorSearchToolModel": {
-      "additionalProperties": false,
-      "description": "First-class Vector Search tool that delegates to ``dao_ai.tools.create_vector_search_tool``.\n\nEquivalent to ``type: factory + name: dao_ai.tools.create_vector_search_tool``,\nbut with typed fields. Exactly one of ``retriever`` or ``vector_store`` is\nrequired.",
-      "properties": {
-        "type": {
-          "const": "vector_search",
-          "default": "vector_search",
-          "description": "Function type discriminator. Must be 'vector_search'.",
-          "title": "Type",
-          "type": "string"
-        },
-        "human_in_the_loop": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/HumanInTheLoopModel"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Human-in-the-loop approval configuration for this tool."
-        },
-        "retriever": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RetrieverModel"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Full retriever configuration with search parameters and reranking. Mutually exclusive with vector_store."
-        },
-        "vector_store": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/VectorStoreModel"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Direct vector store reference (uses default search parameters). Mutually exclusive with retriever."
-        },
-        "name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Tool name visible to the LLM.",
-          "title": "Name"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Tool description shown to the LLM during function calling.",
-          "title": "Description"
-        }
-      },
-      "title": "VectorSearchToolModel",
-      "type": "object"
-    },
-    "VectorStoreModel": {
-      "additionalProperties": false,
-      "description": "Configuration model for a Databricks Vector Search store.\n\nSupports two modes:\n1. **Use Existing Index**: Provide only `index` (fully qualified name).\n   Used for querying an existing vector search index at runtime.\n2. **Provisioning Mode**: Provide `source_table` + `embedding_source_column`.\n   Used for creating a new vector search index.\n\nExamples:\n    Minimal configuration (use existing index):\n    ```yaml\n    vector_stores:\n      products_search:\n        index:\n          name: catalog.schema.my_index\n    ```\n\n    Full provisioning configuration:\n    ```yaml\n    vector_stores:\n      products_search:\n        source_table:\n          schema: *my_schema\n          name: products\n        embedding_source_column: description\n        endpoint:\n          name: my_endpoint\n    ```",
-      "properties": {
-        "on_behalf_of_user": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": false,
-          "description": "Use the calling user's identity (OBO). Works in Model Serving and Databricks Apps.",
-          "title": "On Behalf Of User"
-        },
-        "service_principal": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ServicePrincipalModel"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Service principal for OAuth M2M authentication. Expands to client_id and client_secret."
-        },
-        "client_id": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/CompositeVariableModel"
-            },
-            {
-              "$ref": "#/$defs/EnvironmentVariableModel"
-            },
-            {
-              "$ref": "#/$defs/SecretVariableModel"
-            },
-            {
-              "$ref": "#/$defs/PrimitiveVariableModel"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "integer"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "OAuth client ID for service principal authentication.",
-          "title": "Client Id"
-        },
-        "client_secret": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/CompositeVariableModel"
-            },
-            {
-              "$ref": "#/$defs/EnvironmentVariableModel"
-            },
-            {
-              "$ref": "#/$defs/SecretVariableModel"
-            },
-            {
-              "$ref": "#/$defs/PrimitiveVariableModel"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "integer"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "OAuth client secret for service principal authentication.",
-          "title": "Client Secret"
-        },
-        "workspace_host": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/CompositeVariableModel"
-            },
-            {
-              "$ref": "#/$defs/EnvironmentVariableModel"
-            },
-            {
-              "$ref": "#/$defs/SecretVariableModel"
-            },
-            {
-              "$ref": "#/$defs/PrimitiveVariableModel"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "integer"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Databricks workspace URL (e.g., 'https://my-workspace.cloud.databricks.com').",
-          "title": "Workspace Host"
-        },
-        "pat": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/CompositeVariableModel"
-            },
-            {
-              "$ref": "#/$defs/EnvironmentVariableModel"
-            },
-            {
-              "$ref": "#/$defs/SecretVariableModel"
-            },
-            {
-              "$ref": "#/$defs/PrimitiveVariableModel"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "integer"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Personal access token for PAT-based authentication.",
-          "title": "Pat"
-        },
-        "index": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/IndexModel"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Vector search index to query. Required for runtime; auto-generated in provisioning mode."
-        },
-        "source_table": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TableModel"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Source table for provisioning a new vector search index. Omit when using an existing index."
-        },
-        "embedding_source_column": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Column in the source table containing text to embed. Required in provisioning mode.",
-          "title": "Embedding Source Column"
-        },
-        "embedding_model": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InferenceEndpointModel"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Embedding model endpoint. Defaults to 'databricks-gte-large-en' in provisioning mode."
-        },
-        "endpoint": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/VectorSearchEndpoint"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Vector search endpoint hosting the index. Auto-detected in provisioning mode."
-        },
-        "source_path": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/VolumePathModel"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Volume path for source data files (alternative to source_table)."
-        },
-        "checkpoint_path": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/VolumePathModel"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Volume path for sync checkpoint storage."
-        },
-        "primary_key": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Primary key column in the source table. Auto-detected if omitted.",
-          "title": "Primary Key"
-        },
-        "columns": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Columns to include in search results.",
-          "title": "Columns"
-        },
-        "doc_uri": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Column name containing document URIs for provenance tracking.",
-          "title": "Doc Uri"
-        }
-      },
-      "title": "VectorStoreModel",
       "type": "object"
     },
     "VerifierModel": {

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -1632,12 +1632,13 @@
         },
         "type": {
           "default": "string",
-          "description": "Column data type for value validation",
+          "description": "Column data type. ``array`` denotes an ARRAY<primitive> column on the index; on Databricks VS Standard endpoints these filter via element containment (equality only). The element type is irrelevant for filtering, so a single ``array`` value covers ARRAY<STRING>, ARRAY<INT>, etc.",
           "enum": [
             "string",
             "number",
             "boolean",
-            "datetime"
+            "datetime",
+            "array"
           ],
           "title": "Type",
           "type": "string"
@@ -7660,7 +7661,14 @@
           "anyOf": [
             {
               "items": {
-                "type": "string"
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/$defs/ColumnInfo"
+                  }
+                ]
               },
               "type": "array"
             },
@@ -7668,7 +7676,7 @@
               "type": "null"
             }
           ],
-          "description": "Columns to return from search results. Defaults to the vector store's columns.",
+          "description": "Columns to expose to the LLM as filterable + returnable. Accepts either bare strings (name only \u2014 types are discovered from the index at build time via UC Tables) or ColumnInfo objects that declare name / type / operators / description. Hand-declared ColumnInfo items are authoritative and skip build-time discovery. The two forms may be mixed in one list. Defaults to the vector store's columns (bare strings).",
           "title": "Columns"
         },
         "search_parameters": {

--- a/src/dao_ai/apps/resources.py
+++ b/src/dao_ai/apps/resources.py
@@ -495,76 +495,60 @@ def _resolve_lakebase_branch_path(db: DatabaseModel) -> str:
     return f"projects/{db.project}/branches/{branch_id}"
 
 
+_LAKEBASE_DEFAULT_DATABASE_RESOURCE_ID: str = "databricks-postgres"
+"""Backstop default for ``DatabaseModel.database_id`` when the field is None.
+
+Pydantic already defaults ``DatabaseModel.database_id`` to
+``"databricks-postgres"`` (the Databricks auto-provisioning convention),
+so this constant only matters if a caller passes a ``DatabaseModel``
+built without going through the normal Pydantic path (e.g. tests that
+construct raw dicts or bypass defaults).
+
+Kept as a module constant so the "magic string" lives in exactly one
+place and is grep-able.
+"""
+
+
 def _resolve_lakebase_database_path(db: DatabaseModel, branch_path: str) -> str:
     """Return the Apps-platform database resource path for a Lakebase database.
 
-    The Apps platform's ``postgres`` resource ``database`` field requires
-    full resource form:
-    ``projects/{project_id}/branches/{branch_id}/databases/{database_id}``.
+    Pure config rendering — no SDK call, no auth dependency at
+    bundle-generation time. Two paths:
 
-    The Lakebase ``Database`` resource carries two distinct names:
+    1. If ``db.database`` is already a full resource path
+       (``projects/<p>/branches/<b>/databases/<id>``), return it verbatim.
+       This is the historical escape hatch for configs that pre-declared
+       the full path.
+    2. Otherwise, construct ``{branch_path}/databases/{db.database_id}``.
+       ``db.database_id`` defaults to ``"databricks-postgres"`` in the
+       Pydantic field, which matches the resource id Databricks
+       auto-provisions with every new Lakebase project. Users with a
+       custom-provisioned database (e.g. resource id
+       ``db-vllm-t1lbxazynr``) simply override ``database_id`` in YAML —
+       no need to construct the full resource path by hand.
 
-    1. ``Database.name`` -- the platform resource path (random ID suffix,
-       e.g. ``db-pmke-laez4ing20``). This is what the Apps platform binds to.
-    2. ``Database.status.postgres_database`` -- the Postgres-level database
-       name used by the connection (e.g. ``databricks_postgres``). This is
-       what ``DatabaseModel.database`` carries in dao-ai configs.
-
-    Resolution rules:
-
-    * If ``db.database`` already looks like a full resource path
-      (``projects/.../databases/...``), return it as-is.
-    * Otherwise, list databases under the branch and find the one whose
-      ``status.postgres_database`` matches ``db.database``; return its
-      ``name``.
-    * If no match is found, fall back to the first database under the
-      branch (most Lakebase projects have exactly one).
-    * If the API call fails or returns no databases, raise ``RuntimeError``
-      with a clear message. Silently constructing a path from ``db.database``
-      produces a deploy-time 404 (``db.database`` is the pg-level database
-      name -- typically ``databricks_postgres`` -- not the Lakebase resource
-      id -- typically ``databricks-postgres``); this manifests as a mystery
-      404 far from the auth root cause. Fail loud instead.
+    Validation happens at deploy time — Databricks Apps API rejects a
+    non-existent resource path with a clear error naming the exact
+    resource. Matches Terraform's ``databricks_app`` provider behavior
+    (which also takes the resource path verbatim from user config).
     """
     from dao_ai.config import value_of
 
     database_value = value_of(db.database) if db.database is not None else None
-    database_id: str = str(database_value) if database_value is not None else ""
+    database_str: str = str(database_value) if database_value is not None else ""
 
-    if database_id.startswith("projects/") and "/databases/" in database_id:
-        return database_id
+    if database_str.startswith("projects/") and "/databases/" in database_str:
+        return database_str
 
-    try:
-        w = db.workspace_client
-        databases = list(w.postgres.list_databases(branch_path))
-    except Exception as e:
-        raise RuntimeError(
-            f"Could not list Lakebase databases under '{branch_path}': {e}. "
-            f"The Databricks profile in scope cannot reach this Lakebase project. "
-            f"Re-run with `-p <profile>` / `--profile <profile>` pointing at a "
-            f"workspace where the '{db.project}' project lives."
-        ) from e
-
-    if database_id:
-        for d in databases:
-            pg_name = d.status.postgres_database if d.status else None
-            if pg_name == database_id and d.name:
-                return d.name
-
-    if databases and databases[0].name:
-        if database_id:
-            logger.debug(
-                f"No Lakebase database matched postgres name '{database_id}' under "
-                f"'{branch_path}'; falling back to first database "
-                f"'{databases[0].name}'."
-            )
-        return databases[0].name
-
-    raise RuntimeError(
-        f"No Lakebase databases found under '{branch_path}'. Provision the "
-        f"database before generating the bundle, or re-run with `-p <profile>` "
-        f"pointing at the workspace where the '{db.project}' project lives."
+    database_id_value = (
+        value_of(db.database_id) if db.database_id is not None else None
     )
+    database_id: str = (
+        str(database_id_value)
+        if database_id_value
+        else _LAKEBASE_DEFAULT_DATABASE_RESOURCE_ID
+    )
+    return f"{branch_path}/databases/{database_id}"
 
 
 def _extract_app_resources(

--- a/src/dao_ai/apps/resources.py
+++ b/src/dao_ai/apps/resources.py
@@ -519,9 +519,12 @@ def _resolve_lakebase_database_path(db: DatabaseModel, branch_path: str) -> str:
       ``name``.
     * If no match is found, fall back to the first database under the
       branch (most Lakebase projects have exactly one).
-    * If the API call fails entirely, fall back to constructing a path
-      from ``db.database`` -- the deploy will surface a clear platform
-      error if the constructed path doesn't exist.
+    * If the API call fails or returns no databases, raise ``RuntimeError``
+      with a clear message. Silently constructing a path from ``db.database``
+      produces a deploy-time 404 (``db.database`` is the pg-level database
+      name -- typically ``databricks_postgres`` -- not the Lakebase resource
+      id -- typically ``databricks-postgres``); this manifests as a mystery
+      404 far from the auth root cause. Fail loud instead.
     """
     from dao_ai.config import value_of
 
@@ -534,12 +537,13 @@ def _resolve_lakebase_database_path(db: DatabaseModel, branch_path: str) -> str:
     try:
         w = db.workspace_client
         databases = list(w.postgres.list_databases(branch_path))
-    except Exception as e:  # pragma: no cover -- defensive fallback
-        logger.debug(
-            f"Could not list databases under '{branch_path}': {e}. "
-            f"Falling back to constructed path with database_id='{database_id}'."
-        )
-        return f"{branch_path}/databases/{database_id}"
+    except Exception as e:
+        raise RuntimeError(
+            f"Could not list Lakebase databases under '{branch_path}': {e}. "
+            f"The Databricks profile in scope cannot reach this Lakebase project. "
+            f"Re-run with `-p <profile>` / `--profile <profile>` pointing at a "
+            f"workspace where the '{db.project}' project lives."
+        ) from e
 
     if database_id:
         for d in databases:
@@ -556,7 +560,11 @@ def _resolve_lakebase_database_path(db: DatabaseModel, branch_path: str) -> str:
             )
         return databases[0].name
 
-    return f"{branch_path}/databases/{database_id}"
+    raise RuntimeError(
+        f"No Lakebase databases found under '{branch_path}'. Provision the "
+        f"database before generating the bundle, or re-run with `-p <profile>` "
+        f"pointing at the workspace where the '{db.project}' project lives."
+    )
 
 
 def _extract_app_resources(

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -1133,22 +1133,30 @@ LLMModel = InferenceEndpointModel
 BestOfNConfig.model_rebuild()
 
 
-class VectorSearchEndpointType(str, Enum):
-    """Vector search endpoint compute profile."""
+class AiSearchEndpointType(str, Enum):
+    """AI Search endpoint compute profile.
+
+    (Formerly ``VectorSearchEndpointType`` — Databricks rebranded Vector
+    Search to AI Search. The old name remains as an alias for backwards
+    compatibility; it will eventually be deprecated.)
+    """
 
     STANDARD = "STANDARD"
     OPTIMIZED_STORAGE = "OPTIMIZED_STORAGE"
 
 
-class VectorSearchEndpoint(BaseModel):
-    """Vector search endpoint that hosts one or more vector search indexes."""
+class AiSearchEndpoint(BaseModel):
+    """AI Search endpoint that hosts one or more indexes.
+
+    (Formerly ``VectorSearchEndpoint``. See :class:`AiSearchEndpointType`.)
+    """
 
     model_config = ConfigDict(use_enum_values=True, extra="forbid")
     name: str = Field(
-        description="Vector search endpoint name in the workspace.",
+        description="AI Search endpoint name in the workspace.",
     )
-    type: VectorSearchEndpointType = Field(
-        default=VectorSearchEndpointType.STANDARD,
+    type: AiSearchEndpointType = Field(
+        default=AiSearchEndpointType.STANDARD,
         description="Endpoint type: STANDARD or OPTIMIZED_STORAGE.",
     )
     target_qps: Optional[int] = Field(
@@ -1164,9 +1172,9 @@ class VectorSearchEndpoint(BaseModel):
     )
 
     @field_serializer("type")
-    def serialize_type(self, value: VectorSearchEndpointType) -> str:
+    def serialize_type(self, value: AiSearchEndpointType) -> str:
         """Ensure enum is serialized to string value."""
-        if isinstance(value, VectorSearchEndpointType):
+        if isinstance(value, AiSearchEndpointType):
             return value.value
         return str(value)
 
@@ -1175,12 +1183,18 @@ class VectorSearchEndpoint(BaseModel):
         """Reject target_qps on non-STANDARD endpoints (SDK constraint)."""
         if (
             self.target_qps is not None
-            and self.type != VectorSearchEndpointType.STANDARD
+            and self.type != AiSearchEndpointType.STANDARD
         ):
             raise ValueError(
                 f"target_qps is only supported on STANDARD endpoints, not {self.type!r}"
             )
         return self
+
+
+# Backwards-compatible aliases — Vector Search naming will eventually be
+# deprecated. Both names refer to the same class.
+VectorSearchEndpointType = AiSearchEndpointType
+VectorSearchEndpoint = AiSearchEndpoint
 
 
 class IndexModel(IsDatabricksResource, HasFullName):
@@ -2934,9 +2948,13 @@ class SkillModel(BaseModel):
         )
 
 
-class VectorStoreModel(IsDatabricksResource, ManagedResource):
+class AiSearchIndexModel(IsDatabricksResource, ManagedResource):
     """
-    Configuration model for a Databricks Vector Search store.
+    Configuration model for a Databricks AI Search index.
+
+    (Formerly ``VectorStoreModel``. Databricks rebranded Vector Search to
+    AI Search; the old class name remains as an alias defined at the end
+    of the class body for backwards compatibility.)
 
     Supports two modes:
     1. **Use Existing Index**: Provide only `index` (fully qualified name).
@@ -3281,6 +3299,11 @@ class VectorStoreModel(IsDatabricksResource, ManagedResource):
             raise ValueError("index is required for provisioning")
 
         provider.create_vector_store(self)
+
+
+# Backwards-compatible alias — Vector Search naming will eventually be
+# deprecated. Both names refer to the same class.
+VectorStoreModel = AiSearchIndexModel
 
 
 class ConnectionModel(IsDatabricksResource, HasFullName):
@@ -4486,7 +4509,11 @@ class FunctionType(str, Enum):
     MCP = "mcp"
     INLINE = "inline"
     GENIE = "genie"
+    # Vector Search was renamed to AI Search by Databricks. Both YAML
+    # values (``vector_search`` and ``ai_search``) route to the same
+    # tool model; ``vector_search`` will eventually be deprecated.
     VECTOR_SEARCH = "vector_search"
+    AI_SEARCH = "ai_search"
     SEARCH = "search"
     APP = "app"
     SERVING_ENDPOINT = "serving_endpoint"
@@ -4552,7 +4579,7 @@ class BaseFunctionModel(ABC, BaseModel):
         discriminator="type",
     )
     type: FunctionType = Field(
-        description="Function type discriminator (python, factory, inline, mcp, unity_catalog, genie, vector_search, search, agent, a2a).",
+        description="Function type discriminator (python, factory, inline, mcp, unity_catalog, genie, ai_search, vector_search (legacy alias for ai_search), search, agent, a2a).",
     )
     human_in_the_loop: Optional[HumanInTheLoopModel] = Field(
         default=None,
@@ -5178,26 +5205,33 @@ class GenieToolModel(BaseFunctionModel):
         return [result]
 
 
-class VectorSearchToolModel(BaseFunctionModel):
-    """First-class Vector Search tool that delegates to ``dao_ai.tools.create_vector_search_tool``.
+class AiSearchToolModel(BaseFunctionModel):
+    """First-class AI Search tool that delegates to ``dao_ai.tools.create_ai_search_tool``.
 
-    Equivalent to ``type: factory + name: dao_ai.tools.create_vector_search_tool``,
+    (Formerly ``VectorSearchToolModel``. Databricks rebranded Vector Search
+    to AI Search; the old class name remains as an alias.)
+
+    Equivalent to ``type: factory + name: dao_ai.tools.create_ai_search_tool``,
     but with typed fields. Exactly one of ``retriever`` or ``vector_store`` is
-    required.
+    required. Accepts either ``type: ai_search`` (new) or ``type: vector_search``
+    (legacy) in YAML.
     """
 
     model_config = ConfigDict(use_enum_values=True, extra="forbid")
-    type: Literal[FunctionType.VECTOR_SEARCH] = Field(
-        default=FunctionType.VECTOR_SEARCH,
-        description="Function type discriminator. Must be 'vector_search'.",
+    type: Literal[FunctionType.VECTOR_SEARCH, FunctionType.AI_SEARCH] = Field(
+        default=FunctionType.AI_SEARCH,
+        description=(
+            "Function type discriminator. Accepts 'ai_search' (preferred) "
+            "or 'vector_search' (legacy alias)."
+        ),
     )
     retriever: Optional[RetrieverModel] = Field(
         default=None,
         description="Full retriever configuration with search parameters and reranking. Mutually exclusive with vector_store.",
     )
-    vector_store: Optional[VectorStoreModel] = Field(
+    vector_store: Optional[AiSearchIndexModel] = Field(
         default=None,
-        description="Direct vector store reference (uses default search parameters). Mutually exclusive with retriever.",
+        description="Direct AI Search index reference (uses default search parameters). Mutually exclusive with retriever.",
     )
     name: Optional[str] = Field(
         default=None,
@@ -5212,25 +5246,30 @@ class VectorSearchToolModel(BaseFunctionModel):
     def _retriever_or_vector_store(self) -> Self:
         if self.retriever is None and self.vector_store is None:
             raise ValueError(
-                "VectorSearchToolModel requires exactly one of 'retriever' or 'vector_store'."
+                "AiSearchToolModel requires exactly one of 'retriever' or 'vector_store'."
             )
         if self.retriever is not None and self.vector_store is not None:
             raise ValueError(
-                "VectorSearchToolModel cannot accept both 'retriever' and 'vector_store'."
+                "AiSearchToolModel cannot accept both 'retriever' and 'vector_store'."
             )
         return self
 
     def as_tools(self, **kwargs: Any) -> Sequence[RunnableLike]:
-        from dao_ai.tools import create_vector_search_tool
+        from dao_ai.tools import create_ai_search_tool
 
         return [
-            create_vector_search_tool(
+            create_ai_search_tool(
                 retriever=self.retriever,
                 vector_store=self.vector_store,
                 name=self.name,
                 description=self.description,
             )
         ]
+
+
+# Backwards-compatible alias — Vector Search naming will eventually be
+# deprecated. Both names refer to the same class.
+VectorSearchToolModel = AiSearchToolModel
 
 
 class SearchToolModel(BaseFunctionModel):
@@ -5585,7 +5624,7 @@ AnyTool: TypeAlias = (
         UnityCatalogFunctionModel,
         McpFunctionModel,
         GenieToolModel,
-        VectorSearchToolModel,
+        AiSearchToolModel,
         SearchToolModel,
         AppToolModel,
         ServingEndpointToolModel,

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -4430,9 +4430,17 @@ class RetrieverModel(BaseModel):
     vector_store: VectorStoreModel = Field(
         description="Vector search index configuration used for similarity search.",
     )
-    columns: Optional[list[str]] = Field(
+    columns: Optional[list[str | ColumnInfo]] = Field(
         default_factory=list,
-        description="Columns to return from search results. Defaults to the vector store's columns.",
+        description=(
+            "Columns to expose to the LLM as filterable + returnable. Accepts "
+            "either bare strings (name only — types are discovered from the "
+            "index at build time via UC Tables) or ColumnInfo objects that "
+            "declare name / type / operators / description. Hand-declared "
+            "ColumnInfo items are authoritative and skip build-time discovery. "
+            "The two forms may be mixed in one list. Defaults to the vector "
+            "store's columns (bare strings)."
+        ),
     )
     search_parameters: SearchParametersModel = Field(
         default_factory=SearchParametersModel,
@@ -4450,8 +4458,7 @@ class RetrieverModel(BaseModel):
     @model_validator(mode="after")
     def set_default_columns(self) -> Self:
         if not self.columns:
-            columns: Sequence[str] = self.vector_store.columns
-            self.columns = columns
+            self.columns = list(self.vector_store.columns or [])
         return self
 
     @model_validator(mode="after")

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -4149,9 +4149,15 @@ class ColumnInfo(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str = Field(description="Column name as it appears in the database")
-    type: Literal["string", "number", "boolean", "datetime"] = Field(
+    type: Literal["string", "number", "boolean", "datetime", "array"] = Field(
         default="string",
-        description="Column data type for value validation",
+        description=(
+            "Column data type. ``array`` denotes an ARRAY<primitive> column "
+            "on the index; on Databricks VS Standard endpoints these filter "
+            "via element containment (equality only). The element type is "
+            "irrelevant for filtering, so a single ``array`` value covers "
+            "ARRAY<STRING>, ARRAY<INT>, etc."
+        ),
     )
     operators: list[str] = Field(
         default=["", "NOT", "<", "<=", ">", ">=", "LIKE", "NOT LIKE"],

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -3416,7 +3416,32 @@ class DatabaseModel(IsDatabricksResource):
     )
     database: Optional[AnyVariable] = Field(
         default="databricks_postgres",
-        description="Database name within the PostgreSQL server.",
+        description=(
+            "PostgreSQL-level database name (used in connection strings / "
+            "``PGDATABASE`` at runtime). Distinct from ``database_id``, "
+            "which is the Databricks resource id used in Apps resource "
+            "paths. Convention for auto-provisioned Lakebase projects is "
+            "underscored (``databricks_postgres``); for custom projects "
+            "the pg-level name can be anything (e.g. ``vllm_analytics``). "
+            "As an escape hatch, if this value is set to a full resource "
+            "path (starting with ``projects/``), it takes precedence over "
+            "``database_id`` when constructing the Apps resource binding."
+        ),
+    )
+    database_id: Optional[AnyVariable] = Field(
+        default="databricks-postgres",
+        description=(
+            "Databricks Lakebase resource id — the hyphenated identifier at "
+            "the end of the resource path "
+            "``projects/<project>/branches/<branch>/databases/<database_id>``. "
+            "Distinct from ``database`` (the pg-level DB name). The default "
+            "``databricks-postgres`` matches the resource id Databricks "
+            "auto-provisions with every new Lakebase project — so leaving "
+            "this at default works for the common case. Override when your "
+            "project has a custom-provisioned database (its resource id is "
+            "whatever appears in ``databricks api get "
+            "/api/2.0/postgres/projects/<p>/branches/<b>/databases``)."
+        ),
     )
     port: Optional[AnyVariable] = Field(
         default=5432,

--- a/src/dao_ai/tools/__init__.py
+++ b/src/dao_ai/tools/__init__.py
@@ -38,7 +38,10 @@ from dao_ai.tools.time import (
     time_until_tool,
 )
 from dao_ai.tools.unity_catalog import create_uc_tools
-from dao_ai.tools.vector_search import create_vector_search_tool
+from dao_ai.tools.vector_search import (
+    create_ai_search_tool,
+    create_vector_search_tool,
+)
 from dao_ai.tools.vertex_agent_engine import create_vertex_agent_engine_tool
 from dao_ai.tools.visualization import create_visualization_tool
 
@@ -76,6 +79,7 @@ __all__ = [
     "create_send_teams_message_tool",
     "create_tools",
     "create_uc_tools",
+    "create_ai_search_tool",
     "create_vector_search_tool",
     "create_visualization_tool",
     "current_time_tool",

--- a/src/dao_ai/tools/vector_search.py
+++ b/src/dao_ai/tools/vector_search.py
@@ -300,23 +300,39 @@ def _vsc_for_refresh(vector_store: "VectorStoreModel") -> VectorSearchClient | N
 
 
 def _vector_column_names_from_describe(details: dict | None) -> set[str]:
-    """Return the exact managed-embedding vector column names.
+    """Return the exact vector column names to strip from an index probe.
 
-    Databricks synthesises one vector column per ``embedding_source_column``
-    named ``<source>_vector``. We read the source names from ``describe()``
-    so we strip *only* those synthetics — never a business column that
-    happens to end in ``_vector``.
+    Handles both embedding modes and both index-spec containers:
+
+      * **Managed embeddings** — Databricks synthesises one vector column
+        per ``embedding_source_columns[].name`` entry, named
+        ``<source>_vector``. We read the source names and mint the
+        synthesised names.
+      * **Self-managed embeddings** — the user pre-computes vectors; the
+        vector column is named by ``embedding_vector_columns[].name``
+        (any user-chosen name, e.g. ``vector`` or ``my_embedding``).
+        Strip that exact name.
+      * **Delta-Sync indexes** carry the source list under
+        ``delta_sync_index_spec``; **Direct-Access indexes** under
+        ``direct_access_index_spec``. We check both.
+
+    Reading names from ``describe()`` means we strip only actual
+    synthesised or user-declared vector columns — never a business column
+    that happens to end in ``_vector``.
     """
     if not isinstance(details, dict):
         return set()
-    delta_spec = details.get("delta_sync_index_spec") or {}
-    src_cols = delta_spec.get("embedding_source_columns") or []
     names: set[str] = set()
-    for entry in src_cols:
-        if isinstance(entry, dict):
-            src = entry.get("name")
-            if src:
+    for spec_key in ("delta_sync_index_spec", "direct_access_index_spec"):
+        spec = details.get(spec_key) or {}
+        # Managed embeddings: strip ``<source>_vector``.
+        for entry in spec.get("embedding_source_columns") or []:
+            if isinstance(entry, dict) and (src := entry.get("name")):
                 names.add(f"{src}_vector")
+        # Self-managed embeddings: strip the user-declared name directly.
+        for entry in spec.get("embedding_vector_columns") or []:
+            if isinstance(entry, dict) and (vec := entry.get("name")):
+                names.add(vec)
     return names
 
 
@@ -388,41 +404,65 @@ def _probe_index_columns(
         return names or None
     except Exception as e:  # noqa: BLE001
         logger.debug(
-            "Vector index column probe (scan) failed; "
-            "falling back to source-table columns",
+            "Vector index column probe (scan) failed",
             index=vector_store.index.full_name,
             error=f"{type(e).__name__}: {e}",
         )
         return None
 
 
-def _fetch_column_types(vector_store: "VectorStoreModel") -> dict[str, str] | None:
-    """Return ``{column_name: databricks_type_string}`` from the source table.
+def _fetch_index_column_types(
+    vector_store: "VectorStoreModel",
+) -> dict[str, str] | None:
+    """Return ``{column_name: databricks_type_string}`` from the INDEX itself.
 
-    Uses the Unity Catalog Tables API via the ``VectorStoreModel``'s ambient
-    ``WorkspaceClient``. Returns ``None`` when the source table is unknown or
-    the API call fails — callers should treat that as "unknown types" and
-    permit all operators on all columns.
+    A Vector Search index is a UC entity and its columns are queryable via
+    the Unity Catalog Tables API. This is the pattern databricks-langchain
+    uses (``databricks_langchain.vector_search_retriever_tool``); it gives
+    us BOTH column names AND their Databricks types from a single
+    authoritative source — the index — without depending on the source
+    table (whose columns are a superset and not guaranteed to overlap).
+
+    Vector-embedding columns are stripped automatically:
+      * ``<source>_vector`` — managed-embedding synthesised (via describe)
+      * anything with a leading underscore — CDF / system reserved
+      * ``__db_*_vector`` — db-managed embedding vector
+
+    Returns ``None`` on any failure (soft-fail; caller keeps the
+    permissive operator behavior for every column).
     """
-    if vector_store.source_table is None:
+    if vector_store.index is None:
         return None
     try:
         wc = vector_store.workspace_client_from(None)
-        table = wc.tables.get(vector_store.source_table.full_name)
+        table = wc.tables.get(vector_store.index.full_name)
         cols = getattr(table, "columns", None) or []
-        out: dict[str, str] = {}
-        for col in cols:
-            name = getattr(col, "name", None)
-            t = getattr(col, "type_text", None) or getattr(col, "type_name", None)
-            if name and t:
-                out[name] = str(t)
-        return out or None
     except Exception as e:  # noqa: BLE001
         logger.debug(
-            "column type discovery failed; permitting all filter operators",
+            "UC Tables lookup on VS index failed; "
+            "type-aware operator narrowing disabled",
+            index=vector_store.index.full_name,
             error=f"{type(e).__name__}: {e}",
         )
         return None
+
+    known_vector_cols = _vector_column_names_from_describe(
+        getattr(vector_store, "_index_details", None)
+    )
+    out: dict[str, str] = {}
+    for col in cols:
+        name = getattr(col, "name", None)
+        t = getattr(col, "type_text", None) or getattr(col, "type_name", None)
+        if not name or not t:
+            continue
+        if name.startswith("_"):
+            continue
+        if known_vector_cols and name in known_vector_cols:
+            continue
+        if not known_vector_cols and name.endswith("_vector"):
+            continue
+        out[name] = str(t)
+    return out or None
 
 
 def _build_filter_item_model(
@@ -621,88 +661,112 @@ def create_vector_search_tool(
         raise ValueError("vector_store.index is required for vector search")
 
     index_name: str = vector_store.index.full_name
-    # ``vector_store.columns`` is the authoritative source (populated in YAML
-    # or by ``VectorStoreModel.refresh()``); ``retriever.columns`` is a
-    # projection override. The former ``vector_store.index.columns`` fallback
-    # was dead code — IndexModel does not carry that field.
-    columns: list[str] = list(retriever.columns or vector_store.columns or [])
+    # Column + type source of truth (precedence):
+    #   1. declared ``retriever.columns`` / ``vector_store.columns``, intersected
+    #      with the columns actually on the index — anything declared declared
+    #      that isn't on the index is dropped with a WARN so the LLM can
+    #      never emit a filter key that would fail at the VS API.
+    #   2. Index discovery. The index is a UC entity, so ``wc.tables.get(
+    #      index.full_name)`` returns column names AND their Databricks
+    #      types in one call (mirrors the databricks-langchain library).
+    #      Fallback: ``index.describe().columns_to_sync`` (Direct-Access) →
+    #      ``index.scan().data[0].fields[].key`` (Delta-Sync fallback).
+    #      Vector/system columns are stripped in every path.
+    #   3. Neither available → soft-fallback: build with free-form
+    #      ``FilterItem`` (LLM sees ``key: str``, pre-branch behavior).
+    #
+    # Never source-table columns: source-table has audit columns not on the
+    # index. Both column NAMES and TYPES come from the index itself.
+    declared_columns: list[str] = list(
+        retriever.columns or vector_store.columns or []
+    )
 
-    # If YAML declared no columns, try to hydrate them from the live index at
-    # tool-build time. Two-step fallback:
+    # Always attempt index discovery so we can validate declared against the
+    # live index. Two-step:
     #
-    #   1. ``VectorStoreModel.refresh()`` — reads ``index.describe()``.
-    #      Populates ``source_table``, ``primary_key``, ``endpoint``, and
-    #      (for Direct-Access indexes) ``columns`` from
-    #      ``delta_sync_index_spec.columns_to_sync``. Delta-Sync indexes do
-    #      not carry ``columns_to_sync`` in their describe response, so on
-    #      those we still need step 2.
+    #   * ``refresh()`` populates ``_index_details`` (used by probe for
+    #     vector-column stripping) and, for Direct-Access indexes only,
+    #     ``vector_store.columns`` from ``columns_to_sync``. Note that on
+    #     Delta-Sync indexes and when declared already set ``vector_store.columns``,
+    #     refresh does NOT overwrite — we cannot read ``vector_store.columns``
+    #     to distinguish "from declared" vs "from index".
+    #   * ``_probe_index_columns()`` runs ``index.scan(num_results=1)`` and
+    #     reads the actual field set off the returned document. This is
+    #     authoritative for both index types and independent of declared state.
     #
-    #   2. UC Tables API on the discovered source table — returns both
-    #      column names AND their Databricks types. We call this
-    #      unconditionally (once we have a source_table) because we want
-    #      the types anyway to build the type-aware operator enum below.
-    #
-    # Both steps are soft-fail: if either can't complete (auth, permissions,
-    # network), we log a warning and continue. The tool still builds; the
-    # LLM just gets a free-form ``key`` field (pre-change behavior).
-    # Column auto-discovery — three-step fallback, all soft-fail:
-    #
-    #   1. ``VectorStoreModel.refresh()`` → ``index.describe()`` populates
-    #      ``source_table``, ``primary_key``, ``endpoint``, and (Direct-
-    #      Access indexes only) ``columns`` from ``columns_to_sync``.
-    #   2. ``_probe_index_columns`` → ``index.scan(num_results=1)`` reads
-    #      the actual indexed column set from the returned document —
-    #      required for Delta-Sync indexes whose describe() omits
-    #      ``columns_to_sync``. This is the authoritative filter-key set:
-    #      only columns present in the *index* can be filtered on.
-    #   3. ``_fetch_column_types`` → UC Tables API on the source table
-    #      returns column names AND types. Names are a superset (source
-    #      table has audit columns not indexed); we intersect with (2) to
-    #      keep only the filterable ones and get typed operator narrowing.
-    #
-    # If YAML already declares ``columns`` we still call step 3 to get
-    # types for the operator enum. Missing types just relax the enum to
-    # all suffixes on every column (pre-change behavior).
-    column_types: dict[str, str] | None = None
-    if not columns:
-        # Only pay for a VectorSearchClient + describe + scan when the user
-        # didn't already give us columns via YAML. Everything below is
-        # soft-fail so a network hiccup / permission gap degrades the LLM
-        # experience (looser enum) but never breaks tool construction.
-        vsc_for_discovery: VectorSearchClient | None = _vsc_for_refresh(vector_store)
-        try:
-            vector_store.refresh(vsc=vsc_for_discovery)
-            columns = list(vector_store.columns or [])
-        except Exception as e:  # noqa: BLE001
-            logger.warning(
-                "Vector Search index describe() failed; "
-                "column auto-discovery may be incomplete",
-                index=index_name,
-                error=f"{type(e).__name__}: {e}",
-            )
-        if not columns:
-            probed = _probe_index_columns(vector_store, vsc_for_discovery)
-            if probed:
-                columns = probed
-
-    # Type-aware operator narrowing applies whether columns came from YAML
-    # or from discovery. We call ``_fetch_column_types`` regardless; the
-    # helper is a no-op when ``source_table`` isn't populated. Intersect
-    # with the (possibly YAML-declared) column list so we only advertise
-    # filter keys we can actually type — anything we can't type keeps its
-    # full operator suite (see :func:`_operators_for_type`).
-    if columns:
-        table_types = _fetch_column_types(vector_store)
-        if table_types:
-            in_index = set(columns)
-            column_types = {k: v for k, v in table_types.items() if k in in_index}
-
-        logger.debug(
-            "Vector Search columns resolved",
+    # Soft-fail: if both steps fail and declared has columns, trust declared. If
+    # neither has anything, fall back to free-form ``FilterItem``.
+    discovered_columns: list[str] = []
+    columns_before_refresh = list(vector_store.columns or [])
+    vsc_for_discovery: VectorSearchClient | None = _vsc_for_refresh(vector_store)
+    try:
+        vector_store.refresh(vsc=vsc_for_discovery)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "Vector Search index describe() failed; "
+            "column auto-discovery may be incomplete",
             index=index_name,
-            columns=columns,
-            have_types=bool(column_types),
+            error=f"{type(e).__name__}: {e}",
         )
+    # Prefer UC Tables on the index — it returns names AND types together.
+    index_type_map: dict[str, str] | None = _fetch_index_column_types(vector_store)
+    if index_type_map:
+        discovered_columns = list(index_type_map.keys())
+    else:
+        # Fallback: scan (authoritative filterable set on Delta-Sync).
+        probed = _probe_index_columns(vector_store, vsc_for_discovery)
+        if probed:
+            discovered_columns = probed
+        else:
+            # Direct-Access indexes: refresh may have populated columns from
+            # ``columns_to_sync`` — accept those only if they weren't already
+            # set by declared (i.e. the value changed).
+            columns_after_refresh = list(vector_store.columns or [])
+            if (
+                columns_after_refresh
+                and columns_after_refresh != columns_before_refresh
+            ):
+                discovered_columns = columns_after_refresh
+
+    if declared_columns and discovered_columns:
+        in_index = set(discovered_columns)
+        kept: list[str] = []
+        for col in declared_columns:
+            if col in in_index:
+                kept.append(col)
+            else:
+                logger.warning(
+                    "Declared column not present on index; "
+                    "dropping from filter enum",
+                    column=col,
+                    index=index_name,
+                )
+        columns: list[str] = kept
+    elif declared_columns:
+        # Discovery failed; trust declared (best-effort — LLM may hit VS API
+        # errors if declared lists a bogus column, matching pre-branch behavior).
+        columns = declared_columns
+    else:
+        columns = discovered_columns
+
+    # Types come from the same UC entity as the columns — if the UC Tables
+    # call above succeeded, we have per-column types and can enable
+    # type-aware operator narrowing (LIKE only on strings, ordering only on
+    # numerics/temporal, etc.). Intersect with the final column set so we
+    # never advertise a type for a column we're not exposing.
+    column_types: dict[str, str] | None = None
+    if index_type_map and columns:
+        in_use = set(columns)
+        narrowed = {k: v for k, v in index_type_map.items() if k in in_use}
+        if narrowed:
+            column_types = narrowed
+
+    logger.debug(
+        "Vector Search columns resolved",
+        index=index_name,
+        columns=columns,
+        have_types=bool(column_types),
+    )
     search_parameters: SearchParametersModel = retriever.search_parameters
     rerank_config: Optional[RerankParametersModel] = retriever.rerank
     instructed_config: Optional[InstructedRetrieverModel] = retriever.instructed
@@ -882,7 +946,7 @@ def create_vector_search_tool(
         #      so DatabricksVectorSearch uses the forwarded-bearer WorkspaceClient
         #      directly.
         #   2. Explicit PAT/SP — DATABRICKS_TOKEN / DATABRICKS_CLIENT_ID env vars
-        #      OR YAML vector_store.pat / .client_id / .client_secret; already
+        #      OR declared vector_store.pat / .client_id / .client_secret; already
         #      collected into `client_args` upstream.
         #   3. Ambient App SP on Serverless v5 — WorkspaceClient.config.auth_type
         #      is oauth-m2m; the library handles it natively when we pass

--- a/src/dao_ai/tools/vector_search.py
+++ b/src/dao_ai/tools/vector_search.py
@@ -185,81 +185,39 @@ _FILTER_OPERATOR_SUFFIXES: tuple[str, ...] = (
     " NOT LIKE",
 )
 
-# Databricks type prefixes → subset of operator suffixes that make semantic
-# sense. Keys are matched case-insensitively against the *start* of the type
-# string (so "decimal(10,2)" still matches "decimal"). Anything unmatched
-# falls through to the full ``_FILTER_OPERATOR_SUFFIXES`` list — that's the
-# safe default for complex or unknown types.
-_NUMERIC_OPS: tuple[str, ...] = ("", " NOT", " <", " <=", " >", " >=")
-_STRING_OPS: tuple[str, ...] = ("", " NOT", " LIKE", " NOT LIKE")
-_BOOL_OPS: tuple[str, ...] = ("", " NOT")
-
-
-def _operators_for_type(type_str: str | None) -> tuple[str, ...]:
-    """Return the operator suffixes valid for a given Databricks column type.
-
-    Filters out combinations that don't semantically apply — e.g. ``LIKE`` on
-    an ``int``, ``<`` on a ``boolean``. Unknown / complex types (STRUCT, ARRAY,
-    MAP, custom UDT names) fall through to *all* suffixes so we don't
-    accidentally strip a legitimate combination.
-    """
-    t = (type_str or "").strip().lower()
-    if not t:
-        return _FILTER_OPERATOR_SUFFIXES
-    # Numeric family (integers + fixed/floating point + decimal).
-    if t.startswith(
-        (
-            "int",
-            "long",
-            "short",
-            "tinyint",
-            "smallint",
-            "bigint",
-            "float",
-            "double",
-            "decimal",
-            "numeric",
-            "real",
-            "byte",
-        )
-    ):
-        return _NUMERIC_OPS
-    # Temporal — ordering matters, LIKE doesn't.
-    if t.startswith(("timestamp", "date")):
-        return _NUMERIC_OPS
-    # Boolean: equality-only.
-    if t.startswith("bool"):
-        return _BOOL_OPS
-    # Binary: equality-only. Blobs don't support LIKE or ordering.
-    if t.startswith("binary"):
-        return _BOOL_OPS
-    # String family: equality + token match.
-    if t.startswith(("string", "varchar", "char", "text")):
-        return _STRING_OPS
-    # Complex types (STRUCT / ARRAY / MAP) and any unknown type fall
-    # through to *all* operators. Databricks Vector Search rejects
-    # unsupported filter combinations at query time, and stripping
-    # legitimate combinations here would be more harmful than the
-    # occasional server-side rejection.
-    return _FILTER_OPERATOR_SUFFIXES
-
 
 def _legal_filter_keys(
     columns: list[str],
-    types: dict[str, str] | None = None,
+    operator_overrides: dict[str, list[str]] | None = None,
 ) -> list[str]:
-    """Cross product of columns × operator suffixes, filtered by column type.
+    """Cross product of columns × the 8 operator suffixes.
 
-    ``["price", "name"]`` with ``{"price": "double", "name": "string"}`` →
-    ``["price", "price NOT", "price <", "price <=", "price >", "price >=",
-    "name", "name NOT", "name LIKE", "name NOT LIKE"]``. When ``types`` is
-    ``None`` or a column is missing from it, all operator suffixes are
-    permitted for that column.
+    Every column gets every suffix — no type-aware narrowing. Databricks
+    Vector Search rejects unsupported filter combinations at query time
+    (e.g. ``LIKE`` on a numeric); we let the API be the source of truth
+    for operator applicability, matching upstream databricks-langchain.
+
+    When ``operator_overrides`` names a column, that column's suffixes come
+    from the override list verbatim (bare strings like ``["", "LIKE"]``)
+    instead of the full ``_FILTER_OPERATOR_SUFFIXES`` set. This is the
+    hand-declared ``ColumnInfo.operators`` knob — users who want to lock
+    a column to a narrower operator set can do so.
+
+    Override entries are the operator strings as declared on ColumnInfo
+    (e.g. ``""``, ``"NOT"``, ``"LIKE"``) — no leading space; we add the
+    leading space here so the emitted enum shape matches
+    ``_FILTER_OPERATOR_SUFFIXES``.
     """
     result: list[str] = []
     for c in columns:
-        ops = _operators_for_type((types or {}).get(c)) if types else _FILTER_OPERATOR_SUFFIXES
-        for op in ops:
+        override = (operator_overrides or {}).get(c)
+        if override is not None:
+            # ColumnInfo.operators is stored without the leading space
+            # ("LIKE" not " LIKE"). Map to the suffix shape.
+            suffixes = tuple("" if op == "" else f" {op}" for op in override)
+        else:
+            suffixes = _FILTER_OPERATOR_SUFFIXES
+        for op in suffixes:
             result.append(f"{c}{op}")
     return result
 
@@ -336,117 +294,29 @@ def _vector_column_names_from_describe(details: dict | None) -> set[str]:
     return names
 
 
-def _explicit_columns_to_sync(details: dict | None) -> set[str] | None:
-    """Return the user-declared ``columns_to_sync`` subset, or ``None``.
-
-    Delta-Sync indexes default to syncing every source column; in that mode
-    ``describe()`` reports an empty / absent ``columns_to_sync``. When a
-    user explicitly restricts sync to a subset, the subset appears on
-    ``delta_sync_index_spec.columns_to_sync`` (or ``direct_access_index_spec``
-    for the Direct-Access variant). We use this to intersect against the
-    source-table column set so we don't advertise columns the index doesn't
-    actually carry.
-
-    Returns ``None`` when no subset is declared — the caller should treat
-    the full source-table column set as authoritative.
-    """
-    if not isinstance(details, dict):
-        return None
-    for spec_key in ("delta_sync_index_spec", "direct_access_index_spec"):
-        spec = details.get(spec_key) or {}
-        cols = spec.get("columns_to_sync")
-        if cols:
-            return {c for c in cols if isinstance(c, str)}
-    return None
-
-
-def _fetch_source_table_column_types(
+def _fetch_index_columns(
     vector_store: "VectorStoreModel",
-) -> dict[str, str] | None:
-    """Return ``{column_name: databricks_type_string}`` from the SOURCE TABLE.
-
-    Fallback for when ``_fetch_index_column_types`` (UC Tables on the INDEX)
-    fails — typically a permission / environment mismatch on the index UC
-    entity. Source-table lookup shares the exact same auth surface as the
-    primary path (both go through ``WorkspaceClient.tables.get``), so it
-    trades the auth-fragile scan-based probe for a pure metadata call.
-
-    For Delta-Sync managed-embedding indexes (the common case), the source
-    table's columns are the authoritative filterable set on the index —
-    Databricks syncs every source column plus the synthesised ``_vector``.
-    We strip:
-
-      * **Vector columns** via ``_vector_column_names_from_describe`` (both
-        managed and self-managed) — never the raw source column, only the
-        synthesised / user-declared vector name.
-      * **CDF / system fields** (leading underscore).
-
-    When ``describe()`` carries an explicit ``columns_to_sync`` subset we
-    intersect against it, so users who restrict sync only advertise the
-    columns the index actually holds.
-
-    Returns ``None`` when:
-      * There is no ``source_table`` (Direct-Access indexes; caller has one
-        more fallback via ``refresh()``'s ``columns_to_sync`` handling), or
-      * The UC Tables call fails, or
-      * After stripping there are no columns left.
-    """
-    if vector_store.source_table is None:
-        return None
-    try:
-        wc = vector_store.workspace_client_from(None)
-        table = wc.tables.get(vector_store.source_table.full_name)
-        cols = getattr(table, "columns", None) or []
-    except Exception as e:  # noqa: BLE001
-        logger.debug(
-            "UC Tables lookup on VS source_table failed; "
-            "fallback discovery unavailable",
-            source_table=vector_store.source_table.full_name,
-            error=f"{type(e).__name__}: {e}",
-        )
-        return None
-
-    details = getattr(vector_store, "_index_details", None)
-    known_vector_cols = _vector_column_names_from_describe(details)
-    sync_subset = _explicit_columns_to_sync(details)
-
-    out: dict[str, str] = {}
-    for col in cols:
-        name = getattr(col, "name", None)
-        t = getattr(col, "type_text", None) or getattr(col, "type_name", None)
-        if not name or not t:
-            continue
-        if name.startswith("_"):
-            continue
-        if known_vector_cols and name in known_vector_cols:
-            continue
-        if not known_vector_cols and name.endswith("_vector"):
-            continue
-        if sync_subset is not None and name not in sync_subset:
-            continue
-        out[name] = str(t)
-    return out or None
-
-
-def _fetch_index_column_types(
-    vector_store: "VectorStoreModel",
-) -> dict[str, str] | None:
-    """Return ``{column_name: databricks_type_string}`` from the INDEX itself.
+) -> list[tuple[str, str | None, str | None]] | None:
+    """Return ``[(name, type_str, comment)]`` from the INDEX itself.
 
     A Vector Search index is a UC entity and its columns are queryable via
-    the Unity Catalog Tables API. This is the pattern databricks-langchain
-    uses (``databricks_langchain.vector_search_retriever_tool``); it gives
-    us BOTH column names AND their Databricks types from a single
-    authoritative source — the index — without depending on the source
-    table (whose columns are a superset and not guaranteed to overlap).
+    the Unity Catalog Tables API. This is the same pattern
+    ``databricks_langchain.vector_search_retriever_tool`` uses; a single
+    ``wc.tables.get(index.full_name)`` call returns the authoritative
+    column list, their Databricks types, and any UC column comments the
+    catalog author set.
 
     Vector-embedding columns are stripped automatically:
       * ``<source>_vector`` — managed-embedding synthesised (via describe)
       * anything with a leading underscore — CDF / system reserved
       * ``__db_*_vector`` — db-managed embedding vector
 
-    Returns ``None`` on any failure (soft-fail; caller keeps the
-    permissive operator behavior for every column).
+    Returns ``None`` on any failure (soft-fail; caller falls back to
+    declared columns if present, otherwise free-form filter). No source-
+    table fallback — matches upstream databricks-langchain's single-call
+    behavior. Users hitting permission asymmetry (SP has source-table
+    grants but not index-UC-entity grants) should hand-declare via
+    ``ColumnInfo`` on ``retriever.columns``.
     """
     if vector_store.index is None:
         return None
@@ -457,7 +327,7 @@ def _fetch_index_column_types(
     except Exception as e:  # noqa: BLE001
         logger.debug(
             "UC Tables lookup on VS index failed; "
-            "type-aware operator narrowing disabled",
+            "column auto-discovery unavailable",
             index=vector_store.index.full_name,
             error=f"{type(e).__name__}: {e}",
         )
@@ -466,11 +336,10 @@ def _fetch_index_column_types(
     known_vector_cols = _vector_column_names_from_describe(
         getattr(vector_store, "_index_details", None)
     )
-    out: dict[str, str] = {}
+    out: list[tuple[str, str | None, str | None]] = []
     for col in cols:
         name = getattr(col, "name", None)
-        t = getattr(col, "type_text", None) or getattr(col, "type_name", None)
-        if not name or not t:
+        if not name:
             continue
         if name.startswith("_"):
             continue
@@ -478,13 +347,131 @@ def _fetch_index_column_types(
             continue
         if not known_vector_cols and name.endswith("_vector"):
             continue
-        out[name] = str(t)
+        t = getattr(col, "type_text", None) or getattr(col, "type_name", None)
+        comment = getattr(col, "comment", None)
+        out.append((name, str(t) if t else None, str(comment) if comment else None))
     return out or None
+
+
+# ColumnInfo.type values map to human-readable Databricks type labels used
+# in the tool description. These are not used for operator narrowing (the
+# 8 standard suffixes apply to every column) — only for the "Available
+# columns for filtering: brand (STRING) ..." block in the tool prompt.
+_COLUMN_INFO_TYPE_LABELS: dict[str, str] = {
+    "string": "STRING",
+    "number": "NUMBER",
+    "boolean": "BOOLEAN",
+    "datetime": "DATETIME",
+}
+
+
+def _normalize_declared_columns(
+    items: "list[str | ColumnInfo]",
+) -> tuple[
+    list[str],
+    dict[str, str],
+    dict[str, str],
+    dict[str, list[str]],
+    bool,
+]:
+    """Split a mixed ``list[str | ColumnInfo]`` into flat lookup tables.
+
+    Returns a tuple ``(names, types, descriptions, operator_overrides,
+    any_hand_declared)`` where:
+
+    * ``names`` — column names in declaration order
+    * ``types`` — ``{name: type_label}`` for ColumnInfo entries only;
+      bare strings do not populate this map
+    * ``descriptions`` — ``{name: description}`` for ColumnInfo entries
+      whose ``description`` field is set
+    * ``operator_overrides`` — ``{name: [ops]}`` for ColumnInfo entries
+      whose ``operators`` field was explicitly set by the user (detected
+      via Pydantic's ``model_fields_set``); other columns fall through to
+      the default 8-suffix set at ``_legal_filter_keys`` time
+    * ``any_hand_declared`` — ``True`` when at least one item is a
+      ``ColumnInfo``. Signals to the caller that hand-declaration is in
+      effect and build-time UC calls should be skipped.
+    """
+    # Late import — ColumnInfo is defined in config.py, which imports
+    # from this module transitively via the tool factory. Import at call
+    # time to avoid the circular.
+    from dao_ai.config import ColumnInfo
+
+    names: list[str] = []
+    types: dict[str, str] = {}
+    descriptions: dict[str, str] = {}
+    operator_overrides: dict[str, list[str]] = {}
+    any_hand_declared = False
+
+    for item in items:
+        if isinstance(item, ColumnInfo):
+            any_hand_declared = True
+            name = item.name
+            names.append(name)
+            type_label = _COLUMN_INFO_TYPE_LABELS.get(item.type, item.type.upper())
+            types[name] = type_label
+            if item.description:
+                descriptions[name] = item.description
+            # Only treat operators as an override when the user explicitly
+            # set them (Pydantic tracks this via model_fields_set). If the
+            # field defaulted to the full 8-op list, we let the standard
+            # `_legal_filter_keys` cross-product apply — same as bare
+            # strings — for consistency.
+            if "operators" in item.model_fields_set:
+                operator_overrides[name] = list(item.operators)
+        elif isinstance(item, str):
+            names.append(item)
+        else:
+            logger.debug(
+                "Ignoring unrecognized columns[] entry (not str or ColumnInfo)",
+                item_type=type(item).__name__,
+            )
+    return names, types, descriptions, operator_overrides, any_hand_declared
+
+
+def _build_columns_description(
+    names: list[str],
+    types: dict[str, str],
+    descriptions: dict[str, str],
+) -> str:
+    """Render the "Available columns for filtering" block.
+
+    Format matches upstream ``databricks_langchain.vector_search_retriever_tool``
+    style so the LLM sees the same shape it would from the industry-standard
+    library, plus dao-ai's per-column descriptions when available. Empty
+    ``names`` → empty string (caller can skip the block).
+
+    ``types`` and ``descriptions`` are best-effort. A column with neither is
+    listed as ``- name``.
+    """
+    if not names:
+        return ""
+
+    lines: list[str] = ["Available columns for filtering:"]
+    for name in names:
+        type_label = types.get(name)
+        desc = descriptions.get(name)
+        parts = [f"- {name}"]
+        if type_label:
+            parts.append(f"({type_label})")
+        if desc:
+            parts.append(f": {desc}")
+        elif type_label:
+            # We already emitted "(TYPE)"; nothing more needed.
+            pass
+        lines.append(" ".join(parts))
+    lines.append("")
+    lines.append(
+        "Supports operators: LIKE, NOT LIKE, NOT, <, <=, >, >=, and empty "
+        "(equality/IN). Combine into the filter key like "
+        '``{"key": "brand LIKE", "value": "DEWALT"}``.'
+    )
+    return "\n".join(lines)
 
 
 def _build_filter_item_model(
     columns: list[str],
-    types: dict[str, str] | None = None,
+    operator_overrides: dict[str, list[str]] | None = None,
 ) -> type[BaseModel]:
     """Build a per-tool FilterItem whose ``key`` is Literal-narrowed to columns.
 
@@ -495,15 +482,20 @@ def _build_filter_item_model(
     time, before the retriever is ever invoked.
 
     The narrowing surfaces on the LLM as a JSON-schema ``enum`` on the
-    ``key`` property. That is what closes the "guessed a column name that
-    doesn't exist" hallucination hole (regression: MLflow trace
+    ``key`` property. That closes the "guessed a column name that doesn't
+    exist" hallucination hole (regression: MLflow trace
     ``fc785d795b77675ac0e42fe5296b523a`` — LLM emitted ``"name NOT LIKE"``
     against a products index whose column is ``product_name``).
+
+    ``operator_overrides`` accepts per-column suffix lists from
+    hand-declared ``ColumnInfo.operators`` — users who want to lock a
+    column to a narrower operator set (e.g. ``brand`` limited to
+    ``["", "LIKE"]``) can do so.
     """
     if not columns:
         return FilterItem
 
-    legal_keys = _legal_filter_keys(columns, types)
+    legal_keys = _legal_filter_keys(columns, operator_overrides)
     key_type = Literal[*legal_keys]  # PEP 646 unpacking; Python 3.11+.
 
     return create_model(
@@ -526,7 +518,7 @@ def _build_filter_item_model(
 
 def _build_vector_search_input_model(
     columns: list[str],
-    types: dict[str, str] | None = None,
+    operator_overrides: dict[str, list[str]] | None = None,
 ) -> type[BaseModel]:
     """Build a per-tool VectorSearchInput whose ``filters[]`` is narrowed.
 
@@ -534,13 +526,15 @@ def _build_vector_search_input_model(
     :class:`VectorSearchInput` (behavior identical to pre-change). When
     columns are known, we build a subclass whose ``filters`` type is
     ``list[<DynamicFilterItem for these columns>]``, so the JSON schema
-    the LLM sees carries the enum of legal keys. Type-aware narrowing kicks
-    in when ``types`` is provided (see :func:`_operators_for_type`).
+    the LLM sees carries the enum of legal keys.
+
+    ``operator_overrides`` is forwarded to :func:`_build_filter_item_model`
+    for hand-declared ``ColumnInfo.operators`` support.
     """
     if not columns:
         return VectorSearchInput
 
-    filter_item_cls = _build_filter_item_model(columns, types)
+    filter_item_cls = _build_filter_item_model(columns, operator_overrides)
     return create_model(
         "DynamicVectorSearchInput",
         __base__=VectorSearchInput,
@@ -678,41 +672,45 @@ def create_vector_search_tool(
         raise ValueError("vector_store.index is required for vector search")
 
     index_name: str = vector_store.index.full_name
-    # Column + type source of truth (precedence):
-    #   1. declared ``retriever.columns`` / ``vector_store.columns``, intersected
-    #      with the columns actually on the index — anything declared declared
-    #      that isn't on the index is dropped with a WARN so the LLM can
-    #      never emit a filter key that would fail at the VS API.
-    #   2. Index discovery via UC Tables. Both the index and the source
-    #      table are UC entities, so ``wc.tables.get(...)`` returns column
-    #      names AND their Databricks types in one call. Primary path is
-    #      the INDEX (index-authoritative, mirrors databricks-langchain);
-    #      fallback is the SOURCE TABLE (same auth surface, no VSC / no
-    #      query cost). When ``describe()`` carries an explicit
-    #      ``columns_to_sync`` subset we intersect against it so
-    #      source-table lookups never advertise ghost columns.
-    #   3. Neither available → soft-fallback: build with free-form
-    #      ``FilterItem`` (LLM sees ``key: str``, pre-branch behavior).
-    declared_columns: list[str] = list(
+    # Column source of truth — three modes based on retriever.columns shape:
+    #
+    #   A. Hand-declared. Any item in the list is a ``ColumnInfo``. Names,
+    #      types, descriptions, and (optionally) per-column operator
+    #      restrictions come straight from the declaration. **No UC calls.**
+    #      Matches LangChain ``AttributeInfo`` / LlamaIndex ``MetadataInfo``
+    #      shape — the user owns the schema.
+    #
+    #   B. Bare strings only. Names come from the declared list; UC Tables
+    #      on the index is called best-effort to enrich the tool
+    #      description with types + column comments (not used for
+    #      enforcement). Enum is built from the declared names verbatim.
+    #
+    #   C. Empty. Discover names via a single ``wc.tables.get(index)``
+    #      call (same primary path as ``databricks_langchain``). If that
+    #      fails, degrade to free-form ``FilterItem`` (pre-branch behavior).
+    #
+    # No source-table fallback — matches upstream. Users with permission
+    # asymmetries (SP has source-table grants but not index-UC-entity
+    # grants) should hand-declare via ``ColumnInfo``.
+    declared_items: list[Any] = list(
         retriever.columns or vector_store.columns or []
     )
+    (
+        declared_names,
+        declared_types,
+        declared_descriptions,
+        operator_overrides_raw,
+        any_hand_declared,
+    ) = _normalize_declared_columns(declared_items)
+    operator_overrides: dict[str, list[str]] | None = (
+        operator_overrides_raw or None
+    )
 
-    # Always attempt index discovery so we can validate declared against the
-    # live index. Two steps:
-    #
-    #   * ``refresh()`` populates ``_index_details`` (used for vector-column
-    #     stripping and ``columns_to_sync`` intersection) and, for
-    #     Direct-Access indexes, ``vector_store.columns`` from
-    #     ``columns_to_sync``.
-    #   * UC Tables lookup, first on the index and — if that fails —
-    #     on the source table. Both share the ``WorkspaceClient`` auth
-    #     path; source-table lookup avoids the VSC / PAT / SP dance that
-    #     used to bite the scan-based probe.
-    #
-    # Soft-fail: if all discovery fails and declared has columns, trust
-    # declared. If neither has anything, fall back to free-form ``FilterItem``.
-    discovered_columns: list[str] = []
-    columns_before_refresh = list(vector_store.columns or [])
+    # ``refresh()`` still runs — it populates ``_index_details`` (needed
+    # for vector-column stripping via ``_vector_column_names_from_describe``)
+    # and, for Direct-Access indexes, ``vector_store.columns`` from
+    # ``columns_to_sync``. WARNING log only; downstream discovery is
+    # resilient to a refresh failure.
     vsc_for_refresh: VectorSearchClient | None = _vsc_for_refresh(vector_store)
     try:
         vector_store.refresh(vsc=vsc_for_refresh)
@@ -723,65 +721,51 @@ def create_vector_search_tool(
             index=index_name,
             error=f"{type(e).__name__}: {e}",
         )
-    # Prefer UC Tables on the index; fall back to UC Tables on the source
-    # table. Both paths return {name: type} so type-aware operator narrowing
-    # works on the fallback too. Direct-Access indexes have no source_table;
-    # the source-table lookup returns ``None`` and the ``columns_after_refresh``
-    # branch below catches them via refresh()'s columns_to_sync handling.
-    index_type_map: dict[str, str] | None = _fetch_index_column_types(vector_store)
-    if index_type_map is None:
-        index_type_map = _fetch_source_table_column_types(vector_store)
-    if index_type_map:
-        discovered_columns = list(index_type_map.keys())
-    else:
-        # Direct-Access indexes: refresh may have populated columns from
-        # ``columns_to_sync`` — accept those only if they weren't already
-        # set by declared (i.e. the value changed).
-        columns_after_refresh = list(vector_store.columns or [])
-        if (
-            columns_after_refresh
-            and columns_after_refresh != columns_before_refresh
-        ):
-            discovered_columns = columns_after_refresh
 
-    if declared_columns and discovered_columns:
-        in_index = set(discovered_columns)
-        kept: list[str] = []
-        for col in declared_columns:
-            if col in in_index:
-                kept.append(col)
-            else:
-                logger.warning(
-                    "Declared column not present on index; "
-                    "dropping from filter enum",
-                    column=col,
-                    index=index_name,
-                )
-        columns: list[str] = kept
-    elif declared_columns:
-        # Discovery failed; trust declared (best-effort — LLM may hit VS API
-        # errors if declared lists a bogus column, matching pre-branch behavior).
-        columns = declared_columns
-    else:
-        columns = discovered_columns
+    columns: list[str]
+    description_types: dict[str, str] = dict(declared_types)
+    description_descriptions: dict[str, str] = dict(declared_descriptions)
 
-    # Types come from the same UC entity as the columns — if the UC Tables
-    # call above succeeded, we have per-column types and can enable
-    # type-aware operator narrowing (LIKE only on strings, ordering only on
-    # numerics/temporal, etc.). Intersect with the final column set so we
-    # never advertise a type for a column we're not exposing.
-    column_types: dict[str, str] | None = None
-    if index_type_map and columns:
-        in_use = set(columns)
-        narrowed = {k: v for k, v in index_type_map.items() if k in in_use}
-        if narrowed:
-            column_types = narrowed
+    if any_hand_declared:
+        # Mode A — hand-declared authoritative. No UC calls.
+        columns = declared_names
+    elif declared_names:
+        # Mode B — bare strings. Enum from declared names; UC lookup is
+        # best-effort for description enrichment only.
+        columns = declared_names
+        index_cols = _fetch_index_columns(vector_store)
+        if index_cols:
+            uc_type_map = {name: t for name, t, _ in index_cols if t}
+            uc_comment_map = {name: c for name, _, c in index_cols if c}
+            for name in declared_names:
+                if name not in description_types and name in uc_type_map:
+                    description_types[name] = uc_type_map[name]
+                if name not in description_descriptions and name in uc_comment_map:
+                    description_descriptions[name] = uc_comment_map[name]
+    else:
+        # Mode C — nothing declared. Discover via UC.
+        index_cols = _fetch_index_columns(vector_store)
+        if index_cols:
+            columns = [name for name, _, _ in index_cols]
+            for name, t, c in index_cols:
+                if t and name not in description_types:
+                    description_types[name] = t
+                if c and name not in description_descriptions:
+                    description_descriptions[name] = c
+        else:
+            # Direct-Access indexes: refresh may have populated
+            # ``vector_store.columns`` from ``columns_to_sync``. Use those
+            # if the UC lookup returned nothing.
+            fallback = list(vector_store.columns or [])
+            columns = fallback
 
     logger.debug(
         "Vector Search columns resolved",
         index=index_name,
+        mode="hand-declared" if any_hand_declared else ("declared" if declared_names else "discovered"),
         columns=columns,
-        have_types=bool(column_types),
+        have_types=bool(description_types),
+        have_operator_overrides=bool(operator_overrides),
     )
     search_parameters: SearchParametersModel = retriever.search_parameters
     rerank_config: Optional[RerankParametersModel] = retriever.rerank
@@ -1002,17 +986,16 @@ def create_vector_search_tool(
     # Determine tool name and description
     tool_name: str = name or f"vector_search_{vector_store.index.name}"
 
-    # Build tool description with available columns for filtering
+    # Build tool description with available columns for filtering — matches
+    # the databricks-langchain "Available columns for filtering: name
+    # (TYPE): description" shape, enriched with hand-declared descriptions
+    # when the user provided ColumnInfo entries.
     base_description: str = description or f"Search documents in {index_name}"
-    if columns:
-        columns_list = ", ".join(columns)
-        tool_description = (
-            f"{base_description}. "
-            f"Available filter columns: {columns_list}. "
-            f"Filter operators: 'column' for equality, 'column NOT' for exclusion, "
-            f"'column <', 'column <=', 'column >', 'column >=' for comparison, "
-            f"'column LIKE' for token matching, 'column NOT LIKE' to exclude tokens."
-        )
+    columns_block: str = _build_columns_description(
+        columns, description_types, description_descriptions
+    )
+    if columns_block:
+        tool_description = f"{base_description}\n\n{columns_block}"
     else:
         tool_description = base_description
 
@@ -1242,7 +1225,7 @@ def create_vector_search_tool(
     # is serialised to just a description string and the LLM commonly emits
     # filters as a flat dict.
     VectorSearchSchema: type[BaseModel] = _build_vector_search_input_model(
-        columns, column_types
+        columns, operator_overrides
     )
 
     @tool(

--- a/src/dao_ai/tools/vector_search.py
+++ b/src/dao_ai/tools/vector_search.py
@@ -354,15 +354,33 @@ def _fetch_index_columns(
 
 
 # ColumnInfo.type values map to human-readable Databricks type labels used
-# in the tool description. These are not used for operator narrowing (the
-# 8 standard suffixes apply to every column) — only for the "Available
-# columns for filtering: brand (STRING) ..." block in the tool prompt.
+# in the tool description. Scalar types are just labels (all 8 operator
+# suffixes still apply). Array is narrowed at build time to equality-only
+# (see `_is_array_type` and the factory's operator_overrides logic).
 _COLUMN_INFO_TYPE_LABELS: dict[str, str] = {
     "string": "STRING",
     "number": "NUMBER",
     "boolean": "BOOLEAN",
     "datetime": "DATETIME",
+    "array": "ARRAY",
 }
+
+
+def _is_array_type(type_str: str | None) -> bool:
+    """True when a Databricks type string represents an ARRAY column.
+
+    Matches ``array<string>``, ``ARRAY<INT>``, ``array<double>`` etc. from
+    UC Tables ``type_text`` / ``type_name``, plus the bare ``array`` value
+    users write in ``ColumnInfo.type``. Array-typed columns get a
+    single-operator enum (equality/contains only) in the LLM-facing
+    args_schema — other operators (LIKE, ordering, NOT LIKE) are rejected
+    by VS at query time on array columns (see the Do It Best
+    `hardware-iq` filtering guide, 2026-07-06) and would only mislead
+    the LLM.
+    """
+    if not type_str:
+        return False
+    return type_str.strip().lower().startswith("array")
 
 
 def _normalize_declared_columns(
@@ -416,9 +434,13 @@ def _normalize_declared_columns(
             # set them (Pydantic tracks this via model_fields_set). If the
             # field defaulted to the full 8-op list, we let the standard
             # `_legal_filter_keys` cross-product apply — same as bare
-            # strings — for consistency.
+            # strings — for consistency. Exception: type=="array" narrows
+            # to equality-only ("") by default, since VS rejects every
+            # other operator on array columns.
             if "operators" in item.model_fields_set:
                 operator_overrides[name] = list(item.operators)
+            elif item.type == "array":
+                operator_overrides[name] = [""]
         elif isinstance(item, str):
             names.append(item)
         else:
@@ -448,6 +470,7 @@ def _build_columns_description(
         return ""
 
     lines: list[str] = ["Available columns for filtering:"]
+    any_array = False
     for name in names:
         type_label = types.get(name)
         desc = descriptions.get(name)
@@ -460,12 +483,24 @@ def _build_columns_description(
             # We already emitted "(TYPE)"; nothing more needed.
             pass
         lines.append(" ".join(parts))
+        if type_label and _is_array_type(type_label):
+            any_array = True
     lines.append("")
     lines.append(
         "Supports operators: LIKE, NOT LIKE, NOT, <, <=, >, >=, and empty "
         "(equality/IN). Combine into the filter key like "
         '``{"key": "brand LIKE", "value": "DEWALT"}``.'
     )
+    if any_array:
+        lines.append("")
+        lines.append(
+            "Array columns match via element containment (equality only): "
+            '``{"key": "tags", "value": "cordless"}`` finds records where '
+            "the tags array contains 'cordless'. A list value performs "
+            'OR-of-contains: ``{"key": "tags", "value": ["cordless", '
+            '"brushless"]}``. Other operators (LIKE, ordering, NOT) are '
+            "not supported on array columns and will be rejected."
+        )
     return "\n".join(lines)
 
 
@@ -702,9 +737,10 @@ def create_vector_search_tool(
         operator_overrides_raw,
         any_hand_declared,
     ) = _normalize_declared_columns(declared_items)
-    operator_overrides: dict[str, list[str]] | None = (
-        operator_overrides_raw or None
-    )
+    # Keep as a dict throughout so downstream can add entries (e.g. the
+    # auto-discovered array-narrowing loop). We coerce to `None` when
+    # empty at the point we pass it to `_build_vector_search_input_model`.
+    operator_overrides: dict[str, list[str]] = dict(operator_overrides_raw)
 
     # ``refresh()`` still runs — it populates ``_index_details`` (needed
     # for vector-column stripping via ``_vector_column_names_from_describe``)
@@ -758,6 +794,16 @@ def create_vector_search_tool(
             # if the UC lookup returned nothing.
             fallback = list(vector_store.columns or [])
             columns = fallback
+
+    # Array-typed columns get equality-only (empty suffix). VS rejects
+    # every other operator on ARRAY columns at query time; narrowing the
+    # enum prevents the LLM from emitting invalid filters in the first
+    # place. Hand-declared overrides (via ColumnInfo.operators) still win.
+    for name, uc_type in description_types.items():
+        if name in operator_overrides:
+            continue
+        if _is_array_type(uc_type):
+            operator_overrides[name] = [""]
 
     logger.debug(
         "Vector Search columns resolved",
@@ -1225,7 +1271,7 @@ def create_vector_search_tool(
     # is serialised to just a description string and the LLM commonly emits
     # filters as a flat dict.
     VectorSearchSchema: type[BaseModel] = _build_vector_search_input_model(
-        columns, operator_overrides
+        columns, operator_overrides or None
     )
 
     @tool(

--- a/src/dao_ai/tools/vector_search.py
+++ b/src/dao_ai/tools/vector_search.py
@@ -336,79 +336,96 @@ def _vector_column_names_from_describe(details: dict | None) -> set[str]:
     return names
 
 
-def _probe_index_columns(
-    vector_store: "VectorStoreModel",
-    vsc: VectorSearchClient | None,
-) -> list[str] | None:
-    """Discover the actual set of columns stored in the vector index.
+def _explicit_columns_to_sync(details: dict | None) -> set[str] | None:
+    """Return the user-declared ``columns_to_sync`` subset, or ``None``.
 
-    ``index.describe()`` on Delta-Sync indexes does *not* carry the
-    ``columns_to_sync`` list, and the source table generally has more
-    columns than the index (audit fields, embedding-source raw text, etc.).
-    We ``scan(num_results=1)`` the index and read the ``fields[].key`` list
-    off the returned document — that gives us the ground-truth column set.
+    Delta-Sync indexes default to syncing every source column; in that mode
+    ``describe()`` reports an empty / absent ``columns_to_sync``. When a
+    user explicitly restricts sync to a subset, the subset appears on
+    ``delta_sync_index_spec.columns_to_sync`` (or ``direct_access_index_spec``
+    for the Direct-Access variant). We use this to intersect against the
+    source-table column set so we don't advertise columns the index doesn't
+    actually carry.
 
-    Two categories of field are stripped from the return value:
-
-      * **Managed-embedding vector columns** — synthesised as
-        ``<source>_vector``. We prefer to read the exact source names from
-        ``describe()``'s ``embedding_source_columns`` and drop just those
-        (so a business column literally named e.g. ``product_vector`` is
-        NOT stripped). If ``describe()`` isn't available, we fall back to
-        the ``*_vector`` suffix heuristic.
-      * **Change-data-feed system fields** (``_change_type``,
-        ``_commit_version``, ``_commit_timestamp``) — anything with a
-        leading underscore. Databricks reserves the leading-underscore
-        namespace for CDF/system columns, so this is safe.
-
-    Returns ``None`` on any failure (soft-fail; the caller falls back to
-    whatever ``columns`` it already has).
+    Returns ``None`` when no subset is declared — the caller should treat
+    the full source-table column set as authoritative.
     """
-    if vsc is None:
+    if not isinstance(details, dict):
+        return None
+    for spec_key in ("delta_sync_index_spec", "direct_access_index_spec"):
+        spec = details.get(spec_key) or {}
+        cols = spec.get("columns_to_sync")
+        if cols:
+            return {c for c in cols if isinstance(c, str)}
+    return None
+
+
+def _fetch_source_table_column_types(
+    vector_store: "VectorStoreModel",
+) -> dict[str, str] | None:
+    """Return ``{column_name: databricks_type_string}`` from the SOURCE TABLE.
+
+    Fallback for when ``_fetch_index_column_types`` (UC Tables on the INDEX)
+    fails — typically a permission / environment mismatch on the index UC
+    entity. Source-table lookup shares the exact same auth surface as the
+    primary path (both go through ``WorkspaceClient.tables.get``), so it
+    trades the auth-fragile scan-based probe for a pure metadata call.
+
+    For Delta-Sync managed-embedding indexes (the common case), the source
+    table's columns are the authoritative filterable set on the index —
+    Databricks syncs every source column plus the synthesised ``_vector``.
+    We strip:
+
+      * **Vector columns** via ``_vector_column_names_from_describe`` (both
+        managed and self-managed) — never the raw source column, only the
+        synthesised / user-declared vector name.
+      * **CDF / system fields** (leading underscore).
+
+    When ``describe()`` carries an explicit ``columns_to_sync`` subset we
+    intersect against it, so users who restrict sync only advertise the
+    columns the index actually holds.
+
+    Returns ``None`` when:
+      * There is no ``source_table`` (Direct-Access indexes; caller has one
+        more fallback via ``refresh()``'s ``columns_to_sync`` handling), or
+      * The UC Tables call fails, or
+      * After stripping there are no columns left.
+    """
+    if vector_store.source_table is None:
         return None
     try:
-        idx = vsc.get_index(index_name=vector_store.index.full_name)
-        # Prefer the authoritative set of vector column names from the
-        # describe payload; we already cached it via VectorStoreModel.refresh().
-        known_vector_cols = _vector_column_names_from_describe(
-            getattr(vector_store, "_index_details", None)
-        )
-        scan = idx.scan(num_results=1) or {}
-        data = scan.get("data") or []
-        if not data:
-            return None
-        first = data[0]
-        # scan() returns {"fields": [{"key": name, "value": …}, …]}
-        fields = first.get("fields") if isinstance(first, dict) else None
-        if not fields:
-            return None
-        names: list[str] = []
-        for f in fields:
-            k = f.get("key") if isinstance(f, dict) else None
-            if not k:
-                continue
-            # CDF / system fields — leading underscore is reserved.
-            if k.startswith("_"):
-                continue
-            # Managed-embedding vector column.
-            if known_vector_cols:
-                if k in known_vector_cols:
-                    continue
-            elif k.endswith("_vector"):
-                # Fallback heuristic when describe payload isn't available.
-                # False positives here would be rare (a business column
-                # named ``*_vector``) but non-zero; the primary path above
-                # avoids them entirely.
-                continue
-            names.append(k)
-        return names or None
+        wc = vector_store.workspace_client_from(None)
+        table = wc.tables.get(vector_store.source_table.full_name)
+        cols = getattr(table, "columns", None) or []
     except Exception as e:  # noqa: BLE001
         logger.debug(
-            "Vector index column probe (scan) failed",
-            index=vector_store.index.full_name,
+            "UC Tables lookup on VS source_table failed; "
+            "fallback discovery unavailable",
+            source_table=vector_store.source_table.full_name,
             error=f"{type(e).__name__}: {e}",
         )
         return None
+
+    details = getattr(vector_store, "_index_details", None)
+    known_vector_cols = _vector_column_names_from_describe(details)
+    sync_subset = _explicit_columns_to_sync(details)
+
+    out: dict[str, str] = {}
+    for col in cols:
+        name = getattr(col, "name", None)
+        t = getattr(col, "type_text", None) or getattr(col, "type_name", None)
+        if not name or not t:
+            continue
+        if name.startswith("_"):
+            continue
+        if known_vector_cols and name in known_vector_cols:
+            continue
+        if not known_vector_cols and name.endswith("_vector"):
+            continue
+        if sync_subset is not None and name not in sync_subset:
+            continue
+        out[name] = str(t)
+    return out or None
 
 
 def _fetch_index_column_types(
@@ -666,41 +683,39 @@ def create_vector_search_tool(
     #      with the columns actually on the index — anything declared declared
     #      that isn't on the index is dropped with a WARN so the LLM can
     #      never emit a filter key that would fail at the VS API.
-    #   2. Index discovery. The index is a UC entity, so ``wc.tables.get(
-    #      index.full_name)`` returns column names AND their Databricks
-    #      types in one call (mirrors the databricks-langchain library).
-    #      Fallback: ``index.describe().columns_to_sync`` (Direct-Access) →
-    #      ``index.scan().data[0].fields[].key`` (Delta-Sync fallback).
-    #      Vector/system columns are stripped in every path.
+    #   2. Index discovery via UC Tables. Both the index and the source
+    #      table are UC entities, so ``wc.tables.get(...)`` returns column
+    #      names AND their Databricks types in one call. Primary path is
+    #      the INDEX (index-authoritative, mirrors databricks-langchain);
+    #      fallback is the SOURCE TABLE (same auth surface, no VSC / no
+    #      query cost). When ``describe()`` carries an explicit
+    #      ``columns_to_sync`` subset we intersect against it so
+    #      source-table lookups never advertise ghost columns.
     #   3. Neither available → soft-fallback: build with free-form
     #      ``FilterItem`` (LLM sees ``key: str``, pre-branch behavior).
-    #
-    # Never source-table columns: source-table has audit columns not on the
-    # index. Both column NAMES and TYPES come from the index itself.
     declared_columns: list[str] = list(
         retriever.columns or vector_store.columns or []
     )
 
     # Always attempt index discovery so we can validate declared against the
-    # live index. Two-step:
+    # live index. Two steps:
     #
-    #   * ``refresh()`` populates ``_index_details`` (used by probe for
-    #     vector-column stripping) and, for Direct-Access indexes only,
-    #     ``vector_store.columns`` from ``columns_to_sync``. Note that on
-    #     Delta-Sync indexes and when declared already set ``vector_store.columns``,
-    #     refresh does NOT overwrite — we cannot read ``vector_store.columns``
-    #     to distinguish "from declared" vs "from index".
-    #   * ``_probe_index_columns()`` runs ``index.scan(num_results=1)`` and
-    #     reads the actual field set off the returned document. This is
-    #     authoritative for both index types and independent of declared state.
+    #   * ``refresh()`` populates ``_index_details`` (used for vector-column
+    #     stripping and ``columns_to_sync`` intersection) and, for
+    #     Direct-Access indexes, ``vector_store.columns`` from
+    #     ``columns_to_sync``.
+    #   * UC Tables lookup, first on the index and — if that fails —
+    #     on the source table. Both share the ``WorkspaceClient`` auth
+    #     path; source-table lookup avoids the VSC / PAT / SP dance that
+    #     used to bite the scan-based probe.
     #
-    # Soft-fail: if both steps fail and declared has columns, trust declared. If
-    # neither has anything, fall back to free-form ``FilterItem``.
+    # Soft-fail: if all discovery fails and declared has columns, trust
+    # declared. If neither has anything, fall back to free-form ``FilterItem``.
     discovered_columns: list[str] = []
     columns_before_refresh = list(vector_store.columns or [])
-    vsc_for_discovery: VectorSearchClient | None = _vsc_for_refresh(vector_store)
+    vsc_for_refresh: VectorSearchClient | None = _vsc_for_refresh(vector_store)
     try:
-        vector_store.refresh(vsc=vsc_for_discovery)
+        vector_store.refresh(vsc=vsc_for_refresh)
     except Exception as e:  # noqa: BLE001
         logger.warning(
             "Vector Search index describe() failed; "
@@ -708,25 +723,26 @@ def create_vector_search_tool(
             index=index_name,
             error=f"{type(e).__name__}: {e}",
         )
-    # Prefer UC Tables on the index — it returns names AND types together.
+    # Prefer UC Tables on the index; fall back to UC Tables on the source
+    # table. Both paths return {name: type} so type-aware operator narrowing
+    # works on the fallback too. Direct-Access indexes have no source_table;
+    # the source-table lookup returns ``None`` and the ``columns_after_refresh``
+    # branch below catches them via refresh()'s columns_to_sync handling.
     index_type_map: dict[str, str] | None = _fetch_index_column_types(vector_store)
+    if index_type_map is None:
+        index_type_map = _fetch_source_table_column_types(vector_store)
     if index_type_map:
         discovered_columns = list(index_type_map.keys())
     else:
-        # Fallback: scan (authoritative filterable set on Delta-Sync).
-        probed = _probe_index_columns(vector_store, vsc_for_discovery)
-        if probed:
-            discovered_columns = probed
-        else:
-            # Direct-Access indexes: refresh may have populated columns from
-            # ``columns_to_sync`` — accept those only if they weren't already
-            # set by declared (i.e. the value changed).
-            columns_after_refresh = list(vector_store.columns or [])
-            if (
-                columns_after_refresh
-                and columns_after_refresh != columns_before_refresh
-            ):
-                discovered_columns = columns_after_refresh
+        # Direct-Access indexes: refresh may have populated columns from
+        # ``columns_to_sync`` — accept those only if they weren't already
+        # set by declared (i.e. the value changed).
+        columns_after_refresh = list(vector_store.columns or [])
+        if (
+            columns_after_refresh
+            and columns_after_refresh != columns_before_refresh
+        ):
+            discovered_columns = columns_after_refresh
 
     if declared_columns and discovered_columns:
         in_index = set(discovered_columns)

--- a/src/dao_ai/tools/vector_search.py
+++ b/src/dao_ai/tools/vector_search.py
@@ -14,6 +14,7 @@ from typing import Annotated, Any, Literal, Optional
 
 import mlflow
 from databricks.sdk import WorkspaceClient
+from databricks.vector_search.client import VectorSearchClient
 from databricks.vector_search.reranker import DatabricksReranker
 from databricks_langchain import DatabricksVectorSearch
 from flashrank import Ranker, RerankRequest
@@ -22,7 +23,7 @@ from langchain_core.documents import Document
 from langchain_core.tools import StructuredTool
 from loguru import logger
 from mlflow.entities import SpanType
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, create_model
 
 from dao_ai._tracing import in_caller_context
 from dao_ai.config import (
@@ -173,6 +174,287 @@ class VectorSearchInput(BaseModel):
     )
 
 
+_FILTER_OPERATOR_SUFFIXES: tuple[str, ...] = (
+    "",
+    " NOT",
+    " <",
+    " <=",
+    " >",
+    " >=",
+    " LIKE",
+    " NOT LIKE",
+)
+
+# Databricks type prefixes → subset of operator suffixes that make semantic
+# sense. Keys are matched case-insensitively against the *start* of the type
+# string (so "decimal(10,2)" still matches "decimal"). Anything unmatched
+# falls through to the full ``_FILTER_OPERATOR_SUFFIXES`` list — that's the
+# safe default for complex or unknown types.
+_NUMERIC_OPS: tuple[str, ...] = ("", " NOT", " <", " <=", " >", " >=")
+_STRING_OPS: tuple[str, ...] = ("", " NOT", " LIKE", " NOT LIKE")
+_BOOL_OPS: tuple[str, ...] = ("", " NOT")
+
+
+def _operators_for_type(type_str: str | None) -> tuple[str, ...]:
+    """Return the operator suffixes valid for a given Databricks column type.
+
+    Filters out combinations that don't semantically apply — e.g. ``LIKE`` on
+    an ``int``, ``<`` on a ``boolean``. Unknown / complex types (STRUCT, ARRAY,
+    MAP, custom UDT names) fall through to *all* suffixes so we don't
+    accidentally strip a legitimate combination.
+    """
+    t = (type_str or "").strip().lower()
+    if not t:
+        return _FILTER_OPERATOR_SUFFIXES
+    # Numeric family (integers + fixed/floating point + decimal).
+    if t.startswith(
+        (
+            "int",
+            "long",
+            "short",
+            "tinyint",
+            "smallint",
+            "bigint",
+            "float",
+            "double",
+            "decimal",
+            "numeric",
+            "real",
+            "byte",
+        )
+    ):
+        return _NUMERIC_OPS
+    # Temporal — ordering matters, LIKE doesn't.
+    if t.startswith(("timestamp", "date")):
+        return _NUMERIC_OPS
+    # Boolean: equality-only.
+    if t.startswith("bool"):
+        return _BOOL_OPS
+    # String family: equality + token match.
+    if t.startswith(("string", "varchar", "char", "text")):
+        return _STRING_OPS
+    # Everything else (binary, struct, array, map, unknown): permit all.
+    return _FILTER_OPERATOR_SUFFIXES
+
+
+def _legal_filter_keys(
+    columns: list[str],
+    types: dict[str, str] | None = None,
+) -> list[str]:
+    """Cross product of columns × operator suffixes, filtered by column type.
+
+    ``["price", "name"]`` with ``{"price": "double", "name": "string"}`` →
+    ``["price", "price NOT", "price <", "price <=", "price >", "price >=",
+    "name", "name NOT", "name LIKE", "name NOT LIKE"]``. When ``types`` is
+    ``None`` or a column is missing from it, all operator suffixes are
+    permitted for that column.
+    """
+    result: list[str] = []
+    for c in columns:
+        ops = _operators_for_type((types or {}).get(c)) if types else _FILTER_OPERATOR_SUFFIXES
+        for op in ops:
+            result.append(f"{c}{op}")
+    return result
+
+
+def _vsc_for_refresh(vector_store: "VectorStoreModel") -> VectorSearchClient | None:
+    """Mint a ``VectorSearchClient`` for ``VectorStoreModel.refresh()``.
+
+    Follows the same ambient-auth extraction the factory uses at query time
+    for ``DatabricksVectorSearch`` (see :func:`_client_args_from_ambient_wc`)
+    so build-time ``index.describe()`` calls succeed under all four
+    documented auth modes — including the ambient Serverless-v5 / CLI-profile
+    mode where a bare ``VectorSearchClient()`` raises
+    ``InvalidInputException: Please specify either personal access token or
+    service principal client ID and secret``.
+    """
+    try:
+        wc = vector_store.workspace_client_from(None)
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "Could not build WorkspaceClient for VS refresh; refresh may fail",
+            error=f"{type(e).__name__}: {e}",
+        )
+        return None
+    try:
+        client_args = _client_args_from_ambient_wc(wc)
+        if client_args:
+            return VectorSearchClient(**client_args, disable_notice=True)
+        # Library-native auth path or explicit env-var PAT — a default
+        # VectorSearchClient() is what the provider would build anyway.
+        return VectorSearchClient(disable_notice=True)
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "VectorSearchClient construction for refresh failed; "
+            "letting refresh() fall through to default",
+            error=f"{type(e).__name__}: {e}",
+        )
+        return None
+
+
+def _probe_index_columns(
+    vector_store: "VectorStoreModel",
+    vsc: VectorSearchClient | None,
+) -> list[str] | None:
+    """Discover the actual set of columns stored in the vector index.
+
+    ``index.describe()`` on Delta-Sync indexes does *not* carry the
+    ``columns_to_sync`` list, and the source table generally has more
+    columns than the index (audit fields, embedding-source raw text, etc.).
+    We ``scan(num_results=1)`` the index and read the ``fields[].key`` list
+    off the returned document — that gives us the ground-truth column set.
+
+    Vector columns (any ``<column>_vector`` synthesised by managed
+    embeddings) and change-data-feed system fields (``_change_type``,
+    ``_commit_version``, ``_commit_timestamp``) are stripped so they don't
+    pollute the filter-key enum with keys that would confuse the LLM.
+
+    Returns ``None`` on any failure (soft-fail; the caller falls back to
+    whatever ``columns`` it already has).
+    """
+    if vsc is None:
+        return None
+    try:
+        idx = vsc.get_index(index_name=vector_store.index.full_name)
+        scan = idx.scan(num_results=1) or {}
+        data = scan.get("data") or []
+        if not data:
+            return None
+        first = data[0]
+        # scan() returns {"fields": [{"key": name, "value": …}, …]}
+        fields = first.get("fields") if isinstance(first, dict) else None
+        if not fields:
+            return None
+        names: list[str] = []
+        for f in fields:
+            k = f.get("key") if isinstance(f, dict) else None
+            if not k:
+                continue
+            # Strip managed-embedding vector columns + CDF system fields.
+            if k.endswith("_vector") or k.startswith("_"):
+                continue
+            names.append(k)
+        return names or None
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "Vector index column probe (scan) failed; "
+            "falling back to source-table columns",
+            index=vector_store.index.full_name,
+            error=f"{type(e).__name__}: {e}",
+        )
+        return None
+
+
+def _fetch_column_types(vector_store: "VectorStoreModel") -> dict[str, str] | None:
+    """Return ``{column_name: databricks_type_string}`` from the source table.
+
+    Uses the Unity Catalog Tables API via the ``VectorStoreModel``'s ambient
+    ``WorkspaceClient``. Returns ``None`` when the source table is unknown or
+    the API call fails — callers should treat that as "unknown types" and
+    permit all operators on all columns.
+    """
+    if vector_store.source_table is None:
+        return None
+    try:
+        wc = vector_store.workspace_client_from(None)
+        table = wc.tables.get(vector_store.source_table.full_name)
+        cols = getattr(table, "columns", None) or []
+        out: dict[str, str] = {}
+        for col in cols:
+            name = getattr(col, "name", None)
+            t = getattr(col, "type_text", None) or getattr(col, "type_name", None)
+            if name and t:
+                out[name] = str(t)
+        return out or None
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "column type discovery failed; permitting all filter operators",
+            error=f"{type(e).__name__}: {e}",
+        )
+        return None
+
+
+def _build_filter_item_model(
+    columns: list[str],
+    types: dict[str, str] | None = None,
+) -> type[BaseModel]:
+    """Build a per-tool FilterItem whose ``key`` is Literal-narrowed to columns.
+
+    When ``columns`` is empty we return the free-form module-level
+    :class:`FilterItem` so callers see no change. When columns are known,
+    the returned model has ``key: Literal[<col>, "<col> NOT", "<col> <=",
+    "<col> LIKE", …]`` — a bad key is rejected by pydantic at tool-call
+    time, before the retriever is ever invoked.
+
+    The narrowing surfaces on the LLM as a JSON-schema ``enum`` on the
+    ``key`` property. That is what closes the "guessed a column name that
+    doesn't exist" hallucination hole (regression: MLflow trace
+    ``fc785d795b77675ac0e42fe5296b523a`` — LLM emitted ``"name NOT LIKE"``
+    against a products index whose column is ``product_name``).
+    """
+    if not columns:
+        return FilterItem
+
+    legal_keys = _legal_filter_keys(columns, types)
+    key_type = Literal[*legal_keys]  # PEP 646 unpacking; Python 3.11+.
+
+    return create_model(
+        "DynamicFilterItem",
+        __base__=FilterItem,
+        __module__=__name__,
+        key=(
+            key_type,
+            Field(
+                description=(
+                    "Column name (optionally suffixed with an operator). "
+                    "Must be one of the enumerated values. Operators: "
+                    "(none) equality, 'NOT' exclusion, '< <= > >=' numeric, "
+                    "'LIKE' token match, 'NOT LIKE' token exclude."
+                )
+            ),
+        ),
+    )
+
+
+def _build_vector_search_input_model(
+    columns: list[str],
+    types: dict[str, str] | None = None,
+) -> type[BaseModel]:
+    """Build a per-tool VectorSearchInput whose ``filters[]`` is narrowed.
+
+    When ``columns`` is empty we return the module-level
+    :class:`VectorSearchInput` (behavior identical to pre-change). When
+    columns are known, we build a subclass whose ``filters`` type is
+    ``list[<DynamicFilterItem for these columns>]``, so the JSON schema
+    the LLM sees carries the enum of legal keys. Type-aware narrowing kicks
+    in when ``types`` is provided (see :func:`_operators_for_type`).
+    """
+    if not columns:
+        return VectorSearchInput
+
+    filter_item_cls = _build_filter_item_model(columns, types)
+    return create_model(
+        "DynamicVectorSearchInput",
+        __base__=VectorSearchInput,
+        __module__=__name__,
+        filters=(
+            Optional[list[filter_item_cls]],  # type: ignore[valid-type]
+            Field(
+                default=None,
+                description=(
+                    "Optional metadata filters. Pass a JSON array of objects, "
+                    "each with 'key' and 'value'. Do NOT pass a flat dict. "
+                    'Example: [{"key": "category", "value": "B2B"}, '
+                    '{"key": "price <=", "value": 150}]. '
+                    "The 'key' field is enumerated to the actual index "
+                    "columns × operator suffixes — an unlisted key is "
+                    "rejected. Omit or set to null when no filter applies."
+                ),
+            ),
+        ),
+    )
+
+
 @mlflow.trace(name="rerank_documents", span_type=SpanType.RERANKER)
 def _rerank_documents(
     query: str,
@@ -288,7 +570,87 @@ def create_vector_search_tool(
         raise ValueError("vector_store.index is required for vector search")
 
     index_name: str = vector_store.index.full_name
-    columns: list[str] = list(retriever.columns or vector_store.index.columns or [])
+    # ``vector_store.columns`` is the authoritative source (populated in YAML
+    # or by ``VectorStoreModel.refresh()``); ``retriever.columns`` is a
+    # projection override. The former ``vector_store.index.columns`` fallback
+    # was dead code — IndexModel does not carry that field.
+    columns: list[str] = list(retriever.columns or vector_store.columns or [])
+
+    # If YAML declared no columns, try to hydrate them from the live index at
+    # tool-build time. Two-step fallback:
+    #
+    #   1. ``VectorStoreModel.refresh()`` — reads ``index.describe()``.
+    #      Populates ``source_table``, ``primary_key``, ``endpoint``, and
+    #      (for Direct-Access indexes) ``columns`` from
+    #      ``delta_sync_index_spec.columns_to_sync``. Delta-Sync indexes do
+    #      not carry ``columns_to_sync`` in their describe response, so on
+    #      those we still need step 2.
+    #
+    #   2. UC Tables API on the discovered source table — returns both
+    #      column names AND their Databricks types. We call this
+    #      unconditionally (once we have a source_table) because we want
+    #      the types anyway to build the type-aware operator enum below.
+    #
+    # Both steps are soft-fail: if either can't complete (auth, permissions,
+    # network), we log a warning and continue. The tool still builds; the
+    # LLM just gets a free-form ``key`` field (pre-change behavior).
+    # Column auto-discovery — three-step fallback, all soft-fail:
+    #
+    #   1. ``VectorStoreModel.refresh()`` → ``index.describe()`` populates
+    #      ``source_table``, ``primary_key``, ``endpoint``, and (Direct-
+    #      Access indexes only) ``columns`` from ``columns_to_sync``.
+    #   2. ``_probe_index_columns`` → ``index.scan(num_results=1)`` reads
+    #      the actual indexed column set from the returned document —
+    #      required for Delta-Sync indexes whose describe() omits
+    #      ``columns_to_sync``. This is the authoritative filter-key set:
+    #      only columns present in the *index* can be filtered on.
+    #   3. ``_fetch_column_types`` → UC Tables API on the source table
+    #      returns column names AND types. Names are a superset (source
+    #      table has audit columns not indexed); we intersect with (2) to
+    #      keep only the filterable ones and get typed operator narrowing.
+    #
+    # If YAML already declares ``columns`` we still call step 3 to get
+    # types for the operator enum. Missing types just relax the enum to
+    # all suffixes on every column (pre-change behavior).
+    column_types: dict[str, str] | None = None
+    if not columns:
+        # Only pay for a VectorSearchClient + describe + scan when the user
+        # didn't already give us columns via YAML. Everything below is
+        # soft-fail so a network hiccup / permission gap degrades the LLM
+        # experience (looser enum) but never breaks tool construction.
+        vsc_for_discovery: VectorSearchClient | None = _vsc_for_refresh(vector_store)
+        try:
+            vector_store.refresh(vsc=vsc_for_discovery)
+            columns = list(vector_store.columns or [])
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "Vector Search index describe() failed; "
+                "column auto-discovery may be incomplete",
+                index=index_name,
+                error=f"{type(e).__name__}: {e}",
+            )
+        if not columns:
+            probed = _probe_index_columns(vector_store, vsc_for_discovery)
+            if probed:
+                columns = probed
+
+        # Once we've discovered a column list, look up types from the UC
+        # Tables API on the source table (populated by refresh() above).
+        # Intersect: only advertise filter keys we can actually type.
+        if columns and vector_store.source_table is not None:
+            table_types = _fetch_column_types(vector_store)
+            if table_types:
+                in_index = set(columns)
+                column_types = {k: v for k, v in table_types.items() if k in in_index}
+                columns = [c for c in columns if c in column_types]
+
+        if columns:
+            logger.debug(
+                "Vector Search columns auto-discovered",
+                index=index_name,
+                columns=columns,
+                have_types=bool(column_types),
+            )
     search_parameters: SearchParametersModel = retriever.search_parameters
     rerank_config: Optional[RerankParametersModel] = retriever.rerank
     instructed_config: Optional[InstructedRetrieverModel] = retriever.instructed
@@ -747,10 +1109,14 @@ def create_vector_search_tool(
     # items={key,value}) — without it, Annotated[Optional[list[FilterItem]]]
     # is serialised to just a description string and the LLM commonly emits
     # filters as a flat dict.
+    VectorSearchSchema: type[BaseModel] = _build_vector_search_input_model(
+        columns, column_types
+    )
+
     @tool(
         name_or_callable=tool_name,
         description=tool_description,
-        args_schema=VectorSearchInput,
+        args_schema=VectorSearchSchema,
     )
     def _vector_search_tool(
         query: str,

--- a/src/dao_ai/tools/vector_search.py
+++ b/src/dao_ai/tools/vector_search.py
@@ -139,8 +139,12 @@ def _client_args_from_ambient_wc(wc: WorkspaceClient) -> dict[str, Any] | None:
         return None
 
 
-class VectorSearchInput(BaseModel):
-    """Arguments for the dao-ai vector_search tool factory.
+class AiSearchInput(BaseModel):
+    """Arguments for the dao-ai AI Search tool factory.
+
+    (Formerly ``VectorSearchInput``. Databricks rebranded Vector Search to
+    AI Search; the old class name remains as an alias defined at the end
+    of this module for backwards compatibility.)
 
     Co-located with the @tool decorator so the JSON schema rendered to the LLM
     matches the factory's runtime expectations. Without an explicit args_schema,
@@ -555,10 +559,10 @@ def _build_vector_search_input_model(
     columns: list[str],
     operator_overrides: dict[str, list[str]] | None = None,
 ) -> type[BaseModel]:
-    """Build a per-tool VectorSearchInput whose ``filters[]`` is narrowed.
+    """Build a per-tool AiSearchInput whose ``filters[]`` is narrowed.
 
     When ``columns`` is empty we return the module-level
-    :class:`VectorSearchInput` (behavior identical to pre-change). When
+    :class:`AiSearchInput` (behavior identical to pre-change). When
     columns are known, we build a subclass whose ``filters`` type is
     ``list[<DynamicFilterItem for these columns>]``, so the JSON schema
     the LLM sees carries the enum of legal keys.
@@ -567,12 +571,12 @@ def _build_vector_search_input_model(
     for hand-declared ``ColumnInfo.operators`` support.
     """
     if not columns:
-        return VectorSearchInput
+        return AiSearchInput
 
     filter_item_cls = _build_filter_item_model(columns, operator_overrides)
     return create_model(
         "DynamicVectorSearchInput",
-        __base__=VectorSearchInput,
+        __base__=AiSearchInput,
         __module__=__name__,
         filters=(
             Optional[list[filter_item_cls]],  # type: ignore[valid-type]
@@ -664,14 +668,18 @@ def _rerank_documents(
     return reranked_docs
 
 
-def create_vector_search_tool(
+def create_ai_search_tool(
     retriever: Optional[RetrieverModel | dict[str, Any]] = None,
     vector_store: Optional[VectorStoreModel | dict[str, Any]] = None,
     name: Optional[str] = None,
     description: Optional[str] = None,
 ) -> StructuredTool:
     """
-    Create a Vector Search tool with dynamic schema and optional reranking.
+    Create an AI Search tool with dynamic schema and optional reranking.
+
+    (Formerly ``create_vector_search_tool``. Databricks rebranded Vector
+    Search to AI Search; the old function name remains as an alias
+    defined at the end of this module for backwards compatibility.)
 
     Args:
         retriever: Full retriever configuration with search parameters and reranking
@@ -1470,6 +1478,12 @@ def create_vector_search_tool(
 
         return json.dumps(serialized_docs)
 
-    logger.success("Vector search tool created", name=tool_name, index=index_name)
+    logger.success("AI Search tool created", name=tool_name, index=index_name)
 
     return _vector_search_tool
+
+
+# Backwards-compatible aliases — Vector Search naming will eventually be
+# deprecated. Both names refer to the same class / function.
+VectorSearchInput = AiSearchInput
+create_vector_search_tool = create_ai_search_tool

--- a/src/dao_ai/tools/vector_search.py
+++ b/src/dao_ai/tools/vector_search.py
@@ -230,10 +230,17 @@ def _operators_for_type(type_str: str | None) -> tuple[str, ...]:
     # Boolean: equality-only.
     if t.startswith("bool"):
         return _BOOL_OPS
+    # Binary: equality-only. Blobs don't support LIKE or ordering.
+    if t.startswith("binary"):
+        return _BOOL_OPS
     # String family: equality + token match.
     if t.startswith(("string", "varchar", "char", "text")):
         return _STRING_OPS
-    # Everything else (binary, struct, array, map, unknown): permit all.
+    # Complex types (STRUCT / ARRAY / MAP) and any unknown type fall
+    # through to *all* operators. Databricks Vector Search rejects
+    # unsupported filter combinations at query time, and stripping
+    # legitimate combinations here would be more harmful than the
+    # occasional server-side rejection.
     return _FILTER_OPERATOR_SUFFIXES
 
 
@@ -292,6 +299,27 @@ def _vsc_for_refresh(vector_store: "VectorStoreModel") -> VectorSearchClient | N
         return None
 
 
+def _vector_column_names_from_describe(details: dict | None) -> set[str]:
+    """Return the exact managed-embedding vector column names.
+
+    Databricks synthesises one vector column per ``embedding_source_column``
+    named ``<source>_vector``. We read the source names from ``describe()``
+    so we strip *only* those synthetics — never a business column that
+    happens to end in ``_vector``.
+    """
+    if not isinstance(details, dict):
+        return set()
+    delta_spec = details.get("delta_sync_index_spec") or {}
+    src_cols = delta_spec.get("embedding_source_columns") or []
+    names: set[str] = set()
+    for entry in src_cols:
+        if isinstance(entry, dict):
+            src = entry.get("name")
+            if src:
+                names.add(f"{src}_vector")
+    return names
+
+
 def _probe_index_columns(
     vector_store: "VectorStoreModel",
     vsc: VectorSearchClient | None,
@@ -304,10 +332,18 @@ def _probe_index_columns(
     We ``scan(num_results=1)`` the index and read the ``fields[].key`` list
     off the returned document — that gives us the ground-truth column set.
 
-    Vector columns (any ``<column>_vector`` synthesised by managed
-    embeddings) and change-data-feed system fields (``_change_type``,
-    ``_commit_version``, ``_commit_timestamp``) are stripped so they don't
-    pollute the filter-key enum with keys that would confuse the LLM.
+    Two categories of field are stripped from the return value:
+
+      * **Managed-embedding vector columns** — synthesised as
+        ``<source>_vector``. We prefer to read the exact source names from
+        ``describe()``'s ``embedding_source_columns`` and drop just those
+        (so a business column literally named e.g. ``product_vector`` is
+        NOT stripped). If ``describe()`` isn't available, we fall back to
+        the ``*_vector`` suffix heuristic.
+      * **Change-data-feed system fields** (``_change_type``,
+        ``_commit_version``, ``_commit_timestamp``) — anything with a
+        leading underscore. Databricks reserves the leading-underscore
+        namespace for CDF/system columns, so this is safe.
 
     Returns ``None`` on any failure (soft-fail; the caller falls back to
     whatever ``columns`` it already has).
@@ -316,6 +352,11 @@ def _probe_index_columns(
         return None
     try:
         idx = vsc.get_index(index_name=vector_store.index.full_name)
+        # Prefer the authoritative set of vector column names from the
+        # describe payload; we already cached it via VectorStoreModel.refresh().
+        known_vector_cols = _vector_column_names_from_describe(
+            getattr(vector_store, "_index_details", None)
+        )
         scan = idx.scan(num_results=1) or {}
         data = scan.get("data") or []
         if not data:
@@ -330,8 +371,18 @@ def _probe_index_columns(
             k = f.get("key") if isinstance(f, dict) else None
             if not k:
                 continue
-            # Strip managed-embedding vector columns + CDF system fields.
-            if k.endswith("_vector") or k.startswith("_"):
+            # CDF / system fields — leading underscore is reserved.
+            if k.startswith("_"):
+                continue
+            # Managed-embedding vector column.
+            if known_vector_cols:
+                if k in known_vector_cols:
+                    continue
+            elif k.endswith("_vector"):
+                # Fallback heuristic when describe payload isn't available.
+                # False positives here would be rare (a business column
+                # named ``*_vector``) but non-zero; the primary path above
+                # avoids them entirely.
                 continue
             names.append(k)
         return names or None
@@ -634,23 +685,24 @@ def create_vector_search_tool(
             if probed:
                 columns = probed
 
-        # Once we've discovered a column list, look up types from the UC
-        # Tables API on the source table (populated by refresh() above).
-        # Intersect: only advertise filter keys we can actually type.
-        if columns and vector_store.source_table is not None:
-            table_types = _fetch_column_types(vector_store)
-            if table_types:
-                in_index = set(columns)
-                column_types = {k: v for k, v in table_types.items() if k in in_index}
-                columns = [c for c in columns if c in column_types]
+    # Type-aware operator narrowing applies whether columns came from YAML
+    # or from discovery. We call ``_fetch_column_types`` regardless; the
+    # helper is a no-op when ``source_table`` isn't populated. Intersect
+    # with the (possibly YAML-declared) column list so we only advertise
+    # filter keys we can actually type — anything we can't type keeps its
+    # full operator suite (see :func:`_operators_for_type`).
+    if columns:
+        table_types = _fetch_column_types(vector_store)
+        if table_types:
+            in_index = set(columns)
+            column_types = {k: v for k, v in table_types.items() if k in in_index}
 
-        if columns:
-            logger.debug(
-                "Vector Search columns auto-discovered",
-                index=index_name,
-                columns=columns,
-                have_types=bool(column_types),
-            )
+        logger.debug(
+            "Vector Search columns resolved",
+            index=index_name,
+            columns=columns,
+            have_types=bool(column_types),
+        )
     search_parameters: SearchParametersModel = retriever.search_parameters
     rerank_config: Optional[RerankParametersModel] = retriever.rerank
     instructed_config: Optional[InstructedRetrieverModel] = retriever.instructed

--- a/tests/dao_ai/test_lakebase_app_resources.py
+++ b/tests/dao_ai/test_lakebase_app_resources.py
@@ -503,3 +503,98 @@ class TestModelServingSystemResources:
         db = DatabaseModel(name="x", project="x", on_behalf_of_user=True)
         resources = list(db.as_resources())
         assert all(not isinstance(r, DatabricksLakebase) for r in resources)
+
+
+# =============================================================================
+# _resolve_lakebase_database_path — loud failure when the SDK can't reach the
+# Lakebase project. Silent fall-through used to emit a bogus resource path
+# built from ``DatabaseModel.database`` (a pg-level name like
+# ``databricks_postgres``) which produced a mystery deploy-time 404 far from
+# the auth root cause. Raise instead so operators see the profile / auth issue
+# at generate-bundle time.
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestResolveLakebaseDatabasePathLoudFailure:
+    def test_raises_when_list_databases_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from dao_ai.apps.resources import _resolve_lakebase_database_path
+        from dao_ai.config import DatabaseModel
+
+        db = DatabaseModel(project="commerce-swarm", branch="production")
+
+        class _BoomPostgres:
+            def list_databases(self, _branch_path: str) -> None:
+                raise RuntimeError("401 Unauthorized")
+
+        class _WC:
+            postgres = _BoomPostgres()
+
+        monkeypatch.setattr(
+            DatabaseModel, "workspace_client", property(lambda self: _WC())
+        )
+
+        with pytest.raises(RuntimeError, match=r"--profile"):
+            _resolve_lakebase_database_path(
+                db, "projects/commerce-swarm/branches/production"
+            )
+
+    def test_raises_when_no_databases_under_branch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from dao_ai.apps.resources import _resolve_lakebase_database_path
+        from dao_ai.config import DatabaseModel
+
+        db = DatabaseModel(project="commerce-swarm", branch="production")
+
+        class _EmptyPostgres:
+            def list_databases(self, _branch_path: str) -> list:
+                return []
+
+        class _WC:
+            postgres = _EmptyPostgres()
+
+        monkeypatch.setattr(
+            DatabaseModel, "workspace_client", property(lambda self: _WC())
+        )
+
+        with pytest.raises(RuntimeError, match=r"No Lakebase databases found"):
+            _resolve_lakebase_database_path(
+                db, "projects/commerce-swarm/branches/production"
+            )
+
+    def test_returns_resource_path_when_pg_name_matches(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Happy path: the resolver returns ``d.name`` (with hyphen), not
+        ``db.database`` (the pg-level name, typically underscored)."""
+        from types import SimpleNamespace
+
+        from dao_ai.apps.resources import _resolve_lakebase_database_path
+        from dao_ai.config import DatabaseModel
+
+        db = DatabaseModel(project="commerce-swarm", branch="production")
+
+        class _Postgres:
+            def list_databases(self, _branch_path: str) -> list:
+                return [
+                    SimpleNamespace(
+                        name="projects/commerce-swarm/branches/production/databases/databricks-postgres",
+                        status=SimpleNamespace(postgres_database="databricks_postgres"),
+                    )
+                ]
+
+        class _WC:
+            postgres = _Postgres()
+
+        monkeypatch.setattr(
+            DatabaseModel, "workspace_client", property(lambda self: _WC())
+        )
+
+        result = _resolve_lakebase_database_path(
+            db, "projects/commerce-swarm/branches/production"
+        )
+        assert result.endswith("/databases/databricks-postgres")
+        assert "databricks_postgres" not in result.split("/databases/")[-1]

--- a/tests/dao_ai/test_lakebase_app_resources.py
+++ b/tests/dao_ai/test_lakebase_app_resources.py
@@ -506,95 +506,111 @@ class TestModelServingSystemResources:
 
 
 # =============================================================================
-# _resolve_lakebase_database_path — loud failure when the SDK can't reach the
-# Lakebase project. Silent fall-through used to emit a bogus resource path
-# built from ``DatabaseModel.database`` (a pg-level name like
-# ``databricks_postgres``) which produced a mystery deploy-time 404 far from
-# the auth root cause. Raise instead so operators see the profile / auth issue
-# at generate-bundle time.
+# _resolve_lakebase_database_path — pure config rendering, no SDK call.
+#
+# The resolver returns the Databricks Apps postgres resource path
+# deterministically:
+#   1. If ``db.database`` is already a full resource path, use verbatim.
+#   2. Otherwise, construct ``{branch_path}/databases/databricks-postgres``
+#      (the Databricks auto-provisioning default resource id).
+#
+# No SDK lookup — auth is not required at bundle-generation time. Users
+# with custom-provisioned databases declare the full path in
+# ``db.database``. Deploy-time validation catches wrong paths clearly.
 # =============================================================================
 
 
 @pytest.mark.unit
-class TestResolveLakebaseDatabasePathLoudFailure:
-    def test_raises_when_list_databases_fails(
+class TestResolveLakebaseDatabasePathDeterministic:
+    def test_default_construction_uses_databricks_postgres_hyphen(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """DatabaseModel with just project + branch set → resource path
+        ends in ``/databases/databricks-postgres``. No SDK call is made."""
         from dao_ai.apps.resources import _resolve_lakebase_database_path
         from dao_ai.config import DatabaseModel
 
         db = DatabaseModel(project="commerce-swarm", branch="production")
 
-        class _BoomPostgres:
-            def list_databases(self, _branch_path: str) -> None:
-                raise RuntimeError("401 Unauthorized")
-
-        class _WC:
-            postgres = _BoomPostgres()
-
-        monkeypatch.setattr(
-            DatabaseModel, "workspace_client", property(lambda self: _WC())
-        )
-
-        with pytest.raises(RuntimeError, match=r"--profile"):
-            _resolve_lakebase_database_path(
-                db, "projects/commerce-swarm/branches/production"
+        # Spy: touching db.workspace_client would blow up because there's
+        # no configured auth in the test. If the resolver reaches for it,
+        # this test fails loudly.
+        def _boom(_self: object) -> object:
+            raise AssertionError(
+                "_resolve_lakebase_database_path must not access workspace_client"
             )
 
-    def test_raises_when_no_databases_under_branch(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        from dao_ai.apps.resources import _resolve_lakebase_database_path
-        from dao_ai.config import DatabaseModel
-
-        db = DatabaseModel(project="commerce-swarm", branch="production")
-
-        class _EmptyPostgres:
-            def list_databases(self, _branch_path: str) -> list:
-                return []
-
-        class _WC:
-            postgres = _EmptyPostgres()
-
         monkeypatch.setattr(
-            DatabaseModel, "workspace_client", property(lambda self: _WC())
-        )
-
-        with pytest.raises(RuntimeError, match=r"No Lakebase databases found"):
-            _resolve_lakebase_database_path(
-                db, "projects/commerce-swarm/branches/production"
-            )
-
-    def test_returns_resource_path_when_pg_name_matches(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Happy path: the resolver returns ``d.name`` (with hyphen), not
-        ``db.database`` (the pg-level name, typically underscored)."""
-        from types import SimpleNamespace
-
-        from dao_ai.apps.resources import _resolve_lakebase_database_path
-        from dao_ai.config import DatabaseModel
-
-        db = DatabaseModel(project="commerce-swarm", branch="production")
-
-        class _Postgres:
-            def list_databases(self, _branch_path: str) -> list:
-                return [
-                    SimpleNamespace(
-                        name="projects/commerce-swarm/branches/production/databases/databricks-postgres",
-                        status=SimpleNamespace(postgres_database="databricks_postgres"),
-                    )
-                ]
-
-        class _WC:
-            postgres = _Postgres()
-
-        monkeypatch.setattr(
-            DatabaseModel, "workspace_client", property(lambda self: _WC())
+            DatabaseModel, "workspace_client", property(_boom)
         )
 
         result = _resolve_lakebase_database_path(
             db, "projects/commerce-swarm/branches/production"
         )
-        assert result.endswith("/databases/databricks-postgres")
-        assert "databricks_postgres" not in result.split("/databases/")[-1]
+        assert result == (
+            "projects/commerce-swarm/branches/production/databases/databricks-postgres"
+        )
+
+    def test_full_path_in_database_field_passthrough(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Escape hatch: user declared a full resource path in
+        ``db.database`` (legacy shape). Resolver returns verbatim,
+        no SDK call."""
+        from dao_ai.apps.resources import _resolve_lakebase_database_path
+        from dao_ai.config import DatabaseModel
+
+        custom_path = (
+            "projects/retail-consumer-goods/branches/production/"
+            "databases/db-vllm-t1lbxazynr"
+        )
+        db = DatabaseModel(
+            project="retail-consumer-goods",
+            branch="production",
+            database=custom_path,
+        )
+
+        def _boom(_self: object) -> object:
+            raise AssertionError(
+                "_resolve_lakebase_database_path must not access workspace_client"
+            )
+
+        monkeypatch.setattr(
+            DatabaseModel, "workspace_client", property(_boom)
+        )
+
+        result = _resolve_lakebase_database_path(
+            db, "projects/retail-consumer-goods/branches/production"
+        )
+        assert result == custom_path
+
+    def test_custom_database_id_field_used_in_construction(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Preferred shape for custom-provisioned databases: user sets
+        ``database_id`` to the Lakebase resource id (short hyphenated
+        form). Resolver constructs the path using that id. No SDK call."""
+        from dao_ai.apps.resources import _resolve_lakebase_database_path
+        from dao_ai.config import DatabaseModel
+
+        db = DatabaseModel(
+            project="retail-consumer-goods",
+            branch="production",
+            database_id="db-vllm-t1lbxazynr",
+        )
+
+        def _boom(_self: object) -> object:
+            raise AssertionError(
+                "_resolve_lakebase_database_path must not access workspace_client"
+            )
+
+        monkeypatch.setattr(
+            DatabaseModel, "workspace_client", property(_boom)
+        )
+
+        result = _resolve_lakebase_database_path(
+            db, "projects/retail-consumer-goods/branches/production"
+        )
+        assert result == (
+            "projects/retail-consumer-goods/branches/production/databases/db-vllm-t1lbxazynr"
+        )

--- a/tests/dao_ai/test_vector_search.py
+++ b/tests/dao_ai/test_vector_search.py
@@ -519,7 +519,7 @@ def _capture_client_args_and_invoke(
     captured: dict[str, Any] = {}
     with patch("dao_ai.tools.vector_search.DatabricksVectorSearch") as MockDVS, \
         patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None), \
-        patch("dao_ai.tools.vector_search._probe_index_columns", return_value=None):
+        patch("dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None):
         # Build-time refresh is stubbed out; these tests exercise the
         # query-time auth-mode behavior, not schema hydration.
         vs_model.refresh = MagicMock(return_value=None)

--- a/tests/dao_ai/test_vector_search.py
+++ b/tests/dao_ai/test_vector_search.py
@@ -519,7 +519,7 @@ def _capture_client_args_and_invoke(
     captured: dict[str, Any] = {}
     with patch("dao_ai.tools.vector_search.DatabricksVectorSearch") as MockDVS, \
         patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None), \
-        patch("dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None):
+        patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None):
         # Build-time refresh is stubbed out; these tests exercise the
         # query-time auth-mode behavior, not schema hydration.
         vs_model.refresh = MagicMock(return_value=None)

--- a/tests/dao_ai/test_vector_search.py
+++ b/tests/dao_ai/test_vector_search.py
@@ -517,7 +517,13 @@ def _capture_client_args_and_invoke(
     retriever = RetrieverModel(vector_store=vs_model)
 
     captured: dict[str, Any] = {}
-    with patch("dao_ai.tools.vector_search.DatabricksVectorSearch") as MockDVS:
+    with patch("dao_ai.tools.vector_search.DatabricksVectorSearch") as MockDVS, \
+        patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None), \
+        patch("dao_ai.tools.vector_search._probe_index_columns", return_value=None):
+        # Build-time refresh is stubbed out; these tests exercise the
+        # query-time auth-mode behavior, not schema hydration.
+        vs_model.refresh = MagicMock(return_value=None)
+
         def _capture(**kwargs: Any) -> MagicMock:
             captured.update(kwargs)
             m = MagicMock()

--- a/tests/dao_ai/test_vector_search_dynamic_schema.py
+++ b/tests/dao_ai/test_vector_search_dynamic_schema.py
@@ -41,6 +41,8 @@ from dao_ai.tools.vector_search import (
     _build_vector_search_input_model,
     _legal_filter_keys,
     _operators_for_type,
+    _probe_index_columns,
+    _vector_column_names_from_describe,
     create_vector_search_tool,
 )
 
@@ -131,6 +133,27 @@ class TestOperatorsForType:
             assert " LIKE" in ops
             assert " <=" in ops
             assert " NOT" in ops
+
+    def test_binary_gets_equality_only(self) -> None:
+        # Binary blobs have no meaningful ordering or LIKE semantics. We
+        # treat them like booleans.
+        for t in ("binary", "BINARY"):
+            ops = _operators_for_type(t)
+            assert ops == ("", " NOT"), f"binary type {t!r} should be equality-only, got {ops}"
+
+    def test_type_matching_is_case_insensitive(self) -> None:
+        # Databricks' DESCRIBE / UC Tables API returns type strings in mixed
+        # case ("BIGINT", "Double", "TIMESTAMP"). We must not miss them.
+        assert _operators_for_type("BIGINT") == _operators_for_type("bigint")
+        assert _operators_for_type("STRING") == _operators_for_type("string")
+        assert _operators_for_type("Boolean") == _operators_for_type("boolean")
+
+    def test_parameterized_types_matched_by_prefix(self) -> None:
+        # DESCRIBE returns parameterized versions of decimal/varchar/char.
+        # We match by prefix so these still map to the right family.
+        assert _operators_for_type("decimal(10,2)") == _operators_for_type("bigint")
+        assert _operators_for_type("varchar(255)") == _operators_for_type("string")
+        assert _operators_for_type("char(3)") == _operators_for_type("string")
 
 
 @pytest.mark.unit
@@ -348,3 +371,386 @@ class TestFactoryColumnHydration:
             "DynamicFilterItem"
         )
         assert "enum" not in filter_ref["properties"]["key"]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases surfaced during audit of vector-search configuration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestVectorColumnStripping:
+    """The scan-based column probe must strip *only* the synthesised
+    managed-embedding vector columns — never a business column whose name
+    happens to end in ``_vector``.
+    """
+
+    def test_extracts_managed_vector_names_from_describe(self) -> None:
+        details = _describe_payload()
+        # Payload uses ``description`` as the embedding source, so the
+        # synthesised vector column is ``description_vector``.
+        vec_names = _vector_column_names_from_describe(details)
+        assert vec_names == {"description_vector"}
+
+    def test_extracts_multiple_vector_names(self) -> None:
+        details = _describe_payload(
+            delta_sync_index_spec={
+                "source_table": "cat.sch.multi",
+                "embedding_source_columns": [
+                    {"name": "title", "embedding_model_endpoint_name": "e"},
+                    {"name": "body", "embedding_model_endpoint_name": "e"},
+                ],
+            }
+        )
+        vec_names = _vector_column_names_from_describe(details)
+        assert vec_names == {"title_vector", "body_vector"}
+
+    def test_none_or_missing_details_returns_empty(self) -> None:
+        assert _vector_column_names_from_describe(None) == set()
+        assert _vector_column_names_from_describe({}) == set()
+        assert _vector_column_names_from_describe({"delta_sync_index_spec": {}}) == set()
+
+    def _make_probe_setup(
+        self, *, scan_fields: list[str], describe: dict | None
+    ) -> tuple[Any, Any]:
+        """Build a MagicMock chain that mimics vsc.get_index().scan() and
+        stashes ``describe`` on the vector_store as ``_index_details``."""
+        vs = MagicMock()
+        vs.index.full_name = "cat.sch.probe_test_index"
+        vs._index_details = describe
+        idx = MagicMock()
+        idx.scan.return_value = {
+            "data": [{"fields": [{"key": k, "value": {}} for k in scan_fields]}]
+        }
+        vsc = MagicMock()
+        vsc.get_index.return_value = idx
+        return vs, vsc
+
+    def test_strips_synthesised_vector_column_from_describe(self) -> None:
+        vs, vsc = self._make_probe_setup(
+            scan_fields=["product_id", "product_name", "description", "description_vector"],
+            describe=_describe_payload(),
+        )
+        assert _probe_index_columns(vs, vsc) == ["product_id", "product_name", "description"]
+
+    def test_preserves_business_column_ending_in_vector(self) -> None:
+        """A user column literally named ``product_vector`` must survive
+        — the describe payload's ``embedding_source_columns`` is the
+        authoritative signal for what's a synthesised vector."""
+        vs, vsc = self._make_probe_setup(
+            scan_fields=[
+                "product_id",
+                "product_name",
+                "product_vector",  # a business column, NOT the embedding
+                "description",
+                "description_vector",  # the actual synthesised vector
+            ],
+            describe=_describe_payload(),  # embedding source = "description"
+        )
+        cols = _probe_index_columns(vs, vsc)
+        assert cols is not None
+        assert "product_vector" in cols  # preserved!
+        assert "description_vector" not in cols  # actually synthesised, stripped
+
+    def test_falls_back_to_suffix_heuristic_when_describe_missing(self) -> None:
+        # No describe details cached → we can't know which _vector column
+        # is synthesised, so we strip all of them. This is a controlled
+        # false-positive risk documented in the docstring.
+        vs, vsc = self._make_probe_setup(
+            scan_fields=["product_id", "product_name", "description_vector"],
+            describe=None,
+        )
+        assert _probe_index_columns(vs, vsc) == ["product_id", "product_name"]
+
+    def test_strips_cdf_underscore_prefix_fields(self) -> None:
+        vs, vsc = self._make_probe_setup(
+            scan_fields=["product_id", "_change_type", "_commit_version", "product_name"],
+            describe=_describe_payload(),
+        )
+        assert _probe_index_columns(vs, vsc) == ["product_id", "product_name"]
+
+    def test_empty_scan_result_returns_none(self) -> None:
+        vs = MagicMock()
+        vs.index.full_name = "cat.sch.empty_index"
+        vs._index_details = None
+        idx = MagicMock()
+        idx.scan.return_value = {"data": []}
+        vsc = MagicMock()
+        vsc.get_index.return_value = idx
+        assert _probe_index_columns(vs, vsc) is None
+
+    def test_scan_permission_error_returns_none(self) -> None:
+        vs = MagicMock()
+        vs.index.full_name = "cat.sch.forbidden_index"
+        vs._index_details = None
+        idx = MagicMock()
+        idx.scan.side_effect = PermissionError("forbidden")
+        vsc = MagicMock()
+        vsc.get_index.return_value = idx
+        assert _probe_index_columns(vs, vsc) is None
+
+    def test_null_vsc_returns_none(self) -> None:
+        # Guard against the caller not being able to mint a
+        # VectorSearchClient (e.g. no ambient auth available).
+        assert _probe_index_columns(MagicMock(), None) is None
+
+
+@pytest.mark.unit
+class TestFilterValueShapes:
+    """The LLM-visible ``value`` field on ``FilterItem`` accepts
+    scalars OR lists (IN-style). Confirm every real shape is accepted so
+    the LLM doesn't get validation-error-nagged.
+    """
+
+    def _model(self):
+        return _build_vector_search_input_model(
+            ["sku", "price", "is_b2b_only"],
+            {"sku": "string", "price": "double", "is_b2b_only": "boolean"},
+        )
+
+    def test_string_scalar(self) -> None:
+        m = self._model()(query="x", filters=[{"key": "sku", "value": "FRZ-001"}])
+        assert m.filters[0].value == "FRZ-001"
+
+    def test_int_scalar(self) -> None:
+        m = self._model()(query="x", filters=[{"key": "price", "value": 30}])
+        assert m.filters[0].value == 30
+
+    def test_float_scalar(self) -> None:
+        m = self._model()(query="x", filters=[{"key": "price <=", "value": 29.99}])
+        assert m.filters[0].value == pytest.approx(29.99)
+
+    def test_bool_scalar(self) -> None:
+        m = self._model()(query="x", filters=[{"key": "is_b2b_only", "value": False}])
+        assert m.filters[0].value is False
+
+    def test_array_in_style(self) -> None:
+        # ``value: [a, b, c]`` is the IN-style filter — matches any of.
+        m = self._model()(
+            query="x", filters=[{"key": "sku", "value": ["A", "B", "C"]}]
+        )
+        assert m.filters[0].value == ["A", "B", "C"]
+
+    def test_null_value_rejected(self) -> None:
+        # ``value: null`` isn't a legitimate filter (means "no filter") —
+        # the LLM should just omit the whole item. Pydantic must reject
+        # so the LLM gets a fast, clear error rather than the retriever
+        # blowing up downstream.
+        with pytest.raises(ValidationError):
+            self._model()(query="x", filters=[{"key": "sku", "value": None}])
+
+    def test_empty_filter_list_and_none_both_accepted(self) -> None:
+        M = self._model()
+        assert M(query="x", filters=None).filters is None
+        assert M(query="x", filters=[]).filters == []
+
+    def test_extra_field_on_filter_rejected(self) -> None:
+        # ``FilterItem`` uses ``extra="forbid"`` — the LLM cannot smuggle
+        # a rogue field past validation.
+        with pytest.raises(ValidationError):
+            self._model()(
+                query="x",
+                filters=[{"key": "sku", "value": "A", "operator": ">>"}],  # noqa
+            )
+
+
+@pytest.mark.unit
+class TestScaleAndSpecialColumnNames:
+    """Boundary conditions on the schema builder itself.
+
+    Pydantic's ``Literal`` machinery is used at runtime with ``Literal[*keys]``
+    unpacking. Boring but important: confirm we don't blow up on realistic
+    column counts, name shapes, or duplicate inputs.
+    """
+
+    def test_large_column_count_produces_working_enum(self) -> None:
+        # 50 columns × 4-6 ops-per-column = ~250 legal keys. This is well
+        # under pydantic's practical ceiling and well over any realistic
+        # commerce/product index.
+        cols = [f"col_{i:04d}" for i in range(50)]
+        types = {c: ("string" if i % 2 else "bigint") for i, c in enumerate(cols)}
+        M = _build_vector_search_input_model(cols, types)
+        schema = M.model_json_schema()
+        enum = schema["$defs"]["DynamicFilterItem"]["properties"]["key"]["enum"]
+        assert 200 <= len(enum) <= 300, f"unexpected enum size {len(enum)}"
+        M(query="x", filters=[{"key": "col_0000 <=", "value": 1}])
+        M(query="x", filters=[{"key": "col_0001 LIKE", "value": "x"}])
+        with pytest.raises(ValidationError):
+            M(query="x", filters=[{"key": "col_0050", "value": 1}])
+
+    def test_duplicate_columns_are_deduped(self) -> None:
+        # ``Literal[*keys]`` collapses duplicates. The enum should not
+        # ship the same key twice.
+        M = _build_vector_search_input_model(["a", "a", "b"])
+        enum = M.model_json_schema()["$defs"]["DynamicFilterItem"]["properties"]["key"]["enum"]
+        assert enum.count("a") == 1
+        assert enum.count("b") == 1
+
+    def test_column_name_with_spaces(self) -> None:
+        # Databricks column names can contain spaces when back-quoted.
+        # Keep it working end-to-end.
+        M = _build_vector_search_input_model(["a col", "b_col"])
+        M(query="x", filters=[{"key": "a col LIKE", "value": "y"}])
+        M(query="x", filters=[{"key": "b_col", "value": "z"}])
+
+    def test_single_column_index(self) -> None:
+        # Trivial happy path with just one column.
+        M = _build_vector_search_input_model(["only"], {"only": "string"})
+        enum = M.model_json_schema()["$defs"]["DynamicFilterItem"]["properties"]["key"]["enum"]
+        assert set(enum) == {"only", "only NOT", "only LIKE", "only NOT LIKE"}
+
+
+@pytest.mark.unit
+class TestFactoryEntryShapes:
+    """The factory accepts several call shapes: ``retriever=...``,
+    ``vector_store=...``, ``dict`` inputs. Confirm dynamic schema is applied
+    consistently regardless of entry shape.
+    """
+
+    def _describe(self):
+        return _describe_payload()
+
+    def _patches(self):
+        """Common patch stack: no network, canned describe."""
+        payload = self._describe()
+        original_refresh = VectorStoreModel.refresh
+        return (
+            patch(
+                "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+            ),
+            patch(
+                "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+            ),
+            patch.object(
+                VectorStoreModel,
+                "refresh",
+                autospec=True,
+                side_effect=lambda self, **kw: original_refresh(
+                    self, details=payload
+                ),
+            ),
+            patch(
+                "dao_ai.tools.vector_search._fetch_column_types",
+                return_value=PRODUCTS_TYPES,
+            ),
+        )
+
+    def _bare_vs(self) -> VectorStoreModel:
+        return VectorStoreModel(
+            index=IndexModel(
+                schema=SchemaModel(
+                    catalog_name="retail_consumer_goods",
+                    schema_name="commerce_swarm",
+                ),
+                name="products_description_index",
+            ),
+            endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
+        )
+
+    def test_vector_store_param_entry(self) -> None:
+        vs = self._bare_vs()
+        with self._patches()[0], self._patches()[1], self._patches()[2], self._patches()[3]:
+            tool = create_vector_search_tool(vector_store=vs, name="via_vs")
+        enum = tool.args_schema.model_json_schema()["$defs"][
+            "DynamicFilterItem"
+        ]["properties"]["key"]["enum"]
+        assert "product_name" in enum
+
+    def test_missing_index_raises_at_model_level(self) -> None:
+        # ``VectorStoreModel`` rejects at construction — factory never sees
+        # a store without either ``index`` or ``source_table``. Guarantees
+        # we can't accidentally build a tool without an index.
+        with pytest.raises(ValidationError, match="index"):
+            VectorStoreModel(
+                endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint")
+            )
+
+    def test_neither_retriever_nor_vector_store_raises(self) -> None:
+        with pytest.raises(ValueError):
+            create_vector_search_tool(name="broken")
+
+    def test_both_retriever_and_vector_store_raises(self) -> None:
+        vs = self._bare_vs()
+        vs.columns = ["a"]
+        r = RetrieverModel(vector_store=vs, columns=["a"])
+        with pytest.raises(ValueError):
+            create_vector_search_tool(retriever=r, vector_store=vs, name="both")
+
+
+@pytest.mark.unit
+class TestBackwardCompatibility:
+    """Nothing about existing YAML-declared configurations should change.
+    Regression guards for the shape the majority of dao-ai users are on.
+    """
+
+    def test_existing_yaml_shape_produces_narrowed_enum_with_types(self) -> None:
+        # This mirrors the shape used in commerce_swarm.yaml — columns
+        # declared, types not. The factory should still narrow to the
+        # declared columns and (if source_table is set + types available)
+        # be type-aware.
+        vs = VectorStoreModel(
+            index=IndexModel(
+                schema=SchemaModel(
+                    catalog_name="retail_consumer_goods",
+                    schema_name="commerce_swarm",
+                ),
+                name="products_description_index",
+            ),
+            endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
+            columns=PRODUCTS_COLUMNS,
+        )
+        retriever = RetrieverModel(vector_store=vs, columns=PRODUCTS_COLUMNS)
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+        ), patch.object(VectorStoreModel, "refresh", autospec=True) as mocked_refresh, patch(
+            "dao_ai.tools.vector_search._fetch_column_types",
+            return_value=PRODUCTS_TYPES,
+        ):
+            tool = create_vector_search_tool(
+                retriever=retriever, name="product_search"
+            )
+        # YAML gave us columns → refresh should NOT have been called.
+        mocked_refresh.assert_not_called()
+        enum = tool.args_schema.model_json_schema()["$defs"][
+            "DynamicFilterItem"
+        ]["properties"]["key"]["enum"]
+        # Regression key not present:
+        assert "name NOT LIKE" not in enum
+        # Type awareness applied:
+        assert "price LIKE" not in enum
+        assert "is_b2b_only <" not in enum
+
+    def test_no_types_fetched_still_produces_working_tool(self) -> None:
+        """If source_table isn't set (or UC Tables API returns nothing),
+        the enum should exist but with all operators — the tool still
+        prevents unknown columns, it just doesn't narrow per-type."""
+        vs = self._bare_vs_no_source()
+        retriever = RetrieverModel(vector_store=vs, columns=["a", "b"])
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+        ), patch.object(VectorStoreModel, "refresh", autospec=True), patch(
+            "dao_ai.tools.vector_search._fetch_column_types", return_value=None
+        ):
+            tool = create_vector_search_tool(retriever=retriever, name="t")
+        enum = tool.args_schema.model_json_schema()["$defs"][
+            "DynamicFilterItem"
+        ]["properties"]["key"]["enum"]
+        # No types → all 8 operator suffixes for each column.
+        assert len(enum) == 16
+        assert "a LIKE" in enum and "a >=" in enum and "b NOT" in enum
+
+    def _bare_vs_no_source(self) -> VectorStoreModel:
+        return VectorStoreModel(
+            index=IndexModel(
+                schema=SchemaModel(
+                    catalog_name="retail_consumer_goods",
+                    schema_name="commerce_swarm",
+                ),
+                name="products_description_index",
+            ),
+            endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
+        )

--- a/tests/dao_ai/test_vector_search_dynamic_schema.py
+++ b/tests/dao_ai/test_vector_search_dynamic_schema.py
@@ -29,6 +29,7 @@ import pytest
 from pydantic import ValidationError
 
 from dao_ai.config import (
+    ColumnInfo,
     FilterItem,
     IndexModel,
     RetrieverModel,
@@ -38,12 +39,12 @@ from dao_ai.config import (
 )
 from dao_ai.tools.vector_search import (
     VectorSearchInput,
+    _build_columns_description,
     _build_filter_item_model,
     _build_vector_search_input_model,
+    _fetch_index_columns,
     _legal_filter_keys,
-    _operators_for_type,
-    _explicit_columns_to_sync,
-    _fetch_source_table_column_types,
+    _normalize_declared_columns,
     _vector_column_names_from_describe,
     create_vector_search_tool,
 )
@@ -96,96 +97,31 @@ def _describe_payload(**overrides: Any) -> dict[str, Any]:
 
 
 @pytest.mark.unit
-class TestOperatorsForType:
-    """The type → operator-suffix mapping is what makes the Literal enum
-    semantically useful. Boundaries: no LIKE on numerics, no ordering on
-    booleans, only equality on booleans, unknown types get everything."""
-
-    def test_numeric_gets_equality_and_ordering(self) -> None:
-        for t in ("int", "bigint", "long", "double", "float", "decimal(10,2)"):
-            ops = _operators_for_type(t)
-            assert " <=" in ops
-            assert " LIKE" not in ops
-            assert " NOT LIKE" not in ops
-
-    def test_string_gets_equality_and_like(self) -> None:
-        for t in ("string", "varchar(255)", "char(3)", "text"):
-            ops = _operators_for_type(t)
-            assert " LIKE" in ops
-            assert " NOT LIKE" in ops
-            assert " <=" not in ops
-            assert " >" not in ops
-
-    def test_boolean_equality_only(self) -> None:
-        ops = _operators_for_type("boolean")
-        assert ops == ("", " NOT")
-
-    def test_temporal_behaves_like_numeric(self) -> None:
-        for t in ("timestamp", "date"):
-            ops = _operators_for_type(t)
-            assert " <=" in ops
-            assert " LIKE" not in ops
-
-    def test_unknown_or_missing_type_permits_all(self) -> None:
-        # We deliberately do NOT block operators on types we don't recognise —
-        # complex types like STRUCT/ARRAY can legitimately use unusual ops on
-        # nested fields, and stripping them would produce false negatives.
-        for t in ("", None, "struct<a:int>", "array<string>", "map<string,int>"):
-            ops = _operators_for_type(t)  # type: ignore[arg-type]
-            assert " LIKE" in ops
-            assert " <=" in ops
-            assert " NOT" in ops
-
-    def test_binary_gets_equality_only(self) -> None:
-        # Binary blobs have no meaningful ordering or LIKE semantics. We
-        # treat them like booleans.
-        for t in ("binary", "BINARY"):
-            ops = _operators_for_type(t)
-            assert ops == ("", " NOT"), f"binary type {t!r} should be equality-only, got {ops}"
-
-    def test_type_matching_is_case_insensitive(self) -> None:
-        # Databricks' DESCRIBE / UC Tables API returns type strings in mixed
-        # case ("BIGINT", "Double", "TIMESTAMP"). We must not miss them.
-        assert _operators_for_type("BIGINT") == _operators_for_type("bigint")
-        assert _operators_for_type("STRING") == _operators_for_type("string")
-        assert _operators_for_type("Boolean") == _operators_for_type("boolean")
-
-    def test_parameterized_types_matched_by_prefix(self) -> None:
-        # DESCRIBE returns parameterized versions of decimal/varchar/char.
-        # We match by prefix so these still map to the right family.
-        assert _operators_for_type("decimal(10,2)") == _operators_for_type("bigint")
-        assert _operators_for_type("varchar(255)") == _operators_for_type("string")
-        assert _operators_for_type("char(3)") == _operators_for_type("string")
-
-
-@pytest.mark.unit
 class TestLegalFilterKeys:
-    def test_cross_product_without_types_permits_all(self) -> None:
+    def test_cross_product_permits_all_suffixes(self) -> None:
         keys = _legal_filter_keys(["a", "b"])
         # 2 columns × 8 suffixes = 16
         assert len(keys) == 16
         assert "a" in keys and "a LIKE" in keys
         assert "b <=" in keys
+        assert "a NOT LIKE" in keys and "b >=" in keys
 
-    def test_cross_product_with_types_narrows_per_column(self) -> None:
+    def test_operator_overrides_restrict_a_specific_column(self) -> None:
+        # brand locked to equality + LIKE only; price falls through to
+        # the full 8-suffix set.
         keys = _legal_filter_keys(
-            ["price", "name", "flag"],
-            {"price": "double", "name": "string", "flag": "boolean"},
+            ["brand", "price"],
+            operator_overrides={"brand": ["", "LIKE"]},
         )
-        # 6 (numeric) + 4 (string) + 2 (bool) = 12
-        assert len(keys) == 12
-        assert "price <=" in keys and "price LIKE" not in keys
-        assert "name LIKE" in keys and "name >" not in keys
-        assert "flag NOT" in keys and "flag LIKE" not in keys
+        # 2 (brand override) + 8 (price default) = 10
+        assert len(keys) == 10
+        assert "brand" in keys and "brand LIKE" in keys
+        assert "brand NOT" not in keys and "brand <" not in keys
+        assert "price" in keys and "price LIKE" in keys and "price <" in keys
 
-    def test_missing_column_type_falls_back_to_all_suffixes(self) -> None:
-        keys = _legal_filter_keys(
-            ["price", "unknown"], {"price": "double"}
-        )
-        # price → 6 (numeric); unknown → 8 (fallback)
-        assert len(keys) == 14
-        assert "unknown LIKE" in keys
-        assert "unknown <" in keys
+    def test_empty_operator_overrides_uses_defaults(self) -> None:
+        keys = _legal_filter_keys(["a"], operator_overrides={})
+        assert len(keys) == 8
 
 
 @pytest.mark.unit
@@ -195,20 +131,29 @@ class TestBuildFilterItemModel:
         assert _build_filter_item_model([]) is FilterItem
 
     def test_columns_produce_literal_narrowed_key(self) -> None:
-        M = _build_filter_item_model(PRODUCTS_COLUMNS, PRODUCTS_TYPES)
+        M = _build_filter_item_model(PRODUCTS_COLUMNS)
         schema = M.model_json_schema()
         enum = schema["properties"]["key"]["enum"]
-        # Numeric/bool ops for product_id + price + is_b2b_only, string ops
-        # for the 6 text columns: 6 + 6 + 2 + 4*6 = 38.
-        assert len(enum) == 38
+        # Every column gets every suffix — no type-aware narrowing.
+        # 9 columns × 8 suffixes = 72.
+        assert len(enum) == 72
         assert "product_id" in enum and "product_id <=" in enum
         assert "product_name LIKE" in enum
         assert "is_b2b_only NOT" in enum
-        # And the regression key must NOT appear:
+        # The regression key must NOT appear (column doesn't exist):
         assert "name NOT LIKE" not in enum
-        # Nor should nonsense combos:
-        assert "price LIKE" not in enum
-        assert "is_b2b_only <" not in enum
+
+    def test_operator_overrides_narrow_a_specific_column(self) -> None:
+        # brand locked to ["", "LIKE"]; price gets all 8 suffixes.
+        M = _build_filter_item_model(
+            ["brand", "price"],
+            operator_overrides={"brand": ["", "LIKE"]},
+        )
+        enum = M.model_json_schema()["properties"]["key"]["enum"]
+        assert "brand" in enum and "brand LIKE" in enum
+        assert "brand NOT" not in enum and "brand <" not in enum
+        # price falls through to defaults
+        assert "price" in enum and "price LIKE" in enum and "price <" in enum
 
 
 @pytest.mark.unit
@@ -217,7 +162,7 @@ class TestBuildVectorSearchInputModel:
         assert _build_vector_search_input_model([]) is VectorSearchInput
 
     def test_valid_filter_accepted(self) -> None:
-        M = _build_vector_search_input_model(PRODUCTS_COLUMNS, PRODUCTS_TYPES)
+        M = _build_vector_search_input_model(PRODUCTS_COLUMNS)
         m = M(
             query="peanut-free dessert under 30",
             filters=[
@@ -232,7 +177,7 @@ class TestBuildVectorSearchInputModel:
     def test_regression_bad_column_key_rejected(self) -> None:
         """The exact key emitted by the LLM in trace fc785d795b... — must
         never make it past pydantic validation."""
-        M = _build_vector_search_input_model(PRODUCTS_COLUMNS, PRODUCTS_TYPES)
+        M = _build_vector_search_input_model(PRODUCTS_COLUMNS)
         with pytest.raises(ValidationError) as exc_info:
             M(
                 query="dessert",
@@ -241,19 +186,20 @@ class TestBuildVectorSearchInputModel:
         # Pydantic error message should reference the offending field.
         assert "filters" in str(exc_info.value) and "key" in str(exc_info.value)
 
-    def test_type_wrong_operator_rejected(self) -> None:
-        """LIKE on a numeric column, ordering on a bool — both must be
-        rejected by the type-aware enum."""
-        M = _build_vector_search_input_model(PRODUCTS_COLUMNS, PRODUCTS_TYPES)
-        for bad in ("price LIKE", "price NOT LIKE", "is_b2b_only <"):
-            with pytest.raises(ValidationError):
-                M(query="x", filters=[{"key": bad, "value": 0}])
+    def test_operator_override_rejects_disallowed_suffix(self) -> None:
+        """When ColumnInfo.operators locks a column to a subset, Pydantic
+        rejects any suffix outside that subset."""
+        M = _build_vector_search_input_model(
+            ["brand"], operator_overrides={"brand": ["", "LIKE"]}
+        )
+        with pytest.raises(ValidationError):
+            M(query="x", filters=[{"key": "brand NOT", "value": "y"}])
 
-    def test_falls_back_when_types_missing(self) -> None:
-        # No type info → all suffixes permitted on every column.
+    def test_permissive_when_no_overrides(self) -> None:
+        # No overrides → all 8 suffixes for every column.
         M = _build_vector_search_input_model(PRODUCTS_COLUMNS)
         ok = M(query="x", filters=[{"key": "price LIKE", "value": "3"}])
-        # No exception → falls back to permissive mode.
+        # No exception — the enum allows every suffix regardless of type.
         assert ok.filters[0].key == "price LIKE"
 
 
@@ -287,7 +233,7 @@ class TestFactoryColumnHydration:
         with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
-            "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
+            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
         ), patch.object(
             VectorStoreModel,
             "refresh",
@@ -331,7 +277,7 @@ class TestFactoryColumnHydration:
         ) as mocked_refresh, patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
-            "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
+            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
         ):
             tool = create_vector_search_tool(retriever=retriever, name="product_search")
 
@@ -345,43 +291,25 @@ class TestFactoryColumnHydration:
         # Everything outside the declared subset is absent:
         assert "sku" not in enum and "category" not in enum
 
-    def test_yaml_column_not_on_index_dropped_with_warning(self) -> None:
-        """Config declares a bogus column not on the index → dropped, WARN
-        logged with column name + index name. LLM can never emit a filter
-        that would fail at the VS API."""
+    def test_yaml_columns_trusted_verbatim_no_drift_check(self) -> None:
+        """Bare-string ``retriever.columns`` are trusted verbatim: even a
+        column that isn't on the index is included in the enum. Drift
+        detection is not the framework's job — the VS API will reject the
+        filter at query time. Users who want authoritative schema control
+        should declare ColumnInfo instead."""
         vs = self._make_vs(with_columns=False)
         retriever = RetrieverModel(
             vector_store=vs,
             columns=["product_id", "product_name", "nonexistent_col_xyz"],
         )
-        payload = _describe_payload()
-        original_refresh = VectorStoreModel.refresh
-
-        # loguru bypasses stdlib logging — capture via a dedicated sink.
-        from loguru import logger as loguru_logger
-
-        captured: list[str] = []
-        sink_id = loguru_logger.add(
-            lambda msg: captured.append(str(msg)),
-            level="WARNING",
-            format="{message} {extra}",
-        )
-        try:
-            with patch.object(
-                VectorStoreModel,
-                "refresh",
-                autospec=True,
-                side_effect=lambda self, **kw: original_refresh(self, details=payload),
-            ), patch(
-                "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-            ), patch(
-                "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
-            ):
-                tool = create_vector_search_tool(
-                    retriever=retriever, name="product_search"
-                )
-        finally:
-            loguru_logger.remove(sink_id)
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
+        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+            tool = create_vector_search_tool(
+                retriever=retriever, name="product_search"
+            )
 
         enum = (
             tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
@@ -390,47 +318,35 @@ class TestFactoryColumnHydration:
         )
         assert "product_id" in enum
         assert "product_name" in enum
-        assert not any(k.startswith("nonexistent_col_xyz") for k in enum)
-
-        warnings_text = " ".join(captured)
-        assert "nonexistent_col_xyz" in warnings_text
-        assert "products_description_index" in warnings_text
+        # All three declared cols get every operator suffix — no drift
+        # check against a live index.
+        assert "nonexistent_col_xyz" in enum
+        assert "nonexistent_col_xyz LIKE" in enum
 
     def test_source_table_never_called_for_schema(self) -> None:
-        """Regression guard: schema-building code must call
-        ``wc.tables.get`` only on the INDEX's full_name (mirrors
-        databricks-langchain), never on any other UC entity — most
-        importantly, never on the source table (whose columns aren't
-        guaranteed to be on the index).
+        """Regression guard: this PR intentionally removed source-table
+        UC lookup — only ``wc.tables.get(index.full_name)`` is allowed.
+        Matches upstream databricks-langchain (single call, index only).
+
+        Even under Mode B (bare strings declared), we call
+        ``_fetch_index_columns`` best-effort for description enrichment
+        — but never touch the source table.
         """
         vs = self._make_vs(with_columns=False)
-        retriever = RetrieverModel(vector_store=vs)
-        payload = _describe_payload()
-        original_refresh = VectorStoreModel.refresh
+        retriever = RetrieverModel(vector_store=vs, columns=["product_id"])
         wc_spy = MagicMock()
-        # Simulate a successful UC Tables lookup on the index.
         fake_index_table = MagicMock()
-        fake_index_table.columns = [
-            MagicMock(name="product_id", type_text="bigint"),
-            MagicMock(name="product_name", type_text="string"),
-        ]
-        # MagicMock's name attr is special; set explicitly.
-        for col, real_name in zip(
-            fake_index_table.columns, ["product_id", "product_name"]
-        ):
-            col.name = real_name
+        col = MagicMock()
+        col.name = "product_id"
+        col.type_text = "bigint"
+        col.type_name = "bigint"
+        col.comment = None
+        fake_index_table.columns = [col]
         wc_spy.tables.get.return_value = fake_index_table
 
-        with patch.object(
-            VectorStoreModel,
-            "refresh",
-            autospec=True,
-            side_effect=lambda self, **kw: original_refresh(self, details=payload),
-        ), patch(
+        with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
-        ), patch.object(
+        ), patch.object(VectorStoreModel, "refresh", autospec=True), patch.object(
             VectorStoreModel,
             "workspace_client_from",
             autospec=True,
@@ -438,8 +354,8 @@ class TestFactoryColumnHydration:
         ):
             create_vector_search_tool(retriever=retriever, name="product_search")
 
-        # Every call to wc.tables.get must target the index full name.
-        assert wc_spy.tables.get.call_count >= 1
+        # Every call to wc.tables.get must target the index full name —
+        # never the source table.
         for call in wc_spy.tables.get.call_args_list:
             args, kwargs = call.args, call.kwargs
             target = args[0] if args else kwargs.get("full_name")
@@ -462,10 +378,7 @@ class TestFactoryColumnHydration:
             autospec=True,
             side_effect=RuntimeError("describe unauthorized"),
         ), patch(
-            "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_column_types",
-            return_value=None,
+            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
         ):
             tool = create_vector_search_tool(retriever=retriever, name="product_search")
 
@@ -491,7 +404,7 @@ class TestFactoryColumnHydration:
             autospec=True,
             side_effect=RuntimeError("describe unauthorized"),
         ), patch(
-            "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
+            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
         ):
             tool = create_vector_search_tool(retriever=retriever, name="product_search")
 
@@ -602,163 +515,116 @@ class TestVectorColumnStripping:
         # business column named ``product_vector`` is preserved.
         assert "product_vector" not in _vector_column_names_from_describe(details)
 
-    def _make_source_table_setup(
+    def _make_index_uc_setup(
         self,
         *,
-        table_columns: list[tuple[str, str]],
+        table_columns: list[tuple[str, str | None, str | None]],
         describe: dict | None,
-        source_table_full_name: str = "cat.sch.products",
+        index_full_name: str = "cat.sch.probe_test_index",
     ) -> tuple[Any, Any]:
         """Build a MagicMock chain that mimics
-        ``vs.workspace_client_from(None).tables.get(source_table.full_name)``
+        ``vs.workspace_client_from(None).tables.get(index.full_name)``
         and stashes ``describe`` on the vector_store as ``_index_details``."""
         vs = MagicMock()
-        vs.index.full_name = "cat.sch.probe_test_index"
-        vs.source_table.full_name = source_table_full_name
+        vs.index.full_name = index_full_name
         vs._index_details = describe
         wc = MagicMock()
         table = MagicMock()
         table.columns = [
-            SimpleNamespace(name=n, type_text=t, type_name=t)
-            for n, t in table_columns
+            SimpleNamespace(name=n, type_text=t, type_name=t, comment=c)
+            for n, t, c in table_columns
         ]
         wc.tables.get.return_value = table
         vs.workspace_client_from.return_value = wc
         return vs, wc
 
-    def test_strips_synthesised_vector_column_from_describe(self) -> None:
-        vs, _ = self._make_source_table_setup(
+    def test_index_uc_strips_synthesised_vector_column(self) -> None:
+        vs, _ = self._make_index_uc_setup(
             table_columns=[
-                ("product_id", "bigint"),
-                ("product_name", "string"),
-                ("description", "string"),
-                # Source-table lookup runs against the actual source table,
-                # not the index — so the synthesised ``description_vector``
-                # column doesn't exist here. It's stripped anyway on the
-                # index-side lookup; this test exercises the source-table
-                # happy path where the source cols == index cols.
+                ("product_id", "bigint", None),
+                ("product_name", "string", "Full product name"),
+                ("description", "string", None),
+                ("description_vector", "array<double>", None),
             ],
-            describe=_describe_payload(),
+            describe=_describe_payload(),  # embedding source = "description"
         )
-        assert _fetch_source_table_column_types(vs) == {
-            "product_id": "bigint",
-            "product_name": "string",
-            "description": "string",
-        }
-
-    def test_preserves_business_column_ending_in_vector(self) -> None:
-        """A user column literally named ``product_vector`` on the source
-        table must survive — describe's ``embedding_source_columns`` is
-        the authoritative signal for what's a synthesised vector, and
-        ``product`` is not the embedding source (``description`` is)."""
-        describe = _describe_payload()
-        # Drop the default ``columns_to_sync`` so we're isolating the
-        # vector-stripping behavior, not the sync-subset intersection.
-        describe["delta_sync_index_spec"].pop("columns_to_sync", None)
-        vs, _ = self._make_source_table_setup(
-            table_columns=[
-                ("product_id", "bigint"),
-                ("product_name", "string"),
-                ("product_vector", "array<double>"),
-                ("description", "string"),
-            ],
-            describe=describe,  # embedding source = "description"
-        )
-        out = _fetch_source_table_column_types(vs)
+        out = _fetch_index_columns(vs)
         assert out is not None
-        assert "product_vector" in out  # preserved!
+        names = [n for n, _, _ in out]
+        assert names == ["product_id", "product_name", "description"]
+        # Description carried through when set.
+        assert dict((n, c) for n, _, c in out)["product_name"] == "Full product name"
 
-    def test_falls_back_to_suffix_heuristic_when_describe_missing(self) -> None:
-        """No describe details cached → we can't know which ``_vector``
-        column is synthesised, so we strip all of them. Same controlled
-        false-positive risk as the index-side lookup."""
-        vs, _ = self._make_source_table_setup(
-            table_columns=[
-                ("product_id", "bigint"),
-                ("product_name", "string"),
-                ("description_vector", "array<double>"),
-            ],
-            describe=None,
-        )
-        assert _fetch_source_table_column_types(vs) == {
-            "product_id": "bigint",
-            "product_name": "string",
-        }
-
-    def test_strips_cdf_underscore_prefix_fields(self) -> None:
-        vs, _ = self._make_source_table_setup(
-            table_columns=[
-                ("product_id", "bigint"),
-                ("_change_type", "string"),
-                ("_commit_version", "bigint"),
-                ("product_name", "string"),
-            ],
-            describe=_describe_payload(),
-        )
-        assert _fetch_source_table_column_types(vs) == {
-            "product_id": "bigint",
-            "product_name": "string",
-        }
-
-    def test_intersects_with_columns_to_sync_subset(self) -> None:
-        """When the user explicitly restricts sync to a subset, source-table
-        lookup must not advertise cols the index doesn't hold."""
+    def test_index_uc_preserves_business_column_ending_in_vector(self) -> None:
+        """A user column literally named ``product_vector`` must survive —
+        describe's ``embedding_source_columns`` is the authoritative signal
+        for what's a synthesised vector, and ``product`` is not the
+        embedding source (``description`` is)."""
         describe = _describe_payload()
-        # Explicit subset: only product_id + product_name are synced.
-        describe["delta_sync_index_spec"]["columns_to_sync"] = [
-            "product_id",
-            "product_name",
-        ]
-        vs, _ = self._make_source_table_setup(
+        vs, _ = self._make_index_uc_setup(
             table_columns=[
-                ("product_id", "bigint"),
-                ("product_name", "string"),
-                ("brand", "string"),       # NOT on the index
-                ("category", "string"),    # NOT on the index
-                ("description", "string"),
+                ("product_id", "bigint", None),
+                ("product_name", "string", None),
+                ("product_vector", "array<double>", None),
+                ("description", "string", None),
+                ("description_vector", "array<double>", None),
             ],
             describe=describe,
         )
-        out = _fetch_source_table_column_types(vs)
-        assert out == {"product_id": "bigint", "product_name": "string"}
+        out = _fetch_index_columns(vs)
+        assert out is not None
+        names = [n for n, _, _ in out]
+        assert "product_vector" in names
+        assert "description_vector" not in names
 
-    def test_empty_source_table_returns_none(self) -> None:
-        vs, _ = self._make_source_table_setup(
-            table_columns=[],
+    def test_index_uc_falls_back_to_suffix_heuristic_when_describe_missing(
+        self,
+    ) -> None:
+        vs, _ = self._make_index_uc_setup(
+            table_columns=[
+                ("product_id", "bigint", None),
+                ("product_name", "string", None),
+                ("description_vector", "array<double>", None),
+            ],
             describe=None,
         )
-        assert _fetch_source_table_column_types(vs) is None
+        out = _fetch_index_columns(vs)
+        assert out is not None
+        names = [n for n, _, _ in out]
+        assert names == ["product_id", "product_name"]
 
-    def test_uc_tables_permission_error_returns_none(self) -> None:
+    def test_index_uc_strips_cdf_underscore_prefix_fields(self) -> None:
+        vs, _ = self._make_index_uc_setup(
+            table_columns=[
+                ("product_id", "bigint", None),
+                ("_change_type", "string", None),
+                ("_commit_version", "bigint", None),
+                ("product_name", "string", None),
+            ],
+            describe=_describe_payload(),
+        )
+        out = _fetch_index_columns(vs)
+        assert out is not None
+        names = [n for n, _, _ in out]
+        assert names == ["product_id", "product_name"]
+
+    def test_index_uc_empty_returns_none(self) -> None:
+        vs, _ = self._make_index_uc_setup(table_columns=[], describe=None)
+        assert _fetch_index_columns(vs) is None
+
+    def test_index_uc_permission_error_returns_none(self) -> None:
         vs = MagicMock()
-        vs.source_table.full_name = "cat.sch.forbidden_source"
+        vs.index.full_name = "cat.sch.forbidden_index"
         vs._index_details = None
         wc = MagicMock()
         wc.tables.get.side_effect = PermissionError("forbidden")
         vs.workspace_client_from.return_value = wc
-        assert _fetch_source_table_column_types(vs) is None
+        assert _fetch_index_columns(vs) is None
 
-    def test_direct_access_no_source_table_returns_none(self) -> None:
-        """Direct-Access indexes have no source_table; the fallback returns
-        None and the caller uses ``refresh()``'s ``columns_to_sync`` handling
-        instead. Verifies no AttributeError on the None check."""
+    def test_index_uc_no_index_returns_none(self) -> None:
         vs = MagicMock()
-        vs.source_table = None
-        assert _fetch_source_table_column_types(vs) is None
-
-    def test_explicit_columns_to_sync_helper(self) -> None:
-        """``_explicit_columns_to_sync`` returns None when no subset is
-        declared (default = all cols) and a set when the user restricted."""
-        # No columns_to_sync in payload → None.
-        no_sync = _describe_payload()
-        no_sync["delta_sync_index_spec"].pop("columns_to_sync", None)
-        assert _explicit_columns_to_sync(no_sync) is None
-        # Explicit subset → set.
-        describe = _describe_payload()
-        describe["delta_sync_index_spec"]["columns_to_sync"] = ["a", "b"]
-        assert _explicit_columns_to_sync(describe) == {"a", "b"}
-        # None input → None.
-        assert _explicit_columns_to_sync(None) is None
+        vs.index = None
+        assert _fetch_index_columns(vs) is None
 
 
 @pytest.mark.unit
@@ -770,8 +636,7 @@ class TestFilterValueShapes:
 
     def _model(self):
         return _build_vector_search_input_model(
-            ["sku", "price", "is_b2b_only"],
-            {"sku": "string", "price": "double", "is_b2b_only": "boolean"},
+            ["sku", "price", "is_b2b_only"]
         )
 
     def test_string_scalar(self) -> None:
@@ -830,15 +695,14 @@ class TestScaleAndSpecialColumnNames:
     """
 
     def test_large_column_count_produces_working_enum(self) -> None:
-        # 50 columns × 4-6 ops-per-column = ~250 legal keys. This is well
-        # under pydantic's practical ceiling and well over any realistic
-        # commerce/product index.
+        # 50 columns × 8 suffixes = 400 legal keys. Well under pydantic's
+        # practical ceiling and well over any realistic commerce/product
+        # index.
         cols = [f"col_{i:04d}" for i in range(50)]
-        types = {c: ("string" if i % 2 else "bigint") for i, c in enumerate(cols)}
-        M = _build_vector_search_input_model(cols, types)
+        M = _build_vector_search_input_model(cols)
         schema = M.model_json_schema()
         enum = schema["$defs"]["DynamicFilterItem"]["properties"]["key"]["enum"]
-        assert 200 <= len(enum) <= 300, f"unexpected enum size {len(enum)}"
+        assert len(enum) == 400
         M(query="x", filters=[{"key": "col_0000 <=", "value": 1}])
         M(query="x", filters=[{"key": "col_0001 LIKE", "value": "x"}])
         with pytest.raises(ValidationError):
@@ -860,10 +724,13 @@ class TestScaleAndSpecialColumnNames:
         M(query="x", filters=[{"key": "b_col", "value": "z"}])
 
     def test_single_column_index(self) -> None:
-        # Trivial happy path with just one column.
-        M = _build_vector_search_input_model(["only"], {"only": "string"})
+        # Trivial happy path with just one column — all 8 suffixes.
+        M = _build_vector_search_input_model(["only"])
         enum = M.model_json_schema()["$defs"]["DynamicFilterItem"]["properties"]["key"]["enum"]
-        assert set(enum) == {"only", "only NOT", "only LIKE", "only NOT LIKE"}
+        assert set(enum) == {
+            "only", "only NOT", "only <", "only <=",
+            "only >", "only >=", "only LIKE", "only NOT LIKE",
+        }
 
 
 @pytest.mark.unit
@@ -885,7 +752,7 @@ class TestFactoryEntryShapes:
                 "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
             ),
             patch(
-                "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
+                "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
             ),
             patch.object(
                 VectorStoreModel,
@@ -967,7 +834,7 @@ class TestBackwardCompatibility:
         with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
-            "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
+            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
         ), patch.object(
             VectorStoreModel,
             "refresh",
@@ -996,16 +863,13 @@ class TestBackwardCompatibility:
         with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
-            "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
-        ), patch.object(VectorStoreModel, "refresh", autospec=True), patch(
-            "dao_ai.tools.vector_search._fetch_index_column_types",
-            return_value=None,
-        ):
+            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
+        ), patch.object(VectorStoreModel, "refresh", autospec=True):
             tool = create_vector_search_tool(retriever=retriever, name="t")
         enum = tool.args_schema.model_json_schema()["$defs"][
             "DynamicFilterItem"
         ]["properties"]["key"]["enum"]
-        # No types → all 8 operator suffixes for each column.
+        # Every column always gets all 8 operator suffixes.
         assert len(enum) == 16
         assert "a LIKE" in enum and "a >=" in enum and "b NOT" in enum
 
@@ -1051,7 +915,7 @@ class TestMcpAdapterEntryPoint:
             with patch(
                 "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
             ), patch(
-                "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
+                "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
             ), patch.object(
                 VectorStoreModel,
                 "refresh",
@@ -1099,7 +963,11 @@ class TestIndexScopedTypeLookup:
         wc.tables.get.return_value = table
         return wc
 
-    def test_type_aware_enum_from_index_uc_lookup(self) -> None:
+    def test_index_uc_discovery_powers_the_enum_when_no_config_columns(self) -> None:
+        """Primary discovery path: nothing declared → factory calls
+        ``_fetch_index_columns`` on the index UC entity, uses the resulting
+        column list as the enum names. All 8 operator suffixes apply to
+        every column (no type-aware narrowing)."""
         vs = VectorStoreModel(
             index=IndexModel(
                 schema=SchemaModel(
@@ -1111,29 +979,17 @@ class TestIndexScopedTypeLookup:
             endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
         )
         retriever = RetrieverModel(vector_store=vs)
-        wc = self._wc_with_index_table(
-            [
-                ("product_id", "bigint"),
-                ("product_name", "string"),
-                ("price", "double"),
-                ("is_b2b_only", "boolean"),
-                # A vector column that must be stripped by the leading-
-                # underscore rule (no describe payload available).
-                ("__db_description_vector", "array<float>"),
-            ]
-        )
         with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
-            "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
-        ), patch.object(
-            VectorStoreModel, "refresh", autospec=True
-        ), patch.object(
-            VectorStoreModel,
-            "workspace_client_from",
-            autospec=True,
-            return_value=wc,
-        ):
+            "dao_ai.tools.vector_search._fetch_index_columns",
+            return_value=[
+                ("product_id", "bigint", None),
+                ("product_name", "string", "Full product name"),
+                ("price", "double", None),
+                ("is_b2b_only", "boolean", None),
+            ],
+        ), patch.object(VectorStoreModel, "refresh", autospec=True):
             tool = create_vector_search_tool(
                 retriever=retriever, name="product_search"
             )
@@ -1142,21 +998,22 @@ class TestIndexScopedTypeLookup:
                 "properties"
             ]["key"]["enum"]
         )
-        # Vector column stripped.
-        assert not any("__db_description_vector" in k for k in enum), enum
-        # Type-aware operators:
-        assert "product_name LIKE" in enum  # string → LIKE
-        assert "product_name >" not in enum  # …not ordering
-        assert "price <=" in enum  # double → ordering
-        assert "price LIKE" not in enum  # …not LIKE
-        assert "is_b2b_only NOT" in enum  # bool → equality/NOT
-        assert "is_b2b_only <" not in enum  # …no ordering
+        # 4 discovered columns × 8 suffixes = 32.
+        assert len(enum) == 32
+        # All suffixes valid for every column — no type-aware narrowing.
+        assert "product_name LIKE" in enum
+        assert "product_name >=" in enum        # string with ordering — allowed now
+        assert "price LIKE" in enum             # numeric with LIKE — allowed now
+        assert "is_b2b_only <" in enum          # bool with ordering — allowed now
+        # Hallucinated column still rejected (this is the regression):
+        assert "name NOT LIKE" not in enum
+        # Description enrichment (product_name has a UC comment):
+        assert "Full product name" in tool.description
 
     def test_soft_fallback_when_index_uc_lookup_fails(self) -> None:
-        """UC Tables call on the INDEX fails → factory falls through to
-        UC Tables on the SOURCE TABLE. Because the source-table lookup
-        also returns ``{name: type}``, columns AND type-aware operator
-        narrowing are both preserved on the fallback path."""
+        """UC Tables call fails AND nothing declared → factory degrades to
+        free-form ``FilterItem`` (pre-branch behavior). No source-table
+        fallback (dropped in this PR — matches upstream databricks-langchain)."""
         vs = VectorStoreModel(
             index=IndexModel(
                 schema=SchemaModel(
@@ -1168,35 +1025,269 @@ class TestIndexScopedTypeLookup:
             endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
         )
         retriever = RetrieverModel(vector_store=vs)
-        wc = MagicMock()
-        wc.tables.get.side_effect = PermissionError("no access")
 
         with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
-            "dao_ai.tools.vector_search._fetch_source_table_column_types",
-            return_value={"product_id": "bigint", "product_name": "string"},
-        ), patch.object(
-            VectorStoreModel, "refresh", autospec=True
-        ), patch.object(
-            VectorStoreModel,
-            "workspace_client_from",
-            autospec=True,
-            return_value=wc,
-        ):
+            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
+        ), patch.object(VectorStoreModel, "refresh", autospec=True):
             tool = create_vector_search_tool(retriever=retriever, name="t")
 
-        enum = (
-            tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
-                "properties"
-            ]["key"]["enum"]
+        schema = tool.args_schema.model_json_schema()
+        # No enum on filter key — free-form fallback.
+        filter_ref = schema["$defs"].get("FilterItem") or schema["$defs"].get(
+            "DynamicFilterItem"
         )
-        # Columns narrowed (regression blocked). Types come through from
-        # the source-table fallback, so operators are narrowed too:
-        # bigint gets NUMERIC ops (no LIKE), string gets STRING ops
-        # (no ordering).
-        assert "product_id" in enum and "product_name" in enum
-        assert "product_id LIKE" not in enum  # bigint — no LIKE
-        assert "product_id <=" in enum        # bigint — ordering OK
-        assert "product_name LIKE" in enum    # string — LIKE OK
-        assert "product_name <=" not in enum  # string — no ordering
+        assert "enum" not in filter_ref["properties"]["key"]
+
+
+# ---------------------------------------------------------------------------
+# Hand-declared ColumnInfo — the new first-class knob for column schema
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNormalizeDeclaredColumns:
+    """The helper that splits ``list[str | ColumnInfo]`` into flat lookups."""
+
+    def test_all_strings_no_hand_declaration(self) -> None:
+        names, types, descs, ops, any_hand = _normalize_declared_columns(
+            ["a", "b", "c"]
+        )
+        assert names == ["a", "b", "c"]
+        assert types == {}
+        assert descs == {}
+        assert ops == {}
+        assert any_hand is False
+
+    def test_all_column_info(self) -> None:
+        items = [
+            ColumnInfo(name="brand", type="string", description="Brand name"),
+            ColumnInfo(name="price", type="number"),
+        ]
+        names, types, descs, ops, any_hand = _normalize_declared_columns(items)
+        assert names == ["brand", "price"]
+        assert types == {"brand": "STRING", "price": "NUMBER"}
+        assert descs == {"brand": "Brand name"}  # only where set
+        assert ops == {}  # neither set operators explicitly
+        assert any_hand is True
+
+    def test_column_info_explicit_operators(self) -> None:
+        items = [
+            ColumnInfo(name="brand", type="string", operators=["", "LIKE"]),
+        ]
+        _, _, _, ops, any_hand = _normalize_declared_columns(items)
+        assert ops == {"brand": ["", "LIKE"]}
+        assert any_hand is True
+
+    def test_mixed_str_and_column_info(self) -> None:
+        items = [
+            "product_id",
+            ColumnInfo(name="brand", type="string", description="Brand"),
+            "sku",
+        ]
+        names, types, descs, ops, any_hand = _normalize_declared_columns(items)
+        assert names == ["product_id", "brand", "sku"]
+        # Only brand has type/description; bare strings don't populate.
+        assert types == {"brand": "STRING"}
+        assert descs == {"brand": "Brand"}
+        assert ops == {}
+        assert any_hand is True
+
+    def test_empty_list(self) -> None:
+        names, types, descs, ops, any_hand = _normalize_declared_columns([])
+        assert names == [] and types == {} and descs == {} and ops == {}
+        assert any_hand is False
+
+
+@pytest.mark.unit
+class TestBuildColumnsDescription:
+    def test_names_only(self) -> None:
+        block = _build_columns_description(["a", "b"], {}, {})
+        assert "- a" in block
+        assert "- b" in block
+        assert "Supports operators" in block
+
+    def test_names_with_types(self) -> None:
+        block = _build_columns_description(
+            ["price", "brand"],
+            {"price": "INT64", "brand": "STRING"},
+            {},
+        )
+        assert "- price (INT64)" in block
+        assert "- brand (STRING)" in block
+
+    def test_names_with_types_and_descriptions(self) -> None:
+        block = _build_columns_description(
+            ["brand"],
+            {"brand": "STRING"},
+            {"brand": "Brand — MILWAUKEE, DEWALT, MAKITA"},
+        )
+        assert "- brand (STRING) : Brand — MILWAUKEE, DEWALT, MAKITA" in block
+
+    def test_empty_names_returns_empty(self) -> None:
+        assert _build_columns_description([], {}, {}) == ""
+
+
+@pytest.mark.unit
+class TestHandDeclaredColumnInfoInFactory:
+    """When retriever.columns contains a ColumnInfo, the factory:
+    * uses ColumnInfo.name / .description / .type in the description block,
+    * uses ColumnInfo.operators as operator_overrides in the enum,
+    * SKIPS build-time UC calls (the whole point of hand-declaration).
+    """
+
+    def _bare_vs(self) -> VectorStoreModel:
+        return VectorStoreModel(
+            index=IndexModel(
+                schema=SchemaModel(
+                    catalog_name="retail_consumer_goods",
+                    schema_name="commerce_swarm",
+                ),
+                name="products_description_index",
+            ),
+            endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
+        )
+
+    def test_hand_declared_skips_uc_calls(self) -> None:
+        """When any ColumnInfo is in the list, no UC Tables call is made
+        at build time — hand-declaration is authoritative."""
+        vs = self._bare_vs()
+        retriever = RetrieverModel(
+            vector_store=vs,
+            columns=[
+                ColumnInfo(name="brand", type="string", description="Brand"),
+                ColumnInfo(name="price", type="number"),
+            ],
+        )
+        fetch_mock = MagicMock(return_value=None)
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._fetch_index_columns", fetch_mock
+        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+            create_vector_search_tool(retriever=retriever, name="t")
+        # The factory must NOT have called _fetch_index_columns in
+        # hand-declared mode.
+        fetch_mock.assert_not_called()
+
+    def test_hand_declared_operators_narrow_enum(self) -> None:
+        vs = self._bare_vs()
+        retriever = RetrieverModel(
+            vector_store=vs,
+            columns=[
+                ColumnInfo(
+                    name="brand",
+                    type="string",
+                    operators=["", "LIKE"],  # explicitly locked
+                ),
+                ColumnInfo(name="price", type="number"),  # defaults
+            ],
+        )
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
+        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+            tool = create_vector_search_tool(retriever=retriever, name="t")
+        enum = tool.args_schema.model_json_schema()["$defs"][
+            "DynamicFilterItem"
+        ]["properties"]["key"]["enum"]
+        # brand is locked to 2 ops; price gets full 8.
+        assert "brand" in enum and "brand LIKE" in enum
+        assert "brand NOT" not in enum and "brand <" not in enum
+        assert "price" in enum and "price LIKE" in enum and "price <" in enum
+
+    def test_hand_declared_default_operators_gets_all_suffixes(self) -> None:
+        """ColumnInfo without explicit operators → the default full-list
+        signals 'don't restrict', so all 8 suffixes apply."""
+        vs = self._bare_vs()
+        retriever = RetrieverModel(
+            vector_store=vs,
+            columns=[ColumnInfo(name="brand", type="string")],
+        )
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
+        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+            tool = create_vector_search_tool(retriever=retriever, name="t")
+        enum = tool.args_schema.model_json_schema()["$defs"][
+            "DynamicFilterItem"
+        ]["properties"]["key"]["enum"]
+        # All 8 suffixes for brand.
+        assert len(enum) == 8
+
+    def test_hand_declared_description_appears_in_tool_description(self) -> None:
+        vs = self._bare_vs()
+        retriever = RetrieverModel(
+            vector_store=vs,
+            columns=[
+                ColumnInfo(
+                    name="brand",
+                    type="string",
+                    description="Brand — MILWAUKEE, DEWALT, MAKITA",
+                ),
+            ],
+        )
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
+        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+            tool = create_vector_search_tool(retriever=retriever, name="t")
+        assert "Brand — MILWAUKEE, DEWALT, MAKITA" in tool.description
+        assert "- brand (STRING)" in tool.description
+
+    def test_mixed_str_and_column_info_both_in_enum(self) -> None:
+        vs = self._bare_vs()
+        retriever = RetrieverModel(
+            vector_store=vs,
+            columns=[
+                "product_id",
+                ColumnInfo(name="brand", type="string", operators=["", "LIKE"]),
+                "sku",
+            ],
+        )
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
+        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+            tool = create_vector_search_tool(retriever=retriever, name="t")
+        enum = tool.args_schema.model_json_schema()["$defs"][
+            "DynamicFilterItem"
+        ]["properties"]["key"]["enum"]
+        # brand → 2 ops; product_id + sku → 8 ops each = 18 total.
+        assert len(enum) == 18
+        assert "brand LIKE" in enum and "brand NOT" not in enum
+        assert "product_id LIKE" in enum and "sku <=" in enum
+
+    def test_bare_strings_still_call_uc_for_description(self) -> None:
+        """Mode B: bare-string columns declared → UC call is still made
+        best-effort for description enrichment (types + comments)."""
+        vs = self._bare_vs()
+        retriever = RetrieverModel(
+            vector_store=vs, columns=["brand", "price"]
+        )
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._fetch_index_columns",
+            return_value=[
+                ("brand", "STRING", "Brand — Milwaukee, DeWalt, ..."),
+                ("price", "INT64", None),
+            ],
+        ) as fetch_mock, patch.object(VectorStoreModel, "refresh", autospec=True):
+            tool = create_vector_search_tool(retriever=retriever, name="t")
+        # UC call happened (for description enrichment)
+        fetch_mock.assert_called_once()
+        # But the enum is built from declared names + all 8 suffixes each
+        # — no type-aware narrowing.
+        enum = tool.args_schema.model_json_schema()["$defs"][
+            "DynamicFilterItem"
+        ]["properties"]["key"]["enum"]
+        assert len(enum) == 16
+        assert "price LIKE" in enum  # numeric can LIKE — no narrowing
+        # Description enrichment came through
+        assert "Brand — Milwaukee" in tool.description

--- a/tests/dao_ai/test_vector_search_dynamic_schema.py
+++ b/tests/dao_ai/test_vector_search_dynamic_schema.py
@@ -21,6 +21,7 @@ whole request went ``state=ERROR``.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -41,7 +42,8 @@ from dao_ai.tools.vector_search import (
     _build_vector_search_input_model,
     _legal_filter_keys,
     _operators_for_type,
-    _probe_index_columns,
+    _explicit_columns_to_sync,
+    _fetch_source_table_column_types,
     _vector_column_names_from_describe,
     create_vector_search_tool,
 )
@@ -285,7 +287,7 @@ class TestFactoryColumnHydration:
         with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
-            "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+            "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
         ), patch.object(
             VectorStoreModel,
             "refresh",
@@ -329,7 +331,7 @@ class TestFactoryColumnHydration:
         ) as mocked_refresh, patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
-            "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+            "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
         ):
             tool = create_vector_search_tool(retriever=retriever, name="product_search")
 
@@ -373,7 +375,7 @@ class TestFactoryColumnHydration:
             ), patch(
                 "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
             ), patch(
-                "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+                "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
             ):
                 tool = create_vector_search_tool(
                     retriever=retriever, name="product_search"
@@ -427,7 +429,7 @@ class TestFactoryColumnHydration:
         ), patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
-            "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+            "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
         ), patch.object(
             VectorStoreModel,
             "workspace_client_from",
@@ -460,7 +462,7 @@ class TestFactoryColumnHydration:
             autospec=True,
             side_effect=RuntimeError("describe unauthorized"),
         ), patch(
-            "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+            "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
         ), patch(
             "dao_ai.tools.vector_search._fetch_index_column_types",
             return_value=None,
@@ -489,7 +491,7 @@ class TestFactoryColumnHydration:
             autospec=True,
             side_effect=RuntimeError("describe unauthorized"),
         ), patch(
-            "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+            "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
         ):
             tool = create_vector_search_tool(retriever=retriever, name="product_search")
 
@@ -600,89 +602,163 @@ class TestVectorColumnStripping:
         # business column named ``product_vector`` is preserved.
         assert "product_vector" not in _vector_column_names_from_describe(details)
 
-    def _make_probe_setup(
-        self, *, scan_fields: list[str], describe: dict | None
+    def _make_source_table_setup(
+        self,
+        *,
+        table_columns: list[tuple[str, str]],
+        describe: dict | None,
+        source_table_full_name: str = "cat.sch.products",
     ) -> tuple[Any, Any]:
-        """Build a MagicMock chain that mimics vsc.get_index().scan() and
-        stashes ``describe`` on the vector_store as ``_index_details``."""
+        """Build a MagicMock chain that mimics
+        ``vs.workspace_client_from(None).tables.get(source_table.full_name)``
+        and stashes ``describe`` on the vector_store as ``_index_details``."""
         vs = MagicMock()
         vs.index.full_name = "cat.sch.probe_test_index"
+        vs.source_table.full_name = source_table_full_name
         vs._index_details = describe
-        idx = MagicMock()
-        idx.scan.return_value = {
-            "data": [{"fields": [{"key": k, "value": {}} for k in scan_fields]}]
-        }
-        vsc = MagicMock()
-        vsc.get_index.return_value = idx
-        return vs, vsc
+        wc = MagicMock()
+        table = MagicMock()
+        table.columns = [
+            SimpleNamespace(name=n, type_text=t, type_name=t)
+            for n, t in table_columns
+        ]
+        wc.tables.get.return_value = table
+        vs.workspace_client_from.return_value = wc
+        return vs, wc
 
     def test_strips_synthesised_vector_column_from_describe(self) -> None:
-        vs, vsc = self._make_probe_setup(
-            scan_fields=["product_id", "product_name", "description", "description_vector"],
+        vs, _ = self._make_source_table_setup(
+            table_columns=[
+                ("product_id", "bigint"),
+                ("product_name", "string"),
+                ("description", "string"),
+                # Source-table lookup runs against the actual source table,
+                # not the index — so the synthesised ``description_vector``
+                # column doesn't exist here. It's stripped anyway on the
+                # index-side lookup; this test exercises the source-table
+                # happy path where the source cols == index cols.
+            ],
             describe=_describe_payload(),
         )
-        assert _probe_index_columns(vs, vsc) == ["product_id", "product_name", "description"]
+        assert _fetch_source_table_column_types(vs) == {
+            "product_id": "bigint",
+            "product_name": "string",
+            "description": "string",
+        }
 
     def test_preserves_business_column_ending_in_vector(self) -> None:
-        """A user column literally named ``product_vector`` must survive
-        — the describe payload's ``embedding_source_columns`` is the
-        authoritative signal for what's a synthesised vector."""
-        vs, vsc = self._make_probe_setup(
-            scan_fields=[
-                "product_id",
-                "product_name",
-                "product_vector",  # a business column, NOT the embedding
-                "description",
-                "description_vector",  # the actual synthesised vector
+        """A user column literally named ``product_vector`` on the source
+        table must survive — describe's ``embedding_source_columns`` is
+        the authoritative signal for what's a synthesised vector, and
+        ``product`` is not the embedding source (``description`` is)."""
+        describe = _describe_payload()
+        # Drop the default ``columns_to_sync`` so we're isolating the
+        # vector-stripping behavior, not the sync-subset intersection.
+        describe["delta_sync_index_spec"].pop("columns_to_sync", None)
+        vs, _ = self._make_source_table_setup(
+            table_columns=[
+                ("product_id", "bigint"),
+                ("product_name", "string"),
+                ("product_vector", "array<double>"),
+                ("description", "string"),
             ],
-            describe=_describe_payload(),  # embedding source = "description"
+            describe=describe,  # embedding source = "description"
         )
-        cols = _probe_index_columns(vs, vsc)
-        assert cols is not None
-        assert "product_vector" in cols  # preserved!
-        assert "description_vector" not in cols  # actually synthesised, stripped
+        out = _fetch_source_table_column_types(vs)
+        assert out is not None
+        assert "product_vector" in out  # preserved!
 
     def test_falls_back_to_suffix_heuristic_when_describe_missing(self) -> None:
-        # No describe details cached → we can't know which _vector column
-        # is synthesised, so we strip all of them. This is a controlled
-        # false-positive risk documented in the docstring.
-        vs, vsc = self._make_probe_setup(
-            scan_fields=["product_id", "product_name", "description_vector"],
+        """No describe details cached → we can't know which ``_vector``
+        column is synthesised, so we strip all of them. Same controlled
+        false-positive risk as the index-side lookup."""
+        vs, _ = self._make_source_table_setup(
+            table_columns=[
+                ("product_id", "bigint"),
+                ("product_name", "string"),
+                ("description_vector", "array<double>"),
+            ],
             describe=None,
         )
-        assert _probe_index_columns(vs, vsc) == ["product_id", "product_name"]
+        assert _fetch_source_table_column_types(vs) == {
+            "product_id": "bigint",
+            "product_name": "string",
+        }
 
     def test_strips_cdf_underscore_prefix_fields(self) -> None:
-        vs, vsc = self._make_probe_setup(
-            scan_fields=["product_id", "_change_type", "_commit_version", "product_name"],
+        vs, _ = self._make_source_table_setup(
+            table_columns=[
+                ("product_id", "bigint"),
+                ("_change_type", "string"),
+                ("_commit_version", "bigint"),
+                ("product_name", "string"),
+            ],
             describe=_describe_payload(),
         )
-        assert _probe_index_columns(vs, vsc) == ["product_id", "product_name"]
+        assert _fetch_source_table_column_types(vs) == {
+            "product_id": "bigint",
+            "product_name": "string",
+        }
 
-    def test_empty_scan_result_returns_none(self) -> None:
+    def test_intersects_with_columns_to_sync_subset(self) -> None:
+        """When the user explicitly restricts sync to a subset, source-table
+        lookup must not advertise cols the index doesn't hold."""
+        describe = _describe_payload()
+        # Explicit subset: only product_id + product_name are synced.
+        describe["delta_sync_index_spec"]["columns_to_sync"] = [
+            "product_id",
+            "product_name",
+        ]
+        vs, _ = self._make_source_table_setup(
+            table_columns=[
+                ("product_id", "bigint"),
+                ("product_name", "string"),
+                ("brand", "string"),       # NOT on the index
+                ("category", "string"),    # NOT on the index
+                ("description", "string"),
+            ],
+            describe=describe,
+        )
+        out = _fetch_source_table_column_types(vs)
+        assert out == {"product_id": "bigint", "product_name": "string"}
+
+    def test_empty_source_table_returns_none(self) -> None:
+        vs, _ = self._make_source_table_setup(
+            table_columns=[],
+            describe=None,
+        )
+        assert _fetch_source_table_column_types(vs) is None
+
+    def test_uc_tables_permission_error_returns_none(self) -> None:
         vs = MagicMock()
-        vs.index.full_name = "cat.sch.empty_index"
+        vs.source_table.full_name = "cat.sch.forbidden_source"
         vs._index_details = None
-        idx = MagicMock()
-        idx.scan.return_value = {"data": []}
-        vsc = MagicMock()
-        vsc.get_index.return_value = idx
-        assert _probe_index_columns(vs, vsc) is None
+        wc = MagicMock()
+        wc.tables.get.side_effect = PermissionError("forbidden")
+        vs.workspace_client_from.return_value = wc
+        assert _fetch_source_table_column_types(vs) is None
 
-    def test_scan_permission_error_returns_none(self) -> None:
+    def test_direct_access_no_source_table_returns_none(self) -> None:
+        """Direct-Access indexes have no source_table; the fallback returns
+        None and the caller uses ``refresh()``'s ``columns_to_sync`` handling
+        instead. Verifies no AttributeError on the None check."""
         vs = MagicMock()
-        vs.index.full_name = "cat.sch.forbidden_index"
-        vs._index_details = None
-        idx = MagicMock()
-        idx.scan.side_effect = PermissionError("forbidden")
-        vsc = MagicMock()
-        vsc.get_index.return_value = idx
-        assert _probe_index_columns(vs, vsc) is None
+        vs.source_table = None
+        assert _fetch_source_table_column_types(vs) is None
 
-    def test_null_vsc_returns_none(self) -> None:
-        # Guard against the caller not being able to mint a
-        # VectorSearchClient (e.g. no ambient auth available).
-        assert _probe_index_columns(MagicMock(), None) is None
+    def test_explicit_columns_to_sync_helper(self) -> None:
+        """``_explicit_columns_to_sync`` returns None when no subset is
+        declared (default = all cols) and a set when the user restricted."""
+        # No columns_to_sync in payload → None.
+        no_sync = _describe_payload()
+        no_sync["delta_sync_index_spec"].pop("columns_to_sync", None)
+        assert _explicit_columns_to_sync(no_sync) is None
+        # Explicit subset → set.
+        describe = _describe_payload()
+        describe["delta_sync_index_spec"]["columns_to_sync"] = ["a", "b"]
+        assert _explicit_columns_to_sync(describe) == {"a", "b"}
+        # None input → None.
+        assert _explicit_columns_to_sync(None) is None
 
 
 @pytest.mark.unit
@@ -809,7 +885,7 @@ class TestFactoryEntryShapes:
                 "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
             ),
             patch(
-                "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+                "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
             ),
             patch.object(
                 VectorStoreModel,
@@ -891,7 +967,7 @@ class TestBackwardCompatibility:
         with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
-            "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+            "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
         ), patch.object(
             VectorStoreModel,
             "refresh",
@@ -920,7 +996,7 @@ class TestBackwardCompatibility:
         with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
-            "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+            "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
         ), patch.object(VectorStoreModel, "refresh", autospec=True), patch(
             "dao_ai.tools.vector_search._fetch_index_column_types",
             return_value=None,
@@ -975,7 +1051,7 @@ class TestMcpAdapterEntryPoint:
             with patch(
                 "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
             ), patch(
-                "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+                "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
             ), patch.object(
                 VectorStoreModel,
                 "refresh",
@@ -1049,7 +1125,7 @@ class TestIndexScopedTypeLookup:
         with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
-            "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+            "dao_ai.tools.vector_search._fetch_source_table_column_types", return_value=None
         ), patch.object(
             VectorStoreModel, "refresh", autospec=True
         ), patch.object(
@@ -1077,8 +1153,10 @@ class TestIndexScopedTypeLookup:
         assert "is_b2b_only <" not in enum  # …no ordering
 
     def test_soft_fallback_when_index_uc_lookup_fails(self) -> None:
-        """UC Tables call fails → factory falls through to scan-based
-        column discovery, keeps permissive operators."""
+        """UC Tables call on the INDEX fails → factory falls through to
+        UC Tables on the SOURCE TABLE. Because the source-table lookup
+        also returns ``{name: type}``, columns AND type-aware operator
+        narrowing are both preserved on the fallback path."""
         vs = VectorStoreModel(
             index=IndexModel(
                 schema=SchemaModel(
@@ -1096,8 +1174,8 @@ class TestIndexScopedTypeLookup:
         with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
-            "dao_ai.tools.vector_search._probe_index_columns",
-            return_value=["product_id", "product_name"],
+            "dao_ai.tools.vector_search._fetch_source_table_column_types",
+            return_value={"product_id": "bigint", "product_name": "string"},
         ), patch.object(
             VectorStoreModel, "refresh", autospec=True
         ), patch.object(
@@ -1113,7 +1191,12 @@ class TestIndexScopedTypeLookup:
                 "properties"
             ]["key"]["enum"]
         )
-        # Columns still narrowed (regression still blocked); operators
-        # permissive.
+        # Columns narrowed (regression blocked). Types come through from
+        # the source-table fallback, so operators are narrowed too:
+        # bigint gets NUMERIC ops (no LIKE), string gets STRING ops
+        # (no ordering).
         assert "product_id" in enum and "product_name" in enum
-        assert "product_id LIKE" in enum  # permissive fallback
+        assert "product_id LIKE" not in enum  # bigint — no LIKE
+        assert "product_id <=" in enum        # bigint — ordering OK
+        assert "product_name LIKE" in enum    # string — LIKE OK
+        assert "product_name <=" not in enum  # string — no ordering

--- a/tests/dao_ai/test_vector_search_dynamic_schema.py
+++ b/tests/dao_ai/test_vector_search_dynamic_schema.py
@@ -2,7 +2,7 @@
 
 Covers the two behavior changes on ``create_vector_search_tool``:
 
-  1. When YAML declares no ``columns`` the factory calls
+  1. When Config declares no ``columns`` the factory calls
      ``VectorStoreModel.refresh()`` and hydrates them from
      ``index.describe()``.
   2. The LLM-facing ``args_schema`` is per-tool: ``filters[].key`` is a
@@ -257,9 +257,13 @@ class TestBuildVectorSearchInputModel:
 
 @pytest.mark.unit
 class TestFactoryColumnHydration:
-    """The factory calls VectorStoreModel.refresh() at build time when YAML
-    is silent about ``columns``, and calls _fetch_column_types when the
-    source table is populated."""
+    """The factory calls VectorStoreModel.refresh() at build time to
+    validate any config-declared columns against the live index. declared columns
+    not present on the index are dropped with a WARN before the Literal
+    enum is built. Type-aware operator narrowing is not fetched from the
+    source table (source-table columns are not guaranteed to be on the
+    index); enum degrades to permissive operators when types are unknown.
+    """
 
     def _make_vs(self, *, with_columns: bool = False) -> VectorStoreModel:
         schema = SchemaModel(
@@ -277,12 +281,6 @@ class TestFactoryColumnHydration:
         vs = self._make_vs(with_columns=False)
         payload = _describe_payload()
 
-        # Patch:
-        #  * ``_vsc_for_refresh`` — don't build a real VectorSearchClient
-        #  * ``refresh`` — hydrate via the standard path with our canned
-        #    describe payload (populates source_table, columns_to_sync)
-        #  * ``_fetch_column_types`` — the UC Tables API call for types
-        # Unit tests must not touch the network.
         original_refresh = VectorStoreModel.refresh
         with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
@@ -293,61 +291,165 @@ class TestFactoryColumnHydration:
             "refresh",
             autospec=True,
             side_effect=lambda self, **kw: original_refresh(self, details=payload),
-        ) as mocked_refresh, patch(
-            "dao_ai.tools.vector_search._fetch_column_types",
-            return_value=PRODUCTS_TYPES,
-        ):
+        ) as mocked_refresh:
             retriever = RetrieverModel(vector_store=vs)
             tool = create_vector_search_tool(retriever=retriever, name="product_search")
 
         mocked_refresh.assert_called_once()
-        # The tool now advertises the columns via its args_schema enum.
         enum = (
             tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
                 "properties"
             ]["key"]["enum"]
         )
+        # Every discovered column is in the enum (permissive operators —
+        # types are not fetched from the source table anymore).
+        assert "product_name" in enum
         assert "product_name LIKE" in enum
-        assert "price <=" in enum
-        # And still rejects the regression key:
+        # Regression key stays rejected:
         assert "name NOT LIKE" not in enum
 
-    def test_yaml_columns_take_precedence_no_refresh(self) -> None:
+    def test_yaml_columns_intersected_with_index(self) -> None:
+        """Config declares a subset of index columns → enum is the subset.
+
+        The factory always calls refresh() so it can validate config against
+        the live index. The result is declared ∩ index (in declaration order).
+        """
         vs = self._make_vs(with_columns=False)
         retriever = RetrieverModel(
             vector_store=vs,
             columns=["product_id", "product_name", "price"],
         )
+        payload = _describe_payload()
+        original_refresh = VectorStoreModel.refresh
         with patch.object(
-            VectorStoreModel, "refresh", autospec=True
+            VectorStoreModel,
+            "refresh",
+            autospec=True,
+            side_effect=lambda self, **kw: original_refresh(self, details=payload),
         ) as mocked_refresh, patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
             "dao_ai.tools.vector_search._probe_index_columns", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_column_types",
-            return_value={
-                "product_id": "bigint",
-                "product_name": "string",
-                "price": "double",
-            },
         ):
             tool = create_vector_search_tool(retriever=retriever, name="product_search")
 
-        mocked_refresh.assert_not_called()
+        mocked_refresh.assert_called_once()
         enum = (
             tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
                 "properties"
             ]["key"]["enum"]
         )
-        # Only the three declared columns are in the enum:
-        assert "product_id" in enum and "price <=" in enum
+        assert "product_id" in enum and "price" in enum
+        # Everything outside the declared subset is absent:
         assert "sku" not in enum and "category" not in enum
 
+    def test_yaml_column_not_on_index_dropped_with_warning(self) -> None:
+        """Config declares a bogus column not on the index → dropped, WARN
+        logged with column name + index name. LLM can never emit a filter
+        that would fail at the VS API."""
+        vs = self._make_vs(with_columns=False)
+        retriever = RetrieverModel(
+            vector_store=vs,
+            columns=["product_id", "product_name", "nonexistent_col_xyz"],
+        )
+        payload = _describe_payload()
+        original_refresh = VectorStoreModel.refresh
+
+        # loguru bypasses stdlib logging — capture via a dedicated sink.
+        from loguru import logger as loguru_logger
+
+        captured: list[str] = []
+        sink_id = loguru_logger.add(
+            lambda msg: captured.append(str(msg)),
+            level="WARNING",
+            format="{message} {extra}",
+        )
+        try:
+            with patch.object(
+                VectorStoreModel,
+                "refresh",
+                autospec=True,
+                side_effect=lambda self, **kw: original_refresh(self, details=payload),
+            ), patch(
+                "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+            ), patch(
+                "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+            ):
+                tool = create_vector_search_tool(
+                    retriever=retriever, name="product_search"
+                )
+        finally:
+            loguru_logger.remove(sink_id)
+
+        enum = (
+            tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+                "properties"
+            ]["key"]["enum"]
+        )
+        assert "product_id" in enum
+        assert "product_name" in enum
+        assert not any(k.startswith("nonexistent_col_xyz") for k in enum)
+
+        warnings_text = " ".join(captured)
+        assert "nonexistent_col_xyz" in warnings_text
+        assert "products_description_index" in warnings_text
+
+    def test_source_table_never_called_for_schema(self) -> None:
+        """Regression guard: schema-building code must call
+        ``wc.tables.get`` only on the INDEX's full_name (mirrors
+        databricks-langchain), never on any other UC entity — most
+        importantly, never on the source table (whose columns aren't
+        guaranteed to be on the index).
+        """
+        vs = self._make_vs(with_columns=False)
+        retriever = RetrieverModel(vector_store=vs)
+        payload = _describe_payload()
+        original_refresh = VectorStoreModel.refresh
+        wc_spy = MagicMock()
+        # Simulate a successful UC Tables lookup on the index.
+        fake_index_table = MagicMock()
+        fake_index_table.columns = [
+            MagicMock(name="product_id", type_text="bigint"),
+            MagicMock(name="product_name", type_text="string"),
+        ]
+        # MagicMock's name attr is special; set explicitly.
+        for col, real_name in zip(
+            fake_index_table.columns, ["product_id", "product_name"]
+        ):
+            col.name = real_name
+        wc_spy.tables.get.return_value = fake_index_table
+
+        with patch.object(
+            VectorStoreModel,
+            "refresh",
+            autospec=True,
+            side_effect=lambda self, **kw: original_refresh(self, details=payload),
+        ), patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+        ), patch.object(
+            VectorStoreModel,
+            "workspace_client_from",
+            autospec=True,
+            return_value=wc_spy,
+        ):
+            create_vector_search_tool(retriever=retriever, name="product_search")
+
+        # Every call to wc.tables.get must target the index full name.
+        assert wc_spy.tables.get.call_count >= 1
+        for call in wc_spy.tables.get.call_args_list:
+            args, kwargs = call.args, call.kwargs
+            target = args[0] if args else kwargs.get("full_name")
+            assert target == vs.index.full_name, (
+                f"wc.tables.get called with non-index target {target!r}; "
+                f"only the index itself is allowed"
+            )
+
     def test_refresh_failure_soft_fallback(self) -> None:
-        """If refresh raises we must NOT propagate — the tool still builds,
-        with the pre-change free-form ``FilterItem`` schema. That's a
-        deliberate demo-resilience choice."""
+        """If both refresh AND the UC Tables index lookup fail, and no
+        declared columns are given, the tool still builds with the
+        pre-change free-form ``FilterItem`` schema."""
         vs = self._make_vs(with_columns=False)
         retriever = RetrieverModel(vector_store=vs)
         with patch(
@@ -360,17 +462,43 @@ class TestFactoryColumnHydration:
         ), patch(
             "dao_ai.tools.vector_search._probe_index_columns", return_value=None
         ), patch(
-            "dao_ai.tools.vector_search._fetch_column_types", return_value=None
+            "dao_ai.tools.vector_search._fetch_index_column_types",
+            return_value=None,
         ):
             tool = create_vector_search_tool(retriever=retriever, name="product_search")
 
-        # No columns → args_schema is the module-level VectorSearchInput
-        # (free-form key). Sanity: the schema does NOT carry an enum.
         schema = tool.args_schema.model_json_schema()
         filter_ref = schema["$defs"].get("FilterItem") or schema["$defs"].get(
             "DynamicFilterItem"
         )
         assert "enum" not in filter_ref["properties"]["key"]
+
+    def test_refresh_failure_with_yaml_falls_back_to_yaml(self) -> None:
+        """When discovery fails but config has columns, trust config — the
+        LLM enum is built from declared columns (may hit VS API errors if the
+        user made a typo, matching pre-branch behavior)."""
+        vs = self._make_vs(with_columns=False)
+        retriever = RetrieverModel(
+            vector_store=vs, columns=["product_id", "product_name"]
+        )
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch.object(
+            VectorStoreModel,
+            "refresh",
+            autospec=True,
+            side_effect=RuntimeError("describe unauthorized"),
+        ), patch(
+            "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+        ):
+            tool = create_vector_search_tool(retriever=retriever, name="product_search")
+
+        enum = (
+            tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+                "properties"
+            ]["key"]["enum"]
+        )
+        assert "product_id" in enum and "product_name" in enum
 
 
 # ---------------------------------------------------------------------------
@@ -409,6 +537,68 @@ class TestVectorColumnStripping:
         assert _vector_column_names_from_describe(None) == set()
         assert _vector_column_names_from_describe({}) == set()
         assert _vector_column_names_from_describe({"delta_sync_index_spec": {}}) == set()
+
+    def test_direct_access_managed_embedding_vector_names(self) -> None:
+        """Direct-Access indexes carry the source list under
+        ``direct_access_index_spec`` (not ``delta_sync_index_spec``)."""
+        details = {
+            "name": "cat.sch.ix",
+            "endpoint_name": "ep",
+            "primary_key": "id",
+            "direct_access_index_spec": {
+                "embedding_source_columns": [
+                    {"name": "description", "embedding_model_endpoint_name": "e"}
+                ],
+            },
+        }
+        assert _vector_column_names_from_describe(details) == {"description_vector"}
+
+    def test_self_managed_embedding_vector_column_stripped(self) -> None:
+        """Self-managed indexes precompute vectors under an arbitrary
+        column name declared in ``embedding_vector_columns``. That column
+        (whatever it's called) must be stripped."""
+        details = {
+            "name": "cat.sch.ix",
+            "endpoint_name": "ep",
+            "primary_key": "id",
+            "delta_sync_index_spec": {
+                "source_table": "cat.sch.docs",
+                "embedding_vector_columns": [{"name": "my_embedding"}],
+            },
+        }
+        assert _vector_column_names_from_describe(details) == {"my_embedding"}
+
+    def test_self_managed_on_direct_access_spec(self) -> None:
+        """Self-managed embeddings can appear under either spec container."""
+        details = {
+            "name": "cat.sch.ix",
+            "endpoint_name": "ep",
+            "primary_key": "id",
+            "direct_access_index_spec": {
+                "embedding_vector_columns": [{"name": "vector"}],
+            },
+        }
+        assert _vector_column_names_from_describe(details) == {"vector"}
+
+    def test_business_column_named_foo_vector_preserved_direct_access(self) -> None:
+        """A Direct-Access index with no embedding-source declaration
+        (e.g. a describe payload that doesn't populate them) must NOT
+        strip a business column literally named ``<x>_vector``. The
+        describe-driven path returns only actual synthesised names — any
+        column not in that set survives."""
+        details = {
+            "name": "cat.sch.ix",
+            "endpoint_name": "ep",
+            "primary_key": "id",
+            "direct_access_index_spec": {
+                "embedding_source_columns": [
+                    {"name": "description", "embedding_model_endpoint_name": "e"}
+                ],
+            },
+        }
+        # Only ``description_vector`` is a synthesised name. A hypothetical
+        # business column named ``product_vector`` is preserved.
+        assert "product_vector" not in _vector_column_names_from_describe(details)
 
     def _make_probe_setup(
         self, *, scan_fields: list[str], describe: dict | None
@@ -629,10 +819,6 @@ class TestFactoryEntryShapes:
                     self, details=payload
                 ),
             ),
-            patch(
-                "dao_ai.tools.vector_search._fetch_column_types",
-                return_value=PRODUCTS_TYPES,
-            ),
         )
 
     def _bare_vs(self) -> VectorStoreModel:
@@ -649,7 +835,7 @@ class TestFactoryEntryShapes:
 
     def test_vector_store_param_entry(self) -> None:
         vs = self._bare_vs()
-        with self._patches()[0], self._patches()[1], self._patches()[2], self._patches()[3]:
+        with self._patches()[0], self._patches()[1], self._patches()[2]:
             tool = create_vector_search_tool(vector_store=vs, name="via_vs")
         enum = tool.args_schema.model_json_schema()["$defs"][
             "DynamicFilterItem"
@@ -679,15 +865,15 @@ class TestFactoryEntryShapes:
 
 @pytest.mark.unit
 class TestBackwardCompatibility:
-    """Nothing about existing YAML-declared configurations should change.
+    """Nothing about existing config-declared configurations should change.
     Regression guards for the shape the majority of dao-ai users are on.
     """
 
-    def test_existing_yaml_shape_produces_narrowed_enum_with_types(self) -> None:
-        # This mirrors the shape used in commerce_swarm.yaml — columns
-        # declared, types not. The factory should still narrow to the
-        # declared columns and (if source_table is set + types available)
-        # be type-aware.
+    def test_existing_yaml_shape_produces_narrowed_enum(self) -> None:
+        """The commerce_swarm.yaml shape — columns declared, no explicit
+        types. Factory validates config against the live index and builds
+        a permissive Literal enum (all operators per column). Regression
+        column keys are still rejected."""
         vs = VectorStoreModel(
             index=IndexModel(
                 schema=SchemaModel(
@@ -700,32 +886,35 @@ class TestBackwardCompatibility:
             columns=PRODUCTS_COLUMNS,
         )
         retriever = RetrieverModel(vector_store=vs, columns=PRODUCTS_COLUMNS)
+        payload = _describe_payload()
+        original_refresh = VectorStoreModel.refresh
         with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
             "dao_ai.tools.vector_search._probe_index_columns", return_value=None
-        ), patch.object(VectorStoreModel, "refresh", autospec=True) as mocked_refresh, patch(
-            "dao_ai.tools.vector_search._fetch_column_types",
-            return_value=PRODUCTS_TYPES,
+        ), patch.object(
+            VectorStoreModel,
+            "refresh",
+            autospec=True,
+            side_effect=lambda self, **kw: original_refresh(self, details=payload),
         ):
             tool = create_vector_search_tool(
                 retriever=retriever, name="product_search"
             )
-        # YAML gave us columns → refresh should NOT have been called.
-        mocked_refresh.assert_not_called()
         enum = tool.args_schema.model_json_schema()["$defs"][
             "DynamicFilterItem"
         ]["properties"]["key"]["enum"]
         # Regression key not present:
         assert "name NOT LIKE" not in enum
-        # Type awareness applied:
-        assert "price LIKE" not in enum
-        assert "is_b2b_only <" not in enum
+        # Every declared column is present:
+        for c in PRODUCTS_COLUMNS:
+            assert c in enum
 
-    def test_no_types_fetched_still_produces_working_tool(self) -> None:
-        """If source_table isn't set (or UC Tables API returns nothing),
-        the enum should exist but with all operators — the tool still
-        prevents unknown columns, it just doesn't narrow per-type."""
+    def test_no_types_still_produces_working_tool(self) -> None:
+        """When the UC Tables index lookup fails and no discovery is
+        available, declared columns are trusted as-is and every column
+        gets every operator suffix (permissive fallback). The tool still
+        narrows to the declared columns, blocking hallucinated keys."""
         vs = self._bare_vs_no_source()
         retriever = RetrieverModel(vector_store=vs, columns=["a", "b"])
         with patch(
@@ -733,7 +922,8 @@ class TestBackwardCompatibility:
         ), patch(
             "dao_ai.tools.vector_search._probe_index_columns", return_value=None
         ), patch.object(VectorStoreModel, "refresh", autospec=True), patch(
-            "dao_ai.tools.vector_search._fetch_column_types", return_value=None
+            "dao_ai.tools.vector_search._fetch_index_column_types",
+            return_value=None,
         ):
             tool = create_vector_search_tool(retriever=retriever, name="t")
         enum = tool.args_schema.model_json_schema()["$defs"][
@@ -754,3 +944,176 @@ class TestBackwardCompatibility:
             ),
             endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
         )
+
+
+@pytest.mark.unit
+class TestMcpAdapterEntryPoint:
+    """Both entry points into the factory (`VectorSearchToolModel.as_tools()`
+    and `register_vector_search()` MCP adapter) call the same
+    `create_vector_search_tool(**args)` — so the dynamic args_schema is
+    identical regardless of how the tool is provided. Regression guard
+    against a future divergent build path.
+    """
+
+    def test_kwargs_and_dict_expansion_produce_same_schema(self) -> None:
+        vs = VectorStoreModel(
+            index=IndexModel(
+                schema=SchemaModel(
+                    catalog_name="retail_consumer_goods",
+                    schema_name="commerce_swarm",
+                ),
+                name="products_description_index",
+            ),
+            endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
+            columns=PRODUCTS_COLUMNS,
+        )
+        retriever = RetrieverModel(vector_store=vs, columns=PRODUCTS_COLUMNS)
+        payload = _describe_payload()
+        original_refresh = VectorStoreModel.refresh
+
+        def _build(args: dict) -> Any:
+            with patch(
+                "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+            ), patch(
+                "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+            ), patch.object(
+                VectorStoreModel,
+                "refresh",
+                autospec=True,
+                side_effect=lambda self, **kw: original_refresh(self, details=payload),
+            ):
+                return create_vector_search_tool(**args)
+
+        # ``as_tools()`` style: kwargs pass-through
+        tool_a = _build({"retriever": retriever, "name": "product_search"})
+        # MCP adapter style: `create_vector_search_tool(**args)` where args
+        # arrived as a dict deserialised from tool config.
+        tool_b = _build({"retriever": retriever, "name": "product_search"})
+
+        schema_a = tool_a.args_schema.model_json_schema()
+        schema_b = tool_b.args_schema.model_json_schema()
+        enum_a = schema_a["$defs"]["DynamicFilterItem"]["properties"]["key"]["enum"]
+        enum_b = schema_b["$defs"]["DynamicFilterItem"]["properties"]["key"]["enum"]
+        assert enum_a == enum_b
+        assert "product_name" in enum_a
+
+
+@pytest.mark.unit
+class TestIndexScopedTypeLookup:
+    """Type-aware operator narrowing driven by ``wc.tables.get(index)``.
+
+    The index is a UC entity; asking the UC Tables API for its columns
+    returns column names AND their Databricks types in one call. This is
+    the databricks-langchain pattern — types come from the same
+    authoritative source as the columns, never the source table.
+    """
+
+    def _wc_with_index_table(
+        self, cols_and_types: list[tuple[str, str]]
+    ) -> MagicMock:
+        wc = MagicMock()
+        table = MagicMock()
+        fake_cols: list[MagicMock] = []
+        for name, tt in cols_and_types:
+            c = MagicMock()
+            c.name = name
+            c.type_text = tt
+            fake_cols.append(c)
+        table.columns = fake_cols
+        wc.tables.get.return_value = table
+        return wc
+
+    def test_type_aware_enum_from_index_uc_lookup(self) -> None:
+        vs = VectorStoreModel(
+            index=IndexModel(
+                schema=SchemaModel(
+                    catalog_name="retail_consumer_goods",
+                    schema_name="commerce_swarm",
+                ),
+                name="products_description_index",
+            ),
+            endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
+        )
+        retriever = RetrieverModel(vector_store=vs)
+        wc = self._wc_with_index_table(
+            [
+                ("product_id", "bigint"),
+                ("product_name", "string"),
+                ("price", "double"),
+                ("is_b2b_only", "boolean"),
+                # A vector column that must be stripped by the leading-
+                # underscore rule (no describe payload available).
+                ("__db_description_vector", "array<float>"),
+            ]
+        )
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+        ), patch.object(
+            VectorStoreModel, "refresh", autospec=True
+        ), patch.object(
+            VectorStoreModel,
+            "workspace_client_from",
+            autospec=True,
+            return_value=wc,
+        ):
+            tool = create_vector_search_tool(
+                retriever=retriever, name="product_search"
+            )
+        enum = (
+            tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+                "properties"
+            ]["key"]["enum"]
+        )
+        # Vector column stripped.
+        assert not any("__db_description_vector" in k for k in enum), enum
+        # Type-aware operators:
+        assert "product_name LIKE" in enum  # string → LIKE
+        assert "product_name >" not in enum  # …not ordering
+        assert "price <=" in enum  # double → ordering
+        assert "price LIKE" not in enum  # …not LIKE
+        assert "is_b2b_only NOT" in enum  # bool → equality/NOT
+        assert "is_b2b_only <" not in enum  # …no ordering
+
+    def test_soft_fallback_when_index_uc_lookup_fails(self) -> None:
+        """UC Tables call fails → factory falls through to scan-based
+        column discovery, keeps permissive operators."""
+        vs = VectorStoreModel(
+            index=IndexModel(
+                schema=SchemaModel(
+                    catalog_name="retail_consumer_goods",
+                    schema_name="commerce_swarm",
+                ),
+                name="products_description_index",
+            ),
+            endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
+        )
+        retriever = RetrieverModel(vector_store=vs)
+        wc = MagicMock()
+        wc.tables.get.side_effect = PermissionError("no access")
+
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._probe_index_columns",
+            return_value=["product_id", "product_name"],
+        ), patch.object(
+            VectorStoreModel, "refresh", autospec=True
+        ), patch.object(
+            VectorStoreModel,
+            "workspace_client_from",
+            autospec=True,
+            return_value=wc,
+        ):
+            tool = create_vector_search_tool(retriever=retriever, name="t")
+
+        enum = (
+            tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+                "properties"
+            ]["key"]["enum"]
+        )
+        # Columns still narrowed (regression still blocked); operators
+        # permissive.
+        assert "product_id" in enum and "product_name" in enum
+        assert "product_id LIKE" in enum  # permissive fallback

--- a/tests/dao_ai/test_vector_search_dynamic_schema.py
+++ b/tests/dao_ai/test_vector_search_dynamic_schema.py
@@ -1,0 +1,350 @@
+"""Unit tests for dynamic Vector Search tool schema.
+
+Covers the two behavior changes on ``create_vector_search_tool``:
+
+  1. When YAML declares no ``columns`` the factory calls
+     ``VectorStoreModel.refresh()`` and hydrates them from
+     ``index.describe()``.
+  2. The LLM-facing ``args_schema`` is per-tool: ``filters[].key`` is a
+     :data:`typing.Literal` enum over ``columns × operator suffixes``,
+     with operator suffixes filtered by column type (no ``LIKE`` on int,
+     no ordering on bool, etc.). An unlisted key raises ``ValidationError``
+     before the retriever is ever called.
+
+Regression the Literal narrowing prevents: MLflow trace
+``fc785d795b77675ac0e42fe5296b523a`` — the LLM emitted
+``{"key": "name NOT LIKE", "value": "peanut"}`` against a products index
+whose column is ``product_name``. The vector search API responded with
+``Columns referenced in filters are not present in index: name`` and the
+whole request went ``state=ERROR``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from dao_ai.config import (
+    FilterItem,
+    IndexModel,
+    RetrieverModel,
+    SchemaModel,
+    VectorSearchEndpoint,
+    VectorStoreModel,
+)
+from dao_ai.tools.vector_search import (
+    VectorSearchInput,
+    _build_filter_item_model,
+    _build_vector_search_input_model,
+    _legal_filter_keys,
+    _operators_for_type,
+    create_vector_search_tool,
+)
+
+
+PRODUCTS_COLUMNS = [
+    "product_id",
+    "sku",
+    "product_name",
+    "brand",
+    "category",
+    "subcategory",
+    "description",
+    "price",
+    "is_b2b_only",
+]
+
+PRODUCTS_TYPES = {
+    "product_id": "bigint",
+    "sku": "string",
+    "product_name": "string",
+    "brand": "string",
+    "category": "string",
+    "subcategory": "string",
+    "description": "string",
+    "price": "double",
+    "is_b2b_only": "boolean",
+}
+
+
+def _describe_payload(**overrides: Any) -> dict[str, Any]:
+    """Default ``index.describe()`` shape (mirrors test_vector_store_refresh.py)."""
+    base: dict[str, Any] = {
+        "name": "retail_consumer_goods.commerce_swarm.products_description_index",
+        "endpoint_name": "dbdemos_vs_endpoint",
+        "primary_key": "product_id",
+        "delta_sync_index_spec": {
+            "source_table": "retail_consumer_goods.commerce_swarm.products",
+            "embedding_source_columns": [
+                {
+                    "name": "description",
+                    "embedding_model_endpoint_name": "databricks-gte-large-en",
+                }
+            ],
+            "columns_to_sync": PRODUCTS_COLUMNS,
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.unit
+class TestOperatorsForType:
+    """The type → operator-suffix mapping is what makes the Literal enum
+    semantically useful. Boundaries: no LIKE on numerics, no ordering on
+    booleans, only equality on booleans, unknown types get everything."""
+
+    def test_numeric_gets_equality_and_ordering(self) -> None:
+        for t in ("int", "bigint", "long", "double", "float", "decimal(10,2)"):
+            ops = _operators_for_type(t)
+            assert " <=" in ops
+            assert " LIKE" not in ops
+            assert " NOT LIKE" not in ops
+
+    def test_string_gets_equality_and_like(self) -> None:
+        for t in ("string", "varchar(255)", "char(3)", "text"):
+            ops = _operators_for_type(t)
+            assert " LIKE" in ops
+            assert " NOT LIKE" in ops
+            assert " <=" not in ops
+            assert " >" not in ops
+
+    def test_boolean_equality_only(self) -> None:
+        ops = _operators_for_type("boolean")
+        assert ops == ("", " NOT")
+
+    def test_temporal_behaves_like_numeric(self) -> None:
+        for t in ("timestamp", "date"):
+            ops = _operators_for_type(t)
+            assert " <=" in ops
+            assert " LIKE" not in ops
+
+    def test_unknown_or_missing_type_permits_all(self) -> None:
+        # We deliberately do NOT block operators on types we don't recognise —
+        # complex types like STRUCT/ARRAY can legitimately use unusual ops on
+        # nested fields, and stripping them would produce false negatives.
+        for t in ("", None, "struct<a:int>", "array<string>", "map<string,int>"):
+            ops = _operators_for_type(t)  # type: ignore[arg-type]
+            assert " LIKE" in ops
+            assert " <=" in ops
+            assert " NOT" in ops
+
+
+@pytest.mark.unit
+class TestLegalFilterKeys:
+    def test_cross_product_without_types_permits_all(self) -> None:
+        keys = _legal_filter_keys(["a", "b"])
+        # 2 columns × 8 suffixes = 16
+        assert len(keys) == 16
+        assert "a" in keys and "a LIKE" in keys
+        assert "b <=" in keys
+
+    def test_cross_product_with_types_narrows_per_column(self) -> None:
+        keys = _legal_filter_keys(
+            ["price", "name", "flag"],
+            {"price": "double", "name": "string", "flag": "boolean"},
+        )
+        # 6 (numeric) + 4 (string) + 2 (bool) = 12
+        assert len(keys) == 12
+        assert "price <=" in keys and "price LIKE" not in keys
+        assert "name LIKE" in keys and "name >" not in keys
+        assert "flag NOT" in keys and "flag LIKE" not in keys
+
+    def test_missing_column_type_falls_back_to_all_suffixes(self) -> None:
+        keys = _legal_filter_keys(
+            ["price", "unknown"], {"price": "double"}
+        )
+        # price → 6 (numeric); unknown → 8 (fallback)
+        assert len(keys) == 14
+        assert "unknown LIKE" in keys
+        assert "unknown <" in keys
+
+
+@pytest.mark.unit
+class TestBuildFilterItemModel:
+    def test_empty_columns_returns_free_form_FilterItem(self) -> None:
+        # Baseline: existing behaviour preserved when we can't discover columns.
+        assert _build_filter_item_model([]) is FilterItem
+
+    def test_columns_produce_literal_narrowed_key(self) -> None:
+        M = _build_filter_item_model(PRODUCTS_COLUMNS, PRODUCTS_TYPES)
+        schema = M.model_json_schema()
+        enum = schema["properties"]["key"]["enum"]
+        # Numeric/bool ops for product_id + price + is_b2b_only, string ops
+        # for the 6 text columns: 6 + 6 + 2 + 4*6 = 38.
+        assert len(enum) == 38
+        assert "product_id" in enum and "product_id <=" in enum
+        assert "product_name LIKE" in enum
+        assert "is_b2b_only NOT" in enum
+        # And the regression key must NOT appear:
+        assert "name NOT LIKE" not in enum
+        # Nor should nonsense combos:
+        assert "price LIKE" not in enum
+        assert "is_b2b_only <" not in enum
+
+
+@pytest.mark.unit
+class TestBuildVectorSearchInputModel:
+    def test_empty_columns_returns_module_level_class(self) -> None:
+        assert _build_vector_search_input_model([]) is VectorSearchInput
+
+    def test_valid_filter_accepted(self) -> None:
+        M = _build_vector_search_input_model(PRODUCTS_COLUMNS, PRODUCTS_TYPES)
+        m = M(
+            query="peanut-free dessert under 30",
+            filters=[
+                {"key": "price <=", "value": 30},
+                {"key": "description NOT LIKE", "value": "peanut"},
+                {"key": "is_b2b_only", "value": False},
+            ],
+        )
+        assert len(m.filters) == 3
+        assert m.filters[0].key == "price <="
+
+    def test_regression_bad_column_key_rejected(self) -> None:
+        """The exact key emitted by the LLM in trace fc785d795b... — must
+        never make it past pydantic validation."""
+        M = _build_vector_search_input_model(PRODUCTS_COLUMNS, PRODUCTS_TYPES)
+        with pytest.raises(ValidationError) as exc_info:
+            M(
+                query="dessert",
+                filters=[{"key": "name NOT LIKE", "value": "peanut"}],
+            )
+        # Pydantic error message should reference the offending field.
+        assert "filters" in str(exc_info.value) and "key" in str(exc_info.value)
+
+    def test_type_wrong_operator_rejected(self) -> None:
+        """LIKE on a numeric column, ordering on a bool — both must be
+        rejected by the type-aware enum."""
+        M = _build_vector_search_input_model(PRODUCTS_COLUMNS, PRODUCTS_TYPES)
+        for bad in ("price LIKE", "price NOT LIKE", "is_b2b_only <"):
+            with pytest.raises(ValidationError):
+                M(query="x", filters=[{"key": bad, "value": 0}])
+
+    def test_falls_back_when_types_missing(self) -> None:
+        # No type info → all suffixes permitted on every column.
+        M = _build_vector_search_input_model(PRODUCTS_COLUMNS)
+        ok = M(query="x", filters=[{"key": "price LIKE", "value": "3"}])
+        # No exception → falls back to permissive mode.
+        assert ok.filters[0].key == "price LIKE"
+
+
+@pytest.mark.unit
+class TestFactoryColumnHydration:
+    """The factory calls VectorStoreModel.refresh() at build time when YAML
+    is silent about ``columns``, and calls _fetch_column_types when the
+    source table is populated."""
+
+    def _make_vs(self, *, with_columns: bool = False) -> VectorStoreModel:
+        schema = SchemaModel(
+            catalog_name="retail_consumer_goods", schema_name="commerce_swarm"
+        )
+        vs = VectorStoreModel(
+            index=IndexModel(schema=schema, name="products_description_index"),
+            endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
+        )
+        if with_columns:
+            vs.columns = ["product_id", "sku"]
+        return vs
+
+    def test_refresh_invoked_when_yaml_silent(self) -> None:
+        vs = self._make_vs(with_columns=False)
+        payload = _describe_payload()
+
+        # Patch:
+        #  * ``_vsc_for_refresh`` — don't build a real VectorSearchClient
+        #  * ``refresh`` — hydrate via the standard path with our canned
+        #    describe payload (populates source_table, columns_to_sync)
+        #  * ``_fetch_column_types`` — the UC Tables API call for types
+        # Unit tests must not touch the network.
+        original_refresh = VectorStoreModel.refresh
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+        ), patch.object(
+            VectorStoreModel,
+            "refresh",
+            autospec=True,
+            side_effect=lambda self, **kw: original_refresh(self, details=payload),
+        ) as mocked_refresh, patch(
+            "dao_ai.tools.vector_search._fetch_column_types",
+            return_value=PRODUCTS_TYPES,
+        ):
+            retriever = RetrieverModel(vector_store=vs)
+            tool = create_vector_search_tool(retriever=retriever, name="product_search")
+
+        mocked_refresh.assert_called_once()
+        # The tool now advertises the columns via its args_schema enum.
+        enum = (
+            tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+                "properties"
+            ]["key"]["enum"]
+        )
+        assert "product_name LIKE" in enum
+        assert "price <=" in enum
+        # And still rejects the regression key:
+        assert "name NOT LIKE" not in enum
+
+    def test_yaml_columns_take_precedence_no_refresh(self) -> None:
+        vs = self._make_vs(with_columns=False)
+        retriever = RetrieverModel(
+            vector_store=vs,
+            columns=["product_id", "product_name", "price"],
+        )
+        with patch.object(
+            VectorStoreModel, "refresh", autospec=True
+        ) as mocked_refresh, patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._fetch_column_types",
+            return_value={
+                "product_id": "bigint",
+                "product_name": "string",
+                "price": "double",
+            },
+        ):
+            tool = create_vector_search_tool(retriever=retriever, name="product_search")
+
+        mocked_refresh.assert_not_called()
+        enum = (
+            tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+                "properties"
+            ]["key"]["enum"]
+        )
+        # Only the three declared columns are in the enum:
+        assert "product_id" in enum and "price <=" in enum
+        assert "sku" not in enum and "category" not in enum
+
+    def test_refresh_failure_soft_fallback(self) -> None:
+        """If refresh raises we must NOT propagate — the tool still builds,
+        with the pre-change free-form ``FilterItem`` schema. That's a
+        deliberate demo-resilience choice."""
+        vs = self._make_vs(with_columns=False)
+        retriever = RetrieverModel(vector_store=vs)
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch.object(
+            VectorStoreModel,
+            "refresh",
+            autospec=True,
+            side_effect=RuntimeError("describe unauthorized"),
+        ), patch(
+            "dao_ai.tools.vector_search._probe_index_columns", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._fetch_column_types", return_value=None
+        ):
+            tool = create_vector_search_tool(retriever=retriever, name="product_search")
+
+        # No columns → args_schema is the module-level VectorSearchInput
+        # (free-form key). Sanity: the schema does NOT carry an enum.
+        schema = tool.args_schema.model_json_schema()
+        filter_ref = schema["$defs"].get("FilterItem") or schema["$defs"].get(
+            "DynamicFilterItem"
+        )
+        assert "enum" not in filter_ref["properties"]["key"]

--- a/tests/dao_ai/test_vector_search_dynamic_schema.py
+++ b/tests/dao_ai/test_vector_search_dynamic_schema.py
@@ -43,6 +43,7 @@ from dao_ai.tools.vector_search import (
     _build_filter_item_model,
     _build_vector_search_input_model,
     _fetch_index_columns,
+    _is_array_type,
     _legal_filter_keys,
     _normalize_declared_columns,
     _vector_column_names_from_describe,
@@ -1291,3 +1292,194 @@ class TestHandDeclaredColumnInfoInFactory:
         assert "price LIKE" in enum  # numeric can LIKE — no narrowing
         # Description enrichment came through
         assert "Brand — Milwaukee" in tool.description
+
+
+# ---------------------------------------------------------------------------
+# ARRAY-typed column support (Do It Best hardware-iq presentation, 2026-07-06)
+#
+# Databricks VS on Standard endpoints supports ARRAY<primitive> filtering via
+# element containment (equality only). Other operators (LIKE, ordering,
+# NOT LIKE) are rejected at query time. We narrow the Literal enum at build
+# time to reflect that constraint.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestIsArrayType:
+    def test_array_bracket_variants(self) -> None:
+        assert _is_array_type("array<string>") is True
+        assert _is_array_type("ARRAY<INT>") is True
+        assert _is_array_type("array<double>") is True
+        assert _is_array_type("Array<Boolean>") is True
+
+    def test_bare_array(self) -> None:
+        # Users write plain "array" in ColumnInfo.
+        assert _is_array_type("array") is True
+        assert _is_array_type("ARRAY") is True
+
+    def test_scalars_return_false(self) -> None:
+        for t in ("string", "STRING", "int", "bigint", "double", "boolean",
+                  "timestamp", "date", "decimal(10,2)"):
+            assert _is_array_type(t) is False, t
+
+    def test_empty_or_none_returns_false(self) -> None:
+        assert _is_array_type(None) is False
+        assert _is_array_type("") is False
+        assert _is_array_type("   ") is False
+
+
+@pytest.mark.unit
+class TestArrayColumnInFactory:
+    def _bare_vs(self) -> VectorStoreModel:
+        return VectorStoreModel(
+            index=IndexModel(
+                schema=SchemaModel(
+                    catalog_name="retail_consumer_goods",
+                    schema_name="commerce_swarm",
+                ),
+                name="products_description_index",
+            ),
+            endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
+        )
+
+    def test_hand_declared_array_gets_equality_only(self) -> None:
+        """ColumnInfo(name='tags', type='array') → enum has only 'tags',
+        no operator suffixes. This is the Do It Best hardware-iq use case."""
+        vs = self._bare_vs()
+        retriever = RetrieverModel(
+            vector_store=vs,
+            columns=[
+                ColumnInfo(name="tags", type="array", description="Product tags"),
+                ColumnInfo(name="brand", type="string"),
+            ],
+        )
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
+        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+            tool = create_vector_search_tool(retriever=retriever, name="t")
+        enum = tool.args_schema.model_json_schema()["$defs"][
+            "DynamicFilterItem"
+        ]["properties"]["key"]["enum"]
+        # tags: 1 suffix. brand: 8 suffixes. Total = 9.
+        assert len(enum) == 9
+        assert "tags" in enum
+        # None of the disallowed suffixes appear for the array column:
+        for bad in ("tags NOT", "tags <", "tags <=", "tags >",
+                    "tags >=", "tags LIKE", "tags NOT LIKE"):
+            assert bad not in enum, f"array column got bad suffix: {bad}"
+        # brand still gets the standard set:
+        assert "brand LIKE" in enum and "brand NOT" in enum
+
+    def test_hand_declared_array_with_explicit_operators_wins(self) -> None:
+        """User explicit operators override the array-type default."""
+        vs = self._bare_vs()
+        retriever = RetrieverModel(
+            vector_store=vs,
+            columns=[
+                ColumnInfo(name="tags", type="array", operators=["", "NOT"]),
+            ],
+        )
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
+        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+            tool = create_vector_search_tool(retriever=retriever, name="t")
+        enum = tool.args_schema.model_json_schema()["$defs"][
+            "DynamicFilterItem"
+        ]["properties"]["key"]["enum"]
+        # User asked for equality + NOT — honored.
+        assert set(enum) == {"tags", "tags NOT"}
+
+    def test_auto_discovered_array_gets_equality_only(self) -> None:
+        """Mode C: nothing declared. `_fetch_index_columns` returns an
+        array column → factory adds equality-only override."""
+        vs = self._bare_vs()
+        retriever = RetrieverModel(vector_store=vs)
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._fetch_index_columns",
+            return_value=[("tags", "array<string>", "Product tags")],
+        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+            tool = create_vector_search_tool(retriever=retriever, name="t")
+        key_schema = tool.args_schema.model_json_schema()["$defs"][
+            "DynamicFilterItem"
+        ]["properties"]["key"]
+        # Pydantic renders a single-value Literal as ``const`` (not ``enum``).
+        # Either shape is fine as long as the value is exactly "tags".
+        assert key_schema.get("const") == "tags" or key_schema.get("enum") == ["tags"]
+
+    def test_mixed_array_and_scalar_auto_discovery(self) -> None:
+        """Auto-discovery with a mix: array column narrowed, scalar
+        columns keep full 8 suffixes."""
+        vs = self._bare_vs()
+        retriever = RetrieverModel(vector_store=vs)
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._fetch_index_columns",
+            return_value=[
+                ("tags", "array<string>", None),
+                ("price", "double", None),
+                ("sku", "string", None),
+            ],
+        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+            tool = create_vector_search_tool(retriever=retriever, name="t")
+        enum = tool.args_schema.model_json_schema()["$defs"][
+            "DynamicFilterItem"
+        ]["properties"]["key"]["enum"]
+        # tags: 1 + price: 8 + sku: 8 = 17.
+        assert len(enum) == 17
+        assert "tags" in enum
+        assert "tags LIKE" not in enum
+        assert "price <=" in enum and "sku LIKE" in enum
+
+    def test_array_hint_in_tool_description(self) -> None:
+        """When an array column is present, the tool description
+        includes the array-contains hint."""
+        vs = self._bare_vs()
+        retriever = RetrieverModel(
+            vector_store=vs,
+            columns=[
+                ColumnInfo(name="tags", type="array", description="Product tags"),
+            ],
+        )
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
+        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+            tool = create_vector_search_tool(retriever=retriever, name="t")
+        assert "- tags (ARRAY)" in tool.description
+        assert "Array columns match via element containment" in tool.description
+
+
+@pytest.mark.unit
+class TestArrayInColumnsDescription:
+    def test_array_hint_present_when_array_column(self) -> None:
+        block = _build_columns_description(
+            ["tags"], {"tags": "ARRAY"}, {"tags": "Product tags"}
+        )
+        assert "- tags (ARRAY) : Product tags" in block
+        assert "Array columns match via element containment" in block
+        assert "cordless" in block  # example is present
+
+    def test_no_array_hint_when_no_array_column(self) -> None:
+        block = _build_columns_description(
+            ["brand", "price"],
+            {"brand": "STRING", "price": "INT64"},
+            {},
+        )
+        assert "Array columns match" not in block
+        assert "cordless" not in block
+
+    def test_array_hint_detects_uc_style_type_strings(self) -> None:
+        # UC Tables API returns type_text like "array<string>"; the
+        # description hint should still fire.
+        block = _build_columns_description(
+            ["tags"], {"tags": "array<string>"}, {}
+        )
+        assert "Array columns match via element containment" in block

--- a/tests/dao_ai/test_vector_search_fevm_integration.py
+++ b/tests/dao_ai/test_vector_search_fevm_integration.py
@@ -290,13 +290,17 @@ class TestDynamicSchemaHydration:
         # description, price, is_b2b_only.
         for c in ("product_id", "product_name", "brand", "category", "price", "is_b2b_only"):
             assert c in enum, f"missing column {c!r} in {enum}"
-        # Type-aware guardrails:
+        # Type-aware guardrails (types come from wc.tables.get on the
+        # index — same UC entity as the columns):
         assert "product_name LIKE" in enum  # string col gets LIKE
         assert "product_name >" not in enum  # …but not ordering
         assert "price <=" in enum  # numeric col gets ordering
         assert "price LIKE" not in enum  # …but not LIKE
         assert "is_b2b_only NOT" in enum  # bool gets equality/NOT
         assert "is_b2b_only <" not in enum  # …but no ordering
+        # Regression key still absent (LLM cannot emit ``name`` — real
+        # column is ``product_name``).
+        assert not any(k.startswith("name ") or k == "name" for k in enum), enum
 
     def test_regression_products_bad_key_rejected_before_vs_call(self) -> None:
         """The exact regression from trace fc785d795b... — must fail at

--- a/tests/dao_ai/test_vector_search_fevm_integration.py
+++ b/tests/dao_ai/test_vector_search_fevm_integration.py
@@ -220,3 +220,169 @@ class TestVectorSearchFevmExplicitAuthMode4:
         assert isinstance(docs, list) and len(docs) > 0, (
             f"mode #4 explicit-PAT search returned no docs: {docs!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Dynamic schema hydration — the LLM-facing args_schema is built from the
+# live index metadata (columns via ``index.describe()``, types via UC Tables
+# API) rather than YAML alone. The regression this closes is MLflow trace
+# ``fc785d795b77675ac0e42fe5296b523a`` on ``agent-commerce-super-dao``:
+# the LLM emitted ``{"key": "name NOT LIKE"}`` against
+# ``retail_consumer_goods.commerce_swarm.products_description_index`` which
+# has ``product_name`` (not ``name``), the vector search API rejected the
+# call with ``Columns referenced in filters are not present in index: name``,
+# and the whole trace bubbled to ``state=ERROR``.
+# ---------------------------------------------------------------------------
+
+COMMERCE_SCHEMA = SchemaModel(
+    catalog_name="retail_consumer_goods",
+    schema_name="commerce_swarm",
+)
+
+COMMERCE_VS_ENDPOINT = VectorSearchEndpoint(name="dbdemos_vs_endpoint")
+
+
+def _bare_vector_store(index_name: str) -> VectorStoreModel:
+    """VectorStoreModel with ONLY an index reference — no columns declared.
+
+    Forces the factory down the auto-discovery path (``refresh()`` +
+    ``_fetch_column_types``).
+    """
+    return VectorStoreModel(
+        index=IndexModel(schema=COMMERCE_SCHEMA, name=index_name),
+        endpoint=COMMERCE_VS_ENDPOINT,
+    )
+
+
+def _tool_enum_keys(tool) -> list[str]:
+    """Pull the ``filters[].key`` enum out of the tool's args_schema JSON."""
+    schema = tool.args_schema.model_json_schema()
+    defs = schema.get("$defs", {})
+    item = defs.get("DynamicFilterItem") or defs.get("FilterItem") or {}
+    return item.get("properties", {}).get("key", {}).get("enum", []) or []
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _has_fevm_profile(), reason=SKIP_MSG)
+class TestDynamicSchemaHydration:
+    """Live-hydration tests against the three commerce_swarm indexes on FEVM:
+
+      * ``products_description_index``  (10-col products table)
+      * ``faqs_index``                  (FAQ knowledge base)
+      * ``policies_index``              (policies knowledge base)
+
+    Each test builds a tool from just an index reference (no ``columns:``
+    in YAML) and asserts (a) the args_schema exposes the live column set
+    with type-aware operator suffixes, (b) invalid keys are rejected by
+    pydantic without hitting the retriever, (c) valid keys pass through
+    and the live search returns.
+    """
+
+    def test_products_columns_discovered_from_live_index(self) -> None:
+        vs = _bare_vector_store("products_description_index")
+        tool = create_vector_search_tool(
+            retriever=RetrieverModel(vector_store=vs),
+            name="product_search",
+        )
+        enum = _tool_enum_keys(tool)
+        # Live products index columns (see commerce_swarm data DDL):
+        # product_id, sku, product_name, brand, category, subcategory,
+        # description, price, is_b2b_only.
+        for c in ("product_id", "product_name", "brand", "category", "price", "is_b2b_only"):
+            assert c in enum, f"missing column {c!r} in {enum}"
+        # Type-aware guardrails:
+        assert "product_name LIKE" in enum  # string col gets LIKE
+        assert "product_name >" not in enum  # …but not ordering
+        assert "price <=" in enum  # numeric col gets ordering
+        assert "price LIKE" not in enum  # …but not LIKE
+        assert "is_b2b_only NOT" in enum  # bool gets equality/NOT
+        assert "is_b2b_only <" not in enum  # …but no ordering
+
+    def test_regression_products_bad_key_rejected_before_vs_call(self) -> None:
+        """The exact regression from trace fc785d795b... — must fail at
+        pydantic validation, NOT surface to the retriever."""
+        vs = _bare_vector_store("products_description_index")
+        tool = create_vector_search_tool(
+            retriever=RetrieverModel(vector_store=vs),
+            name="product_search",
+        )
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            tool.invoke(
+                {
+                    "query": "dessert",
+                    "filters": [{"key": "name NOT LIKE", "value": "peanut"}],
+                }
+            )
+
+    def test_products_valid_filter_reaches_vs_and_returns(self) -> None:
+        vs = _bare_vector_store("products_description_index")
+        tool = create_vector_search_tool(
+            retriever=RetrieverModel(vector_store=vs),
+            name="product_search",
+        )
+        tool_call = LCToolCall(
+            name=tool.name,
+            args={
+                "query": "chocolate dessert",
+                "filters": [
+                    {"key": "product_name NOT LIKE", "value": "peanut"},
+                    {"key": "price <=", "value": 50},
+                    {"key": "is_b2b_only", "value": False},
+                ],
+            },
+            id="dyn-schema-tc-1",
+            type="tool_call",
+        )
+        docs = _extract_documents(tool.invoke(tool_call))
+        assert isinstance(docs, list) and len(docs) > 0, (
+            f"live products search with valid dyn-schema filters returned nothing: {docs!r}"
+        )
+
+    def test_faqs_columns_discovered_from_live_index(self) -> None:
+        vs = _bare_vector_store("faqs_index")
+        tool = create_vector_search_tool(
+            retriever=RetrieverModel(vector_store=vs),
+            name="faq_search",
+        )
+        enum = _tool_enum_keys(tool)
+        for c in ("faq_id", "category", "question", "answer"):
+            assert c in enum, f"missing column {c!r} in {enum}"
+
+    def test_policies_columns_discovered_from_live_index(self) -> None:
+        vs = _bare_vector_store("policies_index")
+        tool = create_vector_search_tool(
+            retriever=RetrieverModel(vector_store=vs),
+            name="policy_search",
+        )
+        enum = _tool_enum_keys(tool)
+        for c in ("policy_id", "category", "title", "body", "effective_date"):
+            assert c in enum, f"missing column {c!r} in {enum}"
+
+    def test_multiple_valid_filters_across_types(self) -> None:
+        vs = _bare_vector_store("products_description_index")
+        tool = create_vector_search_tool(
+            retriever=RetrieverModel(vector_store=vs),
+            name="product_search",
+        )
+        tool_call = LCToolCall(
+            name=tool.name,
+            args={
+                "query": "frozen bakery product",
+                "filters": [
+                    {"key": "category", "value": "Frozen Desserts"},
+                    {"key": "price >", "value": 5},
+                    {"key": "is_b2b_only", "value": False},
+                    {"key": "description NOT LIKE", "value": "peanut"},
+                ],
+            },
+            id="dyn-schema-tc-multi",
+            type="tool_call",
+        )
+        docs = _extract_documents(tool.invoke(tool_call))
+        assert isinstance(docs, list), f"unexpected shape: {docs!r}"
+        # An empty result is OK — what we care about is that all four
+        # different type-flavoured operators (equality/string, ordering/
+        # numeric, equality/boolean, NOT LIKE/string) all validated and
+        # reached the retriever without pydantic rejecting any of them.

--- a/tests/dao_ai/test_vector_search_fevm_integration.py
+++ b/tests/dao_ai/test_vector_search_fevm_integration.py
@@ -245,8 +245,8 @@ COMMERCE_VS_ENDPOINT = VectorSearchEndpoint(name="dbdemos_vs_endpoint")
 def _bare_vector_store(index_name: str) -> VectorStoreModel:
     """VectorStoreModel with ONLY an index reference — no columns declared.
 
-    Forces the factory down the auto-discovery path (``refresh()`` +
-    ``_fetch_column_types``).
+    Forces the factory down the auto-discovery path
+    (``refresh()`` + ``_fetch_index_columns``).
     """
     return VectorStoreModel(
         index=IndexModel(schema=COMMERCE_SCHEMA, name=index_name),
@@ -273,8 +273,8 @@ class TestDynamicSchemaHydration:
 
     Each test builds a tool from just an index reference (no ``columns:``
     in YAML) and asserts (a) the args_schema exposes the live column set
-    with type-aware operator suffixes, (b) invalid keys are rejected by
-    pydantic without hitting the retriever, (c) valid keys pass through
+    with all 8 operator suffixes per column, (b) invalid keys are rejected
+    by pydantic without hitting the retriever, (c) valid keys pass through
     and the live search returns.
     """
 
@@ -290,14 +290,15 @@ class TestDynamicSchemaHydration:
         # description, price, is_b2b_only.
         for c in ("product_id", "product_name", "brand", "category", "price", "is_b2b_only"):
             assert c in enum, f"missing column {c!r} in {enum}"
-        # Type-aware guardrails (types come from wc.tables.get on the
-        # index — same UC entity as the columns):
-        assert "product_name LIKE" in enum  # string col gets LIKE
-        assert "product_name >" not in enum  # …but not ordering
-        assert "price <=" in enum  # numeric col gets ordering
-        assert "price LIKE" not in enum  # …but not LIKE
-        assert "is_b2b_only NOT" in enum  # bool gets equality/NOT
-        assert "is_b2b_only <" not in enum  # …but no ordering
+        # Every column gets every operator suffix — no type-aware
+        # narrowing. Databricks VS rejects invalid combinations at query
+        # time (matches upstream databricks-langchain).
+        assert "product_name LIKE" in enum
+        assert "product_name >" in enum      # ordering allowed on any col
+        assert "price <=" in enum
+        assert "price LIKE" in enum          # LIKE allowed on any col
+        assert "is_b2b_only NOT" in enum
+        assert "is_b2b_only <" in enum       # ordering allowed on any col
         # Regression key still absent (LLM cannot emit ``name`` — real
         # column is ``product_name``).
         assert not any(k.startswith("name ") or k == "name" for k in enum), enum

--- a/tests/dao_ai/test_vector_search_hardware_store_fevm.py
+++ b/tests/dao_ai/test_vector_search_hardware_store_fevm.py
@@ -1,0 +1,243 @@
+"""FEVM integration tests for the dynamic VS tool schema on the
+``retail_consumer_goods.hardware_store.products_index`` index.
+
+Purpose: prove the hallucination fix isn't specific to the commerce_swarm
+config. The archived regression trace ``fc785d795b77675ac0e42fe5296b523a``
+was on ``agent-commerce-super-dao``; here we drive the same class of
+regression against a completely different config, catalog, schema, and
+column set — same fix, same outcome.
+
+Prompt shapes are grounded in the live source-table data
+(``retail_consumer_goods.hardware_store.products``) so the filters match
+what an actual user would trigger: real brands (DEWALT, CRAFTSMAN,
+HILLMAN), real ``merchandise_class`` values (WRENCHES, ELECTRICAL FITTINGS).
+
+To run:
+    uv run pytest -m integration tests/dao_ai/test_vector_search_hardware_store_fevm.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import mlflow
+import pytest
+from pydantic import ValidationError
+
+from dao_ai.config import (
+    IndexModel,
+    RetrieverModel,
+    SchemaModel,
+    SearchParametersModel,
+    VectorSearchEndpoint,
+    VectorStoreModel,
+)
+from dao_ai.tools.vector_search import create_vector_search_tool
+
+TEST_PROFILE = os.getenv("DAO_AI_TEST_PROFILE", "fevm")
+
+
+def _has_fevm_profile() -> bool:
+    if os.getenv("DATABRICKS_HOST") and os.getenv("DATABRICKS_TOKEN"):
+        return True
+    cfg = os.path.expanduser("~/.databrickscfg")
+    if not os.path.exists(cfg):
+        return False
+    try:
+        with open(cfg) as f:
+            return f"[{TEST_PROFILE}]" in f.read()
+    except Exception:
+        return False
+
+
+SKIP_MSG = (
+    f"Requires DATABRICKS_CONFIG_PROFILE={TEST_PROFILE} in ~/.databrickscfg "
+    "or DATABRICKS_HOST + DATABRICKS_TOKEN env vars."
+)
+
+# Columns declared in config/examples/15_complete_applications/hardware_store.yaml.
+# The live products_index has these exact columns.
+HARDWARE_STORE_COLUMNS = [
+    "product_id",
+    "sku",
+    "upc",
+    "brand_name",
+    "product_name",
+    "merchandise_class",
+    "class_cd",
+    "description",
+]
+
+
+def _hardware_store_retriever(
+    *, columns: list[str] | None = HARDWARE_STORE_COLUMNS
+) -> RetrieverModel:
+    """Build a retriever mirroring ``hardware_store.yaml`` — same index,
+    endpoint, primary_key, and (by default) column set."""
+    schema = SchemaModel(
+        catalog_name="retail_consumer_goods",
+        schema_name="hardware_store",
+    )
+    return RetrieverModel(
+        vector_store=VectorStoreModel(
+            index=IndexModel(name="products_index", schema=schema),
+            endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
+            primary_key="product_id",
+            embedding_source_column="description",
+            columns=columns,
+        ),
+        search_parameters=SearchParametersModel(num_results=3),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _use_fevm_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Route all workspace calls through the fevm profile."""
+    for var in ("DATABRICKS_TOKEN", "DATABRICKS_CLIENT_ID", "DATABRICKS_CLIENT_SECRET"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("DATABRICKS_CONFIG_PROFILE", TEST_PROFILE)
+
+
+@pytest.fixture
+def local_tracing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Enable local MLflow tracing so we can inspect the tool-call span
+    without depending on a workspace experiment. Autolog LangChain so the
+    dao-ai VS tool emits a proper span with inputs/outputs.
+    """
+    monkeypatch.setenv("MLFLOW_TRACE_SAMPLING_RATIO", "1")
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "false")
+    monkeypatch.setenv("MLFLOW_ALLOW_FILE_STORE", "true")
+    monkeypatch.delenv("MLFLOW_EXPERIMENT_ID", raising=False)
+    mlflow.set_tracking_uri(f"file://{tmp_path}")
+    mlflow.set_experiment("test-hw-vs-tool-schema")
+    mlflow.tracing.enable()
+    mlflow.langchain.autolog(run_tracer_inline=True)
+    try:
+        yield
+    finally:
+        mlflow.langchain.autolog(disable=True)
+        mlflow.tracing.disable()
+
+
+def _tool_call_span_inputs(trace) -> dict:
+    """Return the VS tool's span inputs from an MLflow trace.
+
+    Assumes exactly one tool-call span; raises AssertionError otherwise.
+    """
+    assert trace is not None, "MLflow trace not found"
+    tool_spans = [
+        s
+        for s in trace.data.spans
+        if s.attributes.get("mlflow.spanType") == "TOOL"
+        or (s.name and "hw_search" in s.name)
+    ]
+    assert tool_spans, (
+        f"no tool span in trace {trace.info.request_id}; "
+        f"spans: {[s.name for s in trace.data.spans]}"
+    )
+    span = tool_spans[0]
+    return span.inputs or {}
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _has_fevm_profile(), reason=SKIP_MSG)
+class TestHardwareStoreDynamicSchema:
+    """Hallucination-proof filter enum, verified on a live FEVM index that
+    is NOT the one the regression trace was captured against."""
+
+    def test_dynamic_schema_hallucination_blocked(self) -> None:
+        """The archetypal hallucination — LLM emits a column key that
+        isn't on the index — must be rejected by pydantic before the VS
+        API is ever called. Same failure mode as the commerce_swarm
+        regression, on a different config."""
+        retriever = _hardware_store_retriever()
+        tool = create_vector_search_tool(retriever=retriever, name="hw_search")
+
+        # ``product_name`` is the real column — LLM would hallucinate
+        # ``name``. That must be pre-empted at schema-validation time.
+        with pytest.raises(ValidationError):
+            tool.invoke(
+                {
+                    "query": "screwdriver set",
+                    "filters": [{"key": "name NOT LIKE", "value": "%hammer%"}],
+                }
+            )
+
+    def test_valid_filter_reaches_index_live_with_trace_assertions(
+        self, local_tracing
+    ) -> None:
+        """End-to-end: valid filter shape reaches the VS API and the
+        MLflow trace records the exact ``filters[].key`` values we sent.
+        Asserts (a) no ``ValidationError``, (b) no VS API "not present in
+        index" event, (c) the trace span's inputs contain the filter we
+        sent (proves the tool call is what actually reached the API)."""
+        retriever = _hardware_store_retriever()
+        tool = create_vector_search_tool(retriever=retriever, name="hw_search")
+
+        expected_filter_key = "brand_name LIKE"
+        with mlflow.start_span(name="hw_test_outer") as outer_span:
+            trace_id = outer_span.request_id
+            result = tool.invoke(
+                {
+                    "query": "wrench",
+                    "filters": [
+                        {"key": expected_filter_key, "value": "%"},
+                    ],
+                }
+            )
+
+        # (a) No exception + non-error content.
+        content = result.content if hasattr(result, "content") else result
+        if isinstance(content, str):
+            assert "not present in index" not in content, content
+            if content.startswith("["):
+                json.loads(content)
+
+        # (b) The trace records the tool call with the exact filter key.
+        trace = mlflow.get_trace(trace_id)
+        span_inputs = _tool_call_span_inputs(trace)
+        # Tool inputs can be nested under a ToolCall wrapper — search the
+        # inputs JSON for the expected filter key.
+        inputs_blob = json.dumps(span_inputs)
+        assert expected_filter_key in inputs_blob, (
+            f"expected filter key {expected_filter_key!r} in span inputs; "
+            f"got {inputs_blob[:400]}"
+        )
+
+        # (c) No span carries a VS API "not present in index" event.
+        for span in trace.data.spans:
+            for event in getattr(span, "events", []) or []:
+                event_name = getattr(event, "name", "") or ""
+                event_attrs = getattr(event, "attributes", {}) or {}
+                joined = event_name + " " + json.dumps(event_attrs)
+                assert "not present in index" not in joined, (
+                    f"span {span.name} carries a not-present-in-index event: {joined}"
+                )
+
+    def test_yaml_column_intersection_dropped_with_warning(self) -> None:
+        """YAML declares a bogus column not on the live index → dropped
+        from the Literal enum before the tool is built. The LLM cannot
+        emit a filter using it. Regression guard for the WARN+drop path
+        against a real describe() payload."""
+        retriever = _hardware_store_retriever(
+            columns=[
+                "product_id",
+                "product_name",
+                "brand_name",
+                "nonexistent_column_xyz",
+            ]
+        )
+        tool = create_vector_search_tool(retriever=retriever, name="hw_search")
+
+        enum = (
+            tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+                "properties"
+            ]["key"]["enum"]
+        )
+        assert "product_name" in enum
+        assert "brand_name" in enum
+        assert not any(
+            k.startswith("nonexistent_column_xyz") for k in enum
+        ), f"bogus YAML column leaked into enum: {enum!r}"


### PR DESCRIPTION
## Summary

Two behavior changes on `create_vector_search_tool` that together close a class of LLM hallucination where the model emits a filter with a column key that isn't in the index.

**1. Auto-discovery of columns at build time when YAML is silent.**
- `VectorStoreModel.refresh()` → reads `index.describe()`; hydrates `source_table` / `primary_key` / `endpoint`, plus `columns_to_sync` on Direct-Access indexes.
- New `_probe_index_columns()` → `index.scan(num_results=1)` and reads `fields[].key` off the returned doc — required for Delta-Sync indexes whose describe() omits `columns_to_sync`. Strips vector + CDF system fields.
- New `_fetch_column_types()` → UC Tables API on the source table for Databricks types. Intersected with the discovered set so we only advertise filter keys we can actually type.
- New `_vsc_for_refresh()` mints a `VectorSearchClient` via the same ambient-auth extraction the query-time path uses, so refresh works under all four documented auth modes.

**2. Literal-narrowed `filters[].key` in the LLM-facing args_schema.**
- Per-tool `DynamicFilterItem` where `key` is `Literal[<col>, "<col> NOT", "<col> <=", "<col> LIKE", …]`.
- Type-aware suffix filtering — no `LIKE` on integers, no ordering on booleans, no ordering on strings. Unknown types fall back to permitting all suffixes.
- Pydantic rejects an unlisted key **before** the retriever is called, so the "guessed a column name that isn't in the index" hallucination is impossible.

## The regression this closes

MLflow trace `fc785d795b77675ac0e42fe5296b523a` on `agent-commerce-super-dao` (prompt: *"I'm allergic to peanuts — please recommend a dessert under $30."*):

- The LLM emitted `{"key": "name NOT LIKE", "value": "peanut"}` against `retail_consumer_goods.commerce_swarm.products_description_index`, whose actual column is `product_name`.
- Databricks Vector Search returned `Columns referenced in filters are not present in index: name`.
- The full trace went `state=ERROR`.

After this change, the LLM's tool schema no longer lists `name` as a legal key. Three consecutive live runs of the exact regression prompt against the redeployed apps produce `state=OK` with zero invalid-column events; the LLM only emits enum-legal keys like `category`, `category LIKE`, `price <=`, `description NOT LIKE`.

## Test coverage

- **18 new unit tests** in `tests/dao_ai/test_vector_search_dynamic_schema.py`:
  - `TestOperatorsForType` — per-type operator matrix (numeric → no LIKE, string → no ordering, bool → equality-only, unknown → all).
  - `TestLegalFilterKeys` — cross-product legality, type-narrowing, missing-type fallback.
  - `TestBuildFilterItemModel` / `TestBuildVectorSearchInputModel` — the exact `"name NOT LIKE"` regression is rejected by pydantic; mixed-type valid filters are accepted.
  - `TestFactoryColumnHydration` — `refresh()` is invoked on empty YAML columns; YAML columns take precedence; `refresh()` failure degrades softly to the free-form `FilterItem`.
- **6 new live-integration tests** in `tests/dao_ai/test_vector_search_fevm_integration.py::TestDynamicSchemaHydration` — hits the real `products_description_index`, `faqs_index`, `policies_index` on FEVM, asserts columns are discovered from live indexes and the regression key is rejected before the VS call.

## Live re-validation

- Both `agent-commerce-swarm-dao` and `agent-commerce-super-dao` were redeployed against the branch. All eight Vector-Search-touching demo prompts pass on both apps (16/16).
- Three back-to-back replays of the exact regression prompt against the supervisor app: all three `state=OK`, all three with zero `Columns referenced in filters are not present in index` events.

## Safety / rollback

Everything is soft-fail: any failure in refresh / probe / type lookup logs a WARN and degrades to the pre-change free-form `FilterItem` schema. YAML-declared columns still take precedence over live discovery (opt-in narrowing override), so no in-flight config regresses. Also fixes a pre-existing dead-code bug that referenced `vector_store.index.columns` (attribute doesn't exist on `IndexModel`).

## Test plan

- [ ] `uv run pytest -m unit tests/dao_ai/test_vector_search_dynamic_schema.py tests/dao_ai/test_vector_search.py tests/dao_ai/test_vector_store_refresh.py` → 55 pass
- [ ] `DATABRICKS_CONFIG_PROFILE=fevm uv run pytest -m integration tests/dao_ai/test_vector_search_fevm_integration.py` → 10 pass
- [ ] Redeploy `agent-commerce-super-dao` from this branch and confirm no `state=ERROR` on the regression prompt across 3 consecutive invocations.

This pull request and its description were written by Isaac.