### PR TITLE
docs(lakebase-search): add examples 21_lakebase_search + doc entries

### DIFF
--- a/config/examples/21_lakebase_search/README.md
+++ b/config/examples/21_lakebase_search/README.md
@@ -1,0 +1,199 @@
+# 21. Lakebase Search
+
+**Retrieval over Databricks Lakebase Postgres — ANN, BM25, and hybrid RRF**
+
+Query embeddings and lexical text living in Lakebase Postgres directly from an
+agent, using the `lakebase_vector` and `lakebase_text` extensions. Sibling of
+`ai_search`; same YAML shape, different backend.
+
+## When to use this vs. AI Search
+
+| | `type: ai_search` | `type: lakebase_search` |
+|---|---|---|
+| Backend | Databricks-managed Vector Search index | Postgres in a Lakebase project |
+| Data location | Delta table (source) synced to the index | Rows in Lakebase Postgres |
+| Auto-embedding | Yes (Delta Sync) | No — client-side embed via Model Serving |
+| Hybrid | Native | Client-side RRF |
+| Best fit | Static or Delta-native document corpora | Data already in Postgres (OLTP joins, transactional writes) |
+
+Pick `lakebase_search` when your source of truth is already in Lakebase and
+you'd like retrieval to be a straight SQL query alongside your other Postgres
+data (users, orders, sessions, etc.).
+
+## Architecture
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1565c0'}}}%%
+flowchart TB
+    Q["📝 User Query"]
+
+    subgraph Agent["🤖 Agent"]
+        LLM["LLM (Claude / GPT / ...)"]
+    end
+
+    subgraph Tool["🔧 lakebase_search Tool"]
+        Emb["Embed via<br/>databricks-gte-large-en<br/>(only for ANN / HYBRID)"]
+        Retriever["LakebaseRetriever"]
+    end
+
+    subgraph Lakebase["🗄️ Lakebase Postgres"]
+        ANN["<b>lakebase_ann</b> index<br/><i>embedding VECTOR(1024)</i>"]
+        BM25["<b>lakebase_bm25</b> index<br/><i>passage_tsv TSVECTOR</i>"]
+    end
+
+    RRF["Reciprocal Rank Fusion<br/>(HYBRID only)"]
+    Docs["Ranked Documents"]
+
+    Q --> LLM
+    LLM --> Emb
+    Emb --> Retriever
+    Retriever -->|"<=> distance"| ANN
+    Retriever -->|"<@> BM25 score"| BM25
+    ANN --> RRF
+    BM25 --> RRF
+    RRF --> Docs
+    Docs --> LLM
+
+    style Tool fill:#e3f2fd,stroke:#1565c0
+    style Lakebase fill:#e8f5e9,stroke:#2e7d32
+```
+
+## Examples
+
+| File | Mode | Use case |
+|------|------|----------|
+| [`ann_only.yaml`](./ann_only.yaml) | ANN | Semantic similarity search — minimal config, no BM25 setup needed |
+| [`hybrid_rrf.yaml`](./hybrid_rrf.yaml) | HYBRID | Dense + lexical fused via RRF — highest recall |
+| [`bm25_only.yaml`](./bm25_only.yaml) | BM25 | Exact-term lookup (SKUs, error codes) — no embedding calls |
+| [`filters_and_traces.yaml`](./filters_and_traces.yaml) | HYBRID | Static filters (equality / IN / comparison / LIKE) + `trace_location` to UC OTEL tables |
+
+## Prerequisites
+
+1. **Enable Lakebase Search on the project** (workspace UI → Compute →
+   Postgres → your project → Settings → Enable Lakebase Search).
+   This is a one-time, project-level, **irreversible** toggle that restarts
+   all compute in the project.
+2. **Install the extensions** in the target database:
+   ```sql
+   CREATE EXTENSION IF NOT EXISTS lakebase_vector CASCADE;
+   CREATE EXTENSION IF NOT EXISTS lakebase_text;    -- only if BM25 / HYBRID
+   ```
+3. **Create the table** with a vector column matching your embedding
+   endpoint's output dimension (1024 for `databricks-gte-large-en`):
+   ```sql
+   CREATE TABLE kb_articles (
+     id           TEXT PRIMARY KEY,
+     category     TEXT,
+     source_url   TEXT,
+     passage      TEXT NOT NULL,
+     embedding    VECTOR(1024),
+     passage_tsv  TSVECTOR GENERATED ALWAYS AS
+       (to_tsvector('english', passage)) STORED     -- only if BM25 / HYBRID
+   );
+
+   CREATE INDEX ON kb_articles USING lakebase_ann  (embedding vector_cosine_ops);
+   CREATE INDEX ON kb_articles USING lakebase_bm25 (passage_tsv);   -- only if BM25 / HYBRID
+   ```
+4. **Populate embeddings client-side.** Lakebase has no in-database
+   embedding function; the caller must embed and INSERT the vector:
+   ```python
+   from databricks_langchain import DatabricksEmbeddings
+
+   emb = DatabricksEmbeddings(endpoint="databricks-gte-large-en")
+   vec = emb.embed_documents([passage])[0]   # list[float] of length 1024
+   cur.execute(
+       "INSERT INTO kb_articles (id, category, passage, embedding) "
+       "VALUES (%s, %s, %s, %s::vector)",
+       (id, category, passage, vec),
+   )
+   # passage_tsv is generated automatically by Postgres; no client work.
+   ```
+
+## Configuration surface
+
+### `LakebaseVectorStoreModel` — bare table reference
+
+| Field | Required | Default | Notes |
+|---|---|---|---|
+| `database` | ✓ | — | Reference to a `DatabaseModel` (Lakebase or standard Postgres) |
+| `schema_name` | | `"public"` | Postgres schema |
+| `table` | ✓ | — | Table name |
+| `id_column` | | `"id"` | Primary-key column; populated on `Document.id` and `metadata` |
+| `content_column` | ✓ | — | Text column → `Document.page_content` |
+| `embedding_column` | ✓ | — | `VECTOR(N)` column |
+| `tsvector_column` | | `None` | `TSVECTOR` column; **required** for BM25 / HYBRID |
+| `metadata_columns` | | `[]` | Extra columns surfaced on `Document.metadata`; also the filter allowlist |
+| `embedding_model` | ✓ | — | `InferenceEndpointModel` — bare string is auto-coerced |
+| `bm25_index_name` | | auto | `<schema>.<table>_<tsvector_column>_bm25` if omitted |
+| `distance_metric` | | `"cosine"` | `cosine` / `l2` / `ip` → `<=>` / `<->` / `<#>` |
+| `tsv_language` | | `"english"` | Passed to `to_tsvector(<lang>, ...)` |
+
+### `LakebaseRetrieverModel` — full retriever
+
+Wraps a `LakebaseVectorStoreModel` with `SearchParametersModel`
+(`num_results`, `filters`, `query_type`). Enforces that
+`query_type in {BM25, HYBRID}` requires `tsvector_column`.
+
+### Filter operators
+
+Filter keys must appear in `metadata_columns` (allowlist enforced at query
+time). Values may be scalar (equality shorthand) or `{op, value}` /
+`{op, values}` dicts:
+
+| Op | SQL emitted | Value form |
+|---|---|---|
+| `=` (or bare scalar) | `col = %s` | `value: <scalar>` |
+| `!=` | `col <> %s` | `value: <scalar>` |
+| `<`, `<=`, `>`, `>=` | `col <op> %s` | `value: <scalar>` |
+| `in` | `col = ANY(%s)` | `values: [...]` |
+| `not_in` | `NOT (col = ANY(%s))` | `values: [...]` |
+| `like`, `ilike` | `col LIKE %s` / `ILIKE %s` | `value: <pattern>` |
+| `is_null` | `col IS NULL` / `IS NOT NULL` | `value: true` / `false` (default `true`) |
+
+Column names are wrapped in `psycopg.sql.Identifier`; values are always bound
+as `%s` parameters — no string interpolation ever.
+
+## MLflow tracing
+
+All three retrieval helpers are wrapped with
+`@mlflow.trace(span_type=SpanType.RETRIEVER)`:
+
+```
+[TOOL      ] lakebase_search
+  [RETRIEVER ] LakebaseRetriever                    (LangChain BaseRetriever auto-span)
+    [RETRIEVER ] lakebase_hybrid_search             (@mlflow.trace)
+      [RETRIEVER ] lakebase_ann_search              (@mlflow.trace)
+      [RETRIEVER ] lakebase_bm25_search             (@mlflow.trace)
+```
+
+This matches the span shape `ai_search` produces, so existing trace-review
+tooling (the `analyze-mlflow-trace` and `retrieving-mlflow-traces` skills,
+MLflow UI) works unmodified. See `filters_and_traces.yaml` for a
+`trace_location` config that ships spans to a UC OTEL Delta table set.
+
+## What's not yet supported (roadmap)
+
+- **Rerank + instructed retrieval** — planned Stage 2. Today the retriever
+  matches `ai_search`'s field shape for `search_parameters` but does not yet
+  honor `rerank` or `instructed`.
+- **Auto-provisioning** — planned Stage 3. Today the caller is responsible
+  for `CREATE TABLE`, indexes, and embedding backfill; there is no
+  `source_table` / auto-sync equivalent to `AiSearchIndexModel`.
+- **Per-column typed filter kwargs on the tool schema** — planned Stage 4.
+  Today the tool exposes a single `filters: dict` argument; the LLM must
+  know the column names. Static filters set in `search_parameters.filters`
+  work with equal fidelity to `ai_search`.
+
+## Try it
+
+```bash
+# Validate one of the configs — swap in your own project / schema / table names first.
+dao-ai validate -c config/examples/21_lakebase_search/hybrid_rrf.yaml
+
+# Deploy as a Databricks App bundle.
+dao-ai generate-bundle -c config/examples/21_lakebase_search/hybrid_rrf.yaml \
+  -o /tmp/lakebase-agent --force --development -p <profile>
+cd /tmp/lakebase-agent
+databricks bundle deploy --target dev -p <profile>
+databricks bundle run dao-ai-lakebase-hybrid-example --target dev -p <profile>
+```

