### PR TITLE
feat(lakebase-search): filter parity with ai_search + dynamic per-column schema

### DIFF
--- a/config/examples/21_lakebase_search/README.md
+++ b/config/examples/21_lakebase_search/README.md
@@ -66,6 +66,7 @@ flowchart TB
 | [`hybrid_rrf.yaml`](./hybrid_rrf.yaml) | HYBRID | Dense + lexical fused via RRF — highest recall |
 | [`bm25_only.yaml`](./bm25_only.yaml) | BM25 | Exact-term lookup (SKUs, error codes) — no embedding calls |
 | [`filters_and_traces.yaml`](./filters_and_traces.yaml) | HYBRID | Static filters (equality / IN / comparison / LIKE) + `trace_location` to UC OTEL tables |
+| [`dynamic_schema.yaml`](./dynamic_schema.yaml) | HYBRID | Hand-declared `ColumnInfo` with per-column operator narrowing + LLM-facing descriptions (Mode A discovery) |
 
 ## Prerequisites
 
@@ -134,24 +135,73 @@ Wraps a `LakebaseVectorStoreModel` with `SearchParametersModel`
 (`num_results`, `filters`, `query_type`). Enforces that
 `query_type in {BM25, HYBRID}` requires `tsvector_column`.
 
-### Filter operators
+### Filter operators (aligned with `ai_search`)
 
-Filter keys must appear in `metadata_columns` (allowlist enforced at query
-time). Values may be scalar (equality shorthand) or `{op, value}` /
-`{op, values}` dicts:
+Filter keys use the same suffix convention as `ai_search`: a column name
+optionally followed by a space and an operator token. Two shapes:
 
-| Op | SQL emitted | Value form |
+1. **LLM-facing runtime** (`list[FilterItem]`) — what the LLM emits:
+   ```json
+   [{"key": "category", "value": "auth"},
+    {"key": "priority >=", "value": 2},
+    {"key": "status", "value": ["published", "reviewed"]}]
+   ```
+2. **Static config** (`search_parameters.filters`, `dict[str, Any]`) —
+   what you write in YAML:
+   ```yaml
+   filters:
+     category: auth
+     "priority >=": 2
+     "status": [published, reviewed]
+   ```
+
+Both forms are merged at runtime before hitting Postgres.
+
+| Suffix | SQL emitted (scalar) | SQL emitted (list value) |
 |---|---|---|
-| `=` (or bare scalar) | `col = %s` | `value: <scalar>` |
-| `!=` | `col <> %s` | `value: <scalar>` |
-| `<`, `<=`, `>`, `>=` | `col <op> %s` | `value: <scalar>` |
-| `in` | `col = ANY(%s)` | `values: [...]` |
-| `not_in` | `NOT (col = ANY(%s))` | `values: [...]` |
-| `like`, `ilike` | `col LIKE %s` / `ILIKE %s` | `value: <pattern>` |
-| `is_null` | `col IS NULL` / `IS NOT NULL` | `value: true` / `false` (default `true`) |
+| *(none — equality)* | `col = %s` | `col = ANY(%s)` (IN) |
+| ` NOT` | `col <> %s` | `NOT (col = ANY(%s))` (NOT IN) |
+| ` <` ` <=` ` >` ` >=` | `col <op> %s` | *error — list value not supported* |
+| ` LIKE` | `col ILIKE %s` | *error* |
+| ` NOT LIKE` | `NOT (col ILIKE %s)` | *error* |
 
-Column names are wrapped in `psycopg.sql.Identifier`; values are always bound
-as `%s` parameters — no string interpolation ever.
+Notes:
+- **`LIKE` maps to Postgres `ILIKE`** (case-insensitive). Agent-friendly
+  default — LLMs reason about pattern match without caring about case, and
+  Vector Search's tokenized LIKE is likewise case-insensitive.
+- Column names come from `metadata_columns` on the vector store (or from
+  `retriever.columns` when hand-declared with `ColumnInfo`). Unknown keys
+  fail Pydantic validation at tool-call time; the LLM never sees them as
+  legal options.
+- Column names are wrapped in `psycopg.sql.Identifier`; values are always
+  bound as `%s` parameters — no string interpolation ever.
+- `IS NULL` / `IS NOT NULL` are intentionally not exposed — agents don't
+  reason well about null. Use a static `search_parameters.filters` entry
+  with a specific sentinel value if you need it.
+
+### Dynamic schema
+
+When the retriever can enumerate its columns (Mode A hand-declared /
+Mode B declared + Postgres enrichment / Mode C empty + Postgres discovery),
+the tool's `args_schema` narrows `filters[].key` to a `Literal[...]` of the
+actual `column × suffix` cross-product. The LLM sees the exact enum in its
+function-calling schema — no more guessing column names. Mirrors
+ai_search's `_build_filter_item_model`.
+
+Discovery calls Postgres exactly once per tool build:
+
+```sql
+SELECT column_name, data_type,
+       col_description(...::regclass, ordinal_position) AS comment
+FROM information_schema.columns
+WHERE table_schema = %s AND table_name = %s
+ORDER BY ordinal_position;
+```
+
+Columns used by the retriever internally (id / content / embedding /
+tsvector) are stripped so they don't appear on the LLM-facing filter enum.
+See [`dynamic_schema.yaml`](./dynamic_schema.yaml) for a hand-declared
+example that locks per-column operators via `ColumnInfo.operators`.
 
 ## MLflow tracing
 

--- a/config/examples/21_lakebase_search/dynamic_schema.yaml
+++ b/config/examples/21_lakebase_search/dynamic_schema.yaml
@@ -1,0 +1,103 @@
+# yaml-language-server: $schema=../../../schemas/model_config_schema.json
+
+# Hand-declared column schema for the LLM (Mode A discovery).
+#
+# `retriever.columns` accepts a mixed list of bare strings and ColumnInfo
+# entries. Any ColumnInfo item flips the factory to Mode A — the LLM-facing
+# args_schema is built entirely from the declaration; Postgres
+# information_schema.columns is NOT queried.
+#
+# ColumnInfo.operators locks a column to a subset of the 8 default
+# suffixes. Useful when:
+#   - You want to hide impossible-to-satisfy operators from the LLM (e.g.
+#     `priority LIKE` on an integer column).
+#   - You need to reserve a column for equality-only lookups (e.g. tenant
+#     IDs where LIKE would leak across tenants).
+#   - You want to add a rich `description` string that the LLM sees in the
+#     tool's args_schema (better filter accuracy).
+
+parameters:
+  lakebase_project:
+    description: Lakebase autoscaling Postgres project id
+    default: my-lakebase-project
+  schema_name:
+    default: dao_ai_kb
+  table_name:
+    default: kb_articles
+
+resources:
+  models:
+    default_llm: &default_llm
+      name: databricks-claude-sonnet-4-5
+
+  databases:
+    kb_lakebase: &kb_lakebase
+      project: ${var.lakebase_project}
+
+tools:
+  scoped_kb: &scoped_kb
+    name: scoped_kb
+    function:
+      type: lakebase_search
+      retriever:
+        vector_store:
+          database: *kb_lakebase
+          schema_name: ${var.schema_name}
+          table: ${var.table_name}
+          content_column: passage
+          embedding_column: embedding
+          tsvector_column: passage_tsv
+          embedding_model: databricks-gte-large-en
+          # metadata_columns still set for Document.metadata surfacing;
+          # columns below is what drives the LLM args_schema.
+          metadata_columns:
+            - category
+            - priority
+            - source_url
+        # Hand-declared columns (Mode A — no Postgres discovery call).
+        columns:
+          - name: category
+            type: string
+            operators:                   # locked to a subset of the 8 defaults
+              - ""
+              - LIKE
+            description: "Article category: auth, billing, shipping, returns"
+          - name: priority
+            type: number
+            operators:                   # comparison-only — LIKE makes no sense on an int
+              - ""
+              - "<"
+              - "<="
+              - ">"
+              - ">="
+            description: "Priority tier 1 (highest) - 5 (lowest)"
+          - name: source_url
+            type: string
+            description: "Canonical documentation URL"
+            # `operators` omitted → all 8 suffixes are legal (default).
+        search_parameters:
+          query_type: HYBRID
+          num_results: 5
+
+agents:
+  scoped_agent:
+    name: scoped_agent
+    model: *default_llm
+    tools:
+      - *scoped_kb
+    prompt: |
+      You answer knowledge-base questions. Prefer filtering on the
+      category or priority when the user's question implies scope.
+
+app:
+  name: dao-ai-lb-dyn-schema-example
+  registered_model:
+    name: dao_ai_lb_dyn_schema_example
+  agents:
+    - name: scoped_agent
+      model: *default_llm
+      tools:
+        - *scoped_kb
+      prompt: |
+        You answer knowledge-base questions. Prefer filtering on the
+        category or priority when the user's question implies scope.

