### PR TITLE
feat(retrievers): add lakebase_search tool + LakebaseRetriever

### DIFF
--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -4545,6 +4545,151 @@ class RetrieverModel(BaseModel):
         return self
 
 
+class LakebaseVectorStoreModel(BaseModel):
+    """Configuration for a Databricks Lakebase Postgres table used for retrieval.
+
+    Points at a table that already has ``lakebase_vector`` (and optionally
+    ``lakebase_text``) extensions installed and appropriate indexes built.
+    Stage-1 scope: existing tables only; provisioning is deferred.
+
+    Example (existing table, hybrid-ready):
+    ```yaml
+    vector_store:
+      database:
+        project: my-lakebase-project
+      table: kb_articles
+      content_column: passage
+      embedding_column: embedding
+      tsvector_column: passage_tsv
+      embedding_model: databricks-gte-large-en
+      metadata_columns: [category, source_url]
+      bm25_index_name: kb_articles_passage_bm25
+      distance_metric: cosine
+    ```
+    """
+
+    model_config = ConfigDict(use_enum_values=True, extra="forbid")
+
+    database: DatabaseModel = Field(
+        description=(
+            "Lakebase (or PostgreSQL) database connection. Reuses the "
+            "existing DatabaseModel — pool + auth handled by "
+            "``dao_ai.memory.postgres`` pool managers."
+        ),
+    )
+    schema_name: str = Field(
+        default="public",
+        description="Postgres schema containing the retrieval table.",
+    )
+    table: str = Field(
+        description="Source table with vector (and optionally tsvector) columns.",
+    )
+    id_column: str = Field(
+        default="id",
+        description="Primary-key column exposed as ``Document.metadata['id']``.",
+    )
+    content_column: str = Field(
+        description="Text column returned as ``Document.page_content``.",
+    )
+    embedding_column: str = Field(
+        description=(
+            "``VECTOR(N)`` column indexed by ``lakebase_ann``. "
+            "Dimension must match the embedding model."
+        ),
+    )
+    tsvector_column: Optional[str] = Field(
+        default=None,
+        description=(
+            "``tsvector`` column indexed by ``lakebase_bm25``. "
+            "Required for BM25 and HYBRID query types."
+        ),
+    )
+    metadata_columns: Optional[list[str]] = Field(
+        default_factory=list,
+        description="Additional columns surfaced on ``Document.metadata``.",
+    )
+    embedding_model: InferenceEndpointModel = Field(
+        description=(
+            "Embedding endpoint used to embed the query at retrieval time. "
+            "Accepts a bare endpoint name (e.g. ``databricks-gte-large-en``) "
+            "which is coerced to ``InferenceEndpointModel(name=<str>)``."
+        ),
+    )
+    bm25_index_name: Optional[str] = Field(
+        default=None,
+        description=(
+            "Regclass name required by ``to_bm25query(..., <index>::regclass)``. "
+            "Auto-derived from ``<schema>.<table>_<tsvector_column>_bm25`` if omitted."
+        ),
+    )
+    distance_metric: Literal["cosine", "l2", "ip"] = Field(
+        default="cosine",
+        description=(
+            "Vector distance operator: ``cosine`` (``<=>`` / ``vector_cosine_ops``), "
+            "``l2`` (``<->`` / ``vector_l2_ops``), ``ip`` (``<#>`` / ``vector_ip_ops``)."
+        ),
+    )
+    tsv_language: str = Field(
+        default="english",
+        description="Text-search dictionary passed to ``to_tsvector(<lang>, ...)``.",
+    )
+
+    @field_validator("embedding_model", mode="before")
+    @classmethod
+    def _coerce_embedding_model(cls, v: Any) -> Any:
+        """Accept a bare endpoint name string as shorthand."""
+        if isinstance(v, str):
+            return InferenceEndpointModel(name=v)
+        return v
+
+    @model_validator(mode="after")
+    def _derive_bm25_index_name(self) -> Self:
+        if self.bm25_index_name is None and self.tsvector_column is not None:
+            self.bm25_index_name = (
+                f"{self.schema_name}.{self.table}_{self.tsvector_column}_bm25"
+            )
+        return self
+
+
+class LakebaseRetrieverModel(BaseModel):
+    """Full Lakebase retriever config — vector store plus search parameters."""
+
+    model_config = ConfigDict(use_enum_values=True, extra="forbid")
+
+    vector_store: LakebaseVectorStoreModel = Field(
+        description="Lakebase table + columns + embedding model.",
+    )
+    columns: Optional[list[str | ColumnInfo]] = Field(
+        default_factory=list,
+        description=(
+            "Columns to expose to the LLM as filterable + returnable. "
+            "Defaults to ``vector_store.metadata_columns`` when unset."
+        ),
+    )
+    search_parameters: SearchParametersModel = Field(
+        default_factory=SearchParametersModel,
+        description=(
+            "Search tuning. For Lakebase, ``query_type`` accepts "
+            "``'ANN'``, ``'BM25'``, or ``'HYBRID'`` (RRF client-side)."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _set_default_columns(self) -> Self:
+        if not self.columns:
+            self.columns = list(self.vector_store.metadata_columns or [])
+        return self
+
+    @model_validator(mode="after")
+    def _bm25_requires_tsvector(self) -> Self:
+        qt = (self.search_parameters.query_type or "ANN").upper()
+        if qt in {"BM25", "HYBRID"} and self.vector_store.tsvector_column is None:
+            raise ValueError(
+                f"query_type={qt!r} requires 'tsvector_column' on the vector store."
+            )
+        return self
+
+
 class FunctionType(str, Enum):
     PYTHON = "python"
     FACTORY = "factory"
@@ -4557,6 +4702,7 @@ class FunctionType(str, Enum):
     # tool model; ``vector_search`` will eventually be deprecated.
     VECTOR_SEARCH = "vector_search"
     AI_SEARCH = "ai_search"
+    LAKEBASE_SEARCH = "lakebase_search"
     SEARCH = "search"
     APP = "app"
     SERVING_ENDPOINT = "serving_endpoint"
@@ -5315,6 +5461,67 @@ class AiSearchToolModel(BaseFunctionModel):
 VectorSearchToolModel = AiSearchToolModel
 
 
+class LakebaseSearchToolModel(BaseFunctionModel):
+    """First-class Lakebase retrieval tool that delegates to ``dao_ai.tools.create_lakebase_search_tool``.
+
+    Retrieves from a Databricks Lakebase Postgres table using the
+    ``lakebase_vector`` and (optionally) ``lakebase_text`` extensions.
+    Exactly one of ``retriever`` or ``vector_store`` is required.
+    """
+
+    model_config = ConfigDict(use_enum_values=True, extra="forbid")
+    type: Literal[FunctionType.LAKEBASE_SEARCH] = Field(
+        default=FunctionType.LAKEBASE_SEARCH,
+        description="Function type discriminator. Must be 'lakebase_search'.",
+    )
+    retriever: Optional[LakebaseRetrieverModel] = Field(
+        default=None,
+        description=(
+            "Full Lakebase retriever configuration with search parameters. "
+            "Mutually exclusive with ``vector_store``."
+        ),
+    )
+    vector_store: Optional[LakebaseVectorStoreModel] = Field(
+        default=None,
+        description=(
+            "Direct Lakebase table reference (uses default search parameters). "
+            "Mutually exclusive with ``retriever``."
+        ),
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="Tool name visible to the LLM.",
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="Tool description shown to the LLM during function calling.",
+    )
+
+    @model_validator(mode="after")
+    def _retriever_or_vector_store(self) -> Self:
+        if self.retriever is None and self.vector_store is None:
+            raise ValueError(
+                "LakebaseSearchToolModel requires exactly one of 'retriever' or 'vector_store'."
+            )
+        if self.retriever is not None and self.vector_store is not None:
+            raise ValueError(
+                "LakebaseSearchToolModel cannot accept both 'retriever' and 'vector_store'."
+            )
+        return self
+
+    def as_tools(self, **kwargs: Any) -> Sequence[RunnableLike]:
+        from dao_ai.tools import create_lakebase_search_tool
+
+        return [
+            create_lakebase_search_tool(
+                retriever=self.retriever,
+                vector_store=self.vector_store,
+                name=self.name,
+                description=self.description,
+            )
+        ]
+
+
 class SearchToolModel(BaseFunctionModel):
     """First-class web search tool that delegates to ``dao_ai.tools.create_search_tool``.
 
@@ -5668,6 +5875,7 @@ AnyTool: TypeAlias = (
         McpFunctionModel,
         GenieToolModel,
         AiSearchToolModel,
+        LakebaseSearchToolModel,
         SearchToolModel,
         AppToolModel,
         ServingEndpointToolModel,

--- a/src/dao_ai/retrievers/__init__.py
+++ b/src/dao_ai/retrievers/__init__.py
@@ -1,0 +1,5 @@
+"""dao-ai retriever implementations."""
+
+from dao_ai.retrievers.lakebase import LakebaseRetriever, LakebaseSearchMode
+
+__all__ = ["LakebaseRetriever", "LakebaseSearchMode"]

--- a/src/dao_ai/retrievers/lakebase.py
+++ b/src/dao_ai/retrievers/lakebase.py
@@ -1,0 +1,394 @@
+"""Databricks Lakebase Postgres retriever.
+
+Uses the ``lakebase_vector`` extension for ANN similarity search and the
+``lakebase_text`` extension for BM25 lexical search, combining them
+client-side with Reciprocal Rank Fusion for hybrid queries.
+
+Connection pooling and Lakebase credential rotation are delegated to
+``dao_ai.memory.postgres.PostgresPoolManager`` /
+``AsyncPostgresPoolManager`` so this module never touches
+``w.postgres.generate_database_credential(...)`` directly.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Optional
+
+import mlflow
+from databricks_langchain import DatabricksEmbeddings
+from langchain_core.callbacks import (
+    AsyncCallbackManagerForRetrieverRun,
+    CallbackManagerForRetrieverRun,
+)
+from langchain_core.documents import Document
+from langchain_core.embeddings import Embeddings
+from langchain_core.retrievers import BaseRetriever
+from loguru import logger
+from mlflow.entities import SpanType
+from psycopg import sql
+from psycopg.rows import dict_row
+from pydantic import ConfigDict, PrivateAttr
+
+from dao_ai.config import LakebaseVectorStoreModel, SearchParametersModel
+
+_DISTANCE_OP = {"cosine": "<=>", "l2": "<->", "ip": "<#>"}
+_OPS_CLASS = {
+    "cosine": "vector_cosine_ops",
+    "l2": "vector_l2_ops",
+    "ip": "vector_ip_ops",
+}
+_ALLOWED_OPS = {"=", "!=", "<", "<=", ">", ">=", "like", "ilike"}
+_RRF_K = 60
+
+
+class LakebaseSearchMode(str, Enum):
+    ANN = "ANN"
+    BM25 = "BM25"
+    HYBRID = "HYBRID"
+
+
+class LakebaseRetriever(BaseRetriever):
+    """LangChain retriever over a Lakebase Postgres table."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    vector_store: LakebaseVectorStoreModel
+    search_parameters: SearchParametersModel = SearchParametersModel()
+
+    _embeddings: Optional[Embeddings] = PrivateAttr(default=None)
+    _allowed_filter_cols: frozenset[str] = PrivateAttr(default=frozenset())
+
+    def model_post_init(self, __context: Any) -> None:
+        metadata = self.vector_store.metadata_columns or []
+        self._allowed_filter_cols = frozenset(
+            [*metadata, self.vector_store.id_column]
+        )
+
+    # ------------------------------------------------------------------
+    # LangChain BaseRetriever interface
+    # ------------------------------------------------------------------
+
+    def _get_relevant_documents(
+        self,
+        query: str,
+        *,
+        run_manager: CallbackManagerForRetrieverRun,
+    ) -> list[Document]:
+        mode = self._mode()
+        filters = self._effective_filters()
+        k = self._num_results()
+
+        if mode is LakebaseSearchMode.ANN:
+            rows = self._run_ann_sync(self._embed(query), filters, k)
+            return [self._row_to_document(r) for r in rows]
+        if mode is LakebaseSearchMode.BM25:
+            rows = self._run_bm25_sync(query, filters, k)
+            return [self._row_to_document(r) for r in rows]
+        return self._run_hybrid_sync(query, filters, k)
+
+    async def _aget_relevant_documents(
+        self,
+        query: str,
+        *,
+        run_manager: AsyncCallbackManagerForRetrieverRun,
+    ) -> list[Document]:
+        mode = self._mode()
+        filters = self._effective_filters()
+        k = self._num_results()
+
+        if mode is LakebaseSearchMode.ANN:
+            rows = await self._run_ann_async(self._embed(query), filters, k)
+            return [self._row_to_document(r) for r in rows]
+        if mode is LakebaseSearchMode.BM25:
+            rows = await self._run_bm25_async(query, filters, k)
+            return [self._row_to_document(r) for r in rows]
+        return await self._run_hybrid_async(query, filters, k)
+
+    # ------------------------------------------------------------------
+    # Mode / config helpers
+    # ------------------------------------------------------------------
+
+    def _mode(self) -> LakebaseSearchMode:
+        raw = (self.search_parameters.query_type or "ANN").upper()
+        try:
+            return LakebaseSearchMode(raw)
+        except ValueError as e:
+            raise ValueError(
+                f"Unsupported query_type for Lakebase: {raw!r}. "
+                "Expected one of: ANN, BM25, HYBRID."
+            ) from e
+
+    def _num_results(self) -> int:
+        return int(self.search_parameters.num_results or 10)
+
+    def _effective_filters(self) -> dict[str, Any]:
+        return dict(self.search_parameters.filters or {})
+
+    def _embed(self, query: str) -> list[float]:
+        if self._embeddings is None:
+            self._embeddings = DatabricksEmbeddings(
+                endpoint=self.vector_store.embedding_model.name
+            )
+        return self._embeddings.embed_query(query)
+
+    # ------------------------------------------------------------------
+    # SQL builders (pure — testable without a live DB)
+    # ------------------------------------------------------------------
+
+    def _qualified_table(self) -> sql.Composed:
+        return sql.SQL("{}.{}").format(
+            sql.Identifier(self.vector_store.schema_name),
+            sql.Identifier(self.vector_store.table),
+        )
+
+    def _select_columns(self, extra: list[sql.Composable] | None = None) -> sql.Composed:
+        vs = self.vector_store
+        cols: list[sql.Composable] = [sql.Identifier(vs.id_column), sql.Identifier(vs.content_column)]
+        cols.extend(sql.Identifier(c) for c in (vs.metadata_columns or []))
+        if extra:
+            cols.extend(extra)
+        return sql.SQL(", ").join(cols)
+
+    def _build_where(
+        self, filters: dict[str, Any]
+    ) -> tuple[sql.Composable, list[Any]]:
+        """Translate a filter dict into a WHERE fragment + params.
+
+        Unknown columns and operators raise ValueError before any SQL is built.
+        Values are always passed as parameters (``%s``); column names are
+        wrapped in ``sql.Identifier`` for safe quoting.
+        """
+        if not filters:
+            return sql.SQL(""), []
+
+        clauses: list[sql.Composable] = []
+        params: list[Any] = []
+        for key, spec in filters.items():
+            if key not in self._allowed_filter_cols:
+                raise ValueError(
+                    f"Unknown filter column {key!r}; "
+                    f"allowed: {sorted(self._allowed_filter_cols)}"
+                )
+            col = sql.Identifier(key)
+
+            if not isinstance(spec, dict):
+                clauses.append(sql.SQL("{} = %s").format(col))
+                params.append(spec)
+                continue
+
+            op = str(spec.get("op", "=")).lower()
+            if op == "in":
+                clauses.append(sql.SQL("{} = ANY(%s)").format(col))
+                params.append(list(spec["values"]))
+            elif op == "not_in":
+                clauses.append(sql.SQL("NOT ({} = ANY(%s))").format(col))
+                params.append(list(spec["values"]))
+            elif op == "is_null":
+                is_null = bool(spec.get("value", True))
+                clauses.append(
+                    sql.SQL("{} IS NULL").format(col)
+                    if is_null
+                    else sql.SQL("{} IS NOT NULL").format(col)
+                )
+            elif op in _ALLOWED_OPS:
+                op_sql = sql.SQL(op.upper()) if op in {"like", "ilike"} else sql.SQL(op)
+                clauses.append(sql.SQL("{} {} %s").format(col, op_sql))
+                params.append(spec["value"])
+            else:
+                raise ValueError(f"Unsupported filter op {op!r} on column {key!r}")
+
+        return sql.SQL(" AND ") + sql.SQL(" AND ").join(clauses), params
+
+    def _build_ann_sql(
+        self, filters: dict[str, Any], k: int
+    ) -> tuple[sql.Composed, list[Any]]:
+        vs = self.vector_store
+        op = _DISTANCE_OP[vs.distance_metric]
+        where_sql, where_params = self._build_where(filters)
+        query = sql.SQL(
+            "SELECT {cols}, ({emb} {op} %s::vector) AS _distance "
+            "FROM {table} "
+            "WHERE {emb} IS NOT NULL{where} "
+            "ORDER BY {emb} {op} %s::vector "
+            "LIMIT %s"
+        ).format(
+            cols=self._select_columns(),
+            emb=sql.Identifier(vs.embedding_column),
+            op=sql.SQL(op),
+            table=self._qualified_table(),
+            where=where_sql,
+        )
+        return query, [*where_params, k]  # embedding + limit prepended per-call
+
+    def _build_bm25_sql(
+        self, filters: dict[str, Any], k: int
+    ) -> tuple[sql.Composed, list[Any]]:
+        vs = self.vector_store
+        if vs.tsvector_column is None or vs.bm25_index_name is None:
+            raise ValueError(
+                "BM25 search requires 'tsvector_column' and 'bm25_index_name' on the vector store."
+            )
+        where_sql, where_params = self._build_where(filters)
+        score_expr = sql.SQL(
+            "({tsv} <@> to_bm25query(to_tsvector(%s, %s), %s::regclass))"
+        ).format(tsv=sql.Identifier(vs.tsvector_column))
+        query = sql.SQL(
+            "SELECT {cols}, {score} AS _score "
+            "FROM {table} "
+            "WHERE {tsv} IS NOT NULL{where} "
+            "ORDER BY {score} ASC "
+            "LIMIT %s"
+        ).format(
+            cols=self._select_columns(),
+            score=score_expr,
+            table=self._qualified_table(),
+            tsv=sql.Identifier(vs.tsvector_column),
+            where=where_sql,
+        )
+        return query, [*where_params, k]
+
+    # ------------------------------------------------------------------
+    # Execution — sync
+    # ------------------------------------------------------------------
+
+    def _sync_pool(self):
+        from dao_ai.memory.postgres import PostgresPoolManager
+
+        return PostgresPoolManager.get_pool(self.vector_store.database)
+
+    @mlflow.trace(name="lakebase_ann_search", span_type=SpanType.RETRIEVER)
+    def _run_ann_sync(
+        self, query_vec: list[float], filters: dict[str, Any], k: int
+    ) -> list[dict[str, Any]]:
+        stmt, tail = self._build_ann_sql(filters, k)
+        # ANN SQL binds the vector twice (SELECT distance + ORDER BY),
+        # with WHERE params in between, and k as the final LIMIT bind.
+        where_params = tail[:-1]
+        params = [query_vec, *where_params, query_vec, k]
+        pool = self._sync_pool()
+        with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(stmt, params)
+            return list(cur.fetchall())
+
+    @mlflow.trace(name="lakebase_bm25_search", span_type=SpanType.RETRIEVER)
+    def _run_bm25_sync(
+        self, query_text: str, filters: dict[str, Any], k: int
+    ) -> list[dict[str, Any]]:
+        stmt, tail = self._build_bm25_sql(filters, k)
+        where_params = tail[:-1]
+        lang = self.vector_store.tsv_language
+        idx = self.vector_store.bm25_index_name
+        # score_expr appears twice (SELECT + ORDER BY) so bind 6 tsquery params total.
+        pre = [lang, query_text, idx]
+        params = [*pre, *where_params, *pre, k]
+        pool = self._sync_pool()
+        with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(stmt, params)
+            return list(cur.fetchall())
+
+    @mlflow.trace(name="lakebase_hybrid_search", span_type=SpanType.RETRIEVER)
+    def _run_hybrid_sync(
+        self, query: str, filters: dict[str, Any], k: int
+    ) -> list[Document]:
+        fetch_k = max(k * 2, 20)
+        ann_rows = self._run_ann_sync(self._embed(query), filters, fetch_k)
+        bm25_rows = self._run_bm25_sync(query, filters, fetch_k)
+        return self._rrf(ann_rows, bm25_rows, k)
+
+    # ------------------------------------------------------------------
+    # Execution — async
+    # ------------------------------------------------------------------
+
+    async def _async_pool(self):
+        from dao_ai.memory.postgres import AsyncPostgresPoolManager
+
+        return await AsyncPostgresPoolManager.get_pool(self.vector_store.database)
+
+    @mlflow.trace(name="lakebase_ann_search", span_type=SpanType.RETRIEVER)
+    async def _run_ann_async(
+        self, query_vec: list[float], filters: dict[str, Any], k: int
+    ) -> list[dict[str, Any]]:
+        stmt, tail = self._build_ann_sql(filters, k)
+        where_params = tail[:-1]
+        params = [query_vec, *where_params, query_vec, k]
+        pool = await self._async_pool()
+        async with pool.connection() as conn:
+            async with conn.cursor(row_factory=dict_row) as cur:
+                await cur.execute(stmt, params)
+                return list(await cur.fetchall())
+
+    @mlflow.trace(name="lakebase_bm25_search", span_type=SpanType.RETRIEVER)
+    async def _run_bm25_async(
+        self, query_text: str, filters: dict[str, Any], k: int
+    ) -> list[dict[str, Any]]:
+        stmt, tail = self._build_bm25_sql(filters, k)
+        where_params = tail[:-1]
+        lang = self.vector_store.tsv_language
+        idx = self.vector_store.bm25_index_name
+        pre = [lang, query_text, idx]
+        params = [*pre, *where_params, *pre, k]
+        pool = await self._async_pool()
+        async with pool.connection() as conn:
+            async with conn.cursor(row_factory=dict_row) as cur:
+                await cur.execute(stmt, params)
+                return list(await cur.fetchall())
+
+    @mlflow.trace(name="lakebase_hybrid_search", span_type=SpanType.RETRIEVER)
+    async def _run_hybrid_async(
+        self, query: str, filters: dict[str, Any], k: int
+    ) -> list[Document]:
+        fetch_k = max(k * 2, 20)
+        ann_rows = await self._run_ann_async(self._embed(query), filters, fetch_k)
+        bm25_rows = await self._run_bm25_async(query, filters, fetch_k)
+        return self._rrf(ann_rows, bm25_rows, k)
+
+    # ------------------------------------------------------------------
+    # Fusion + row mapping
+    # ------------------------------------------------------------------
+
+    def _rrf(
+        self,
+        ann_rows: list[dict[str, Any]],
+        bm25_rows: list[dict[str, Any]],
+        k: int,
+    ) -> list[Document]:
+        id_col = self.vector_store.id_column
+        fused: dict[Any, dict[str, Any]] = {}
+        scores: dict[Any, float] = {}
+        for rank, row in enumerate(ann_rows, start=1):
+            rid = row[id_col]
+            scores[rid] = scores.get(rid, 0.0) + 1.0 / (_RRF_K + rank)
+            fused.setdefault(rid, row)
+        for rank, row in enumerate(bm25_rows, start=1):
+            rid = row[id_col]
+            scores[rid] = scores.get(rid, 0.0) + 1.0 / (_RRF_K + rank)
+            fused.setdefault(rid, row)
+        ranked = sorted(fused.items(), key=lambda kv: scores[kv[0]], reverse=True)
+        docs: list[Document] = []
+        for rid, row in ranked[:k]:
+            doc = self._row_to_document(row)
+            doc.metadata["_rrf_score"] = scores[rid]
+            docs.append(doc)
+        return docs
+
+    def _row_to_document(self, row: dict[str, Any]) -> Document:
+        vs = self.vector_store
+        page_content = row.get(vs.content_column, "") or ""
+        raw_id = row.get(vs.id_column)
+        doc_id = str(raw_id) if raw_id is not None else None
+        metadata: dict[str, Any] = {vs.id_column: raw_id}
+        for col in vs.metadata_columns or []:
+            if col in row:
+                metadata[col] = row[col]
+        if "_distance" in row:
+            metadata["_distance"] = row["_distance"]
+        if "_score" in row:
+            metadata["_score"] = row["_score"]
+        logger.trace(
+            "Lakebase document",
+            id=doc_id,
+            score=metadata.get("_score"),
+            distance=metadata.get("_distance"),
+        )
+        return Document(id=doc_id, page_content=str(page_content), metadata=metadata)

--- a/src/dao_ai/tools/__init__.py
+++ b/src/dao_ai/tools/__init__.py
@@ -38,6 +38,7 @@ from dao_ai.tools.time import (
     time_until_tool,
 )
 from dao_ai.tools.unity_catalog import create_uc_tools
+from dao_ai.tools.lakebase_search import create_lakebase_search_tool
 from dao_ai.tools.vector_search import (
     create_ai_search_tool,
     create_vector_search_tool,
@@ -80,6 +81,7 @@ __all__ = [
     "create_tools",
     "create_uc_tools",
     "create_ai_search_tool",
+    "create_lakebase_search_tool",
     "create_vector_search_tool",
     "create_visualization_tool",
     "current_time_tool",

--- a/src/dao_ai/tools/lakebase_search.py
+++ b/src/dao_ai/tools/lakebase_search.py
@@ -1,0 +1,133 @@
+"""Factory for the ``lakebase_search`` first-class tool.
+
+Wraps ``dao_ai.retrievers.LakebaseRetriever`` in a LangChain ``StructuredTool``.
+Mirrors the shape of ``create_ai_search_tool`` (mutual exclusivity of
+``retriever`` vs ``vector_store``, dict-to-model coercion) so both tools have
+a consistent surface from YAML config.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+import mlflow
+from langchain_core.tools import StructuredTool
+from loguru import logger
+from mlflow.entities import SpanType
+from pydantic import BaseModel, Field
+
+from dao_ai.config import LakebaseRetrieverModel, LakebaseVectorStoreModel
+from dao_ai.retrievers.lakebase import LakebaseRetriever
+
+
+class LakebaseSearchInput(BaseModel):
+    """Args exposed to the LLM for the ``lakebase_search`` tool."""
+
+    query: str = Field(description="Natural-language search query.")
+    filters: Optional[dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Optional metadata filters keyed by column name. "
+            "Values may be scalars (equality) or dicts of shape "
+            "``{op: <=|>=|=|!=|<|>|in|not_in|like|ilike|is_null, value|values: ...}``."
+        ),
+    )
+
+
+_DEFAULT_DESCRIPTION = (
+    "Retrieve relevant documents from a Databricks Lakebase Postgres table using "
+    "vector similarity (ANN), BM25 lexical search, or hybrid (RRF) — depending on "
+    "the retriever's configured query_type."
+)
+
+
+def create_lakebase_search_tool(
+    retriever: Optional[LakebaseRetrieverModel | dict[str, Any]] = None,
+    vector_store: Optional[LakebaseVectorStoreModel | dict[str, Any]] = None,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+) -> StructuredTool:
+    """Build a Lakebase retrieval tool.
+
+    Exactly one of ``retriever`` or ``vector_store`` must be supplied.
+    Both accept dict literals (auto-coerced) for YAML friendliness.
+    """
+    if retriever is None and vector_store is None:
+        raise ValueError(
+            "create_lakebase_search_tool requires either 'retriever' or 'vector_store'."
+        )
+    if retriever is not None and vector_store is not None:
+        raise ValueError(
+            "create_lakebase_search_tool cannot accept both 'retriever' and 'vector_store'."
+        )
+
+    if vector_store is not None:
+        if isinstance(vector_store, dict):
+            vector_store = LakebaseVectorStoreModel(**vector_store)
+        retriever_model = LakebaseRetrieverModel(vector_store=vector_store)
+    else:
+        if isinstance(retriever, dict):
+            retriever_model = LakebaseRetrieverModel(**retriever)
+        else:
+            retriever_model = retriever
+
+    lb_retriever = LakebaseRetriever(
+        vector_store=retriever_model.vector_store,
+        search_parameters=retriever_model.search_parameters,
+    )
+
+    vs = retriever_model.vector_store
+    tool_name = name or "lakebase_search"
+    tool_description = description or _DEFAULT_DESCRIPTION
+
+    @mlflow.trace(name=tool_name, span_type=SpanType.RETRIEVER)
+    def _lakebase_search(
+        query: str,
+        filters: Optional[dict[str, Any]] = None,
+    ) -> str:
+        call_filters: dict[str, Any] = {
+            **(retriever_model.search_parameters.filters or {}),
+            **(filters or {}),
+        }
+        # Merge without mutating the config's static filters.
+        effective_params = retriever_model.search_parameters.model_copy(
+            update={"filters": call_filters}
+        )
+        lb_retriever.search_parameters = effective_params
+
+        docs = lb_retriever.invoke(query)
+        serialized = [
+            {"page_content": d.page_content, "metadata": _jsonable(d.metadata)}
+            for d in docs
+        ]
+        return json.dumps(serialized)
+
+    tool = StructuredTool.from_function(
+        func=_lakebase_search,
+        name=tool_name,
+        description=tool_description,
+        args_schema=LakebaseSearchInput,
+    )
+
+    logger.success(
+        "Lakebase search tool created",
+        name=tool_name,
+        schema=vs.schema_name,
+        table=vs.table,
+        query_type=retriever_model.search_parameters.query_type,
+    )
+    return tool
+
+
+def _jsonable(value: Any) -> Any:
+    """Best-effort conversion of non-JSON-serialisable metadata values."""
+    if isinstance(value, dict):
+        return {k: _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    if hasattr(value, "item"):  # numpy scalar
+        return value.item()
+    if hasattr(value, "isoformat"):  # datetime/date
+        return value.isoformat()
+    return value

--- a/tests/dao_ai/test_lakebase_search.py
+++ b/tests/dao_ai/test_lakebase_search.py
@@ -1,0 +1,473 @@
+"""Unit tests for the lakebase_search first-class tool + LakebaseRetriever.
+
+These tests don't require a live Postgres/Lakebase. They cover:
+
+- Config: Pydantic discriminator dispatch, embedding-model string coercion,
+  BM25/HYBRID guard against missing tsvector, mutual-exclusivity guard.
+- Retriever SQL builders: correct operator selection, filter translation
+  (allowlist, IN / IS NULL / comparisons), unknown-column rejection.
+- Retriever RRF: deterministic fusion of two ranked lists.
+- Retriever end-to-end: ANN and BM25 paths against a mocked psycopg pool.
+- Tool factory: mutual exclusivity, dict-to-model coercion, name/description.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from dao_ai.config import (
+    FunctionType,
+    InferenceEndpointModel,
+    LakebaseRetrieverModel,
+    LakebaseSearchToolModel,
+    LakebaseVectorStoreModel,
+    SearchParametersModel,
+    ToolModel,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _vs_dict(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "database": {"project": "test-lakebase"},
+        "table": "kb_articles",
+        "content_column": "passage",
+        "embedding_column": "embedding",
+        "tsvector_column": "passage_tsv",
+        "embedding_model": "databricks-gte-large-en",
+        "metadata_columns": ["category", "source_url"],
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture()
+def vector_store() -> LakebaseVectorStoreModel:
+    return LakebaseVectorStoreModel(**_vs_dict())
+
+
+@pytest.fixture()
+def retriever_model(
+    vector_store: LakebaseVectorStoreModel,
+) -> LakebaseRetrieverModel:
+    return LakebaseRetrieverModel(
+        vector_store=vector_store,
+        search_parameters=SearchParametersModel(query_type="ANN", num_results=5),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config-layer tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfig:
+    def test_embedding_model_string_coerced(self) -> None:
+        vs = LakebaseVectorStoreModel(**_vs_dict())
+        assert isinstance(vs.embedding_model, InferenceEndpointModel)
+        assert vs.embedding_model.name == "databricks-gte-large-en"
+
+    def test_embedding_model_object_passthrough(self) -> None:
+        vs = LakebaseVectorStoreModel(
+            **_vs_dict(
+                embedding_model=InferenceEndpointModel(name="my-endpoint"),
+            )
+        )
+        assert vs.embedding_model.name == "my-endpoint"
+
+    def test_bm25_index_name_auto_derived(self) -> None:
+        vs = LakebaseVectorStoreModel(**_vs_dict())
+        assert vs.bm25_index_name == "public.kb_articles_passage_tsv_bm25"
+
+    def test_bm25_index_name_explicit_respected(self) -> None:
+        vs = LakebaseVectorStoreModel(**_vs_dict(bm25_index_name="my.custom_bm25"))
+        assert vs.bm25_index_name == "my.custom_bm25"
+
+    def test_discriminator_dispatch(self) -> None:
+        m = ToolModel.model_validate(
+            {
+                "name": "kb",
+                "function": {"type": "lakebase_search", "vector_store": _vs_dict()},
+            }
+        )
+        assert isinstance(m.function, LakebaseSearchToolModel)
+        assert m.function.type == FunctionType.LAKEBASE_SEARCH.value
+
+    def test_mutual_exclusivity(self) -> None:
+        with pytest.raises(ValidationError):
+            LakebaseSearchToolModel.model_validate(
+                {
+                    "type": "lakebase_search",
+                    "vector_store": _vs_dict(),
+                    "retriever": {"vector_store": _vs_dict()},
+                }
+            )
+
+    def test_at_least_one_required(self) -> None:
+        with pytest.raises(ValidationError):
+            LakebaseSearchToolModel.model_validate({"type": "lakebase_search"})
+
+    @pytest.mark.parametrize("mode", ["BM25", "HYBRID"])
+    def test_bm25_hybrid_require_tsvector(self, mode: str) -> None:
+        vs = LakebaseVectorStoreModel(
+            **_vs_dict(tsvector_column=None, bm25_index_name=None)
+        )
+        with pytest.raises(ValidationError):
+            LakebaseRetrieverModel(
+                vector_store=vs,
+                search_parameters=SearchParametersModel(query_type=mode),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Retriever SQL builder tests
+# ---------------------------------------------------------------------------
+
+
+class TestSqlBuilders:
+    def _make(
+        self,
+        vs: LakebaseVectorStoreModel,
+        query_type: str = "ANN",
+    ):
+        from dao_ai.retrievers.lakebase import LakebaseRetriever
+
+        return LakebaseRetriever(
+            vector_store=vs,
+            search_parameters=SearchParametersModel(
+                query_type=query_type, num_results=5
+            ),
+        )
+
+    @pytest.mark.parametrize(
+        "metric,expected_op",
+        [("cosine", "<=>"), ("l2", "<->"), ("ip", "<#>")],
+    )
+    def test_ann_sql_uses_correct_operator(
+        self, metric: str, expected_op: str
+    ) -> None:
+        vs = LakebaseVectorStoreModel(**_vs_dict(distance_metric=metric))
+        r = self._make(vs)
+        stmt, params = r._build_ann_sql({}, k=5)
+        rendered = stmt.as_string(None)
+        # Distance op appears in SELECT and ORDER BY.
+        assert rendered.count(expected_op) >= 2
+        assert '"embedding"' in rendered
+        assert '"kb_articles"' in rendered
+        assert params == [5]  # only LIMIT param (vector injected at execute time)
+
+    def test_bm25_sql_composes_to_bm25query(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        r = self._make(vector_store, query_type="BM25")
+        stmt, params = r._build_bm25_sql({}, k=5)
+        rendered = stmt.as_string(None)
+        assert "to_bm25query" in rendered
+        assert "<@>" in rendered
+        assert '"passage_tsv"' in rendered
+        assert params == [5]
+
+    def test_where_scalar_equality(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        r = self._make(vector_store)
+        clause, params = r._build_where({"category": "faq"})
+        rendered = clause.as_string(None)
+        assert '"category" = %s' in rendered
+        assert params == ["faq"]
+
+    def test_where_in_operator(self, vector_store: LakebaseVectorStoreModel) -> None:
+        r = self._make(vector_store)
+        clause, params = r._build_where(
+            {"category": {"op": "in", "values": ["faq", "howto"]}}
+        )
+        rendered = clause.as_string(None)
+        assert '= ANY(%s)' in rendered
+        assert params == [["faq", "howto"]]
+
+    def test_where_comparison_operators(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        r = self._make(vector_store)
+        clause, params = r._build_where(
+            {"source_url": {"op": ">=", "value": "https://a"}}
+        )
+        rendered = clause.as_string(None)
+        assert '"source_url" >= %s' in rendered
+        assert params == ["https://a"]
+
+    def test_where_is_null(self, vector_store: LakebaseVectorStoreModel) -> None:
+        r = self._make(vector_store)
+        clause, _ = r._build_where({"category": {"op": "is_null"}})
+        assert '"category" IS NULL' in clause.as_string(None)
+
+        clause_neg, _ = r._build_where(
+            {"category": {"op": "is_null", "value": False}}
+        )
+        assert '"category" IS NOT NULL' in clause_neg.as_string(None)
+
+    def test_where_unknown_column_rejected(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        r = self._make(vector_store)
+        with pytest.raises(ValueError, match="Unknown filter column"):
+            r._build_where({"totally_not_a_column": "x"})
+
+    def test_where_unsupported_op_rejected(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        r = self._make(vector_store)
+        with pytest.raises(ValueError, match="Unsupported filter op"):
+            r._build_where({"category": {"op": "regex", "value": "foo"}})
+
+
+# ---------------------------------------------------------------------------
+# RRF fusion test
+# ---------------------------------------------------------------------------
+
+
+class TestRrf:
+    def test_rrf_orders_by_fused_score(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        from dao_ai.retrievers.lakebase import LakebaseRetriever
+
+        r = LakebaseRetriever(
+            vector_store=vector_store,
+            search_parameters=SearchParametersModel(query_type="HYBRID"),
+        )
+        # doc "A" is #1 in ANN, #3 in BM25 → highest RRF score.
+        ann = [
+            {"id": "A", "passage": "alpha", "category": "faq", "source_url": None},
+            {"id": "B", "passage": "beta", "category": "faq", "source_url": None},
+            {"id": "C", "passage": "gamma", "category": "faq", "source_url": None},
+        ]
+        bm25 = [
+            {"id": "C", "passage": "gamma", "category": "faq", "source_url": None},
+            {"id": "B", "passage": "beta", "category": "faq", "source_url": None},
+            {"id": "A", "passage": "alpha", "category": "faq", "source_url": None},
+        ]
+        docs = r._rrf(ann, bm25, k=3)
+        # A and C tie at (1/61 + 1/63); B in the middle; A wins by insertion order.
+        ids = [d.metadata["id"] for d in docs]
+        assert ids[0] in {"A", "C"}
+        assert set(ids) == {"A", "B", "C"}
+        # RRF score must be populated
+        assert all("_rrf_score" in d.metadata for d in docs)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end with mocked pool
+# ---------------------------------------------------------------------------
+
+
+class _MockCursor:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+        self.executed: list[tuple[Any, Any]] = []
+
+    def __enter__(self) -> "_MockCursor":
+        return self
+
+    def __exit__(self, *a: Any) -> None:
+        pass
+
+    def execute(self, stmt: Any, params: Any) -> None:
+        self.executed.append((stmt, params))
+
+    def fetchall(self) -> list[dict[str, Any]]:
+        return self._rows
+
+
+class _MockConn:
+    def __init__(self, cursor: _MockCursor) -> None:
+        self._cursor = cursor
+
+    def __enter__(self) -> "_MockConn":
+        return self
+
+    def __exit__(self, *a: Any) -> None:
+        pass
+
+    def cursor(self, **_kw: Any) -> _MockCursor:
+        return self._cursor
+
+
+class _MockPool:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.cursor = _MockCursor(rows)
+
+    @contextmanager
+    def connection(self):
+        yield _MockConn(self.cursor)
+
+
+class TestEndToEnd:
+    def test_ann_returns_documents(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        from dao_ai.retrievers.lakebase import LakebaseRetriever
+
+        rows = [
+            {
+                "id": "d1",
+                "passage": "How to reset your password",
+                "category": "faq",
+                "source_url": "https://ex/1",
+                "_distance": 0.1,
+            },
+            {
+                "id": "d2",
+                "passage": "Enabling MFA",
+                "category": "faq",
+                "source_url": "https://ex/2",
+                "_distance": 0.3,
+            },
+        ]
+        pool = _MockPool(rows)
+        r = LakebaseRetriever(
+            vector_store=vector_store,
+            search_parameters=SearchParametersModel(query_type="ANN", num_results=5),
+        )
+        with (
+            patch.object(r, "_sync_pool", return_value=pool),
+            patch.object(r, "_embed", return_value=[0.0] * 1024),
+        ):
+            docs = r.invoke("reset password")
+
+        assert len(docs) == 2
+        assert docs[0].page_content == "How to reset your password"
+        # Both Document.id (LangChain top-level) and metadata[id_column] populated.
+        assert docs[0].id == "d1"
+        assert docs[0].metadata["id"] == "d1"
+        assert docs[0].metadata["_distance"] == 0.1
+        # SQL was executed with expected LIMIT bind at end.
+        _, params = pool.cursor.executed[0]
+        assert params[-1] == 5
+
+    def test_ann_with_filters_injects_where(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        from dao_ai.retrievers.lakebase import LakebaseRetriever
+
+        pool = _MockPool([])
+        r = LakebaseRetriever(
+            vector_store=vector_store,
+            search_parameters=SearchParametersModel(
+                query_type="ANN",
+                num_results=5,
+                filters={"category": "faq"},
+            ),
+        )
+        with (
+            patch.object(r, "_sync_pool", return_value=pool),
+            patch.object(r, "_embed", return_value=[0.0] * 1024),
+        ):
+            r.invoke("x")
+        stmt, params = pool.cursor.executed[0]
+        rendered = stmt.as_string(None)
+        assert '"category" = %s' in rendered
+        # Params: [vector, "faq", vector, limit]
+        assert params[1] == "faq"
+        assert params[-1] == 5
+
+    def test_bm25_returns_documents(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        from dao_ai.retrievers.lakebase import LakebaseRetriever
+
+        rows = [
+            {
+                "id": "d1",
+                "passage": "password reset instructions",
+                "category": "faq",
+                "source_url": None,
+                "_score": -8.2,
+            },
+        ]
+        pool = _MockPool(rows)
+        r = LakebaseRetriever(
+            vector_store=vector_store,
+            search_parameters=SearchParametersModel(query_type="BM25", num_results=5),
+        )
+        with patch.object(r, "_sync_pool", return_value=pool):
+            docs = r.invoke("password reset")
+        assert len(docs) == 1
+        assert docs[0].metadata["_score"] == -8.2
+
+
+# ---------------------------------------------------------------------------
+# Factory tests
+# ---------------------------------------------------------------------------
+
+
+class TestFactory:
+    def test_factory_requires_one(self) -> None:
+        from dao_ai.tools import create_lakebase_search_tool
+
+        with pytest.raises(ValueError):
+            create_lakebase_search_tool()
+
+    def test_factory_rejects_both(self) -> None:
+        from dao_ai.tools import create_lakebase_search_tool
+
+        with pytest.raises(ValueError):
+            create_lakebase_search_tool(retriever={}, vector_store={})
+
+    def test_factory_from_vector_store_dict(self) -> None:
+        from dao_ai.tools import create_lakebase_search_tool
+
+        tool = create_lakebase_search_tool(vector_store=_vs_dict())
+        assert tool.name == "lakebase_search"
+        assert "Lakebase" in (tool.description or "")
+
+    def test_factory_custom_name_description(self) -> None:
+        from dao_ai.tools import create_lakebase_search_tool
+
+        tool = create_lakebase_search_tool(
+            vector_store=_vs_dict(),
+            name="policy_search",
+            description="Search company policies.",
+        )
+        assert tool.name == "policy_search"
+        assert tool.description == "Search company policies."
+
+    def test_factory_output_is_json(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        from dao_ai.retrievers.lakebase import LakebaseRetriever
+        from dao_ai.tools import create_lakebase_search_tool
+
+        rows = [
+            {
+                "id": "d1",
+                "passage": "hello",
+                "category": "faq",
+                "source_url": None,
+                "_distance": 0.1,
+            }
+        ]
+        pool = _MockPool(rows)
+
+        tool = create_lakebase_search_tool(vector_store=vector_store.model_dump())
+        # Patch the retriever the tool closed over.
+        with (
+            patch.object(LakebaseRetriever, "_sync_pool", return_value=pool),
+            patch.object(LakebaseRetriever, "_embed", return_value=[0.0] * 1024),
+        ):
+            output = tool.invoke({"query": "hi"})
+
+        parsed = json.loads(output)
+        assert isinstance(parsed, list)
+        assert parsed[0]["page_content"] == "hello"
+        assert parsed[0]["metadata"]["id"] == "d1"

--- a/tests/dao_ai/test_lakebase_search_live.py
+++ b/tests/dao_ai/test_lakebase_search_live.py
@@ -1,0 +1,469 @@
+"""Live end-to-end tests for LakebaseRetriever + create_lakebase_search_tool.
+
+Runs against a real Databricks Lakebase project with the ``lakebase_vector``
+and ``lakebase_text`` extensions enabled. Skipped unless:
+
+    LAKEBASE_TEST_PROJECT=<project id>            (required)
+    LAKEBASE_TEST_SECRET_SCOPE=<secret scope>     (required)
+    LAKEBASE_TEST_CLIENT_ID_KEY=<key>             (required)
+    LAKEBASE_TEST_CLIENT_SECRET_KEY=<key>         (required)
+    LAKEBASE_TEST_HOST_KEY=<key>                  (required)
+    LAKEBASE_TEST_SCHEMA=<schema>                 (default: dao_ai_lakebase_test)
+    LAKEBASE_TEST_TABLE=<table>                   (default: kb_articles)
+    LAKEBASE_TEST_EMBEDDING_ENDPOINT=<endpoint>   (default: databricks-gte-large-en)
+
+Also requires ``DATABRICKS_CONFIG_PROFILE`` (or ambient auth) to be able to
+read the secret scope.
+
+The fixture provisions its own schema, table, and indexes and seeds a small
+KB; the tests then exercise every query type × several filter shapes.
+
+Marked ``integration`` so it's excluded from the default fast unit run:
+
+    uv run pytest tests/dao_ai/test_lakebase_search_live.py -v -m integration
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import pytest
+from psycopg import sql
+
+from dao_ai.config import (
+    DatabaseModel,
+    LakebaseRetrieverModel,
+    LakebaseVectorStoreModel,
+    SearchParametersModel,
+)
+from dao_ai.memory.postgres import PostgresPoolManager
+from dao_ai.retrievers.lakebase import LakebaseRetriever
+from dao_ai.tools import create_lakebase_search_tool
+
+pytestmark = pytest.mark.integration
+
+REQUIRED_ENV = (
+    "LAKEBASE_TEST_PROJECT",
+    "LAKEBASE_TEST_SECRET_SCOPE",
+    "LAKEBASE_TEST_CLIENT_ID_KEY",
+    "LAKEBASE_TEST_CLIENT_SECRET_KEY",
+    "LAKEBASE_TEST_HOST_KEY",
+)
+
+if any(os.environ.get(k) is None for k in REQUIRED_ENV):
+    pytest.skip(
+        f"live Lakebase tests require env vars: {', '.join(REQUIRED_ENV)}",
+        allow_module_level=True,
+    )
+
+SCHEMA = os.environ.get("LAKEBASE_TEST_SCHEMA", "dao_ai_lakebase_test")
+TABLE = os.environ.get("LAKEBASE_TEST_TABLE", "kb_articles")
+EMBEDDING_ENDPOINT = os.environ.get(
+    "LAKEBASE_TEST_EMBEDDING_ENDPOINT", "databricks-gte-large-en"
+)
+EMBEDDING_DIM = 1024  # matches databricks-gte-large-en
+
+
+SEED_DOCS: list[dict[str, Any]] = [
+    {"id": "d01", "category": "auth",     "priority": 1, "passage": "To reset your password, go to Settings then Security and click 'Reset password'."},
+    {"id": "d02", "category": "auth",     "priority": 2, "passage": "Enable multi-factor authentication (MFA) from your account security page."},
+    {"id": "d03", "category": "billing",  "priority": 3, "passage": "Invoices are issued on the first of each month for the previous billing cycle."},
+    {"id": "d04", "category": "billing",  "priority": 1, "passage": "You can update your payment method under Billing then Payment methods."},
+    {"id": "d05", "category": "shipping", "priority": 2, "passage": "Standard shipping takes 3-5 business days within the continental US."},
+    {"id": "d06", "category": "shipping", "priority": 3, "passage": "International orders may incur customs duties calculated at checkout."},
+    {"id": "d07", "category": "returns",  "priority": 1, "passage": "Returns are accepted within 30 days of delivery with a valid receipt."},
+    {"id": "d08", "category": "returns",  "priority": 2, "passage": "Refunds are processed to the original payment method within 7 business days."},
+    {"id": "d09", "category": "auth",     "priority": 3, "passage": "If you forgot your username, contact support with the email on file."},
+    {"id": "d10", "category": "shipping", "priority": 1, "passage": "Track your package status from the Orders page in your account."},
+    {"id": "d11", "category": "billing",  "priority": 2, "passage": "Late payments incur a 2% monthly finance charge after 30 days overdue."},
+    {"id": "d12", "category": "auth",     "priority": 1, "passage": "Password reset links expire after 24 hours for security reasons."},
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def database() -> DatabaseModel:
+    return DatabaseModel(
+        project=os.environ["LAKEBASE_TEST_PROJECT"],
+        client_id={
+            "scope": os.environ["LAKEBASE_TEST_SECRET_SCOPE"],
+            "secret": os.environ["LAKEBASE_TEST_CLIENT_ID_KEY"],
+        },
+        client_secret={
+            "scope": os.environ["LAKEBASE_TEST_SECRET_SCOPE"],
+            "secret": os.environ["LAKEBASE_TEST_CLIENT_SECRET_KEY"],
+        },
+        workspace_host={
+            "scope": os.environ["LAKEBASE_TEST_SECRET_SCOPE"],
+            "secret": os.environ["LAKEBASE_TEST_HOST_KEY"],
+        },
+    )
+
+
+@pytest.fixture(scope="module")
+def seeded_table(database: DatabaseModel) -> None:
+    """Provision schema/table/indexes and seed embeddings once per module."""
+    from databricks_langchain import DatabricksEmbeddings
+
+    pool = PostgresPoolManager.get_pool(database)
+    with pool.connection() as conn:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("CREATE EXTENSION IF NOT EXISTS lakebase_vector CASCADE")
+            cur.execute("CREATE EXTENSION IF NOT EXISTS lakebase_text")
+            cur.execute(
+                sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(SCHEMA))
+            )
+            cur.execute(
+                sql.SQL(
+                    "CREATE TABLE IF NOT EXISTS {}.{} ("
+                    "id TEXT PRIMARY KEY, "
+                    "category TEXT, "
+                    "priority INTEGER, "
+                    "passage TEXT NOT NULL, "
+                    "embedding VECTOR({dim}), "
+                    "passage_tsv TSVECTOR GENERATED ALWAYS AS "
+                    "  (to_tsvector('english', passage)) STORED)"
+                ).format(
+                    sql.Identifier(SCHEMA),
+                    sql.Identifier(TABLE),
+                    dim=sql.SQL(str(EMBEDDING_DIM)),
+                )
+            )
+            # Ensure priority column exists even if the table was created by
+            # a prior schema (idempotent — safe to re-run).
+            cur.execute(
+                sql.SQL(
+                    "ALTER TABLE {}.{} ADD COLUMN IF NOT EXISTS priority INTEGER"
+                ).format(sql.Identifier(SCHEMA), sql.Identifier(TABLE))
+            )
+            cur.execute(
+                sql.SQL("SELECT COUNT(*) AS n FROM {}.{} WHERE priority IS NOT NULL").format(
+                    sql.Identifier(SCHEMA), sql.Identifier(TABLE)
+                )
+            )
+            existing = int(cur.fetchone()["n"])
+
+    if existing < len(SEED_DOCS):
+        embeddings = DatabricksEmbeddings(endpoint=EMBEDDING_ENDPOINT)
+        vectors = embeddings.embed_documents([d["passage"] for d in SEED_DOCS])
+        with pool.connection() as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                for doc, vec in zip(SEED_DOCS, vectors):
+                    cur.execute(
+                        sql.SQL(
+                            "INSERT INTO {}.{} (id, category, priority, passage, embedding) "
+                            "VALUES (%s, %s, %s, %s, %s::vector) "
+                            "ON CONFLICT (id) DO UPDATE SET "
+                            "category = EXCLUDED.category, "
+                            "priority = EXCLUDED.priority, "
+                            "passage = EXCLUDED.passage, "
+                            "embedding = EXCLUDED.embedding"
+                        ).format(sql.Identifier(SCHEMA), sql.Identifier(TABLE)),
+                        (doc["id"], doc["category"], doc["priority"], doc["passage"], vec),
+                    )
+
+    with pool.connection() as conn:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute(
+                sql.SQL(
+                    "CREATE INDEX IF NOT EXISTS {} ON {}.{} "
+                    "USING lakebase_ann (embedding vector_cosine_ops)"
+                ).format(
+                    sql.Identifier(f"{TABLE}_embedding_ann"),
+                    sql.Identifier(SCHEMA),
+                    sql.Identifier(TABLE),
+                )
+            )
+            cur.execute(
+                sql.SQL(
+                    "CREATE INDEX IF NOT EXISTS {} ON {}.{} "
+                    "USING lakebase_bm25 (passage_tsv)"
+                ).format(
+                    sql.Identifier(f"{TABLE}_passage_tsv_bm25"),
+                    sql.Identifier(SCHEMA),
+                    sql.Identifier(TABLE),
+                )
+            )
+
+
+@pytest.fixture()
+def vector_store(
+    database: DatabaseModel, seeded_table: None
+) -> LakebaseVectorStoreModel:
+    return LakebaseVectorStoreModel(
+        database=database,
+        schema_name=SCHEMA,
+        table=TABLE,
+        id_column="id",
+        content_column="passage",
+        embedding_column="embedding",
+        tsvector_column="passage_tsv",
+        embedding_model=EMBEDDING_ENDPOINT,
+        metadata_columns=["category", "priority"],
+        distance_metric="cosine",
+    )
+
+
+def _retriever(
+    vs: LakebaseVectorStoreModel,
+    query_type: str,
+    filters: dict[str, Any] | None = None,
+    k: int = 5,
+) -> LakebaseRetriever:
+    return LakebaseRetriever(
+        vector_store=vs,
+        search_parameters=SearchParametersModel(
+            query_type=query_type, num_results=k, filters=filters or {}
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Query type coverage
+# ---------------------------------------------------------------------------
+
+
+class TestQueryTypes:
+    """Every query_type against real Lakebase — verifies retrieval correctness."""
+
+    def test_ann_returns_semantically_relevant_docs(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        docs = _retriever(vector_store, "ANN", k=3).invoke(
+            "how do I reset a forgotten password?"
+        )
+        assert len(docs) == 3
+        # Top 3 should be dominated by auth-category docs (password-related).
+        top_categories = [d.metadata["category"] for d in docs]
+        assert top_categories.count("auth") >= 2
+        assert all("_distance" in d.metadata for d in docs)
+
+    def test_bm25_matches_literal_terms(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        docs = _retriever(vector_store, "BM25", k=5).invoke("password reset")
+        assert len(docs) >= 1
+        # Top-ranked doc must contain at least one query term literally.
+        # (BM25 fills the LIMIT even with weak matches on a small corpus, so
+        # we assert on the winner rather than every returned row.)
+        top = docs[0].page_content.lower()
+        assert "password" in top or "reset" in top
+        assert all("_score" in d.metadata for d in docs)
+
+    def test_bm25_scores_are_negative(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        docs = _retriever(vector_store, "BM25", k=3).invoke("shipping")
+        assert docs, "expected at least one BM25 hit for 'shipping'"
+        # Lakebase BM25 returns negative scores (more negative = better).
+        assert all(d.metadata["_score"] <= 0 for d in docs)
+
+    def test_hybrid_fuses_both_signals(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        docs = _retriever(vector_store, "HYBRID", k=5).invoke("password reset")
+        assert len(docs) >= 1
+        # RRF must have populated a fused score.
+        assert all("_rrf_score" in d.metadata for d in docs)
+        # Top result should be a password/auth doc.
+        assert docs[0].metadata["category"] == "auth"
+
+    def test_hybrid_covers_both_lexical_and_semantic_hits(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        # "forgot" is not in the corpus verbatim; ANN should still surface d09.
+        docs = _retriever(vector_store, "HYBRID", k=5).invoke("I forgot my login")
+        ids = {d.metadata["id"] for d in docs}
+        assert "d09" in ids  # "If you forgot your username, contact support..."
+
+
+# ---------------------------------------------------------------------------
+# Filter coverage
+# ---------------------------------------------------------------------------
+
+
+class TestFilters:
+    """Live coverage for the operator allowlist in ``_build_where``."""
+
+    def test_scalar_equality(self, vector_store: LakebaseVectorStoreModel) -> None:
+        docs = _retriever(
+            vector_store, "ANN", filters={"category": "billing"}, k=10
+        ).invoke("payment")
+        assert docs
+        assert all(d.metadata["category"] == "billing" for d in docs)
+
+    def test_in_operator(self, vector_store: LakebaseVectorStoreModel) -> None:
+        docs = _retriever(
+            vector_store,
+            "ANN",
+            filters={"category": {"op": "in", "values": ["returns", "shipping"]}},
+            k=10,
+        ).invoke("order")
+        assert docs
+        assert all(d.metadata["category"] in {"returns", "shipping"} for d in docs)
+
+    def test_not_in_operator(self, vector_store: LakebaseVectorStoreModel) -> None:
+        docs = _retriever(
+            vector_store,
+            "ANN",
+            filters={"category": {"op": "not_in", "values": ["auth"]}},
+            k=10,
+        ).invoke("account")
+        assert docs
+        assert all(d.metadata["category"] != "auth" for d in docs)
+
+    def test_comparison_greater_or_equal(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        docs = _retriever(
+            vector_store,
+            "ANN",
+            filters={"priority": {"op": ">=", "value": 2}},
+            k=10,
+        ).invoke("service")
+        assert docs
+        assert all(d.metadata["priority"] >= 2 for d in docs)
+
+    def test_comparison_less_than(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        docs = _retriever(
+            vector_store,
+            "ANN",
+            filters={"priority": {"op": "<", "value": 2}},
+            k=10,
+        ).invoke("service")
+        assert docs
+        assert all(d.metadata["priority"] < 2 for d in docs)
+
+    def test_not_equal(self, vector_store: LakebaseVectorStoreModel) -> None:
+        docs = _retriever(
+            vector_store,
+            "ANN",
+            filters={"category": {"op": "!=", "value": "billing"}},
+            k=10,
+        ).invoke("customer")
+        assert docs
+        assert all(d.metadata["category"] != "billing" for d in docs)
+
+    def test_ilike_operator(self, vector_store: LakebaseVectorStoreModel) -> None:
+        docs = _retriever(
+            vector_store,
+            "ANN",
+            filters={"category": {"op": "ilike", "value": "ship%"}},
+            k=10,
+        ).invoke("delivery")
+        assert docs
+        assert all(d.metadata["category"] == "shipping" for d in docs)
+
+    def test_filters_work_with_bm25(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        docs = _retriever(
+            vector_store,
+            "BM25",
+            filters={"category": "auth"},
+            k=5,
+        ).invoke("password")
+        assert docs
+        assert all(d.metadata["category"] == "auth" for d in docs)
+
+    def test_filters_work_with_hybrid(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        docs = _retriever(
+            vector_store,
+            "HYBRID",
+            filters={"category": {"op": "in", "values": ["returns", "billing"]}},
+            k=5,
+        ).invoke("get a refund")
+        assert docs
+        assert all(d.metadata["category"] in {"returns", "billing"} for d in docs)
+
+    def test_unknown_column_rejected(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        with pytest.raises(ValueError, match="Unknown filter column"):
+            _retriever(
+                vector_store, "ANN", filters={"nonexistent_col": "x"}, k=3
+            ).invoke("anything")
+
+
+# ---------------------------------------------------------------------------
+# Tool factory — live invocation
+# ---------------------------------------------------------------------------
+
+
+class TestToolFactory:
+    """Verify the StructuredTool wrapper works end-to-end and returns JSON."""
+
+    def test_tool_json_shape(self, vector_store: LakebaseVectorStoreModel) -> None:
+        tool = create_lakebase_search_tool(
+            retriever=LakebaseRetrieverModel(
+                vector_store=vector_store,
+                search_parameters=SearchParametersModel(
+                    query_type="ANN", num_results=3
+                ),
+            )
+        )
+        raw = tool.invoke({"query": "how do I reset my password?"})
+        parsed = json.loads(raw)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 3
+        for item in parsed:
+            assert "page_content" in item
+            assert "metadata" in item
+            assert "id" in item["metadata"]
+
+    def test_tool_hybrid_with_filters(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        tool = create_lakebase_search_tool(
+            retriever=LakebaseRetrieverModel(
+                vector_store=vector_store,
+                search_parameters=SearchParametersModel(
+                    query_type="HYBRID", num_results=3
+                ),
+            )
+        )
+        raw = tool.invoke(
+            {
+                "query": "how do I get a refund?",
+                "filters": {
+                    "category": {"op": "in", "values": ["returns", "billing"]}
+                },
+            }
+        )
+        parsed = json.loads(raw)
+        assert parsed
+        assert all(
+            item["metadata"]["category"] in {"returns", "billing"} for item in parsed
+        )
+
+    def test_tool_from_vector_store_dict(
+        self, database: DatabaseModel, seeded_table: None
+    ) -> None:
+        """Bare vector_store dict is coerced through LakebaseRetrieverModel."""
+        tool = create_lakebase_search_tool(
+            vector_store={
+                "database": database.model_dump(),
+                "schema_name": SCHEMA,
+                "table": TABLE,
+                "content_column": "passage",
+                "embedding_column": "embedding",
+                "tsvector_column": "passage_tsv",
+                "embedding_model": EMBEDDING_ENDPOINT,
+                "metadata_columns": ["category", "priority"],
+            }
+        )
+        raw = tool.invoke({"query": "password"})
+        assert json.loads(raw)


### PR DESCRIPTION
## Summary

- First-class `lakebase_search` tool + `LakebaseRetriever` for Databricks Lakebase Postgres. Sibling of `ai_search`. Supports ANN (`lakebase_vector` / `lakebase_ann`), BM25 (`lakebase_text` / `lakebase_bm25`), and HYBRID (client-side RRF).
- Config surface mirrors `ai_search`: factory accepts either a bare `LakebaseVectorStoreModel` or a full `LakebaseRetrieverModel` (mutually exclusive). YAML-friendly: dicts auto-coerce; `embedding_model` accepts a bare endpoint-name string.
- Safe filter translator with column allowlist + operator allowlist (`=`, `!=`, `<`, `<=`, `>`, `>=`, `in`, `not_in`, `like`, `ilike`, `is_null`). Uses `psycopg.sql.Identifier` for column names; values always parameterized.
- Reuses existing `PostgresPoolManager` / `AsyncPostgresPoolManager` so Lakebase credential rotation is inherited — no direct SDK calls in the retriever.
- MLflow tracing: `@mlflow.trace(span_type=RETRIEVER)` on all three retrieval helpers plus the tool wrapper, matching the span shape `ai_search` already produces so existing trace-inspection tooling works unmodified.

## Test plan

- [x] Unit tests — 28/28 (`tests/dao_ai/test_lakebase_search.py`): config validators (embedding-model coercion, tsvector guard, mutual exclusivity, discriminator dispatch), SQL builders for all 3 distance metrics, WHERE-clause translator including all operator paths + rejection cases, RRF fusion, mocked-pool end-to-end, StructuredTool JSON shape.
- [x] Integration tests — 18/18 (`tests/dao_ai/test_lakebase_search_live.py`), gated by `LAKEBASE_TEST_*` env vars. Covers every query_type × every filter operator against a real Lakebase project. Ran green against `retail-consumer-goods` in FEVM.
- [x] End-to-end in a deployed Databricks App: `dao-ai generate-bundle` → `databricks bundle deploy` → `bundle run`. 4 chat queries produced grounded answers via `HybridRetriever` → `RRF`. MLflow OTEL traces landed in `retail_consumer_goods.default.lakebase_e2e_03_otel_spans` with the expected tree: `[TOOL] lakebase_search → [RETRIEVER] LakebaseRetriever → [RETRIEVER] lakebase_hybrid_search → [RETRIEVER] lakebase_ann_search + [RETRIEVER] lakebase_bm25_search`.
- [x] `Document.id` and `metadata["id"]` populate correctly (added assertions in unit tests; verified in deployed app traces).

## Deferred (not in this PR)

- Stage 2: rerank + instructed retrieval + shared `DaoAiBaseRetriever` if real duplication with `AiSearchRetriever` emerges.
- Stage 3: provisioning mode — auto-create table, add extensions, embedding-refresh job. Mirror `AiSearchIndexModel`'s `source_table` + `embedding_source_column`.
- Stage 4: typed per-column filter kwargs on the tool's `args_schema` (parity with `create_ai_search_tool`'s dynamic Pydantic schema; today filters is a single `dict[str, Any]` arg).
- A companion `lakebase_query` tool (parallel to `create_execute_statement_tool` but for Postgres directly) — natural next step for exposing arbitrary Lakebase SQL as an agent tool.

## Prerequisites for consumers

- Lakebase Search must be enabled on the target Postgres project (workspace UI → Compute → Postgres → project → Settings → Enable Lakebase Search). Adds `lakebase_vector` + `lakebase_text` to `shared_preload_libraries`; irreversible; restarts computes.
- `CREATE EXTENSION lakebase_vector CASCADE; CREATE EXTENSION lakebase_text;` in the target database.
- Vector column dimension must match the embedding endpoint (1024 for `databricks-gte-large-en`).
- Optional `tsvector_column` is a Postgres-generated column (`GENERATED ALWAYS AS (to_tsvector('english', <content_column>)) STORED`).

This pull request and its description were written by Isaac.