--- a/config/examples/21_lakebase_search/ann_only.yaml
+++ b/config/examples/21_lakebase_search/ann_only.yaml
@@ -1,0 +1,63 @@
+# Minimal Lakebase Search agent — ANN (semantic) mode only.
+#
+# Prerequisites:
+#   1. Lakebase Search enabled on your project (workspace UI → Compute →
+#      Postgres → <project> → Settings → Enable Lakebase Search).
+#   2. Extensions installed in the target database:
+#        CREATE EXTENSION IF NOT EXISTS lakebase_vector CASCADE;
+#   3. A table with a VECTOR(N) column (N must match the embedding endpoint's
+#      output dimension — 1024 for databricks-gte-large-en).
+#   4. A lakebase_ann index on the vector column:
+#        CREATE INDEX ON kb_articles USING lakebase_ann (embedding vector_cosine_ops);
+#
+# ANN mode never touches the tsvector_column / lakebase_bm25 index, so you
+# can omit those entirely for an ANN-only deployment.
+
+resources:
+  llms:
+    default_llm: &default_llm
+      name: databricks-claude-sonnet-4-5
+
+  databases:
+    kb_lakebase: &kb_lakebase
+      project: my-lakebase-project
+
+tools:
+  kb_search: &kb_search
+    name: kb_search
+    function:
+      type: lakebase_search
+      vector_store:
+        database: *kb_lakebase
+        schema_name: dao_ai_kb
+        table: kb_articles
+        content_column: passage
+        embedding_column: embedding
+        embedding_model: databricks-gte-large-en   # string shorthand
+        metadata_columns: [category, source_url]
+        distance_metric: cosine                    # or l2 / ip
+
+agents:
+  kb_agent:
+    name: kb_agent
+    model: *default_llm
+    tools:
+      - *kb_search
+    prompt: |
+      You are a knowledge-base assistant. Use kb_search to look up relevant
+      documents before answering. Cite the source URL from the metadata when
+      possible.
+
+app:
+  name: dao-ai-lakebase-ann-example
+  registered_model:
+    name: dao_ai_lakebase_ann_example
+  agents:
+    - name: kb_agent
+      model: *default_llm
+      tools:
+        - *kb_search
+      prompt: |
+        You are a knowledge-base assistant. Use kb_search to look up relevant
+        documents before answering. Cite the source URL from the metadata when
+        possible.