--- a/config/examples/21_lakebase_search/filters_and_traces.yaml
+++ b/config/examples/21_lakebase_search/filters_and_traces.yaml
@@ -93,23 +93,23 @@ tools:
         search_parameters:
           query_type: HYBRID
           num_results: 5
+          # Filter keys follow ai_search's suffixed-key convention. The
+          # bare column name means equality; the LLM-facing FilterItem
+          # list uses the exact same suffix language.
+          #
+          # Supported suffixes (identical to ai_search):
+          #   ""          equality             ("col": <value>)
+          #   " NOT"      not-equals / not-in  ("col NOT": <value|list>)
+          #   " <" " <=" " >" " >="  comparisons
+          #   " LIKE"     case-insensitive     ("col LIKE": "pattern%")
+          #   " NOT LIKE" case-insensitive not ("col NOT LIKE": "pattern")
+          #
+          # A list value with the bare / NOT suffix triggers IN / NOT IN.
           filters:
-            # Scalar equality — bare value shorthand.
-            category: auth
-            # IN operator — dict-form with `values` list.
-            status:
-              op: in
-              values:
-                - published
-                - reviewed
-            # Comparison — dict-form with `value` scalar.
-            priority:
-              op: ">="
-              value: 2
-            # LIKE / ILIKE — case-sensitive / -insensitive pattern match.
-            source_url:
-              op: ilike
-              value: "https://docs.%.com/%"
+            category: auth                          # equality
+            "status": [published, reviewed]         # list value → IN
+            "priority >=": 2                        # comparison
+            "source_url LIKE": "https://docs.%.com/%"   # LIKE (Postgres ILIKE)
 
 agents:
   auth_agent:

--- a/src/dao_ai/retrievers/lakebase.py
+++ b/src/dao_ai/retrievers/lakebase.py
@@ -38,8 +38,21 @@ _OPS_CLASS = {
     "l2": "vector_l2_ops",
     "ip": "vector_ip_ops",
 }
-_ALLOWED_OPS = {"=", "!=", "<", "<=", ">", ">=", "like", "ilike"}
 _RRF_K = 60
+
+# Filter-key suffixes we recognize on the dict keys reaching `_build_where`.
+# These match ai_search's `_FILTER_OPERATOR_SUFFIXES` (with the leading
+# space). Order matters — longest first so we don't misparse
+# `"col NOT LIKE"` as `"col NOT" + " LIKE"` or similar.
+_FILTER_SUFFIXES: tuple[str, ...] = (
+    " NOT LIKE",
+    " LIKE",
+    " <=",
+    " >=",
+    " NOT",
+    " <",
+    " >",
+)
 
 
 class LakebaseSearchMode(str, Enum):
@@ -150,53 +163,89 @@ class LakebaseRetriever(BaseRetriever):
             cols.extend(extra)
         return sql.SQL(", ").join(cols)
 
+    def _parse_filter_key(self, key: str) -> tuple[str, str]:
+        """Split ``"col SUFFIX"`` into ``(col, suffix)``.
+
+        Suffix is one of ``_FILTER_SUFFIXES`` (with leading space) or ``""``
+        for equality. Matches ai_search's operator-suffix convention on
+        ``FilterItem.key`` so downstream tooling / prompts are portable.
+        """
+        for suffix in _FILTER_SUFFIXES:
+            if key.endswith(suffix):
+                return key[: -len(suffix)], suffix
+        return key, ""
+
     def _build_where(
         self, filters: dict[str, Any]
     ) -> tuple[sql.Composable, list[Any]]:
-        """Translate a filter dict into a WHERE fragment + params.
+        """Translate a suffix-keyed filter dict into a WHERE fragment + params.
 
-        Unknown columns and operators raise ValueError before any SQL is built.
-        Values are always passed as parameters (``%s``); column names are
-        wrapped in ``sql.Identifier`` for safe quoting.
+        Keys use ai_search's operator-suffix convention (``"col LIKE"``,
+        ``"col >="``, ``"col NOT"``, plain ``"col"`` for equality). Values
+        may be scalars or lists — lists trigger IN semantics on the ``""`` /
+        ``" NOT"`` suffixes and are rejected on comparison / LIKE suffixes.
+
+        ``LIKE`` / ``NOT LIKE`` translate to Postgres ``ILIKE`` /
+        ``NOT ILIKE`` (case-insensitive is the agent-friendly default).
+
+        Unknown columns and operators raise ``ValueError`` before any SQL is
+        built. Column names are wrapped in ``sql.Identifier`` for safe
+        quoting; values are always bound as ``%s`` parameters.
         """
         if not filters:
             return sql.SQL(""), []
 
         clauses: list[sql.Composable] = []
         params: list[Any] = []
-        for key, spec in filters.items():
-            if key not in self._allowed_filter_cols:
+        for raw_key, value in filters.items():
+            col_name, suffix = self._parse_filter_key(raw_key)
+            if col_name not in self._allowed_filter_cols:
                 raise ValueError(
-                    f"Unknown filter column {key!r}; "
+                    f"Unknown filter column {col_name!r} (from key {raw_key!r}); "
                     f"allowed: {sorted(self._allowed_filter_cols)}"
                 )
-            col = sql.Identifier(key)
+            col = sql.Identifier(col_name)
+            is_list = isinstance(value, list)
 
-            if not isinstance(spec, dict):
-                clauses.append(sql.SQL("{} = %s").format(col))
-                params.append(spec)
-                continue
-
-            op = str(spec.get("op", "=")).lower()
-            if op == "in":
-                clauses.append(sql.SQL("{} = ANY(%s)").format(col))
-                params.append(list(spec["values"]))
-            elif op == "not_in":
-                clauses.append(sql.SQL("NOT ({} = ANY(%s))").format(col))
-                params.append(list(spec["values"]))
-            elif op == "is_null":
-                is_null = bool(spec.get("value", True))
-                clauses.append(
-                    sql.SQL("{} IS NULL").format(col)
-                    if is_null
-                    else sql.SQL("{} IS NOT NULL").format(col)
-                )
-            elif op in _ALLOWED_OPS:
-                op_sql = sql.SQL(op.upper()) if op in {"like", "ilike"} else sql.SQL(op)
+            if suffix == "":
+                if is_list:
+                    clauses.append(sql.SQL("{} = ANY(%s)").format(col))
+                    params.append(list(value))
+                else:
+                    clauses.append(sql.SQL("{} = %s").format(col))
+                    params.append(value)
+            elif suffix == " NOT":
+                if is_list:
+                    clauses.append(sql.SQL("NOT ({} = ANY(%s))").format(col))
+                    params.append(list(value))
+                else:
+                    clauses.append(sql.SQL("{} <> %s").format(col))
+                    params.append(value)
+            elif suffix in {" <", " <=", " >", " >="}:
+                if is_list:
+                    raise ValueError(
+                        f"Comparison suffix {suffix.strip()!r} on {col_name!r} "
+                        "does not support list values"
+                    )
+                op_sql = sql.SQL(suffix.strip())
                 clauses.append(sql.SQL("{} {} %s").format(col, op_sql))
-                params.append(spec["value"])
-            else:
-                raise ValueError(f"Unsupported filter op {op!r} on column {key!r}")
+                params.append(value)
+            elif suffix == " LIKE":
+                if is_list:
+                    raise ValueError(
+                        f"LIKE suffix on {col_name!r} does not support list values"
+                    )
+                clauses.append(sql.SQL("{} ILIKE %s").format(col))
+                params.append(value)
+            elif suffix == " NOT LIKE":
+                if is_list:
+                    raise ValueError(
+                        f"NOT LIKE suffix on {col_name!r} does not support list values"
+                    )
+                clauses.append(sql.SQL("NOT ({} ILIKE %s)").format(col))
+                params.append(value)
+            else:  # pragma: no cover — suffix set is closed
+                raise ValueError(f"Unsupported filter suffix {suffix!r}")
 
         return sql.SQL(" AND ") + sql.SQL(" AND ").join(clauses), params
 

--- a/src/dao_ai/tools/lakebase_search.py
+++ b/src/dao_ai/tools/lakebase_search.py
@@ -1,9 +1,11 @@
 """Factory for the ``lakebase_search`` first-class tool.
 
 Wraps ``dao_ai.retrievers.LakebaseRetriever`` in a LangChain ``StructuredTool``.