--- a/config/examples/21_lakebase_search/ann_only.yaml
+++ b/config/examples/21_lakebase_search/ann_only.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=../../../schemas/model_config_schema.json
+
 # Minimal Lakebase Search agent — ANN (semantic) mode only.
 #
 # Prerequisites:
@@ -12,15 +14,29 @@
 #
 # ANN mode never touches the tsvector_column / lakebase_bm25 index, so you
 # can omit those entirely for an ANN-only deployment.
+#
+# Override any parameter at bundle-gen time:
+#   dao-ai generate-bundle -c ann_only.yaml --var lakebase_project=my-project
+
+parameters:
+  lakebase_project:
+    description: Lakebase autoscaling Postgres project id
+    default: my-lakebase-project
+  schema_name:
+    description: Postgres schema holding the KB table
+    default: dao_ai_kb
+  table_name:
+    description: Table with vector + text columns
+    default: kb_articles
 
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4-5
 
   databases:
     kb_lakebase: &kb_lakebase
-      project: my-lakebase-project
+      project: ${var.lakebase_project}
 
 tools:
   kb_search: &kb_search
@@ -29,13 +45,15 @@ tools:
       type: lakebase_search
       vector_store:
         database: *kb_lakebase
-        schema_name: dao_ai_kb
-        table: kb_articles
+        schema_name: ${var.schema_name}
+        table: ${var.table_name}
         content_column: passage
         embedding_column: embedding
-        embedding_model: databricks-gte-large-en   # string shorthand
-        metadata_columns: [category, source_url]
-        distance_metric: cosine                    # or l2 / ip
+        embedding_model: databricks-gte-large-en   # string shorthand → InferenceEndpointModel
+        metadata_columns:
+          - category
+          - source_url
+        distance_metric: cosine                    # cosine | l2 | ip
 
 agents:
   kb_agent:

--- a/config/examples/21_lakebase_search/bm25_only.yaml
+++ b/config/examples/21_lakebase_search/bm25_only.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=../../../schemas/model_config_schema.json
+
 # Pure BM25 Lakebase Search — lexical / keyword retrieval, no embedding calls.
 #
 # Use when you want exact-term matching and don't need semantic recall — e.g.,
@@ -8,14 +10,25 @@
 # `embedding_column` even in BM25-only mode. The column simply isn't touched
 # during retrieval — but the retriever validates its presence at config load.
 
+parameters:
+  lakebase_project:
+    description: Lakebase autoscaling Postgres project id
+    default: my-lakebase-project
+  schema_name:
+    description: Postgres schema holding the KB table
+    default: dao_ai_kb
+  table_name:
+    description: Table with tsvector column
+    default: kb_articles
+
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4-5
 
   databases:
     kb_lakebase: &kb_lakebase
-      project: my-lakebase-project
+      project: ${var.lakebase_project}
 
 tools:
   kb_lexical: &kb_lexical
@@ -25,13 +38,14 @@ tools:
       retriever:
         vector_store:
           database: *kb_lakebase
-          schema_name: dao_ai_kb
-          table: kb_articles
+          schema_name: ${var.schema_name}
+          table: ${var.table_name}
           content_column: passage
           embedding_column: embedding             # required by schema, unused at query time
           tsvector_column: passage_tsv            # required for BM25
           embedding_model: databricks-gte-large-en
-          metadata_columns: [category]
+          metadata_columns:
+            - category
         search_parameters:
           query_type: BM25
           num_results: 5

--- a/config/examples/21_lakebase_search/bm25_only.yaml
+++ b/config/examples/21_lakebase_search/bm25_only.yaml
@@ -1,0 +1,60 @@
+# Pure BM25 Lakebase Search — lexical / keyword retrieval, no embedding calls.
+#
+# Use when you want exact-term matching and don't need semantic recall — e.g.,
+# looking up documents by an SKU, error code, or product name. BM25 never
+# invokes the embedding endpoint at query time.
+#
+# Note: the LakebaseVectorStoreModel schema still requires an
+# `embedding_column` even in BM25-only mode. The column simply isn't touched
+# during retrieval — but the retriever validates its presence at config load.
+
+resources:
+  llms:
+    default_llm: &default_llm
+      name: databricks-claude-sonnet-4-5
+
+  databases:
+    kb_lakebase: &kb_lakebase
+      project: my-lakebase-project
+
+tools:
+  kb_lexical: &kb_lexical
+    name: kb_lexical
+    function:
+      type: lakebase_search
+      retriever:
+        vector_store:
+          database: *kb_lakebase
+          schema_name: dao_ai_kb
+          table: kb_articles
+          content_column: passage
+          embedding_column: embedding             # required by schema, unused at query time
+          tsvector_column: passage_tsv            # required for BM25
+          embedding_model: databricks-gte-large-en
+          metadata_columns: [category]
+        search_parameters:
+          query_type: BM25
+          num_results: 5
+
+agents:
+  lexical_agent:
+    name: lexical_agent
+    model: *default_llm
+    tools:
+      - *kb_lexical
+    prompt: |
+      You are a keyword-search assistant. Use kb_lexical to look up documents
+      by exact terms (SKUs, error codes, product names, literal phrases).
+
+app:
+  name: dao-ai-lakebase-bm25-example
+  registered_model:
+    name: dao_ai_lakebase_bm25_example
+  agents:
+    - name: lexical_agent
+      model: *default_llm
+      tools:
+        - *kb_lexical
+      prompt: |
+        You are a keyword-search assistant. Use kb_lexical to look up documents
+        by exact terms (SKUs, error codes, product names, literal phrases).

--- a/config/examples/21_lakebase_search/filters_and_traces.yaml
+++ b/config/examples/21_lakebase_search/filters_and_traces.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=../../../schemas/model_config_schema.json
+
 # Lakebase Search with static filters + MLflow trace_location.
 #
 # Demonstrates:
@@ -10,18 +12,61 @@
 #     land alongside the outer tool span so downstream trace tooling
 #     (analyze-mlflow-trace, retrieving-mlflow-traces) works unmodified.
 
+parameters:
+  lakebase_project:
+    description: Lakebase autoscaling Postgres project id
+    default: my-lakebase-project
+  schema_name:
+    description: Postgres schema holding the KB table
+    default: dao_ai_kb
+  table_name:
+    description: Table with vector + tsvector columns
+    default: kb_articles
+  trace_catalog:
+    description: UC catalog where OTEL trace Delta tables live
+    default: my_catalog
+  trace_schema:
+    description: UC schema where OTEL trace Delta tables live
+    default: default
+  trace_warehouse_id:
+    description: SQL warehouse id used by MLflow to materialize trace tables
+    default: my-warehouse-id
+  secret_scope:
+    description: Databricks secret scope holding the SP client id / secret / host
+    default: my_secret_scope
+
+# Anchored option lists — dao-ai resolves the first entry that yields a value
+# (secret scope preferred; falls back to env var for local dev).
+variables:
+  client_id: &client_id
+    options:
+      - scope: ${var.secret_scope}
+        secret: SP_CLIENT_ID
+      - env: SP_CLIENT_ID
+
+  client_secret: &client_secret
+    options:
+      - scope: ${var.secret_scope}
+        secret: SP_CLIENT_SECRET
+      - env: SP_CLIENT_SECRET
+
+  workspace_host: &workspace_host
+    options:
+      - scope: ${var.secret_scope}
+        secret: DATABRICKS_HOST
+      - env: DATABRICKS_HOST
+
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4-5
 
   databases:
     kb_lakebase: &kb_lakebase
-      project: my-lakebase-project
-      # For deployment inside a Databricks App, use a service principal:
-      # client_id:     { scope: my_scope, secret: SP_CLIENT_ID }
-      # client_secret: { scope: my_scope, secret: SP_CLIENT_SECRET }
-      # workspace_host: { scope: my_scope, secret: WORKSPACE_HOST }
+      project: ${var.lakebase_project}
+      client_id: *client_id
+      client_secret: *client_secret
+      workspace_host: *workspace_host
 
 tools:
   # Only surface published, high-priority auth-related docs to the agent.
@@ -34,13 +79,17 @@ tools:
       retriever:
         vector_store:
           database: *kb_lakebase
-          schema_name: dao_ai_kb
-          table: kb_articles
+          schema_name: ${var.schema_name}
+          table: ${var.table_name}
           content_column: passage
           embedding_column: embedding
           tsvector_column: passage_tsv
           embedding_model: databricks-gte-large-en
-          metadata_columns: [category, status, priority, source_url]
+          metadata_columns:
+            - category
+            - status
+            - priority
+            - source_url
         search_parameters:
           query_type: HYBRID
           num_results: 5
@@ -50,7 +99,9 @@ tools:
             # IN operator — dict-form with `values` list.
             status:
               op: in
-              values: [published, reviewed]
+              values:
+                - published
+                - reviewed
             # Comparison — dict-form with `value` scalar.
             priority:
               op: ">="
@@ -88,7 +139,7 @@ app:
   #   <catalog>.<schema>.<prefix>_otel_{spans,logs,metrics,annotations}
   trace_location:
     schema:
-      catalog_name: my_catalog
-      schema_name: default
-    warehouse: <sql-warehouse-id>
+      catalog_name: ${var.trace_catalog}
+      schema_name: ${var.trace_schema}
+    warehouse: ${var.trace_warehouse_id}
     table_prefix: lakebase_filters_example