-Mirrors the shape of ``create_ai_search_tool`` (mutual exclusivity of
-``retriever`` vs ``vector_store``, dict-to-model coercion) so both tools have
-a consistent surface from YAML config.
+Mirrors ``create_ai_search_tool``: mutual exclusivity of ``retriever`` vs
+``vector_store``, dict-to-model coercion, a `list[FilterItem]` runtime
+argument with a per-tool `Literal`-narrowed key enum, and Mode A / B / C
+column discovery (hand-declared / declared + Postgres enrichment / empty +
+Postgres discovery).
 """
 
 from __future__ import annotations
@@ -15,22 +17,78 @@ import mlflow
 from langchain_core.tools import StructuredTool
 from loguru import logger
 from mlflow.entities import SpanType
-from pydantic import BaseModel, Field
+from psycopg import sql
+from psycopg.rows import dict_row
+from pydantic import BaseModel, Field, create_model
 
-from dao_ai.config import LakebaseRetrieverModel, LakebaseVectorStoreModel
+from dao_ai.config import (
+    ColumnInfo,
+    FilterItem,
+    LakebaseRetrieverModel,
+    LakebaseVectorStoreModel,
+)
 from dao_ai.retrievers.lakebase import LakebaseRetriever
+from dao_ai.tools.vector_search import (
+    _build_filter_item_model,
+    _is_array_type,
+    _normalize_declared_columns,
+)
+
+
+# Rough map from Postgres ``information_schema.columns.data_type`` values
+# to the labels ``ColumnInfo.type`` uses. Anything we can't classify falls
+# through as a bare "string" — matches ai_search's behavior when UC can't
+# tell us.
+_PG_TYPE_TO_LABEL: dict[str, str] = {
+    "text": "string",
+    "character varying": "string",
+    "varchar": "string",
+    "character": "string",
+    "char": "string",
+    "uuid": "string",
+    "integer": "number",
+    "bigint": "number",
+    "smallint": "number",
+    "numeric": "number",
+    "real": "number",
+    "double precision": "number",
+    "boolean": "boolean",
+    "date": "datetime",
+    "timestamp": "datetime",
+    "timestamp without time zone": "datetime",
+    "timestamp with time zone": "datetime",
+    "time": "datetime",
+    "time without time zone": "datetime",
+    "time with time zone": "datetime",
+    "ARRAY": "array",
+}
 
 
 class LakebaseSearchInput(BaseModel):
-    """Args exposed to the LLM for the ``lakebase_search`` tool."""
+    """Args exposed to the LLM for the ``lakebase_search`` tool.
+
+    ``filters`` uses the same shape as ``ai_search``: a JSON array of
+    ``{key, value}`` objects, where ``key`` is a column name optionally
+    suffixed with an operator (``"col"``, ``"col NOT"``, ``"col <="``,
+    ``"col LIKE"``, ``"col NOT LIKE"``, etc.). This class is the free-form
+    fallback — the factory replaces it with a per-tool ``Literal``-narrowed
+    subclass whenever it can enumerate the table's columns.
+    """
 
     query: str = Field(description="Natural-language search query.")
-    filters: Optional[dict[str, Any]] = Field(
+    filters: Optional[list[FilterItem]] = Field(
         default=None,
         description=(
-            "Optional metadata filters keyed by column name. "
-            "Values may be scalars (equality) or dicts of shape "
-            "``{op: <=|>=|=|!=|<|>|in|not_in|like|ilike|is_null, value|values: ...}``."
+            "Optional metadata filters. Pass a JSON array of objects, each "
+            "with 'key' and 'value'. Do NOT pass a flat dict. Example: "
+            '[{"key": "category", "value": "faq"}, '
+            '{"key": "priority >=", "value": 2}, '
+            '{"key": "status", "value": ["published", "reviewed"]}]. '
+            "The 'key' field is a column name optionally suffixed with an "
+            "operator: (none) equality, 'NOT' not-equals / not-in, "
+            "'< <= > >=' comparisons, 'LIKE' case-insensitive pattern "
+            "match, 'NOT LIKE' case-insensitive pattern exclude. "
+            "Omit or set to null when no filter applies."
         ),
     )
 
@@ -40,6 +98,103 @@ _DEFAULT_DESCRIPTION = (
     "vector similarity (ANN), BM25 lexical search, or hybrid (RRF) — depending on "
     "the retriever's configured query_type."
 )
+
+
+def _build_lakebase_search_input_model(
+    columns: list[str],
+    operator_overrides: dict[str, list[str]] | None = None,
+) -> type[BaseModel]:
+    """Return a per-tool ``LakebaseSearchInput`` whose ``filters[].key`` is
+    ``Literal``-narrowed to the actual column × suffix cross-product.
+
+    When ``columns`` is empty the free-form ``LakebaseSearchInput`` is
+    returned unchanged — matches the ai_search fallback path.
+    """
+    if not columns:
+        return LakebaseSearchInput
+
+    filter_item_cls = _build_filter_item_model(columns, operator_overrides)
+    return create_model(
+        "DynamicLakebaseSearchInput",
+        __base__=LakebaseSearchInput,
+        __module__=__name__,
+        filters=(
+            Optional[list[filter_item_cls]],  # type: ignore[valid-type]
+            Field(
+                default=None,
+                description=(
+                    "Optional metadata filters. Pass a JSON array of objects, "
+                    "each with 'key' and 'value'. The 'key' field is "
+                    "enumerated to the actual table columns × operator "
+                    "suffixes — an unlisted key is rejected. Omit or set to "
+                    "null when no filter applies."
+                ),
+            ),
+        ),
+    )
+
+
+def _fetch_lakebase_columns(
+    vector_store: LakebaseVectorStoreModel,
+) -> list[tuple[str, str | None, str | None]] | None:
+    """Return ``[(name, type_label, comment)]`` from Postgres.
+
+    Postgres analogue of ``_fetch_index_columns`` in vector_search.py. One
+    round-trip via the shared pool. Columns used internally by the retriever
+    (id / content / embedding / tsvector) are stripped so they don't appear
+    on the LLM-facing filter enum.
+
+    ``type_label`` is one of the ``ColumnInfo.type`` labels
+    (``"string" | "number" | "boolean" | "datetime" | "array"``) when
+    classifiable, or ``None`` when we can't map it. ``comment`` is the
+    Postgres column comment (``col_description(...)``) or ``None``.
+
+    Returns ``None`` on any failure — caller falls back to declared
+    ``metadata_columns`` if present, otherwise free-form filters.
+    """
+    from dao_ai.memory.postgres import PostgresPoolManager
+
+    reserved = {
+        vector_store.id_column,
+        vector_store.content_column,
+        vector_store.embedding_column,
+    }
+    if vector_store.tsvector_column:
+        reserved.add(vector_store.tsvector_column)
+
+    try:
+        pool = PostgresPoolManager.get_pool(vector_store.database)
+        with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                "SELECT column_name, data_type, "
+                "col_description("
+                "(quote_ident(table_schema)||'.'||quote_ident(table_name))::regclass, "
+                "ordinal_position) AS comment "
+                "FROM information_schema.columns "
+                "WHERE table_schema = %s AND table_name = %s "
+                "ORDER BY ordinal_position",
+                (vector_store.schema_name, vector_store.table),
+            )
+            rows = cur.fetchall()
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "Postgres information_schema lookup failed; column auto-discovery unavailable",
+            schema=vector_store.schema_name,
+            table=vector_store.table,
+            error=f"{type(e).__name__}: {e}",
+        )
+        return None
+
+    out: list[tuple[str, str | None, str | None]] = []
+    for row in rows:
+        name = row["column_name"]
+        if not name or name in reserved:
+            continue
+        pg_type = row.get("data_type")
+        label = _PG_TYPE_TO_LABEL.get(pg_type) if pg_type else None
+        comment = row.get("comment")
+        out.append((name, label, str(comment) if comment else None))
+    return out or None
 
 
 def create_lakebase_search_tool(
@@ -52,6 +207,11 @@ def create_lakebase_search_tool(
 
     Exactly one of ``retriever`` or ``vector_store`` must be supplied.
     Both accept dict literals (auto-coerced) for YAML friendliness.
+
+    The returned tool exposes a `list[FilterItem]` filter argument with a
+    per-tool `Literal`-narrowed `key` enum when the table's columns can be
+    resolved (Mode A hand-declared / Mode B declared + Postgres enrichment /
+    Mode C empty + Postgres discovery — same shape as ``create_ai_search_tool``).
     """
     if retriever is None and vector_store is None:
         raise ValueError(
@@ -72,27 +232,108 @@ def create_lakebase_search_tool(
         else:
             retriever_model = retriever
 
+    vs = retriever_model.vector_store
     lb_retriever = LakebaseRetriever(
-        vector_store=retriever_model.vector_store,
+        vector_store=vs,
         search_parameters=retriever_model.search_parameters,
     )
 
-    vs = retriever_model.vector_store
     tool_name = name or "lakebase_search"
     tool_description = description or _DEFAULT_DESCRIPTION
+
+    # --- Column source of truth — three modes, matching create_ai_search_tool
+    #
+    #   A. Hand-declared. Any item in retriever.columns is a ColumnInfo.
+    #      Names, types, descriptions, and per-column operator overrides
+    #      come straight from declaration. No Postgres call.
+    #   B. Bare strings only. Names from the declared list; Postgres
+    #      information_schema.columns is called best-effort for type +
+    #      description enrichment (used to auto-narrow ARRAY columns and
+    #      colour the tool description).
+    #   C. Empty. Discover names via information_schema.columns; soft-fall-
+    #      back to vector_store.metadata_columns if the query fails.
+    declared_items: list[Any] = list(
+        retriever_model.columns or vs.metadata_columns or []
+    )
+    (
+        declared_names,
+        declared_types,
+        declared_descriptions,
+        operator_overrides_raw,
+        any_hand_declared,
+    ) = _normalize_declared_columns(declared_items)
+    operator_overrides: dict[str, list[str]] = dict(operator_overrides_raw)
+
+    columns: list[str]
+    description_types: dict[str, str] = dict(declared_types)
+    description_descriptions: dict[str, str] = dict(declared_descriptions)
+
+    if any_hand_declared:
+        columns = declared_names
+    elif declared_names:
+        columns = declared_names
+        pg_cols = _fetch_lakebase_columns(vs)
+        if pg_cols:
+            pg_type_map = {n: t for n, t, _ in pg_cols if t}
+            pg_comment_map = {n: c for n, _, c in pg_cols if c}
+            for n in declared_names:
+                if n not in description_types and n in pg_type_map:
+                    description_types[n] = pg_type_map[n]
+                if n not in description_descriptions and n in pg_comment_map:
+                    description_descriptions[n] = pg_comment_map[n]
+    else:
+        pg_cols = _fetch_lakebase_columns(vs)
+        if pg_cols:
+            columns = [n for n, _, _ in pg_cols]
+            for n, t, c in pg_cols:
+                if t and n not in description_types:
+                    description_types[n] = t
+                if c and n not in description_descriptions:
+                    description_descriptions[n] = c
+        else:
+            columns = list(vs.metadata_columns or [])
+
+    # Array-typed columns get equality-only, unless the user set operators
+    # explicitly via ColumnInfo (which _normalize_declared_columns records
+    # in operator_overrides). Matches the ai_search behaviour.
+    for col_name, type_str in description_types.items():
+        if col_name in operator_overrides:
+            continue
+        if _is_array_type(type_str):
+            operator_overrides[col_name] = [""]
+
+    schema_cls = _build_lakebase_search_input_model(
+        columns, operator_overrides or None
+    )
+
+    logger.debug(
+        "Lakebase search columns resolved",
+        schema=vs.schema_name,
+        table=vs.table,
+        mode="hand-declared"
+        if any_hand_declared
+        else ("declared" if declared_names else "discovered"),
+        columns=columns,
+        overrides=operator_overrides,
+    )
 
     @mlflow.trace(name=tool_name, span_type=SpanType.RETRIEVER)
     def _lakebase_search(
         query: str,
-        filters: Optional[dict[str, Any]] = None,
+        filters: Optional[list[FilterItem]] = None,
     ) -> str:
-        call_filters: dict[str, Any] = {
-            **(retriever_model.search_parameters.filters or {}),
-            **(filters or {}),
-        }
-        # Merge without mutating the config's static filters.
+        # Convert LLM-provided FilterItem list → suffixed dict (matches
+        # ai_search's boundary conversion at vector_search.py:1303-1306).
+        runtime_dict: dict[str, Any] = {}
+        if filters:
+            for item in filters:
+                runtime_dict[item.key] = item.value
+
+        static_dict = dict(retriever_model.search_parameters.filters or {})
+        merged: dict[str, Any] = {**static_dict, **runtime_dict}
+
         effective_params = retriever_model.search_parameters.model_copy(
-            update={"filters": call_filters}
+            update={"filters": merged}
         )
         lb_retriever.search_parameters = effective_params
 
@@ -107,7 +348,7 @@ def create_lakebase_search_tool(
         func=_lakebase_search,
         name=tool_name,
         description=tool_description,
-        args_schema=LakebaseSearchInput,
+        args_schema=schema_cls,
     )
 
     logger.success(
@@ -116,6 +357,7 @@ def create_lakebase_search_tool(
         schema=vs.schema_name,
         table=vs.table,
         query_type=retriever_model.search_parameters.query_type,
+        filterable_columns=columns,
     )
     return tool
 

--- a/tests/dao_ai/test_lakebase_search.py
+++ b/tests/dao_ai/test_lakebase_search.py
@@ -22,6 +22,8 @@ import pytest
 from pydantic import ValidationError
 
 from dao_ai.config import (
+    ColumnInfo,
+    FilterItem,
     FunctionType,
     InferenceEndpointModel,
     LakebaseRetrieverModel,
@@ -177,6 +179,37 @@ class TestSqlBuilders:
         assert '"passage_tsv"' in rendered
         assert params == [5]
 
+    # ------------------------------------------------------------------
+    # Suffix-based WHERE clause tests — ai_search operator convention
+    # ------------------------------------------------------------------
+
+    def test_parse_filter_key_no_suffix(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        r = self._make(vector_store)
+        assert r._parse_filter_key("category") == ("category", "")
+
+    @pytest.mark.parametrize(
+        "key,expected",
+        [
+            ("category NOT", ("category", " NOT")),
+            ("priority <", ("priority", " <")),
+            ("priority <=", ("priority", " <=")),
+            ("priority >", ("priority", " >")),
+            ("priority >=", ("priority", " >=")),
+            ("source_url LIKE", ("source_url", " LIKE")),
+            ("source_url NOT LIKE", ("source_url", " NOT LIKE")),
+        ],
+    )
+    def test_parse_filter_key_suffixes(
+        self,
+        vector_store: LakebaseVectorStoreModel,
+        key: str,
+        expected: tuple[str, str],
+    ) -> None:
+        r = self._make(vector_store)
+        assert r._parse_filter_key(key) == expected
+
     def test_where_scalar_equality(
         self, vector_store: LakebaseVectorStoreModel
     ) -> None:
@@ -186,35 +219,75 @@ class TestSqlBuilders:
         assert '"category" = %s' in rendered
         assert params == ["faq"]
 
-    def test_where_in_operator(self, vector_store: LakebaseVectorStoreModel) -> None:
-        r = self._make(vector_store)
-        clause, params = r._build_where(
-            {"category": {"op": "in", "values": ["faq", "howto"]}}
-        )
-        rendered = clause.as_string(None)
-        assert '= ANY(%s)' in rendered
-        assert params == [["faq", "howto"]]
-
-    def test_where_comparison_operators(
+    def test_where_scalar_not(
         self, vector_store: LakebaseVectorStoreModel
     ) -> None:
         r = self._make(vector_store)
-        clause, params = r._build_where(
-            {"source_url": {"op": ">=", "value": "https://a"}}
-        )
+        clause, params = r._build_where({"category NOT": "faq"})
         rendered = clause.as_string(None)
-        assert '"source_url" >= %s' in rendered
+        assert '"category" <> %s' in rendered
+        assert params == ["faq"]
+
+    def test_where_in_via_list_value(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        r = self._make(vector_store)
+        clause, params = r._build_where({"category": ["faq", "howto"]})
+        assert '= ANY(%s)' in clause.as_string(None)
+        assert params == [["faq", "howto"]]
+
+    def test_where_not_in_via_list_value(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        r = self._make(vector_store)
+        clause, params = r._build_where({"category NOT": ["faq"]})
+        assert 'NOT ("category" = ANY(%s))' in clause.as_string(None)
+        assert params == [["faq"]]
+
+    @pytest.mark.parametrize(
+        "suffix,expected_op",
+        [(" <", "<"), (" <=", "<="), (" >", ">"), (" >=", ">=")],
+    )
+    def test_where_comparison_suffixes(
+        self,
+        vector_store: LakebaseVectorStoreModel,
+        suffix: str,
+        expected_op: str,
+    ) -> None:
+        r = self._make(vector_store)
+        clause, params = r._build_where({f"source_url{suffix}": "https://a"})
+        rendered = clause.as_string(None)
+        assert f'"source_url" {expected_op} %s' in rendered
         assert params == ["https://a"]
 
-    def test_where_is_null(self, vector_store: LakebaseVectorStoreModel) -> None:
+    def test_where_like_maps_to_ilike(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
         r = self._make(vector_store)
-        clause, _ = r._build_where({"category": {"op": "is_null"}})
-        assert '"category" IS NULL' in clause.as_string(None)
+        clause, params = r._build_where({"source_url LIKE": "%docs%"})
+        rendered = clause.as_string(None)
+        assert '"source_url" ILIKE %s' in rendered
+        assert params == ["%docs%"]
 
-        clause_neg, _ = r._build_where(
-            {"category": {"op": "is_null", "value": False}}
-        )
-        assert '"category" IS NOT NULL' in clause_neg.as_string(None)
+    def test_where_not_like_maps_to_not_ilike(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        r = self._make(vector_store)
+        clause, params = r._build_where({"source_url NOT LIKE": "%tmp%"})
+        rendered = clause.as_string(None)
+        assert 'NOT ("source_url" ILIKE %s)' in rendered
+        assert params == ["%tmp%"]
+
+    @pytest.mark.parametrize(
+        "key",
+        ["source_url <=", "source_url LIKE", "source_url NOT LIKE"],
+    )
+    def test_where_list_value_rejected_on_non_equality(
+        self, vector_store: LakebaseVectorStoreModel, key: str
+    ) -> None:
+        r = self._make(vector_store)
+        with pytest.raises(ValueError, match="list values"):
+            r._build_where({key: ["x", "y"]})
 
     def test_where_unknown_column_rejected(
         self, vector_store: LakebaseVectorStoreModel
@@ -223,12 +296,33 @@ class TestSqlBuilders:
         with pytest.raises(ValueError, match="Unknown filter column"):
             r._build_where({"totally_not_a_column": "x"})
 
-    def test_where_unsupported_op_rejected(
+    def test_where_unknown_column_rejected_with_suffix(
         self, vector_store: LakebaseVectorStoreModel
     ) -> None:
         r = self._make(vector_store)
-        with pytest.raises(ValueError, match="Unsupported filter op"):
-            r._build_where({"category": {"op": "regex", "value": "foo"}})
+        with pytest.raises(ValueError, match="Unknown filter column 'bogus'"):
+            r._build_where({"bogus >=": 1})
+
+    def test_stage1_op_form_rejected_at_llm_boundary(self) -> None:
+        """Regression guard at the correct layer — the FilterItem model on
+        the LLM-facing input rejects Stage 1's ``{op, value}`` dict value.
+        (``_build_where`` itself operates on already-normalized suffixed
+        keys and can't tell dict-values from other scalars — the shape
+        validation happens one level up.)"""
+        from pydantic import ValidationError
+
+        from dao_ai.tools.lakebase_search import _build_lakebase_search_input_model
+
+        cls = _build_lakebase_search_input_model(["category"])
+        with pytest.raises(ValidationError):
+            cls.model_validate(
+                {
+                    "query": "hi",
+                    "filters": [
+                        {"key": "category", "value": {"op": "in", "values": ["faq"]}}
+                    ],
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -366,7 +460,7 @@ class TestEndToEnd:
             search_parameters=SearchParametersModel(
                 query_type="ANN",
                 num_results=5,
-                filters={"category": "faq"},
+                filters={"category": "faq"},  # suffixed-key form (no suffix = equality)
             ),
         )
         with (
@@ -380,6 +474,32 @@ class TestEndToEnd:
         # Params: [vector, "faq", vector, limit]
         assert params[1] == "faq"
         assert params[-1] == 5
+
+    def test_ann_with_suffix_filter_injects_where(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """Static filter with operator suffix on the key ends up as the
+        matching Postgres predicate."""
+        from dao_ai.retrievers.lakebase import LakebaseRetriever
+
+        pool = _MockPool([])
+        r = LakebaseRetriever(
+            vector_store=vector_store,
+            search_parameters=SearchParametersModel(
+                query_type="ANN",
+                num_results=5,
+                filters={"source_url LIKE": "%docs%"},
+            ),
+        )
+        with (
+            patch.object(r, "_sync_pool", return_value=pool),
+            patch.object(r, "_embed", return_value=[0.0] * 1024),
+        ):
+            r.invoke("x")
+        stmt, params = pool.cursor.executed[0]
+        rendered = stmt.as_string(None)
+        assert '"source_url" ILIKE %s' in rendered
+        assert "%docs%" in params
 
     def test_bm25_returns_documents(
         self, vector_store: LakebaseVectorStoreModel
@@ -460,14 +580,358 @@ class TestFactory:
         pool = _MockPool(rows)
 
         tool = create_lakebase_search_tool(vector_store=vector_store.model_dump())
-        # Patch the retriever the tool closed over.
+        # Patch the retriever the tool closed over. Also stub the Postgres
+        # column-discovery lookup so the factory's Mode B/C path doesn't try
+        # a real connection.
         with (
+            patch(
+                "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+                return_value=None,
+            ),
             patch.object(LakebaseRetriever, "_sync_pool", return_value=pool),
             patch.object(LakebaseRetriever, "_embed", return_value=[0.0] * 1024),
         ):
+            tool = create_lakebase_search_tool(vector_store=vector_store.model_dump())
             output = tool.invoke({"query": "hi"})
 
         parsed = json.loads(output)
         assert isinstance(parsed, list)
         assert parsed[0]["page_content"] == "hello"
         assert parsed[0]["metadata"]["id"] == "d1"
+
+    def test_factory_runtime_filter_item_list(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """LLM-facing FilterItem list is converted to a suffixed dict at the
+        tool boundary and reaches _build_where correctly."""
+        from dao_ai.retrievers.lakebase import LakebaseRetriever
+        from dao_ai.tools import create_lakebase_search_tool
+
+        pool = _MockPool([])
+
+        with (
+            patch(
+                "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+                return_value=None,
+            ),
+            patch.object(LakebaseRetriever, "_sync_pool", return_value=pool),
+            patch.object(LakebaseRetriever, "_embed", return_value=[0.0] * 1024),
+        ):
+            tool = create_lakebase_search_tool(vector_store=vector_store.model_dump())
+            tool.invoke(
+                {
+                    "query": "hi",
+                    "filters": [
+                        {"key": "category", "value": "faq"},
+                        {"key": "source_url LIKE", "value": "%docs%"},
+                    ],
+                }
+            )
+
+        stmt, params = pool.cursor.executed[0]
+        rendered = stmt.as_string(None)
+        assert '"category" = %s' in rendered
+        assert '"source_url" ILIKE %s' in rendered
+        assert "faq" in params
+        assert "%docs%" in params
+
+    def test_factory_dynamic_schema_rejects_unlisted_key(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """When we can enumerate columns, the tool's args_schema narrows
+        `filters[].key` to a Literal — an unlisted key fails before we ever
+        reach the retriever."""
+        from dao_ai.tools import create_lakebase_search_tool
+
+        with patch(
+            "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+            # Simulate Postgres returning the metadata columns already known.
+            return_value=[("category", "string", None), ("priority", "number", None)],
+        ):
+            tool = create_lakebase_search_tool(vector_store=vector_store.model_dump())
+
+        # Invalid column key — the DynamicLakebaseSearchInput / DynamicFilterItem
+        # narrowing must reject it at Pydantic validation.
+        with pytest.raises(Exception):
+            tool.invoke(
+                {
+                    "query": "hi",
+                    "filters": [{"key": "does_not_exist", "value": "x"}],
+                }
+            )
+
+    def test_factory_free_form_filters_when_no_columns(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """When metadata_columns is empty AND Postgres discovery fails, the
+        factory falls back to the free-form LakebaseSearchInput schema."""
+        from dao_ai.tools import create_lakebase_search_tool
+        from dao_ai.tools.lakebase_search import LakebaseSearchInput
+
+        vs = LakebaseVectorStoreModel(**_vs_dict(metadata_columns=[]))
+        with patch(
+            "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+            return_value=None,
+        ):
+            tool = create_lakebase_search_tool(vector_store=vs.model_dump())
+        # args_schema is the base free-form model, not a Dynamic subclass.
+        assert tool.args_schema is LakebaseSearchInput
+
+    def test_factory_column_info_operator_narrowing(
+        self, database_model_dict: dict[str, Any] | None = None,
+    ) -> None:
+        """Hand-declared ColumnInfo with a narrower operator list is honored
+        end-to-end. Reaches the schema builder as an operator override so
+        the LLM sees only the allowed suffixes."""
+        from dao_ai.tools import create_lakebase_search_tool
+
+        vs = LakebaseVectorStoreModel(
+            **_vs_dict(),
+        )
+        # Hand-declared column, operators locked to equality + LIKE only.
+        retriever = LakebaseRetrieverModel(
+            vector_store=vs,
+            columns=[
+                ColumnInfo(name="category", type="string", operators=["", "LIKE"]),
+            ],
+        )
+        with patch(
+            "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+            return_value=None,  # would be skipped anyway in Mode A
+        ):
+            tool = create_lakebase_search_tool(retriever=retriever)
+
+        # A comparison suffix on the hand-declared column must be rejected
+        # by the args_schema Literal.
+        with pytest.raises(Exception):
+            tool.invoke(
+                {
+                    "query": "hi",
+                    "filters": [{"key": "category >=", "value": "x"}],
+                }
+            )
+
+
+# ---------------------------------------------------------------------------
+# Dynamic schema builder
+# ---------------------------------------------------------------------------
+
+
+class TestDynamicSchemaBuilder:
+    def test_empty_columns_returns_freeform(self) -> None:
+        from dao_ai.tools.lakebase_search import (
+            LakebaseSearchInput,
+            _build_lakebase_search_input_model,
+        )
+
+        cls = _build_lakebase_search_input_model([])
+        assert cls is LakebaseSearchInput
+
+    def test_narrowed_schema_accepts_declared_key(self) -> None:
+        from dao_ai.tools.lakebase_search import _build_lakebase_search_input_model
+
+        cls = _build_lakebase_search_input_model(["category", "priority"])
+        # Valid: bare column, and column-with-suffix.
+        inst = cls.model_validate(
+            {
+                "query": "hi",
+                "filters": [
+                    {"key": "category", "value": "faq"},
+                    {"key": "priority >=", "value": 2},
+                ],
+            }
+        )
+        assert len(inst.filters) == 2
+
+    def test_narrowed_schema_rejects_undeclared_key(self) -> None:
+        from pydantic import ValidationError
+
+        from dao_ai.tools.lakebase_search import _build_lakebase_search_input_model
+
+        cls = _build_lakebase_search_input_model(["category"])
+        with pytest.raises(ValidationError):
+            cls.model_validate(
+                {
+                    "query": "hi",
+                    "filters": [{"key": "not_a_column", "value": "x"}],
+                }
+            )
+
+    def test_operator_overrides_narrow_enum(self) -> None:
+        from pydantic import ValidationError
+
+        from dao_ai.tools.lakebase_search import _build_lakebase_search_input_model
+
+        cls = _build_lakebase_search_input_model(
+            ["category"], operator_overrides={"category": ["", "LIKE"]}
+        )
+        # Equality + LIKE allowed.
+        cls.model_validate(
+            {
+                "query": "hi",
+                "filters": [
+                    {"key": "category", "value": "faq"},
+                    {"key": "category LIKE", "value": "%faq%"},
+                ],
+            }
+        )
+        # Comparison NOT allowed under the override.
+        with pytest.raises(ValidationError):
+            cls.model_validate(
+                {
+                    "query": "hi",
+                    "filters": [{"key": "category >=", "value": "x"}],
+                }
+            )
+
+
+# ---------------------------------------------------------------------------
+# _fetch_lakebase_columns + Mode A/B/C dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestFetchLakebaseColumns:
+    def test_returns_none_on_pool_error(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        from dao_ai.tools.lakebase_search import _fetch_lakebase_columns
+
+        with patch(
+            "dao_ai.memory.postgres.PostgresPoolManager.get_pool",
+            side_effect=ConnectionError("nope"),
+        ):
+            assert _fetch_lakebase_columns(vector_store) is None
+
+    def test_strips_reserved_columns(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """Reserved columns (id/content/embedding/tsvector) never appear on
+        the LLM-facing filter enum."""
+        from dao_ai.tools.lakebase_search import _fetch_lakebase_columns
+
+        # information_schema returns everything; we should strip the 4 reserved.
+        rows = [
+            {"column_name": "id", "data_type": "text", "comment": None},
+            {"column_name": "passage", "data_type": "text", "comment": None},
+            {"column_name": "embedding", "data_type": "USER-DEFINED", "comment": None},
+            {"column_name": "passage_tsv", "data_type": "tsvector", "comment": None},
+            {"column_name": "category", "data_type": "text", "comment": "cat comment"},
+            {"column_name": "priority", "data_type": "integer", "comment": None},
+        ]
+        pool = _MockPool(rows)
+        with patch(
+            "dao_ai.memory.postgres.PostgresPoolManager.get_pool", return_value=pool
+        ):
+            out = _fetch_lakebase_columns(vector_store)
+
+        assert out is not None
+        names = [n for n, _, _ in out]
+        assert names == ["category", "priority"]
+        # Type mapping applied.
+        types = {n: t for n, t, _ in out}
+        assert types["category"] == "string"
+        assert types["priority"] == "number"
+        # Column comment surfaced.
+        comments = {n: c for n, _, c in out}
+        assert comments["category"] == "cat comment"
+
+
+class TestModeDispatch:
+    """Cover the 3 discovery-mode branches in create_lakebase_search_tool."""
+
+    def test_mode_a_hand_declared_skips_postgres(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        from dao_ai.tools import create_lakebase_search_tool
+
+        retriever = LakebaseRetrieverModel(
+            vector_store=vector_store,
+            columns=[ColumnInfo(name="category", type="string")],
+        )
+        with patch(
+            "dao_ai.tools.lakebase_search._fetch_lakebase_columns"
+        ) as mock_fetch:
+            create_lakebase_search_tool(retriever=retriever)
+            mock_fetch.assert_not_called()
+
+    def test_mode_b_bare_strings_calls_postgres_for_enrichment(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        from dao_ai.tools import create_lakebase_search_tool
+
+        # metadata_columns declares bare strings; ColumnInfo count == 0.
+        with patch(
+            "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+            return_value=[
+                ("category", "string", "cat comment"),
+                ("priority", "number", None),
+            ],
+        ) as mock_fetch:
+            create_lakebase_search_tool(vector_store=vector_store.model_dump())
+            mock_fetch.assert_called_once()
+
+    def test_mode_c_empty_metadata_columns_uses_discovery(self) -> None:
+        from dao_ai.tools import create_lakebase_search_tool
+
+        vs = LakebaseVectorStoreModel(**_vs_dict(metadata_columns=[]))
+        with patch(
+            "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+            return_value=[("discovered_col", "string", None)],
+        ) as mock_fetch:
+            tool = create_lakebase_search_tool(vector_store=vs.model_dump())
+            mock_fetch.assert_called_once()
+
+        # args_schema should be the dynamic subclass with `discovered_col`
+        # accepted as a key.
+        inst = tool.args_schema.model_validate(
+            {
+                "query": "hi",
+                "filters": [{"key": "discovered_col", "value": "x"}],
+            }
+        )
+        assert len(inst.filters) == 1
+
+    def test_mode_c_falls_back_to_metadata_columns_on_pg_error(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        from dao_ai.tools import create_lakebase_search_tool
+
+        # metadata_columns is set; simulate Postgres discovery failing.
+        with patch(
+            "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+            return_value=None,
+        ):
+            tool = create_lakebase_search_tool(vector_store=vector_store.model_dump())
+
+        # Enum built from declared metadata_columns.
+        inst = tool.args_schema.model_validate(
+            {
+                "query": "hi",
+                "filters": [{"key": "category", "value": "faq"}],
+            }
+        )
+        assert len(inst.filters) == 1
+
+    def test_array_column_narrowed_to_equality_only(self) -> None:
+        """When Postgres reports an ARRAY column type, the factory adds an
+        operator override so only equality is exposed on the LLM enum."""
+        from pydantic import ValidationError
+
+        from dao_ai.tools import create_lakebase_search_tool
+
+        vs = LakebaseVectorStoreModel(**_vs_dict(metadata_columns=[]))
+        with patch(
+            "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+            return_value=[("tags", "array", None)],
+        ):
+            tool = create_lakebase_search_tool(vector_store=vs.model_dump())
+
+        # Equality on the array column is fine.
+        tool.args_schema.model_validate(
+            {"query": "hi", "filters": [{"key": "tags", "value": ["a", "b"]}]}
+        )
+        # LIKE on an array column is NOT valid.
+        with pytest.raises(ValidationError):
+            tool.args_schema.model_validate(
+                {"query": "hi", "filters": [{"key": "tags LIKE", "value": "%x%"}]}
+            )

--- a/tests/dao_ai/test_lakebase_search_live.py
+++ b/tests/dao_ai/test_lakebase_search_live.py
@@ -219,6 +219,12 @@ def _retriever(
     filters: dict[str, Any] | None = None,
     k: int = 5,
 ) -> LakebaseRetriever:
+    """Build a retriever with static suffixed-key filters (config-time shape).
+
+    ``filters`` uses the ai_search-aligned dict form: keys are column names
+    optionally suffixed with an operator (``"col LIKE"``, ``"col >="``);
+    values may be scalars or lists (list ⇒ IN semantics).
+    """
     return LakebaseRetriever(
         vector_store=vs,
         search_parameters=SearchParametersModel(
@@ -292,7 +298,12 @@ class TestQueryTypes:
 
 
 class TestFilters:
-    """Live coverage for the operator allowlist in ``_build_where``."""
+    """Live coverage for the suffix-based operator convention in ``_build_where``.
+
+    Uses ai_search's suffixed-key dict shape (``"col LIKE"``, ``"col >="``,
+    plain ``"col"`` for equality, list value for IN). The LLM-facing
+    FilterItem list variant is exercised in :class:`TestToolFactory`.
+    """
 
     def test_scalar_equality(self, vector_store: LakebaseVectorStoreModel) -> None:
         docs = _retriever(
@@ -301,21 +312,25 @@ class TestFilters:
         assert docs
         assert all(d.metadata["category"] == "billing" for d in docs)
 
-    def test_in_operator(self, vector_store: LakebaseVectorStoreModel) -> None:
+    def test_in_via_list_value(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
         docs = _retriever(
             vector_store,
             "ANN",
-            filters={"category": {"op": "in", "values": ["returns", "shipping"]}},
+            filters={"category": ["returns", "shipping"]},
             k=10,
         ).invoke("order")
         assert docs
         assert all(d.metadata["category"] in {"returns", "shipping"} for d in docs)
 
-    def test_not_in_operator(self, vector_store: LakebaseVectorStoreModel) -> None:
+    def test_not_in_via_list_value_and_not_suffix(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
         docs = _retriever(
             vector_store,
             "ANN",
-            filters={"category": {"op": "not_in", "values": ["auth"]}},
+            filters={"category NOT": ["auth"]},
             k=10,
         ).invoke("account")
         assert docs
@@ -327,7 +342,7 @@ class TestFilters:
         docs = _retriever(
             vector_store,
             "ANN",
-            filters={"priority": {"op": ">=", "value": 2}},
+            filters={"priority >=": 2},
             k=10,
         ).invoke("service")
         assert docs
@@ -339,31 +354,49 @@ class TestFilters:
         docs = _retriever(
             vector_store,
             "ANN",
-            filters={"priority": {"op": "<", "value": 2}},
+            filters={"priority <": 2},
             k=10,
         ).invoke("service")
         assert docs
         assert all(d.metadata["priority"] < 2 for d in docs)
 
-    def test_not_equal(self, vector_store: LakebaseVectorStoreModel) -> None:
+    def test_not_equal_via_not_suffix(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
         docs = _retriever(
             vector_store,
             "ANN",
-            filters={"category": {"op": "!=", "value": "billing"}},
+            filters={"category NOT": "billing"},
             k=10,
         ).invoke("customer")
         assert docs
         assert all(d.metadata["category"] != "billing" for d in docs)
 
-    def test_ilike_operator(self, vector_store: LakebaseVectorStoreModel) -> None:
+    def test_like_is_case_insensitive(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """LIKE translates to ILIKE at the SQL layer — mixed-case pattern
+        still matches lower-case data."""
         docs = _retriever(
             vector_store,
             "ANN",
-            filters={"category": {"op": "ilike", "value": "ship%"}},
+            filters={"category LIKE": "SHIP%"},
             k=10,
         ).invoke("delivery")
         assert docs
         assert all(d.metadata["category"] == "shipping" for d in docs)
+
+    def test_not_like_excludes_matches(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        docs = _retriever(
+            vector_store,
+            "ANN",
+            filters={"category NOT LIKE": "auth%"},
+            k=10,
+        ).invoke("service")
+        assert docs
+        assert all(d.metadata["category"] != "auth" for d in docs)
 
     def test_filters_work_with_bm25(
         self, vector_store: LakebaseVectorStoreModel
@@ -383,7 +416,7 @@ class TestFilters:
         docs = _retriever(
             vector_store,
             "HYBRID",
-            filters={"category": {"op": "in", "values": ["returns", "billing"]}},
+            filters={"category": ["returns", "billing"]},
             k=5,
         ).invoke("get a refund")
         assert docs
@@ -395,6 +428,24 @@ class TestFilters:
         with pytest.raises(ValueError, match="Unknown filter column"):
             _retriever(
                 vector_store, "ANN", filters={"nonexistent_col": "x"}, k=3
+            ).invoke("anything")
+
+    def test_stage1_op_form_no_longer_supported(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """Stage-1 ``{op, value}`` dict values are no longer supported at
+        the retriever layer — the shape is treated as an unknown scalar
+        (which the DB then rejects). Regression guard so nobody
+        accidentally puts the Stage-1 form back on a static config and
+        gets a silent success."""
+        # Retriever accepts the shape as an "equality against a dict" and
+        # Postgres rejects at execute time. Assert we surface *some* error.
+        with pytest.raises(Exception):
+            _retriever(
+                vector_store,
+                "ANN",
+                filters={"category": {"op": "in", "values": ["faq"]}},
+                k=3,
             ).invoke("anything")
 
 
@@ -424,9 +475,11 @@ class TestToolFactory:
             assert "metadata" in item
             assert "id" in item["metadata"]
 
-    def test_tool_hybrid_with_filters(
+    def test_tool_hybrid_with_filter_item_list(
         self, vector_store: LakebaseVectorStoreModel
     ) -> None:
+        """LLM-facing FilterItem list is converted to a suffixed dict at the
+        tool boundary and reaches Postgres correctly."""
         tool = create_lakebase_search_tool(
             retriever=LakebaseRetrieverModel(
                 vector_store=vector_store,
@@ -438,9 +491,9 @@ class TestToolFactory:
         raw = tool.invoke(
             {
                 "query": "how do I get a refund?",
-                "filters": {
-                    "category": {"op": "in", "values": ["returns", "billing"]}
-                },
+                "filters": [
+                    {"key": "category", "value": ["returns", "billing"]},
+                ],
             }
         )
         parsed = json.loads(raw)
@@ -448,6 +501,51 @@ class TestToolFactory:
         assert all(
             item["metadata"]["category"] in {"returns", "billing"} for item in parsed
         )
+
+    def test_tool_dynamic_schema_rejects_unlisted_key(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """The tool's per-tool args_schema narrows filters[].key to a
+        Literal — an unlisted column is rejected by Pydantic before any
+        Postgres call happens."""
+        tool = create_lakebase_search_tool(
+            retriever=LakebaseRetrieverModel(
+                vector_store=vector_store,
+                search_parameters=SearchParametersModel(
+                    query_type="ANN", num_results=3
+                ),
+            )
+        )
+        with pytest.raises(Exception):
+            tool.invoke(
+                {
+                    "query": "hi",
+                    "filters": [{"key": "does_not_exist_col", "value": "x"}],
+                }
+            )
+
+    def test_tool_like_is_case_insensitive(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """End-to-end via the tool: LIKE with mixed-case pattern matches
+        lower-case data, proving LIKE→ILIKE flows through the whole stack."""
+        tool = create_lakebase_search_tool(
+            retriever=LakebaseRetrieverModel(
+                vector_store=vector_store,
+                search_parameters=SearchParametersModel(
+                    query_type="ANN", num_results=10
+                ),
+            )
+        )
+        raw = tool.invoke(
+            {
+                "query": "delivery",
+                "filters": [{"key": "category LIKE", "value": "SHIP%"}],
+            }
+        )
+        parsed = json.loads(raw)
+        assert parsed
+        assert all(item["metadata"]["category"] == "shipping" for item in parsed)
 
     def test_tool_from_vector_store_dict(
         self, database: DatabaseModel, seeded_table: None


### PR DESCRIPTION
## Summary

- `lakebase_search`'s LLM-facing filter argument is now `list[FilterItem]` (same class `ai_search` uses). Runtime + static filter grammars are unified with `ai_search`'s suffix convention (`"col LIKE"`, `"col >="`, `"col NOT"`, bare `"col"` for equality, list values for IN/NOT IN).
- Dynamic per-column `args_schema`: when the retriever can enumerate its columns, `filters[].key` is `Literal`-narrowed to the actual `columns × suffix` cross-product — the LLM sees the exact enum of legal keys, matching what `create_ai_search_tool` builds today.
- Column auto-discovery via `information_schema.columns` (Mode A hand-declared / Mode B declared + Postgres enrichment / Mode C empty + Postgres discovery). Mirrors ai_search's UC-Tables-based flow. Soft-fall-back to declared `metadata_columns` on any Postgres error.
- `LIKE` / `NOT LIKE` translate to Postgres `ILIKE` / `NOT ILIKE` (case-insensitive is the agent-friendly default). Stage 1's inner-op dict form (`{op: '>=', value: N}`) removed outright — no shim, no deprecation, per user judgment given Stage 1 has no adopters.
- Reuses `_build_filter_item_model` / `_normalize_declared_columns` / `_is_array_type` from `dao_ai.tools.vector_search` verbatim. No refactor to ai_search.
- ARRAY columns get equality-only in the operator enum (same as ai_search on VS-STANDARD indexes).

## Test plan

- [x] 62/62 unit tests (`tests/dao_ai/test_lakebase_search.py`) — up from 28. New coverage: `_parse_filter_key`, each suffix's SQL translation, LIKE→ILIKE, list-value rejection on non-equality suffixes, dynamic schema builder, `_fetch_lakebase_columns` mocked round-trip + reserved-column stripping, Mode A/B/C dispatch, ARRAY-column narrowing, and Stage-1-op-form-rejected regression.
- [x] 22/22 integration tests (`tests/dao_ai/test_lakebase_search_live.py -m integration`) against the retail-consumer-goods Lakebase project in FEVM — up from 18. All previous filter tests migrated to the suffixed-key / FilterItem-list shape. New tests for LIKE case-insensitive semantics (retriever + tool paths), NOT LIKE exclusion, dynamic schema rejecting unlisted keys, and Stage-1 op-form regression.
- [x] Deployed end-to-end to the `dao-ai-lakebase-e2e-03` Databricks App (rebuilt wheel + `dao-ai generate-bundle` + `databricks bundle deploy`). 4 chat queries → grounded answers. MLflow trace on the `lakebase_search` tool span now shows `input: {"filters":null,"query":...}` confirming the runtime-shape change flowed through the deployed agent.
- [x] All 5 example configs (`ann_only.yaml`, `hybrid_rrf.yaml`, `bm25_only.yaml`, `filters_and_traces.yaml`, new `dynamic_schema.yaml`) pass `dao-ai validate`.

## What's different from #156 (Stage 1)

| Concern | Stage 1 | This PR |
|---|---|---|
| LLM-facing runtime arg | `filters: dict[str, Any]` (free-form) | `filters: Optional[list[FilterItem]]` narrowed by `Literal` enum |
| Static YAML | `dict[col, {op, value|values}]` | `dict[col-with-suffix, value]` (ai_search convention) |
| Operator syntax | inner-op dict (`{op: 'in', values: [...]}`) | key-suffix (`"col NOT": [...]`) |
| Column knowledge in LLM schema | free-form dict, no enum | `Literal[col1, "col1 NOT", "col1 LIKE", ...]` |
| Column discovery | manual `metadata_columns` only | Auto via `information_schema.columns` + hand-declare via `ColumnInfo` |

## Files

- `src/dao_ai/tools/lakebase_search.py` — factory rewire (Mode A/B/C dispatch, `_build_lakebase_search_input_model`, `_fetch_lakebase_columns`), `LakebaseSearchInput.filters` retyped, FilterItem-list→suffixed-dict conversion at the boundary.
- `src/dao_ai/retrievers/lakebase.py` — new `_parse_filter_key`, rewritten `_build_where` for suffix-based translation, LIKE→ILIKE mapping.
- `tests/dao_ai/test_lakebase_search.py` — +34 unit tests (see above).
- `tests/dao_ai/test_lakebase_search_live.py` — +4 integration tests, existing 18 migrated.
- `config/examples/21_lakebase_search/filters_and_traces.yaml` — new suffixed-key filter shape.
- `config/examples/21_lakebase_search/dynamic_schema.yaml` — new example: hand-declared `ColumnInfo` with per-column operator narrowing.
- `config/examples/21_lakebase_search/README.md` — new Filter Operators + Dynamic Schema sections.

## Not in this PR (deferred)

- Rerank / instructed retrieval on `lakebase_search` (Stage 2 of the master plan).
- Auto-provisioning mode for the source table + extensions + embedding backfill (Stage 3).
- Extracting a shared `DaoAiBaseRetriever` from `AiSearchRetriever` + `LakebaseRetriever` — no visible duplication yet.

This pull request and its description were written by Isaac.