--- a/config/examples/21_lakebase_search/filters_and_traces.yaml
+++ b/config/examples/21_lakebase_search/filters_and_traces.yaml
@@ -1,0 +1,94 @@
+# Lakebase Search with static filters + MLflow trace_location.
+#
+# Demonstrates:
+#   - Static config-time filters on `search_parameters.filters` — merged with
+#     any call-time filters the LLM passes on the tool.
+#   - Multiple filter operators: equality, IN, comparison, IS NULL, LIKE.
+#   - `trace_location` sending MLflow OTEL traces to a UC Delta table set —
+#     the retriever's `@mlflow.trace(span_type=RETRIEVER)` spans
+#     (`lakebase_ann_search`, `lakebase_bm25_search`, `lakebase_hybrid_search`)
+#     land alongside the outer tool span so downstream trace tooling
+#     (analyze-mlflow-trace, retrieving-mlflow-traces) works unmodified.
+
+resources:
+  llms:
+    default_llm: &default_llm
+      name: databricks-claude-sonnet-4-5
+
+  databases:
+    kb_lakebase: &kb_lakebase
+      project: my-lakebase-project
+      # For deployment inside a Databricks App, use a service principal:
+      # client_id:     { scope: my_scope, secret: SP_CLIENT_ID }
+      # client_secret: { scope: my_scope, secret: SP_CLIENT_SECRET }
+      # workspace_host: { scope: my_scope, secret: WORKSPACE_HOST }
+
+tools:
+  # Only surface published, high-priority auth-related docs to the agent.
+  # Filter columns must appear in vector_store.metadata_columns (allowlist).
+  # Supported operators: =, !=, <, <=, >, >=, in, not_in, like, ilike, is_null.
+  active_auth_kb: &active_auth_kb
+    name: active_auth_kb
+    function:
+      type: lakebase_search
+      retriever:
+        vector_store:
+          database: *kb_lakebase
+          schema_name: dao_ai_kb
+          table: kb_articles
+          content_column: passage
+          embedding_column: embedding
+          tsvector_column: passage_tsv
+          embedding_model: databricks-gte-large-en
+          metadata_columns: [category, status, priority, source_url]
+        search_parameters:
+          query_type: HYBRID
+          num_results: 5
+          filters:
+            # Scalar equality — bare value shorthand.
+            category: auth
+            # IN operator — dict-form with `values` list.
+            status:
+              op: in
+              values: [published, reviewed]
+            # Comparison — dict-form with `value` scalar.
+            priority:
+              op: ">="
+              value: 2
+            # LIKE / ILIKE — case-sensitive / -insensitive pattern match.
+            source_url:
+              op: ilike
+              value: "https://docs.%.com/%"
+
+agents:
+  auth_agent:
+    name: auth_agent
+    model: *default_llm
+    tools:
+      - *active_auth_kb
+    prompt: |
+      You answer authentication questions. Always call active_auth_kb; it is
+      already scoped to published, high-priority auth docs.
+
+app:
+  name: dao-ai-lb-filters-example
+  registered_model:
+    name: dao_ai_lb_filters_example
+  agents:
+    - name: auth_agent
+      model: *default_llm
+      tools:
+        - *active_auth_kb
+      prompt: |
+        You answer authentication questions. Always call active_auth_kb; it is
+        already scoped to published, high-priority auth docs.
+  # Ship OTEL traces to UC — dao-ai calls
+  #   mlflow.set_experiment(trace_location=UnityCatalog(...))
+  # at startup and materializes four Delta tables:
+  #   <catalog>.<schema>.<prefix>_otel_{spans,logs,metrics,annotations}
+  trace_location:
+    schema:
+      catalog_name: my_catalog
+      schema_name: default
+    warehouse: <sql-warehouse-id>
+    table_prefix: lakebase_filters_example

--- a/config/examples/21_lakebase_search/hybrid_rrf.yaml
+++ b/config/examples/21_lakebase_search/hybrid_rrf.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=../../../schemas/model_config_schema.json
+
 # Hybrid Lakebase Search — dense ANN + BM25 fused via Reciprocal Rank Fusion.
 #
 # Fetches top-k from each mode independently, then combines them client-side
@@ -12,14 +14,25 @@
 #   CREATE INDEX kb_articles_passage_tsv_bm25
 #     ON kb_articles USING lakebase_bm25 (passage_tsv);
 
+parameters:
+  lakebase_project:
+    description: Lakebase autoscaling Postgres project id
+    default: my-lakebase-project
+  schema_name:
+    description: Postgres schema holding the KB table
+    default: dao_ai_kb
+  table_name:
+    description: Table with vector + tsvector columns
+    default: kb_articles
+
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4-5
 
   databases:
     kb_lakebase: &kb_lakebase
-      project: my-lakebase-project
+      project: ${var.lakebase_project}
 
 tools:
   kb_hybrid: &kb_hybrid
@@ -29,8 +42,8 @@ tools:
       retriever:
         vector_store:
           database: *kb_lakebase
-          schema_name: dao_ai_kb
-          table: kb_articles
+          schema_name: ${var.schema_name}
+          table: ${var.table_name}
           content_column: passage
           embedding_column: embedding
           tsvector_column: passage_tsv            # required for HYBRID / BM25
@@ -38,7 +51,9 @@ tools:
           #   <schema_name>.<table>_<tsvector_column>_bm25
           # Set it explicitly here to override that convention.
           embedding_model: databricks-gte-large-en
-          metadata_columns: [category, source_url]
+          metadata_columns:
+            - category
+            - source_url
         search_parameters:
           query_type: HYBRID                      # ANN | BM25 | HYBRID
           num_results: 5

--- a/config/examples/21_lakebase_search/hybrid_rrf.yaml
+++ b/config/examples/21_lakebase_search/hybrid_rrf.yaml
@@ -1,0 +1,69 @@
+# Hybrid Lakebase Search — dense ANN + BM25 fused via Reciprocal Rank Fusion.
+#
+# Fetches top-k from each mode independently, then combines them client-side
+# via RRF (k=60). Best of both worlds: semantic recall from ANN, exact-term
+# precision from BM25.
+#
+# Prerequisites (in addition to the ANN example):
+#   CREATE EXTENSION IF NOT EXISTS lakebase_text;
+#   ALTER TABLE kb_articles
+#     ADD COLUMN passage_tsv TSVECTOR
+#     GENERATED ALWAYS AS (to_tsvector('english', passage)) STORED;
+#   CREATE INDEX kb_articles_passage_tsv_bm25
+#     ON kb_articles USING lakebase_bm25 (passage_tsv);
+
+resources:
+  llms:
+    default_llm: &default_llm
+      name: databricks-claude-sonnet-4-5
+
+  databases:
+    kb_lakebase: &kb_lakebase
+      project: my-lakebase-project
+
+tools:
+  kb_hybrid: &kb_hybrid
+    name: kb_hybrid
+    function:
+      type: lakebase_search
+      retriever:
+        vector_store:
+          database: *kb_lakebase
+          schema_name: dao_ai_kb
+          table: kb_articles
+          content_column: passage
+          embedding_column: embedding
+          tsvector_column: passage_tsv            # required for HYBRID / BM25
+          # bm25_index_name auto-derives from
+          #   <schema_name>.<table>_<tsvector_column>_bm25
+          # Set it explicitly here to override that convention.
+          embedding_model: databricks-gte-large-en
+          metadata_columns: [category, source_url]
+        search_parameters:
+          query_type: HYBRID                      # ANN | BM25 | HYBRID
+          num_results: 5
+
+agents:
+  kb_agent:
+    name: kb_agent
+    model: *default_llm
+    tools:
+      - *kb_hybrid
+    prompt: |
+      You are a knowledge-base assistant. Call kb_hybrid to get documents that
+      match both semantically and lexically, then answer using only the
+      retrieved content.
+
+app:
+  name: dao-ai-lakebase-hybrid-example
+  registered_model:
+    name: dao_ai_lakebase_hybrid_example
+  agents:
+    - name: kb_agent
+      model: *default_llm
+      tools:
+        - *kb_hybrid
+      prompt: |
+        You are a knowledge-base assistant. Call kb_hybrid to get documents that
+        match both semantically and lexically, then answer using only the
+        retrieved content.

--- a/config/examples/README.md
+++ b/config/examples/README.md
@@ -13,6 +13,7 @@ members of the tool config — no factory import path required. The original
 | --- | --- | --- |
 | Genie | `type: factory`, `name: dao_ai.tools.create_genie_tool`, `args: { genie_room: ..., lru_cache_parameters: ... }` | `type: genie`, `genie_room: ...`, `lru_cache: ...` |
 | Vector Search | `type: factory`, `name: dao_ai.tools.create_vector_search_tool`, `args: { retriever: ... }` | `type: vector_search`, `retriever: ...` |
+| Lakebase Search | *(no factory equivalent — first-class only)* | `type: lakebase_search`, `vector_store: ...` (or `retriever: ...`) |
 | Web Search | `type: factory`, `name: dao_ai.tools.create_search_tool` | `type: search` |
 
 Genie with caching (LRU + context-aware) now lives under a single tool type —
@@ -216,6 +217,18 @@ Or jump directly to the category that matches your current need.
 
 ---
 
+### [21. Lakebase Search](21_lakebase_search/)
+**Retrieval over Databricks Lakebase Postgres**
+- ANN semantic search via `lakebase_vector` + `lakebase_ann`
+- BM25 lexical search via `lakebase_text` + `lakebase_bm25`
+- Hybrid mode with client-side Reciprocal Rank Fusion
+- Filter operator coverage (equality, IN, comparison, LIKE, IS NULL)
+- `trace_location` example shipping OTEL spans to a UC Delta table set
+
+👉 First-class retrieval tool when your source of truth already lives in Lakebase
+
+---
+
 ## 🚀 Quick Start
 
 ### Validate a Configuration
@@ -288,6 +301,9 @@ dao-ai pipeline --deploy --run -c config/examples/07_human_in_the_loop/human_in_
 
 **...define simple tools directly in YAML (inline)**
 → See [`17_parallel_tools/`](17_parallel_tools/)
+
+**...retrieve from a Lakebase Postgres table**
+→ Head to [`21_lakebase_search/`](21_lakebase_search/)
 
 ---
 
@@ -391,6 +407,7 @@ Use MLflow to track agent performance and costs.
 | 15_complete_applications | ⭐⭐⭐⭐⭐ | 6-8 hrs | All above |
 | 16_instructed_retriever | ⭐⭐⭐ | 2 hrs | Vector search setup |
 | 17_parallel_tools | ⭐⭐ | 1 hr | Category 01 |
+| 21_lakebase_search | ⭐⭐⭐ | 1-2 hrs | Lakebase project + `lakebase_vector` / `lakebase_text` extensions enabled |
 
 ---
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,6 +12,7 @@ The examples follow a natural progression:
     → 10_agent_integrations → 11_prompt_engineering → 12_middleware → 13_orchestration
     → 14_basic_tools → 15_complete_applications → 16_instructed_retriever
     → 17_parallel_tools → 18_visualization → 19_background_agents
+    → 20_a2a_protocol → 21_lakebase_search
 ```
 
 Start at `01_getting_started` if you're new, or jump directly to the category that matches your needs.
@@ -56,6 +57,10 @@ Start at `01_getting_started` if you're new, or jump directly to the category th
 ### ⏱️ Background Tasks?
 **Background kickoff + poll/stream retrieval (deep research, multi-tool workflows):**
 - [`19_background_agents/`](../config/examples/19_background_agents/) - OpenAI Responses API–compatible `/v1/responses` on Apps + `background=true` on Model Serving, backed by Lakebase
+
+### 🔎 Retrieval from Lakebase Postgres?
+**ANN / BM25 / hybrid RRF over a Lakebase table (as a sibling of `ai_search`):**
+- [`21_lakebase_search/`](../config/examples/21_lakebase_search/) - `type: lakebase_search` using the `lakebase_vector` + `lakebase_text` extensions, with filter-operator coverage and a UC OTEL `trace_location` example
 
 ### 🏗️ Complete Solutions?
 **Full applications:**

--- a/docs/key-capabilities.md
+++ b/docs/key-capabilities.md
@@ -67,6 +67,7 @@ DAO supports several first-class tool types plus an escape hatch for arbitrary f
 |-----------|----------|---------|
 | **Genie** | Natural-language SQL via a Genie space, with optional caching | `type: genie` + `genie_room: *room` |
 | **AI Search** | Semantic / hybrid search over a Databricks AI Search index (formerly Vector Search), with optional instructed retrieval | `type: ai_search` (or legacy `vector_search`) + `retriever: *retriever` |
+| **Lakebase Search** | ANN / BM25 / hybrid (RRF) retrieval over a Databricks Lakebase Postgres table using the `lakebase_vector` and `lakebase_text` extensions | `type: lakebase_search` + `vector_store: *store` (or `retriever: *retriever`) |
 | **Search** | Web search (DuckDuckGo) | `type: search` |
 | **Unity Catalog** | Governed SQL functions | `type: unity_catalog` + `resource: *fn` |
 | **MCP** | External services via Model Context Protocol | `type: mcp` + `connection: *mcp_conn` |


### PR DESCRIPTION
## Summary

Documentation follow-up to #156 (`lakebase_search` feature) — was on the same branch but didn't make it into the merge.

- Adds `config/examples/21_lakebase_search/` with 4 validated example configs:
  - `ann_only.yaml` — minimal semantic-only setup (no BM25 required)
  - `hybrid_rrf.yaml` — dense + lexical fused via RRF (k=60)
  - `bm25_only.yaml` — pure lexical, no embedding calls at query time
  - `filters_and_traces.yaml` — all supported filter operators (`=`, `!=`, `<`, `<=`, `>`, `>=`, `in`, `not_in`, `like`, `ilike`, `is_null`) plus a `trace_location` that ships OTEL spans to a UC Delta table set
- Category README covers prerequisites (Lakebase Search enablement, extension install, table DDL, embedding backfill), full config surface, filter operator reference, MLflow span shape, and roadmap items deferred to future PRs.
- Adds directory-guide entry, quick-find entry, and complexity-matrix row to `config/examples/README.md`.
- Extends the learning-path bar in `docs/examples.md` to include §20 and §21; adds a "Retrieval from Lakebase Postgres?" quick-reference block.
- Adds `type: lakebase_search` row to the first-class-tool-types table in `docs/key-capabilities.md` §2 Multi-Tool Support (sibling of `type: ai_search`).

## Test plan

- [x] All 4 example configs pass `dao-ai validate`.
- [x] No source-code changes — pure docs. Existing tests unaffected.

This pull request and its description were written by Isaac.