### PR TITLE
feat(lakebase-search): FlashRank reranking (Stage 2 PR A)

### DIFF
--- a/config/examples/21_lakebase_search/README.md
+++ b/config/examples/21_lakebase_search/README.md
@@ -67,6 +67,7 @@ flowchart TB
 | [`bm25_only.yaml`](./bm25_only.yaml) | BM25 | Exact-term lookup (SKUs, error codes) — no embedding calls |
 | [`filters_and_traces.yaml`](./filters_and_traces.yaml) | HYBRID | Static filters (equality / IN / comparison / LIKE) + `trace_location` to UC OTEL tables |
 | [`dynamic_schema.yaml`](./dynamic_schema.yaml) | HYBRID | Hand-declared `ColumnInfo` with per-column operator narrowing + LLM-facing descriptions (Mode A discovery) |
+| [`reranked.yaml`](./reranked.yaml) | HYBRID / ANN | FlashRank cross-encoder reranking (`rerank: true` shorthand + full `RerankParametersModel` form) |
 
 ## Prerequisites
 
@@ -247,3 +248,37 @@ cd /tmp/lakebase-agent
 databricks bundle deploy --target dev -p <profile>
 databricks bundle run dao-ai-lakebase-hybrid-example --target dev -p <profile>
 ```
+
+## Reranking
+
+FlashRank cross-encoder reranking, same shape ai_search uses. The retriever
+fetches `num_results` docs (ANN / BM25 / HYBRID); FlashRank then re-scores
+each `(query, doc)` pair and returns the top `rerank.top_n` in descending
+score order. Every returned `Document.metadata` carries a `reranker_score`
+field.
+
+```yaml
+retrievers:
+  kb_reranked:
+    vector_store: *products_vector_store
+    search_parameters:
+      num_results: 20                   # cast a wide net
+      query_type: HYBRID
+    rerank:                             # narrow to top-5 after cross-encoder
+      model: ms-marco-MiniLM-L-12-v2
+      top_n: 5
+```
+
+**`rerank: true` shorthand** — equivalent to
+`rerank: { model: ms-marco-MiniLM-L-12-v2 }` with no `top_n`, matching
+`ai_search`'s default coercion.
+
+**No serving endpoint required.** FlashRank is a local ONNX cross-encoder;
+weights download once to `~/.dao_ai/cache/flashrank/` (or
+`/tmp/dao_ai/cache/flashrank` under Databricks Apps / Model Serving).
+
+**Works with all three query types.** ANN / BM25 / HYBRID all produce a
+`list[Document]`; the same rerank pass runs on any of them. Verified live
+against `retail-consumer-goods`.
+
+See [`reranked.yaml`](./reranked.yaml) for a full config.

--- a/config/examples/21_lakebase_search/README.md
+++ b/config/examples/21_lakebase_search/README.md
@@ -66,6 +66,7 @@ flowchart TB
 | [`hybrid_rrf.yaml`](./hybrid_rrf.yaml) | HYBRID | Dense + lexical fused via RRF — highest recall |
 | [`bm25_only.yaml`](./bm25_only.yaml) | BM25 | Exact-term lookup (SKUs, error codes) — no embedding calls |
 | [`filters_and_traces.yaml`](./filters_and_traces.yaml) | HYBRID | Static filters (equality / IN / comparison / LIKE) + `trace_location` to UC OTEL tables |
+| [`dynamic_schema.yaml`](./dynamic_schema.yaml) | HYBRID | Hand-declared `ColumnInfo` with per-column operator narrowing + LLM-facing descriptions (Mode A discovery) |
 
 ## Prerequisites
 
@@ -134,24 +135,73 @@ Wraps a `LakebaseVectorStoreModel` with `SearchParametersModel`
 (`num_results`, `filters`, `query_type`). Enforces that
 `query_type in {BM25, HYBRID}` requires `tsvector_column`.
 
-### Filter operators
+### Filter operators (aligned with `ai_search`)
 
-Filter keys must appear in `metadata_columns` (allowlist enforced at query
-time). Values may be scalar (equality shorthand) or `{op, value}` /
-`{op, values}` dicts:
+Filter keys use the same suffix convention as `ai_search`: a column name
+optionally followed by a space and an operator token. Two shapes:
 
-| Op | SQL emitted | Value form |
+1. **LLM-facing runtime** (`list[FilterItem]`) — what the LLM emits:
+   ```json
+   [{"key": "category", "value": "auth"},
+    {"key": "priority >=", "value": 2},
+    {"key": "status", "value": ["published", "reviewed"]}]
+   ```
+2. **Static config** (`search_parameters.filters`, `dict[str, Any]`) —
+   what you write in YAML:
+   ```yaml
+   filters:
+     category: auth
+     "priority >=": 2
+     "status": [published, reviewed]
+   ```
+
+Both forms are merged at runtime before hitting Postgres.
+
+| Suffix | SQL emitted (scalar) | SQL emitted (list value) |
 |---|---|---|
-| `=` (or bare scalar) | `col = %s` | `value: <scalar>` |
-| `!=` | `col <> %s` | `value: <scalar>` |
-| `<`, `<=`, `>`, `>=` | `col <op> %s` | `value: <scalar>` |
-| `in` | `col = ANY(%s)` | `values: [...]` |
-| `not_in` | `NOT (col = ANY(%s))` | `values: [...]` |
-| `like`, `ilike` | `col LIKE %s` / `ILIKE %s` | `value: <pattern>` |
-| `is_null` | `col IS NULL` / `IS NOT NULL` | `value: true` / `false` (default `true`) |
+| *(none — equality)* | `col = %s` | `col = ANY(%s)` (IN) |
+| ` NOT` | `col <> %s` | `NOT (col = ANY(%s))` (NOT IN) |
+| ` <` ` <=` ` >` ` >=` | `col <op> %s` | *error — list value not supported* |
+| ` LIKE` | `col ILIKE %s` | *error* |
+| ` NOT LIKE` | `NOT (col ILIKE %s)` | *error* |
 
-Column names are wrapped in `psycopg.sql.Identifier`; values are always bound
-as `%s` parameters — no string interpolation ever.
+Notes:
+- **`LIKE` maps to Postgres `ILIKE`** (case-insensitive). Agent-friendly
+  default — LLMs reason about pattern match without caring about case, and
+  Vector Search's tokenized LIKE is likewise case-insensitive.
+- Column names come from `metadata_columns` on the vector store (or from
+  `retriever.columns` when hand-declared with `ColumnInfo`). Unknown keys
+  fail Pydantic validation at tool-call time; the LLM never sees them as
+  legal options.
+- Column names are wrapped in `psycopg.sql.Identifier`; values are always
+  bound as `%s` parameters — no string interpolation ever.
+- `IS NULL` / `IS NOT NULL` are intentionally not exposed — agents don't
+  reason well about null. Use a static `search_parameters.filters` entry
+  with a specific sentinel value if you need it.
+
+### Dynamic schema
+
+When the retriever can enumerate its columns (Mode A hand-declared /
+Mode B declared + Postgres enrichment / Mode C empty + Postgres discovery),
+the tool's `args_schema` narrows `filters[].key` to a `Literal[...]` of the
+actual `column × suffix` cross-product. The LLM sees the exact enum in its
+function-calling schema — no more guessing column names. Mirrors
+ai_search's `_build_filter_item_model`.
+
+Discovery calls Postgres exactly once per tool build:
+
+```sql
+SELECT column_name, data_type,
+       col_description(...::regclass, ordinal_position) AS comment
+FROM information_schema.columns
+WHERE table_schema = %s AND table_name = %s
+ORDER BY ordinal_position;
+```
+
+Columns used by the retriever internally (id / content / embedding /
+tsvector) are stripped so they don't appear on the LLM-facing filter enum.
+See [`dynamic_schema.yaml`](./dynamic_schema.yaml) for a hand-declared
+example that locks per-column operators via `ColumnInfo.operators`.
 
 ## MLflow tracing
 

--- a/config/examples/21_lakebase_search/dynamic_schema.yaml
+++ b/config/examples/21_lakebase_search/dynamic_schema.yaml
@@ -1,0 +1,103 @@
+# yaml-language-server: $schema=../../../schemas/model_config_schema.json
+
+# Hand-declared column schema for the LLM (Mode A discovery).
+#
+# `retriever.columns` accepts a mixed list of bare strings and ColumnInfo
+# entries. Any ColumnInfo item flips the factory to Mode A — the LLM-facing
+# args_schema is built entirely from the declaration; Postgres
+# information_schema.columns is NOT queried.
+#
+# ColumnInfo.operators locks a column to a subset of the 8 default
+# suffixes. Useful when:
+#   - You want to hide impossible-to-satisfy operators from the LLM (e.g.
+#     `priority LIKE` on an integer column).
+#   - You need to reserve a column for equality-only lookups (e.g. tenant
+#     IDs where LIKE would leak across tenants).
+#   - You want to add a rich `description` string that the LLM sees in the
+#     tool's args_schema (better filter accuracy).
+
+parameters:
+  lakebase_project:
+    description: Lakebase autoscaling Postgres project id
+    default: my-lakebase-project
+  schema_name:
+    default: dao_ai_kb
+  table_name:
+    default: kb_articles
+
+resources:
+  models:
+    default_llm: &default_llm
+      name: databricks-claude-sonnet-4-5
+
+  databases:
+    kb_lakebase: &kb_lakebase
+      project: ${var.lakebase_project}
+
+tools:
+  scoped_kb: &scoped_kb
+    name: scoped_kb
+    function:
+      type: lakebase_search
+      retriever:
+        vector_store:
+          database: *kb_lakebase
+          schema_name: ${var.schema_name}
+          table: ${var.table_name}
+          content_column: passage
+          embedding_column: embedding
+          tsvector_column: passage_tsv
+          embedding_model: databricks-gte-large-en
+          # metadata_columns still set for Document.metadata surfacing;
+          # columns below is what drives the LLM args_schema.
+          metadata_columns:
+            - category
+            - priority
+            - source_url
+        # Hand-declared columns (Mode A — no Postgres discovery call).
+        columns:
+          - name: category
+            type: string
+            operators:                   # locked to a subset of the 8 defaults
+              - ""
+              - LIKE
+            description: "Article category: auth, billing, shipping, returns"
+          - name: priority
+            type: number
+            operators:                   # comparison-only — LIKE makes no sense on an int
+              - ""
+              - "<"
+              - "<="
+              - ">"
+              - ">="
+            description: "Priority tier 1 (highest) - 5 (lowest)"
+          - name: source_url
+            type: string
+            description: "Canonical documentation URL"
+            # `operators` omitted → all 8 suffixes are legal (default).
+        search_parameters:
+          query_type: HYBRID
+          num_results: 5
+
+agents:
+  scoped_agent:
+    name: scoped_agent
+    model: *default_llm
+    tools:
+      - *scoped_kb
+    prompt: |
+      You answer knowledge-base questions. Prefer filtering on the
+      category or priority when the user's question implies scope.
+
+app:
+  name: dao-ai-lb-dyn-schema-example
+  registered_model:
+    name: dao_ai_lb_dyn_schema_example
+  agents:
+    - name: scoped_agent
+      model: *default_llm
+      tools:
+        - *scoped_kb
+      prompt: |
+        You answer knowledge-base questions. Prefer filtering on the
+        category or priority when the user's question implies scope.

--- a/config/examples/21_lakebase_search/filters_and_traces.yaml
+++ b/config/examples/21_lakebase_search/filters_and_traces.yaml
@@ -93,23 +93,23 @@ tools:
         search_parameters:
           query_type: HYBRID
           num_results: 5
+          # Filter keys follow ai_search's suffixed-key convention. The
+          # bare column name means equality; the LLM-facing FilterItem
+          # list uses the exact same suffix language.
+          #
+          # Supported suffixes (identical to ai_search):
+          #   ""          equality             ("col": <value>)
+          #   " NOT"      not-equals / not-in  ("col NOT": <value|list>)
+          #   " <" " <=" " >" " >="  comparisons
+          #   " LIKE"     case-insensitive     ("col LIKE": "pattern%")
+          #   " NOT LIKE" case-insensitive not ("col NOT LIKE": "pattern")
+          #
+          # A list value with the bare / NOT suffix triggers IN / NOT IN.
           filters:
-            # Scalar equality — bare value shorthand.
-            category: auth
-            # IN operator — dict-form with `values` list.
-            status:
-              op: in
-              values:
-                - published
-                - reviewed
-            # Comparison — dict-form with `value` scalar.
-            priority:
-              op: ">="
-              value: 2
-            # LIKE / ILIKE — case-sensitive / -insensitive pattern match.
-            source_url:
-              op: ilike
-              value: "https://docs.%.com/%"
+            category: auth                          # equality
+            "status": [published, reviewed]         # list value → IN
+            "priority >=": 2                        # comparison
+            "source_url LIKE": "https://docs.%.com/%"   # LIKE (Postgres ILIKE)
 
 agents:
   auth_agent:

--- a/config/examples/21_lakebase_search/reranked.yaml
+++ b/config/examples/21_lakebase_search/reranked.yaml
@@ -1,0 +1,103 @@
+# yaml-language-server: $schema=../../../schemas/model_config_schema.json
+
+# Lakebase Search with FlashRank cross-encoder reranking.
+#
+# The retriever fetches num_results docs from Lakebase (ANN/BM25/HYBRID),
+# then FlashRank re-scores each (query, doc) pair and returns the top_n
+# in descending score order. Each returned Document.metadata carries a
+# `reranker_score` field.
+#
+# FlashRank is a *local* cross-encoder — no serving endpoint required.
+# Model weights download once to ~/.dao_ai/cache/flashrank/ (or
+# /tmp/dao_ai/cache/flashrank under Databricks Apps / Model Serving).
+#
+# Same shape ai_search uses. Set `rerank: true` for the default
+# ms-marco-MiniLM-L-12-v2 model, or provide a RerankParametersModel for
+# a specific model + top_n.
+
+parameters:
+  lakebase_project:
+    description: Lakebase autoscaling Postgres project id
+    default: my-lakebase-project
+  schema_name:
+    default: dao_ai_kb
+  table_name:
+    default: kb_articles
+
+resources:
+  models:
+    default_llm: &default_llm
+      name: databricks-claude-sonnet-4-5
+
+  databases:
+    kb_lakebase: &kb_lakebase
+      project: ${var.lakebase_project}
+
+tools:
+  # Cast a wide net, then rerank down to the top 5 most relevant.
+  kb_reranked: &kb_reranked
+    name: kb_reranked
+    function:
+      type: lakebase_search
+      retriever:
+        vector_store:
+          database: *kb_lakebase
+          schema_name: ${var.schema_name}
+          table: ${var.table_name}
+          content_column: passage
+          embedding_column: embedding
+          tsvector_column: passage_tsv
+          embedding_model: databricks-gte-large-en
+          metadata_columns: [category, priority]
+        search_parameters:
+          query_type: HYBRID
+          num_results: 20                # broad recall — cast the wide net
+        rerank:
+          model: ms-marco-MiniLM-L-12-v2
+          top_n: 5                       # narrow to top-5 after reranking
+
+  # Simpler variant — bool defaults to ms-marco-MiniLM-L-12-v2, no top_n
+  # (returns all num_results docs, just reordered by rerank score).
+  kb_reranked_default: &kb_reranked_default
+    name: kb_reranked_default
+    function:
+      type: lakebase_search
+      retriever:
+        vector_store:
+          database: *kb_lakebase
+          schema_name: ${var.schema_name}
+          table: ${var.table_name}
+          content_column: passage
+          embedding_column: embedding
+          tsvector_column: passage_tsv
+          embedding_model: databricks-gte-large-en
+          metadata_columns: [category]
+        search_parameters:
+          query_type: ANN
+          num_results: 5
+        rerank: true                     # shorthand → default FlashRank model
+
+agents:
+  kb_agent:
+    name: kb_agent
+    model: *default_llm
+    tools:
+      - *kb_reranked
+    prompt: |
+      You are a knowledge-base assistant. Call kb_reranked to fetch the
+      top-5 most relevant documents (cross-encoder reranked) and answer
+      using only the retrieved content.
+
+app:
+  name: dao-ai-lb-reranked-example
+  registered_model:
+    name: dao_ai_lb_reranked_example
+  agents:
+    - name: kb_agent
+      model: *default_llm
+      tools:
+        - *kb_reranked
+      prompt: |
+        You are a knowledge-base assistant. Call kb_reranked to fetch the
+        top-5 most relevant documents (cross-encoder reranked) and answer
+        using only the retrieved content.

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -135,14 +135,29 @@ resources:
                                             # Raw "/Volumes/..." strings auto-promote
                                             # to VolumePathModel by the validator.
 
-# Retriever configurations
+# Retriever configurations — discriminated union of AiSearchRetrieverModel
+# and LakebaseRetrieverModel. The ``type`` field defaults to ``ai_search``
+# when omitted, so existing YAMLs continue to parse unchanged.
 retrievers:
-  retriever_name: &retriever_name
-    vector_store: *store_name
+  # AI Search retriever (default when ``type`` is omitted)
+  products_retriever: &products_retriever
+    type: ai_search                             # optional (default)
+    vector_store: *store_name                   # AiSearchIndexModel reference
     columns: [string]
     search_parameters:
       num_results: int
       query_type: ANN | HYBRID
+    rerank: bool | *rerank_params_model         # optional FlashRank / instruction-aware
+    instructed: *instructed_retriever_model     # optional query decomposition
+
+  # Lakebase Postgres retriever
+  kb_retriever: &kb_retriever
+    type: lakebase_search                       # required for the Lakebase branch
+    vector_store: *lakebase_vector_store_model  # LakebaseVectorStoreModel reference
+    columns: [string | *column_info]
+    search_parameters:
+      num_results: int
+      query_type: ANN | BM25 | HYBRID
 
 # Tool definitions
 tools:

--- a/docs/key-capabilities.md
+++ b/docs/key-capabilities.md
@@ -433,6 +433,8 @@ genie_tool:
 
 *(AI Search is the current Databricks name; older docs and configs may still call it Vector Search — dao-ai accepts both.)*
 
+> **`lakebase_search` parity (Stage 2, PR A):** the same `rerank` field with identical semantics is now available on `LakebaseRetrieverModel`. Set `rerank: true` for the default FlashRank model or provide a full `RerankParametersModel` — applies uniformly to the retriever's ANN, BM25, or HYBRID output. See [config/examples/21_lakebase_search/reranked.yaml](../config/examples/21_lakebase_search/reranked.yaml).
+
 **The problem:** AI Search (semantic similarity) is fast but sometimes returns loosely related results. It's like a librarian who quickly grabs 50 books that *might* be relevant.
 
 **The solution:** Reranking is like having an expert review those 50 books and pick the best 5 that *actually* answer your question.

--- a/notebooks/02_provision_vector_search.py
+++ b/notebooks/02_provision_vector_search.py
@@ -96,14 +96,18 @@ for _, vector_store in vector_stores.items():
 from typing import Dict, Any, List
 
 from databricks.vector_search.index import VectorSearchIndex
-from dao_ai.config import RetrieverModel
+from dao_ai.config import AiSearchRetrieverModel
 
 
 question: str = "How many grills do we have in stock?"
 
 for name, retriever in config.retrievers.items():
-  retriever: RetrieverModel
-  index: VectorSearchIndex = retriever.vector_store.as_index() 
+  # AppConfig.retrievers is a discriminated union of AiSearchRetrieverModel
+  # and LakebaseRetrieverModel. This notebook is Vector Search only, so
+  # skip Lakebase entries.
+  if not isinstance(retriever, AiSearchRetrieverModel):
+    continue
+  index: VectorSearchIndex = retriever.vector_store.as_index()
   k: int = 3
 
   search_results: Dict[str, Any] = index.similarity_search(

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -9,6 +9,7 @@ from os import PathLike
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     Callable,
     Final,
@@ -86,8 +87,10 @@ from pydantic import (
     AliasChoices,
     BaseModel,
     ConfigDict,
+    Discriminator,
     Field,
     PrivateAttr,
+    Tag,
     field_serializer,
     field_validator,
     model_validator,
@@ -4495,28 +4498,75 @@ class RankingResult(BaseModel):
     )
 
 
-class RetrieverModel(BaseModel):
-    """Retriever combining a vector store with search parameters, reranking, and instructed retrieval."""
+class RetrieverType(str, Enum):
+    """Discriminator values for the ``AnyRetriever`` discriminated union.
+
+    Values match the corresponding ``FunctionType`` tool aliases so YAML
+    ``retrievers:`` entries and ``tools[].function.type`` entries speak the
+    same vocabulary.
+    """
+
+    AI_SEARCH = "ai_search"
+    LAKEBASE_SEARCH = "lakebase_search"
+
+
+class BaseRetrieverModel(ABC, BaseModel):
+    """Common surface for all retriever configs.
+
+    Every concrete retriever exposes ``columns`` + ``search_parameters`` and
+    knows how to produce a ``StructuredTool`` via :meth:`as_tools`. Concrete
+    subclasses add a ``type`` discriminator field (Literal-narrowed) and a
+    ``vector_store`` field whose type is retriever-specific.
+    """
 
     model_config = ConfigDict(use_enum_values=True, extra="forbid")
-    vector_store: VectorStoreModel = Field(
-        description="Vector search index configuration used for similarity search.",
-    )
+
     columns: Optional[list[str | ColumnInfo]] = Field(
         default_factory=list,
         description=(
             "Columns to expose to the LLM as filterable + returnable. Accepts "
             "either bare strings (name only — types are discovered from the "
-            "index at build time via UC Tables) or ColumnInfo objects that "
-            "declare name / type / operators / description. Hand-declared "
-            "ColumnInfo items are authoritative and skip build-time discovery. "
-            "The two forms may be mixed in one list. Defaults to the vector "
-            "store's columns (bare strings)."
+            "index at build time) or ColumnInfo objects that declare name / "
+            "type / operators / description. Hand-declared ColumnInfo items "
+            "are authoritative and skip build-time discovery. The two forms "
+            "may be mixed in one list."
         ),
     )
     search_parameters: SearchParametersModel = Field(
         default_factory=SearchParametersModel,
         description="Search tuning: number of results, query type, and metadata filters.",
+    )
+
+    @abstractmethod
+    def as_tools(self, **kwargs: Any) -> Sequence[RunnableLike]:
+        """Build the retrieval tool(s) from this config.
+
+        Subclasses delegate to the matching factory
+        (``create_ai_search_tool`` / ``create_lakebase_search_tool``).
+        Signature mirrors :meth:`BaseFunctionModel.as_tools`.
+        """
+        ...
+
+
+class AiSearchRetrieverModel(BaseRetrieverModel):
+    """Retriever backed by a Databricks AI Search (formerly Vector Search) index.
+
+    (Formerly ``RetrieverModel``. Renamed to disambiguate now that Lakebase
+    Postgres has its own retriever config — see :class:`LakebaseRetrieverModel`.)
+    """
+
+    model_config = ConfigDict(use_enum_values=True, extra="forbid")
+
+    # String Literal instead of Literal[RetrieverType.AI_SEARCH] — Pydantic's
+    # use_enum_values doesn't coerce enum instances inside a Literal-typed
+    # field during model_dump, which broke yaml.safe_dump round-tripping.
+    # The enum values (:class:`RetrieverType`) still document the vocabulary.
+    type: Literal["ai_search"] = Field(
+        default="ai_search",
+        description="Discriminator. Must be 'ai_search' (or omitted — defaults).",
+    )
+    vector_store: VectorStoreModel = Field(
+        description="AI Search / Vector Search index configuration used for similarity search.",
     )
     rerank: Optional[RerankParametersModel | bool] = Field(
         default=None,
@@ -4543,6 +4593,11 @@ class RetrieverModel(BaseModel):
         if isinstance(self.rerank, bool) and self.rerank:
             self.rerank = RerankParametersModel(model="ms-marco-MiniLM-L-12-v2")
         return self
+
+    def as_tools(self, **kwargs: Any) -> Sequence[RunnableLike]:
+        from dao_ai.tools import create_ai_search_tool
+
+        return [create_ai_search_tool(retriever=self, **kwargs)]
 
 
 class LakebaseVectorStoreModel(BaseModel):
@@ -4651,28 +4706,23 @@ class LakebaseVectorStoreModel(BaseModel):
         return self
 
 
-class LakebaseRetrieverModel(BaseModel):
+class LakebaseRetrieverModel(BaseRetrieverModel):
     """Full Lakebase retriever config — vector store plus search parameters."""
 
     model_config = ConfigDict(use_enum_values=True, extra="forbid")
 
+    type: Literal["lakebase_search"] = Field(
+        default="lakebase_search",
+        description="Discriminator. Must be 'lakebase_search'.",
+    )
     vector_store: LakebaseVectorStoreModel = Field(
         description="Lakebase table + columns + embedding model.",
     )
-    columns: Optional[list[str | ColumnInfo]] = Field(
-        default_factory=list,
-        description=(
-            "Columns to expose to the LLM as filterable + returnable. "
-            "Defaults to ``vector_store.metadata_columns`` when unset."
-        ),
-    )
-    search_parameters: SearchParametersModel = Field(
-        default_factory=SearchParametersModel,
-        description=(
-            "Search tuning. For Lakebase, ``query_type`` accepts "
-            "``'ANN'``, ``'BM25'``, or ``'HYBRID'`` (RRF client-side)."
-        ),
-    )
+
+    # Note: ``columns`` and ``search_parameters`` are inherited from
+    # ``BaseRetrieverModel``. Description below repurposes the inherited
+    # ``columns`` default to draw from ``metadata_columns`` on the vector
+    # store rather than ``vector_store.columns`` (which doesn't exist here).
 
     @model_validator(mode="after")
     def _set_default_columns(self) -> Self:
@@ -4688,6 +4738,48 @@ class LakebaseRetrieverModel(BaseModel):
                 f"query_type={qt!r} requires 'tsvector_column' on the vector store."
             )
         return self
+
+    def as_tools(self, **kwargs: Any) -> Sequence[RunnableLike]:
+        from dao_ai.tools import create_lakebase_search_tool
+
+        return [create_lakebase_search_tool(retriever=self, **kwargs)]
+
+
+def _retriever_discriminator(v: Any) -> str:
+    """Callable discriminator for :data:`AnyRetriever`.
+
+    Pydantic v2 tagged unions do not honour Literal defaults on missing tag
+    fields — the tag must be present in the raw input. This callable
+    normalizes both dict input (YAML) and already-instantiated models to a
+    discriminator string, defaulting to ``"ai_search"`` when ``type`` is
+    absent. That's the load-bearing back-compat hook that lets existing
+    YAML ``retrievers:`` entries (which never specified ``type:``) keep
+    parsing as AI Search retrievers.
+    """
+    if isinstance(v, BaseRetrieverModel):
+        return v.type if isinstance(v.type, str) else v.type.value
+    if isinstance(v, dict):
+        raw = v.get("type")
+        if raw is None:
+            return RetrieverType.AI_SEARCH.value
+        return raw.value if isinstance(raw, RetrieverType) else str(raw)
+    raise ValueError(
+        f"cannot infer retriever discriminator from {type(v).__name__}"
+    )
+
+
+# Discriminated union — Pydantic dispatches to the concrete class using the
+# callable above. Existing YAML retriever entries that omit ``type`` default
+# to ``AiSearchRetrieverModel`` for back-compat. Each Union member needs an
+# explicit ``Tag`` because the discriminator is callable (Pydantic v2
+# requirement).
+AnyRetriever: TypeAlias = Annotated[
+    Union[
+        Annotated[AiSearchRetrieverModel, Tag(RetrieverType.AI_SEARCH.value)],
+        Annotated[LakebaseRetrieverModel, Tag(RetrieverType.LAKEBASE_SEARCH.value)],
+    ],
+    Discriminator(_retriever_discriminator),
+]
 
 
 class FunctionType(str, Enum):
@@ -5414,7 +5506,7 @@ class AiSearchToolModel(BaseFunctionModel):
             "or 'vector_search' (legacy alias)."
         ),
     )
-    retriever: Optional[RetrieverModel] = Field(
+    retriever: Optional[AiSearchRetrieverModel] = Field(
         default=None,
         description="Full retriever configuration with search parameters and reranking. Mutually exclusive with vector_store.",
     )
@@ -9395,9 +9487,15 @@ class AppConfig(BaseModel):
         default=None,
         description="Databricks resource declarations: LLMs, vector stores, Genie rooms, tables, warehouses, databases, and more.",
     )
-    retrievers: dict[str, RetrieverModel] = Field(
+    retrievers: dict[str, AnyRetriever] = Field(
         default_factory=dict,
-        description="Named retriever configurations combining a vector store with search parameters and optional reranking.",
+        description=(
+            "Named retriever configurations, keyed by name. Each entry is a "
+            "discriminated union — the ``type`` field selects between "
+            "``AiSearchRetrieverModel`` (default, `type: ai_search`) and "
+            "``LakebaseRetrieverModel`` (`type: lakebase_search`). Existing "
+            "YAMLs that omit ``type`` continue to parse as AI Search retrievers."
+        ),
     )
     tools: dict[str, ToolModel] = Field(
         default_factory=dict,

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -4718,6 +4718,17 @@ class LakebaseRetrieverModel(BaseRetrieverModel):
     vector_store: LakebaseVectorStoreModel = Field(
         description="Lakebase table + columns + embedding model.",
     )
+    rerank: Optional[RerankParametersModel | bool] = Field(
+        default=None,
+        description=(
+            "Optional FlashRank cross-encoder reranking pass over the "
+            "retriever's raw hits. Set to ``true`` for defaults, or "
+            "provide a ``RerankParametersModel`` for a specific model + "
+            "``top_n``. Applies to ANN / BM25 / HYBRID output uniformly. "
+            "For LLM instruction-aware reranking use ``instructed.rerank`` "
+            "instead."
+        ),
+    )
 
     # Note: ``columns`` and ``search_parameters`` are inherited from
     # ``BaseRetrieverModel``. Description below repurposes the inherited
@@ -4737,6 +4748,13 @@ class LakebaseRetrieverModel(BaseRetrieverModel):
             raise ValueError(
                 f"query_type={qt!r} requires 'tsvector_column' on the vector store."
             )
+        return self
+
+    @model_validator(mode="after")
+    def _set_default_reranker(self) -> Self:
+        """``rerank: true`` → default FlashRank model. Parity with ai_search."""
+        if isinstance(self.rerank, bool) and self.rerank:
+            self.rerank = RerankParametersModel(model="ms-marco-MiniLM-L-12-v2")
         return self
 
     def as_tools(self, **kwargs: Any) -> Sequence[RunnableLike]:

--- a/src/dao_ai/retrievers/lakebase.py
+++ b/src/dao_ai/retrievers/lakebase.py
@@ -38,8 +38,21 @@ _OPS_CLASS = {
     "l2": "vector_l2_ops",
     "ip": "vector_ip_ops",
 }
-_ALLOWED_OPS = {"=", "!=", "<", "<=", ">", ">=", "like", "ilike"}
 _RRF_K = 60
+
+# Filter-key suffixes we recognize on the dict keys reaching `_build_where`.
+# These match ai_search's `_FILTER_OPERATOR_SUFFIXES` (with the leading
+# space). Order matters — longest first so we don't misparse
+# `"col NOT LIKE"` as `"col NOT" + " LIKE"` or similar.
+_FILTER_SUFFIXES: tuple[str, ...] = (
+    " NOT LIKE",
+    " LIKE",
+    " <=",
+    " >=",
+    " NOT",
+    " <",
+    " >",
+)
 
 
 class LakebaseSearchMode(str, Enum):
@@ -150,53 +163,89 @@ class LakebaseRetriever(BaseRetriever):
             cols.extend(extra)
         return sql.SQL(", ").join(cols)
 
+    def _parse_filter_key(self, key: str) -> tuple[str, str]:
+        """Split ``"col SUFFIX"`` into ``(col, suffix)``.
+
+        Suffix is one of ``_FILTER_SUFFIXES`` (with leading space) or ``""``
+        for equality. Matches ai_search's operator-suffix convention on
+        ``FilterItem.key`` so downstream tooling / prompts are portable.
+        """
+        for suffix in _FILTER_SUFFIXES:
+            if key.endswith(suffix):
+                return key[: -len(suffix)], suffix
+        return key, ""
+
     def _build_where(
         self, filters: dict[str, Any]
     ) -> tuple[sql.Composable, list[Any]]:
-        """Translate a filter dict into a WHERE fragment + params.
+        """Translate a suffix-keyed filter dict into a WHERE fragment + params.
 
-        Unknown columns and operators raise ValueError before any SQL is built.
-        Values are always passed as parameters (``%s``); column names are
-        wrapped in ``sql.Identifier`` for safe quoting.
+        Keys use ai_search's operator-suffix convention (``"col LIKE"``,
+        ``"col >="``, ``"col NOT"``, plain ``"col"`` for equality). Values
+        may be scalars or lists — lists trigger IN semantics on the ``""`` /
+        ``" NOT"`` suffixes and are rejected on comparison / LIKE suffixes.
+
+        ``LIKE`` / ``NOT LIKE`` translate to Postgres ``ILIKE`` /
+        ``NOT ILIKE`` (case-insensitive is the agent-friendly default).
+
+        Unknown columns and operators raise ``ValueError`` before any SQL is
+        built. Column names are wrapped in ``sql.Identifier`` for safe
+        quoting; values are always bound as ``%s`` parameters.
         """
         if not filters:
             return sql.SQL(""), []
 
         clauses: list[sql.Composable] = []
         params: list[Any] = []
-        for key, spec in filters.items():
-            if key not in self._allowed_filter_cols:
+        for raw_key, value in filters.items():
+            col_name, suffix = self._parse_filter_key(raw_key)
+            if col_name not in self._allowed_filter_cols:
                 raise ValueError(
-                    f"Unknown filter column {key!r}; "
+                    f"Unknown filter column {col_name!r} (from key {raw_key!r}); "
                     f"allowed: {sorted(self._allowed_filter_cols)}"
                 )
-            col = sql.Identifier(key)
+            col = sql.Identifier(col_name)
+            is_list = isinstance(value, list)
 
-            if not isinstance(spec, dict):
-                clauses.append(sql.SQL("{} = %s").format(col))
-                params.append(spec)
-                continue
-
-            op = str(spec.get("op", "=")).lower()
-            if op == "in":
-                clauses.append(sql.SQL("{} = ANY(%s)").format(col))
-                params.append(list(spec["values"]))
-            elif op == "not_in":
-                clauses.append(sql.SQL("NOT ({} = ANY(%s))").format(col))
-                params.append(list(spec["values"]))
-            elif op == "is_null":
-                is_null = bool(spec.get("value", True))
-                clauses.append(
-                    sql.SQL("{} IS NULL").format(col)
-                    if is_null
-                    else sql.SQL("{} IS NOT NULL").format(col)
-                )
-            elif op in _ALLOWED_OPS:
-                op_sql = sql.SQL(op.upper()) if op in {"like", "ilike"} else sql.SQL(op)
+            if suffix == "":
+                if is_list:
+                    clauses.append(sql.SQL("{} = ANY(%s)").format(col))
+                    params.append(list(value))
+                else:
+                    clauses.append(sql.SQL("{} = %s").format(col))
+                    params.append(value)
+            elif suffix == " NOT":
+                if is_list:
+                    clauses.append(sql.SQL("NOT ({} = ANY(%s))").format(col))
+                    params.append(list(value))
+                else:
+                    clauses.append(sql.SQL("{} <> %s").format(col))
+                    params.append(value)
+            elif suffix in {" <", " <=", " >", " >="}:
+                if is_list:
+                    raise ValueError(
+                        f"Comparison suffix {suffix.strip()!r} on {col_name!r} "
+                        "does not support list values"
+                    )
+                op_sql = sql.SQL(suffix.strip())
                 clauses.append(sql.SQL("{} {} %s").format(col, op_sql))
-                params.append(spec["value"])
-            else:
-                raise ValueError(f"Unsupported filter op {op!r} on column {key!r}")
+                params.append(value)
+            elif suffix == " LIKE":
+                if is_list:
+                    raise ValueError(
+                        f"LIKE suffix on {col_name!r} does not support list values"
+                    )
+                clauses.append(sql.SQL("{} ILIKE %s").format(col))
+                params.append(value)
+            elif suffix == " NOT LIKE":
+                if is_list:
+                    raise ValueError(
+                        f"NOT LIKE suffix on {col_name!r} does not support list values"
+                    )
+                clauses.append(sql.SQL("NOT ({} ILIKE %s)").format(col))
+                params.append(value)
+            else:  # pragma: no cover — suffix set is closed
+                raise ValueError(f"Unsupported filter suffix {suffix!r}")
 
         return sql.SQL(" AND ") + sql.SQL(" AND ").join(clauses), params
 

--- a/src/dao_ai/tools/lakebase_search.py
+++ b/src/dao_ai/tools/lakebase_search.py
@@ -1,9 +1,11 @@
 """Factory for the ``lakebase_search`` first-class tool.
 
 Wraps ``dao_ai.retrievers.LakebaseRetriever`` in a LangChain ``StructuredTool``.
-Mirrors the shape of ``create_ai_search_tool`` (mutual exclusivity of
-``retriever`` vs ``vector_store``, dict-to-model coercion) so both tools have
-a consistent surface from YAML config.
+Mirrors ``create_ai_search_tool``: mutual exclusivity of ``retriever`` vs
+``vector_store``, dict-to-model coercion, a `list[FilterItem]` runtime
+argument with a per-tool `Literal`-narrowed key enum, and Mode A / B / C
+column discovery (hand-declared / declared + Postgres enrichment / empty +
+Postgres discovery).
 """
 
 from __future__ import annotations
@@ -15,22 +17,78 @@ import mlflow
 from langchain_core.tools import StructuredTool
 from loguru import logger
 from mlflow.entities import SpanType
-from pydantic import BaseModel, Field
+from psycopg import sql
+from psycopg.rows import dict_row
+from pydantic import BaseModel, Field, create_model
 
-from dao_ai.config import LakebaseRetrieverModel, LakebaseVectorStoreModel
+from dao_ai.config import (
+    ColumnInfo,
+    FilterItem,
+    LakebaseRetrieverModel,
+    LakebaseVectorStoreModel,
+)
 from dao_ai.retrievers.lakebase import LakebaseRetriever
+from dao_ai.tools.vector_search import (
+    _build_filter_item_model,
+    _is_array_type,
+    _normalize_declared_columns,
+)
+
+
+# Rough map from Postgres ``information_schema.columns.data_type`` values
+# to the labels ``ColumnInfo.type`` uses. Anything we can't classify falls
+# through as a bare "string" — matches ai_search's behavior when UC can't
+# tell us.
+_PG_TYPE_TO_LABEL: dict[str, str] = {
+    "text": "string",
+    "character varying": "string",
+    "varchar": "string",
+    "character": "string",
+    "char": "string",
+    "uuid": "string",
+    "integer": "number",
+    "bigint": "number",
+    "smallint": "number",
+    "numeric": "number",
+    "real": "number",
+    "double precision": "number",
+    "boolean": "boolean",
+    "date": "datetime",
+    "timestamp": "datetime",
+    "timestamp without time zone": "datetime",
+    "timestamp with time zone": "datetime",
+    "time": "datetime",
+    "time without time zone": "datetime",
+    "time with time zone": "datetime",
+    "ARRAY": "array",
+}
 
 
 class LakebaseSearchInput(BaseModel):
-    """Args exposed to the LLM for the ``lakebase_search`` tool."""
+    """Args exposed to the LLM for the ``lakebase_search`` tool.
+
+    ``filters`` uses the same shape as ``ai_search``: a JSON array of
+    ``{key, value}`` objects, where ``key`` is a column name optionally
+    suffixed with an operator (``"col"``, ``"col NOT"``, ``"col <="``,
+    ``"col LIKE"``, ``"col NOT LIKE"``, etc.). This class is the free-form
+    fallback — the factory replaces it with a per-tool ``Literal``-narrowed
+    subclass whenever it can enumerate the table's columns.
+    """
 
     query: str = Field(description="Natural-language search query.")
-    filters: Optional[dict[str, Any]] = Field(
+    filters: Optional[list[FilterItem]] = Field(
         default=None,
         description=(
-            "Optional metadata filters keyed by column name. "
-            "Values may be scalars (equality) or dicts of shape "
-            "``{op: <=|>=|=|!=|<|>|in|not_in|like|ilike|is_null, value|values: ...}``."
+            "Optional metadata filters. Pass a JSON array of objects, each "
+            "with 'key' and 'value'. Do NOT pass a flat dict. Example: "
+            '[{"key": "category", "value": "faq"}, '
+            '{"key": "priority >=", "value": 2}, '
+            '{"key": "status", "value": ["published", "reviewed"]}]. '
+            "The 'key' field is a column name optionally suffixed with an "
+            "operator: (none) equality, 'NOT' not-equals / not-in, "
+            "'< <= > >=' comparisons, 'LIKE' case-insensitive pattern "
+            "match, 'NOT LIKE' case-insensitive pattern exclude. "
+            "Omit or set to null when no filter applies."
         ),
     )
 
@@ -40,6 +98,103 @@ _DEFAULT_DESCRIPTION = (
     "vector similarity (ANN), BM25 lexical search, or hybrid (RRF) — depending on "
     "the retriever's configured query_type."
 )
+
+
+def _build_lakebase_search_input_model(
+    columns: list[str],
+    operator_overrides: dict[str, list[str]] | None = None,
+) -> type[BaseModel]:
+    """Return a per-tool ``LakebaseSearchInput`` whose ``filters[].key`` is
+    ``Literal``-narrowed to the actual column × suffix cross-product.
+
+    When ``columns`` is empty the free-form ``LakebaseSearchInput`` is
+    returned unchanged — matches the ai_search fallback path.
+    """
+    if not columns:
+        return LakebaseSearchInput
+
+    filter_item_cls = _build_filter_item_model(columns, operator_overrides)
+    return create_model(
+        "DynamicLakebaseSearchInput",
+        __base__=LakebaseSearchInput,
+        __module__=__name__,
+        filters=(
+            Optional[list[filter_item_cls]],  # type: ignore[valid-type]
+            Field(
+                default=None,
+                description=(
+                    "Optional metadata filters. Pass a JSON array of objects, "
+                    "each with 'key' and 'value'. The 'key' field is "
+                    "enumerated to the actual table columns × operator "
+                    "suffixes — an unlisted key is rejected. Omit or set to "
+                    "null when no filter applies."
+                ),
+            ),
+        ),
+    )
+
+
+def _fetch_lakebase_columns(
+    vector_store: LakebaseVectorStoreModel,
+) -> list[tuple[str, str | None, str | None]] | None:
+    """Return ``[(name, type_label, comment)]`` from Postgres.
+
+    Postgres analogue of ``_fetch_index_columns`` in vector_search.py. One
+    round-trip via the shared pool. Columns used internally by the retriever
+    (id / content / embedding / tsvector) are stripped so they don't appear
+    on the LLM-facing filter enum.
+
+    ``type_label`` is one of the ``ColumnInfo.type`` labels
+    (``"string" | "number" | "boolean" | "datetime" | "array"``) when
+    classifiable, or ``None`` when we can't map it. ``comment`` is the
+    Postgres column comment (``col_description(...)``) or ``None``.
+
+    Returns ``None`` on any failure — caller falls back to declared
+    ``metadata_columns`` if present, otherwise free-form filters.
+    """
+    from dao_ai.memory.postgres import PostgresPoolManager
+
+    reserved = {
+        vector_store.id_column,
+        vector_store.content_column,
+        vector_store.embedding_column,
+    }
+    if vector_store.tsvector_column:
+        reserved.add(vector_store.tsvector_column)
+
+    try:
+        pool = PostgresPoolManager.get_pool(vector_store.database)
+        with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                "SELECT column_name, data_type, "
+                "col_description("
+                "(quote_ident(table_schema)||'.'||quote_ident(table_name))::regclass, "
+                "ordinal_position) AS comment "
+                "FROM information_schema.columns "
+                "WHERE table_schema = %s AND table_name = %s "
+                "ORDER BY ordinal_position",
+                (vector_store.schema_name, vector_store.table),
+            )
+            rows = cur.fetchall()
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "Postgres information_schema lookup failed; column auto-discovery unavailable",
+            schema=vector_store.schema_name,
+            table=vector_store.table,
+            error=f"{type(e).__name__}: {e}",
+        )
+        return None
+
+    out: list[tuple[str, str | None, str | None]] = []
+    for row in rows:
+        name = row["column_name"]
+        if not name or name in reserved:
+            continue
+        pg_type = row.get("data_type")
+        label = _PG_TYPE_TO_LABEL.get(pg_type) if pg_type else None
+        comment = row.get("comment")
+        out.append((name, label, str(comment) if comment else None))
+    return out or None
 
 
 def create_lakebase_search_tool(
@@ -52,6 +207,11 @@ def create_lakebase_search_tool(
 
     Exactly one of ``retriever`` or ``vector_store`` must be supplied.
     Both accept dict literals (auto-coerced) for YAML friendliness.
+
+    The returned tool exposes a `list[FilterItem]` filter argument with a
+    per-tool `Literal`-narrowed `key` enum when the table's columns can be
+    resolved (Mode A hand-declared / Mode B declared + Postgres enrichment /
+    Mode C empty + Postgres discovery — same shape as ``create_ai_search_tool``).
     """
     if retriever is None and vector_store is None:
         raise ValueError(
@@ -72,27 +232,108 @@ def create_lakebase_search_tool(
         else:
             retriever_model = retriever
 
+    vs = retriever_model.vector_store
     lb_retriever = LakebaseRetriever(
-        vector_store=retriever_model.vector_store,
+        vector_store=vs,
         search_parameters=retriever_model.search_parameters,
     )
 
-    vs = retriever_model.vector_store
     tool_name = name or "lakebase_search"
     tool_description = description or _DEFAULT_DESCRIPTION
+
+    # --- Column source of truth — three modes, matching create_ai_search_tool
+    #
+    #   A. Hand-declared. Any item in retriever.columns is a ColumnInfo.
+    #      Names, types, descriptions, and per-column operator overrides
+    #      come straight from declaration. No Postgres call.
+    #   B. Bare strings only. Names from the declared list; Postgres
+    #      information_schema.columns is called best-effort for type +
+    #      description enrichment (used to auto-narrow ARRAY columns and
+    #      colour the tool description).
+    #   C. Empty. Discover names via information_schema.columns; soft-fall-
+    #      back to vector_store.metadata_columns if the query fails.
+    declared_items: list[Any] = list(
+        retriever_model.columns or vs.metadata_columns or []
+    )
+    (
+        declared_names,
+        declared_types,
+        declared_descriptions,
+        operator_overrides_raw,
+        any_hand_declared,
+    ) = _normalize_declared_columns(declared_items)
+    operator_overrides: dict[str, list[str]] = dict(operator_overrides_raw)
+
+    columns: list[str]
+    description_types: dict[str, str] = dict(declared_types)
+    description_descriptions: dict[str, str] = dict(declared_descriptions)
+
+    if any_hand_declared:
+        columns = declared_names
+    elif declared_names:
+        columns = declared_names
+        pg_cols = _fetch_lakebase_columns(vs)
+        if pg_cols:
+            pg_type_map = {n: t for n, t, _ in pg_cols if t}
+            pg_comment_map = {n: c for n, _, c in pg_cols if c}
+            for n in declared_names:
+                if n not in description_types and n in pg_type_map:
+                    description_types[n] = pg_type_map[n]
+                if n not in description_descriptions and n in pg_comment_map:
+                    description_descriptions[n] = pg_comment_map[n]
+    else:
+        pg_cols = _fetch_lakebase_columns(vs)
+        if pg_cols:
+            columns = [n for n, _, _ in pg_cols]
+            for n, t, c in pg_cols:
+                if t and n not in description_types:
+                    description_types[n] = t
+                if c and n not in description_descriptions:
+                    description_descriptions[n] = c
+        else:
+            columns = list(vs.metadata_columns or [])
+
+    # Array-typed columns get equality-only, unless the user set operators
+    # explicitly via ColumnInfo (which _normalize_declared_columns records
+    # in operator_overrides). Matches the ai_search behaviour.
+    for col_name, type_str in description_types.items():
+        if col_name in operator_overrides:
+            continue
+        if _is_array_type(type_str):
+            operator_overrides[col_name] = [""]
+
+    schema_cls = _build_lakebase_search_input_model(
+        columns, operator_overrides or None
+    )
+
+    logger.debug(
+        "Lakebase search columns resolved",
+        schema=vs.schema_name,
+        table=vs.table,
+        mode="hand-declared"
+        if any_hand_declared
+        else ("declared" if declared_names else "discovered"),
+        columns=columns,
+        overrides=operator_overrides,
+    )
 
     @mlflow.trace(name=tool_name, span_type=SpanType.RETRIEVER)
     def _lakebase_search(
         query: str,
-        filters: Optional[dict[str, Any]] = None,
+        filters: Optional[list[FilterItem]] = None,
     ) -> str:
-        call_filters: dict[str, Any] = {
-            **(retriever_model.search_parameters.filters or {}),
-            **(filters or {}),
-        }
-        # Merge without mutating the config's static filters.
+        # Convert LLM-provided FilterItem list → suffixed dict (matches
+        # ai_search's boundary conversion at vector_search.py:1303-1306).
+        runtime_dict: dict[str, Any] = {}
+        if filters:
+            for item in filters:
+                runtime_dict[item.key] = item.value
+
+        static_dict = dict(retriever_model.search_parameters.filters or {})
+        merged: dict[str, Any] = {**static_dict, **runtime_dict}
+
         effective_params = retriever_model.search_parameters.model_copy(
-            update={"filters": call_filters}
+            update={"filters": merged}
         )
         lb_retriever.search_parameters = effective_params
 
@@ -107,7 +348,7 @@ def create_lakebase_search_tool(
         func=_lakebase_search,
         name=tool_name,
         description=tool_description,
-        args_schema=LakebaseSearchInput,
+        args_schema=schema_cls,
     )
 
     logger.success(
@@ -116,6 +357,7 @@ def create_lakebase_search_tool(
         schema=vs.schema_name,
         table=vs.table,
         query_type=retriever_model.search_parameters.query_type,
+        filterable_columns=columns,
     )
     return tool
 

--- a/src/dao_ai/tools/lakebase_search.py
+++ b/src/dao_ai/tools/lakebase_search.py
@@ -26,12 +26,15 @@ from dao_ai.config import (
     FilterItem,
     LakebaseRetrieverModel,
     LakebaseVectorStoreModel,
+    RerankParametersModel,
 )
 from dao_ai.retrievers.lakebase import LakebaseRetriever
 from dao_ai.tools.vector_search import (
     _build_filter_item_model,
     _is_array_type,
     _normalize_declared_columns,
+    build_flashrank_ranker,
+    rerank_documents,
 )
 
 
@@ -317,6 +320,18 @@ def create_lakebase_search_tool(
         overrides=operator_overrides,
     )
 
+    # Optional FlashRank ranker — parity with ai_search. Reuses the shared
+    # helper from vector_search.py so both backends share the same init +
+    # ONNX-compatibility patching. Returns None when rerank is unset OR
+    # when init failed (soft-fail); the downstream "if ranker" guard
+    # handles both uniformly.
+    rerank_config = (
+        retriever_model.rerank
+        if isinstance(retriever_model.rerank, RerankParametersModel)
+        else None
+    )
+    ranker = build_flashrank_ranker(rerank_config)
+
     @mlflow.trace(name=tool_name, span_type=SpanType.RETRIEVER)
     def _lakebase_search(
         query: str,
@@ -338,6 +353,13 @@ def create_lakebase_search_tool(
         lb_retriever.search_parameters = effective_params
 
         docs = lb_retriever.invoke(query)
+
+        # Optional FlashRank cross-encoder pass. Same helper ai_search
+        # uses — reranker_score lands in each Document.metadata.
+        if ranker is not None and rerank_config is not None and docs:
+            logger.debug("Applying FlashRank reranking to Lakebase results")
+            docs = rerank_documents(query, docs, ranker, rerank_config)
+
         serialized = [
             {"page_content": d.page_content, "metadata": _jsonable(d.metadata)}
             for d in docs

--- a/src/dao_ai/tools/vector_search.py
+++ b/src/dao_ai/tools/vector_search.py
@@ -779,23 +779,30 @@ def create_ai_search_tool(
         columns = declared_names
         index_cols = _fetch_index_columns(vector_store)
         if index_cols:
-            uc_type_map = {name: t for name, t, _ in index_cols if t}
-            uc_comment_map = {name: c for name, _, c in index_cols if c}
-            for name in declared_names:
-                if name not in description_types and name in uc_type_map:
-                    description_types[name] = uc_type_map[name]
-                if name not in description_descriptions and name in uc_comment_map:
-                    description_descriptions[name] = uc_comment_map[name]
+            # NB: use ``col_name`` instead of ``name`` — the outer function
+            # takes a ``name`` parameter (the LLM-facing tool name), and
+            # binding ``name`` in a for-loop here shadows it. After the loop,
+            # ``name`` would leak the last declared column, and the eventual
+            # ``tool_name = name or ...`` (line ~1041) would pick up that
+            # stale value instead of the caller's tool name.
+            uc_type_map = {col_name: t for col_name, t, _ in index_cols if t}
+            uc_comment_map = {col_name: c for col_name, _, c in index_cols if c}
+            for col_name in declared_names:
+                if col_name not in description_types and col_name in uc_type_map:
+                    description_types[col_name] = uc_type_map[col_name]
+                if col_name not in description_descriptions and col_name in uc_comment_map:
+                    description_descriptions[col_name] = uc_comment_map[col_name]
     else:
         # Mode C — nothing declared. Discover via UC.
         index_cols = _fetch_index_columns(vector_store)
         if index_cols:
-            columns = [name for name, _, _ in index_cols]
-            for name, t, c in index_cols:
-                if t and name not in description_types:
-                    description_types[name] = t
-                if c and name not in description_descriptions:
-                    description_descriptions[name] = c
+            # Same ``col_name`` shadowing avoidance as above.
+            columns = [col_name for col_name, _, _ in index_cols]
+            for col_name, t, c in index_cols:
+                if t and col_name not in description_types:
+                    description_types[col_name] = t
+                if c and col_name not in description_descriptions:
+                    description_descriptions[col_name] = c
         else:
             # Direct-Access indexes: refresh may have populated
             # ``vector_store.columns`` from ``columns_to_sync``. Use those
@@ -807,11 +814,12 @@ def create_ai_search_tool(
     # every other operator on ARRAY columns at query time; narrowing the
     # enum prevents the LLM from emitting invalid filters in the first
     # place. Hand-declared overrides (via ColumnInfo.operators) still win.
-    for name, uc_type in description_types.items():
-        if name in operator_overrides:
+    # (``col_name`` again — see the shadowing note above.)
+    for col_name, uc_type in description_types.items():
+        if col_name in operator_overrides:
             continue
         if _is_array_type(uc_type):
-            operator_overrides[name] = [""]
+            operator_overrides[col_name] = [""]
 
     logger.debug(
         "Vector Search columns resolved",

--- a/src/dao_ai/tools/vector_search.py
+++ b/src/dao_ai/tools/vector_search.py
@@ -596,8 +596,99 @@ def _build_vector_search_input_model(
     )
 
 
+def build_flashrank_ranker(
+    rerank_config: Optional[RerankParametersModel],
+) -> Optional[Ranker]:
+    """Initialize a FlashRank ``Ranker`` from a rerank config, or ``None``.
+
+    Returns ``None`` when:
+    - ``rerank_config`` is ``None`` or has no ``model`` set (nothing to init).
+    - Ranker construction throws (soft-fail — logs a warning; caller should
+      skip reranking when the returned value is ``None``).
+
+    Under Databricks Model Serving the home directory isn't writable, so
+    the FlashRank cache is forced to ``/tmp/dao_ai/cache/flashrank`` (any
+    user-configured ``cache_dir`` is overridden with a warning).
+
+    Also installs an ONNX-compatibility patch on the returned ranker so
+    ``token_type_ids`` is always populated on the ONNX input tensor —
+    some ONNX runtimes require the key even when the model doesn't use
+    it, and FlashRank normally omits it when all zeros
+    (https://github.com/huggingface/optimum/issues/1500).
+
+    Shared by :func:`create_ai_search_tool` and
+    :func:`create_lakebase_search_tool` — same FlashRank init for both
+    backends.
+    """
+    if rerank_config is None or not rerank_config.model:
+        return None
+
+    logger.debug(
+        "Initializing FlashRank ranker",
+        model=rerank_config.model,
+        top_n=rerank_config.top_n or "auto",
+    )
+    try:
+        if is_in_model_serving():
+            cache_dir = "/tmp/dao_ai/cache/flashrank"
+            if rerank_config.cache_dir != cache_dir:
+                logger.warning(
+                    "FlashRank cache_dir overridden in Model Serving",
+                    configured=rerank_config.cache_dir,
+                    actual=cache_dir,
+                )
+        else:
+            cache_dir = os.path.expanduser(rerank_config.cache_dir)
+        ranker = Ranker(model_name=rerank_config.model, cache_dir=cache_dir)
+
+        # ONNX-compatibility patch — always emit token_type_ids.
+        if ranker.session is not None:
+            import numpy as np
+
+            _original_rerank = ranker.rerank  # noqa: F841 (kept for parity)
+
+            def _patched_rerank(request):
+                query = request.query
+                passages = request.passages
+                query_passage_pairs = [[query, p["text"]] for p in passages]
+
+                input_text = ranker.tokenizer.encode_batch(query_passage_pairs)
+                input_ids = np.array([e.ids for e in input_text])
+                token_type_ids = np.array([e.type_ids for e in input_text])
+                attention_mask = np.array([e.attention_mask for e in input_text])
+
+                onnx_input = {
+                    "input_ids": input_ids.astype(np.int64),
+                    "attention_mask": attention_mask.astype(np.int64),
+                    "token_type_ids": token_type_ids.astype(np.int64),
+                }
+
+                outputs = ranker.session.run(None, onnx_input)
+                logits = outputs[0]
+
+                if logits.shape[1] == 1:
+                    scores = 1 / (1 + np.exp(-logits.flatten()))
+                else:
+                    exp_logits = np.exp(logits)
+                    scores = exp_logits[:, 1] / np.sum(exp_logits, axis=1)
+
+                for score, passage in zip(scores, passages):
+                    passage["score"] = score
+
+                passages.sort(key=lambda x: x["score"], reverse=True)
+                return passages
+
+            ranker.rerank = _patched_rerank
+
+        logger.success("FlashRank ranker initialized", model=rerank_config.model)
+        return ranker
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Failed to initialize FlashRank ranker", error=str(e))
+        return None
+
+
 @mlflow.trace(name="rerank_documents", span_type=SpanType.RERANKER)
-def _rerank_documents(
+def rerank_documents(
     query: str,
     documents: list[Document],
     ranker: Ranker,
@@ -606,10 +697,14 @@ def _rerank_documents(
     """
     Rerank documents using FlashRank cross-encoder model.
 
+    Backend-agnostic — takes a ``list[Document]`` from any retriever
+    (`ai_search`, `lakebase_search`, ...) and returns a re-ordered list
+    with each doc's metadata carrying a ``reranker_score`` (0-1).
+
     Args:
         query: The search query string
         documents: List of documents to rerank
-        ranker: The FlashRank Ranker instance
+        ranker: The FlashRank Ranker instance (see :func:`build_flashrank_ranker`)
         rerank_config: Reranking configuration
 
     Returns:
@@ -851,75 +946,10 @@ def create_ai_search_tool(
         instructed_config.verifier if instructed_config else None
     )
 
-    # Initialize FlashRank ranker if configured
-    ranker: Optional[Ranker] = None
-    if rerank_config and rerank_config.model:
-        logger.debug(
-            "Initializing FlashRank ranker",
-            model=rerank_config.model,
-            top_n=rerank_config.top_n or "auto",
-        )
-        try:
-            # Use /tmp for cache in Model Serving (home dir may not be writable)
-            if is_in_model_serving():
-                cache_dir = "/tmp/dao_ai/cache/flashrank"
-                if rerank_config.cache_dir != cache_dir:
-                    logger.warning(
-                        "FlashRank cache_dir overridden in Model Serving",
-                        configured=rerank_config.cache_dir,
-                        actual=cache_dir,
-                    )
-            else:
-                cache_dir = os.path.expanduser(rerank_config.cache_dir)
-            ranker = Ranker(model_name=rerank_config.model, cache_dir=cache_dir)
-
-            # Patch rerank to always include token_type_ids for ONNX compatibility
-            # Some ONNX runtimes require token_type_ids even when the model doesn't use them
-            # FlashRank conditionally excludes them when all zeros, but ONNX may still expect them
-            # See: https://github.com/huggingface/optimum/issues/1500
-            if ranker.session is not None:
-                import numpy as np
-
-                _original_rerank = ranker.rerank
-
-                def _patched_rerank(request):
-                    query = request.query
-                    passages = request.passages
-                    query_passage_pairs = [[query, p["text"]] for p in passages]
-
-                    input_text = ranker.tokenizer.encode_batch(query_passage_pairs)
-                    input_ids = np.array([e.ids for e in input_text])
-                    token_type_ids = np.array([e.type_ids for e in input_text])
-                    attention_mask = np.array([e.attention_mask for e in input_text])
-
-                    # Always include token_type_ids (the fix for ONNX compatibility)
-                    onnx_input = {
-                        "input_ids": input_ids.astype(np.int64),
-                        "attention_mask": attention_mask.astype(np.int64),
-                        "token_type_ids": token_type_ids.astype(np.int64),
-                    }
-
-                    outputs = ranker.session.run(None, onnx_input)
-                    logits = outputs[0]
-
-                    if logits.shape[1] == 1:
-                        scores = 1 / (1 + np.exp(-logits.flatten()))
-                    else:
-                        exp_logits = np.exp(logits)
-                        scores = exp_logits[:, 1] / np.sum(exp_logits, axis=1)
-
-                    for score, passage in zip(scores, passages):
-                        passage["score"] = score
-
-                    passages.sort(key=lambda x: x["score"], reverse=True)
-                    return passages
-
-                ranker.rerank = _patched_rerank
-
-            logger.success("FlashRank ranker initialized", model=rerank_config.model)
-        except Exception as e:
-            logger.warning("Failed to initialize FlashRank ranker", error=str(e))
-            rerank_config = None
+    # Initialize FlashRank ranker if configured. On init failure the helper
+    # returns None and we skip the reranker; the downstream "if ranker" guard
+    # handles both "not configured" and "init failed" uniformly.
+    ranker: Optional[Ranker] = build_flashrank_ranker(rerank_config)
 
     # Log instructed retrieval configuration
     if instructed_config and decomposition_config:
@@ -1387,7 +1417,7 @@ def create_ai_search_tool(
             # Apply FlashRank reranking if configured
             if ranker and rerank_config and documents:
                 logger.debug("Applying FlashRank reranking")
-                documents = _rerank_documents(query, documents, ranker, rerank_config)
+                documents = rerank_documents(query, documents, ranker, rerank_config)
 
             # Apply instruction-aware reranking
             documents = _apply_post_processing(

--- a/src/dao_ai/tools/vector_search.py
+++ b/src/dao_ai/tools/vector_search.py
@@ -33,7 +33,7 @@ from dao_ai.config import (
     InstructedRetrieverModel,
     InstructionAwareRerankModel,
     RerankParametersModel,
-    RetrieverModel,
+    AiSearchRetrieverModel,
     RouterModel,
     SearchParametersModel,
     SearchQuery,
@@ -669,7 +669,7 @@ def _rerank_documents(
 
 
 def create_ai_search_tool(
-    retriever: Optional[RetrieverModel | dict[str, Any]] = None,
+    retriever: Optional[AiSearchRetrieverModel | dict[str, Any]] = None,
     vector_store: Optional[VectorStoreModel | dict[str, Any]] = None,
     name: Optional[str] = None,
     description: Optional[str] = None,
@@ -703,10 +703,10 @@ def create_ai_search_tool(
     if vector_store is not None:
         if isinstance(vector_store, dict):
             vector_store = VectorStoreModel(**vector_store)
-        retriever = RetrieverModel(vector_store=vector_store)
+        retriever = AiSearchRetrieverModel(vector_store=vector_store)
     else:
         if isinstance(retriever, dict):
-            retriever = RetrieverModel(**retriever)
+            retriever = AiSearchRetrieverModel(**retriever)
 
     vector_store: VectorStoreModel = retriever.vector_store
 

--- a/tests/dao_ai/test_instructed_retriever.py
+++ b/tests/dao_ai/test_instructed_retriever.py
@@ -13,7 +13,7 @@ from dao_ai.config import (
     FilterItem,
     InstructedRetrieverModel,
     LLMModel,
-    RetrieverModel,
+    AiSearchRetrieverModel,
     SearchQuery,
     VectorStoreModel,
 )
@@ -174,15 +174,15 @@ def create_mock_vector_store() -> Mock:
 
 @pytest.mark.unit
 class TestRetrieverModelWithInstructed:
-    """Unit tests for RetrieverModel with instructed configuration."""
+    """Unit tests for AiSearchRetrieverModel with instructed configuration."""
 
     def test_retriever_with_instructed(self) -> None:
-        """Test that RetrieverModel accepts instructed configuration."""
+        """Test that AiSearchRetrieverModel accepts instructed configuration."""
         vector_store = create_mock_vector_store()
 
         instructed = InstructedRetrieverModel(columns=BASIC_COLUMNS)
 
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vector_store,
             instructed=instructed,
         )
@@ -191,10 +191,10 @@ class TestRetrieverModelWithInstructed:
         assert len(retriever.instructed.columns) == 2
 
     def test_retriever_without_instructed(self) -> None:
-        """Test that RetrieverModel works without instructed."""
+        """Test that AiSearchRetrieverModel works without instructed."""
         vector_store = create_mock_vector_store()
 
-        retriever = RetrieverModel(vector_store=vector_store)
+        retriever = AiSearchRetrieverModel(vector_store=vector_store)
 
         assert retriever.instructed is None
 

--- a/tests/dao_ai/test_lakebase_search.py
+++ b/tests/dao_ai/test_lakebase_search.py
@@ -22,6 +22,8 @@ import pytest
 from pydantic import ValidationError
 
 from dao_ai.config import (
+    ColumnInfo,
+    FilterItem,
     FunctionType,
     InferenceEndpointModel,
     LakebaseRetrieverModel,
@@ -177,6 +179,37 @@ class TestSqlBuilders:
         assert '"passage_tsv"' in rendered
         assert params == [5]
 
+    # ------------------------------------------------------------------
+    # Suffix-based WHERE clause tests — ai_search operator convention
+    # ------------------------------------------------------------------
+
+    def test_parse_filter_key_no_suffix(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        r = self._make(vector_store)
+        assert r._parse_filter_key("category") == ("category", "")
+
+    @pytest.mark.parametrize(
+        "key,expected",
+        [
+            ("category NOT", ("category", " NOT")),
+            ("priority <", ("priority", " <")),
+            ("priority <=", ("priority", " <=")),
+            ("priority >", ("priority", " >")),
+            ("priority >=", ("priority", " >=")),
+            ("source_url LIKE", ("source_url", " LIKE")),
+            ("source_url NOT LIKE", ("source_url", " NOT LIKE")),
+        ],
+    )
+    def test_parse_filter_key_suffixes(
+        self,
+        vector_store: LakebaseVectorStoreModel,
+        key: str,
+        expected: tuple[str, str],
+    ) -> None:
+        r = self._make(vector_store)
+        assert r._parse_filter_key(key) == expected
+
     def test_where_scalar_equality(
         self, vector_store: LakebaseVectorStoreModel
     ) -> None:
@@ -186,35 +219,75 @@ class TestSqlBuilders:
         assert '"category" = %s' in rendered
         assert params == ["faq"]
 
-    def test_where_in_operator(self, vector_store: LakebaseVectorStoreModel) -> None:
-        r = self._make(vector_store)
-        clause, params = r._build_where(
-            {"category": {"op": "in", "values": ["faq", "howto"]}}
-        )
-        rendered = clause.as_string(None)
-        assert '= ANY(%s)' in rendered
-        assert params == [["faq", "howto"]]
-
-    def test_where_comparison_operators(
+    def test_where_scalar_not(
         self, vector_store: LakebaseVectorStoreModel
     ) -> None:
         r = self._make(vector_store)
-        clause, params = r._build_where(
-            {"source_url": {"op": ">=", "value": "https://a"}}
-        )
+        clause, params = r._build_where({"category NOT": "faq"})
         rendered = clause.as_string(None)
-        assert '"source_url" >= %s' in rendered
+        assert '"category" <> %s' in rendered
+        assert params == ["faq"]
+
+    def test_where_in_via_list_value(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        r = self._make(vector_store)
+        clause, params = r._build_where({"category": ["faq", "howto"]})
+        assert '= ANY(%s)' in clause.as_string(None)
+        assert params == [["faq", "howto"]]
+
+    def test_where_not_in_via_list_value(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        r = self._make(vector_store)
+        clause, params = r._build_where({"category NOT": ["faq"]})
+        assert 'NOT ("category" = ANY(%s))' in clause.as_string(None)
+        assert params == [["faq"]]
+
+    @pytest.mark.parametrize(
+        "suffix,expected_op",
+        [(" <", "<"), (" <=", "<="), (" >", ">"), (" >=", ">=")],
+    )
+    def test_where_comparison_suffixes(
+        self,
+        vector_store: LakebaseVectorStoreModel,
+        suffix: str,
+        expected_op: str,
+    ) -> None:
+        r = self._make(vector_store)
+        clause, params = r._build_where({f"source_url{suffix}": "https://a"})
+        rendered = clause.as_string(None)
+        assert f'"source_url" {expected_op} %s' in rendered
         assert params == ["https://a"]
 
-    def test_where_is_null(self, vector_store: LakebaseVectorStoreModel) -> None:
+    def test_where_like_maps_to_ilike(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
         r = self._make(vector_store)
-        clause, _ = r._build_where({"category": {"op": "is_null"}})
-        assert '"category" IS NULL' in clause.as_string(None)
+        clause, params = r._build_where({"source_url LIKE": "%docs%"})
+        rendered = clause.as_string(None)
+        assert '"source_url" ILIKE %s' in rendered
+        assert params == ["%docs%"]
 
-        clause_neg, _ = r._build_where(
-            {"category": {"op": "is_null", "value": False}}
-        )
-        assert '"category" IS NOT NULL' in clause_neg.as_string(None)
+    def test_where_not_like_maps_to_not_ilike(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        r = self._make(vector_store)
+        clause, params = r._build_where({"source_url NOT LIKE": "%tmp%"})
+        rendered = clause.as_string(None)
+        assert 'NOT ("source_url" ILIKE %s)' in rendered
+        assert params == ["%tmp%"]
+
+    @pytest.mark.parametrize(
+        "key",
+        ["source_url <=", "source_url LIKE", "source_url NOT LIKE"],
+    )
+    def test_where_list_value_rejected_on_non_equality(
+        self, vector_store: LakebaseVectorStoreModel, key: str
+    ) -> None:
+        r = self._make(vector_store)
+        with pytest.raises(ValueError, match="list values"):
+            r._build_where({key: ["x", "y"]})
 
     def test_where_unknown_column_rejected(
         self, vector_store: LakebaseVectorStoreModel
@@ -223,12 +296,33 @@ class TestSqlBuilders:
         with pytest.raises(ValueError, match="Unknown filter column"):
             r._build_where({"totally_not_a_column": "x"})
 
-    def test_where_unsupported_op_rejected(
+    def test_where_unknown_column_rejected_with_suffix(
         self, vector_store: LakebaseVectorStoreModel
     ) -> None:
         r = self._make(vector_store)
-        with pytest.raises(ValueError, match="Unsupported filter op"):
-            r._build_where({"category": {"op": "regex", "value": "foo"}})
+        with pytest.raises(ValueError, match="Unknown filter column 'bogus'"):
+            r._build_where({"bogus >=": 1})
+
+    def test_stage1_op_form_rejected_at_llm_boundary(self) -> None:
+        """Regression guard at the correct layer — the FilterItem model on
+        the LLM-facing input rejects Stage 1's ``{op, value}`` dict value.
+        (``_build_where`` itself operates on already-normalized suffixed
+        keys and can't tell dict-values from other scalars — the shape
+        validation happens one level up.)"""
+        from pydantic import ValidationError
+
+        from dao_ai.tools.lakebase_search import _build_lakebase_search_input_model
+
+        cls = _build_lakebase_search_input_model(["category"])
+        with pytest.raises(ValidationError):
+            cls.model_validate(
+                {
+                    "query": "hi",
+                    "filters": [
+                        {"key": "category", "value": {"op": "in", "values": ["faq"]}}
+                    ],
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -366,7 +460,7 @@ class TestEndToEnd:
             search_parameters=SearchParametersModel(
                 query_type="ANN",
                 num_results=5,
-                filters={"category": "faq"},
+                filters={"category": "faq"},  # suffixed-key form (no suffix = equality)
             ),
         )
         with (
@@ -380,6 +474,32 @@ class TestEndToEnd:
         # Params: [vector, "faq", vector, limit]
         assert params[1] == "faq"
         assert params[-1] == 5
+
+    def test_ann_with_suffix_filter_injects_where(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """Static filter with operator suffix on the key ends up as the
+        matching Postgres predicate."""
+        from dao_ai.retrievers.lakebase import LakebaseRetriever
+
+        pool = _MockPool([])
+        r = LakebaseRetriever(
+            vector_store=vector_store,
+            search_parameters=SearchParametersModel(
+                query_type="ANN",
+                num_results=5,
+                filters={"source_url LIKE": "%docs%"},
+            ),
+        )
+        with (
+            patch.object(r, "_sync_pool", return_value=pool),
+            patch.object(r, "_embed", return_value=[0.0] * 1024),
+        ):
+            r.invoke("x")
+        stmt, params = pool.cursor.executed[0]
+        rendered = stmt.as_string(None)
+        assert '"source_url" ILIKE %s' in rendered
+        assert "%docs%" in params
 
     def test_bm25_returns_documents(
         self, vector_store: LakebaseVectorStoreModel
@@ -460,14 +580,358 @@ class TestFactory:
         pool = _MockPool(rows)
 
         tool = create_lakebase_search_tool(vector_store=vector_store.model_dump())
-        # Patch the retriever the tool closed over.
+        # Patch the retriever the tool closed over. Also stub the Postgres
+        # column-discovery lookup so the factory's Mode B/C path doesn't try
+        # a real connection.
         with (
+            patch(
+                "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+                return_value=None,
+            ),
             patch.object(LakebaseRetriever, "_sync_pool", return_value=pool),
             patch.object(LakebaseRetriever, "_embed", return_value=[0.0] * 1024),
         ):
+            tool = create_lakebase_search_tool(vector_store=vector_store.model_dump())
             output = tool.invoke({"query": "hi"})
 
         parsed = json.loads(output)
         assert isinstance(parsed, list)
         assert parsed[0]["page_content"] == "hello"
         assert parsed[0]["metadata"]["id"] == "d1"
+
+    def test_factory_runtime_filter_item_list(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """LLM-facing FilterItem list is converted to a suffixed dict at the
+        tool boundary and reaches _build_where correctly."""
+        from dao_ai.retrievers.lakebase import LakebaseRetriever
+        from dao_ai.tools import create_lakebase_search_tool
+
+        pool = _MockPool([])
+
+        with (
+            patch(
+                "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+                return_value=None,
+            ),
+            patch.object(LakebaseRetriever, "_sync_pool", return_value=pool),
+            patch.object(LakebaseRetriever, "_embed", return_value=[0.0] * 1024),
+        ):
+            tool = create_lakebase_search_tool(vector_store=vector_store.model_dump())
+            tool.invoke(
+                {
+                    "query": "hi",
+                    "filters": [
+                        {"key": "category", "value": "faq"},
+                        {"key": "source_url LIKE", "value": "%docs%"},
+                    ],
+                }
+            )
+
+        stmt, params = pool.cursor.executed[0]
+        rendered = stmt.as_string(None)
+        assert '"category" = %s' in rendered
+        assert '"source_url" ILIKE %s' in rendered
+        assert "faq" in params
+        assert "%docs%" in params
+
+    def test_factory_dynamic_schema_rejects_unlisted_key(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """When we can enumerate columns, the tool's args_schema narrows
+        `filters[].key` to a Literal — an unlisted key fails before we ever
+        reach the retriever."""
+        from dao_ai.tools import create_lakebase_search_tool
+
+        with patch(
+            "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+            # Simulate Postgres returning the metadata columns already known.
+            return_value=[("category", "string", None), ("priority", "number", None)],
+        ):
+            tool = create_lakebase_search_tool(vector_store=vector_store.model_dump())
+
+        # Invalid column key — the DynamicLakebaseSearchInput / DynamicFilterItem
+        # narrowing must reject it at Pydantic validation.
+        with pytest.raises(Exception):
+            tool.invoke(
+                {
+                    "query": "hi",
+                    "filters": [{"key": "does_not_exist", "value": "x"}],
+                }
+            )
+
+    def test_factory_free_form_filters_when_no_columns(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """When metadata_columns is empty AND Postgres discovery fails, the
+        factory falls back to the free-form LakebaseSearchInput schema."""
+        from dao_ai.tools import create_lakebase_search_tool
+        from dao_ai.tools.lakebase_search import LakebaseSearchInput
+
+        vs = LakebaseVectorStoreModel(**_vs_dict(metadata_columns=[]))
+        with patch(
+            "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+            return_value=None,
+        ):
+            tool = create_lakebase_search_tool(vector_store=vs.model_dump())
+        # args_schema is the base free-form model, not a Dynamic subclass.
+        assert tool.args_schema is LakebaseSearchInput
+
+    def test_factory_column_info_operator_narrowing(
+        self, database_model_dict: dict[str, Any] | None = None,
+    ) -> None:
+        """Hand-declared ColumnInfo with a narrower operator list is honored
+        end-to-end. Reaches the schema builder as an operator override so
+        the LLM sees only the allowed suffixes."""
+        from dao_ai.tools import create_lakebase_search_tool
+
+        vs = LakebaseVectorStoreModel(
+            **_vs_dict(),
+        )
+        # Hand-declared column, operators locked to equality + LIKE only.
+        retriever = LakebaseRetrieverModel(
+            vector_store=vs,
+            columns=[
+                ColumnInfo(name="category", type="string", operators=["", "LIKE"]),
+            ],
+        )
+        with patch(
+            "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+            return_value=None,  # would be skipped anyway in Mode A
+        ):
+            tool = create_lakebase_search_tool(retriever=retriever)
+
+        # A comparison suffix on the hand-declared column must be rejected
+        # by the args_schema Literal.
+        with pytest.raises(Exception):
+            tool.invoke(
+                {
+                    "query": "hi",
+                    "filters": [{"key": "category >=", "value": "x"}],
+                }
+            )
+
+
+# ---------------------------------------------------------------------------
+# Dynamic schema builder
+# ---------------------------------------------------------------------------
+
+
+class TestDynamicSchemaBuilder:
+    def test_empty_columns_returns_freeform(self) -> None:
+        from dao_ai.tools.lakebase_search import (
+            LakebaseSearchInput,
+            _build_lakebase_search_input_model,
+        )
+
+        cls = _build_lakebase_search_input_model([])
+        assert cls is LakebaseSearchInput
+
+    def test_narrowed_schema_accepts_declared_key(self) -> None:
+        from dao_ai.tools.lakebase_search import _build_lakebase_search_input_model
+
+        cls = _build_lakebase_search_input_model(["category", "priority"])
+        # Valid: bare column, and column-with-suffix.
+        inst = cls.model_validate(
+            {
+                "query": "hi",
+                "filters": [
+                    {"key": "category", "value": "faq"},
+                    {"key": "priority >=", "value": 2},
+                ],
+            }
+        )
+        assert len(inst.filters) == 2
+
+    def test_narrowed_schema_rejects_undeclared_key(self) -> None:
+        from pydantic import ValidationError
+
+        from dao_ai.tools.lakebase_search import _build_lakebase_search_input_model
+
+        cls = _build_lakebase_search_input_model(["category"])
+        with pytest.raises(ValidationError):
+            cls.model_validate(
+                {
+                    "query": "hi",
+                    "filters": [{"key": "not_a_column", "value": "x"}],
+                }
+            )
+
+    def test_operator_overrides_narrow_enum(self) -> None:
+        from pydantic import ValidationError
+
+        from dao_ai.tools.lakebase_search import _build_lakebase_search_input_model
+
+        cls = _build_lakebase_search_input_model(
+            ["category"], operator_overrides={"category": ["", "LIKE"]}
+        )
+        # Equality + LIKE allowed.
+        cls.model_validate(
+            {
+                "query": "hi",
+                "filters": [
+                    {"key": "category", "value": "faq"},
+                    {"key": "category LIKE", "value": "%faq%"},
+                ],
+            }
+        )
+        # Comparison NOT allowed under the override.
+        with pytest.raises(ValidationError):
+            cls.model_validate(
+                {
+                    "query": "hi",
+                    "filters": [{"key": "category >=", "value": "x"}],
+                }
+            )
+
+
+# ---------------------------------------------------------------------------
+# _fetch_lakebase_columns + Mode A/B/C dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestFetchLakebaseColumns:
+    def test_returns_none_on_pool_error(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        from dao_ai.tools.lakebase_search import _fetch_lakebase_columns
+
+        with patch(
+            "dao_ai.memory.postgres.PostgresPoolManager.get_pool",
+            side_effect=ConnectionError("nope"),
+        ):
+            assert _fetch_lakebase_columns(vector_store) is None
+
+    def test_strips_reserved_columns(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """Reserved columns (id/content/embedding/tsvector) never appear on
+        the LLM-facing filter enum."""
+        from dao_ai.tools.lakebase_search import _fetch_lakebase_columns
+
+        # information_schema returns everything; we should strip the 4 reserved.
+        rows = [
+            {"column_name": "id", "data_type": "text", "comment": None},
+            {"column_name": "passage", "data_type": "text", "comment": None},
+            {"column_name": "embedding", "data_type": "USER-DEFINED", "comment": None},
+            {"column_name": "passage_tsv", "data_type": "tsvector", "comment": None},
+            {"column_name": "category", "data_type": "text", "comment": "cat comment"},
+            {"column_name": "priority", "data_type": "integer", "comment": None},
+        ]
+        pool = _MockPool(rows)
+        with patch(
+            "dao_ai.memory.postgres.PostgresPoolManager.get_pool", return_value=pool
+        ):
+            out = _fetch_lakebase_columns(vector_store)
+
+        assert out is not None
+        names = [n for n, _, _ in out]
+        assert names == ["category", "priority"]
+        # Type mapping applied.
+        types = {n: t for n, t, _ in out}
+        assert types["category"] == "string"
+        assert types["priority"] == "number"
+        # Column comment surfaced.
+        comments = {n: c for n, _, c in out}
+        assert comments["category"] == "cat comment"
+
+
+class TestModeDispatch:
+    """Cover the 3 discovery-mode branches in create_lakebase_search_tool."""
+
+    def test_mode_a_hand_declared_skips_postgres(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        from dao_ai.tools import create_lakebase_search_tool
+
+        retriever = LakebaseRetrieverModel(
+            vector_store=vector_store,
+            columns=[ColumnInfo(name="category", type="string")],
+        )
+        with patch(
+            "dao_ai.tools.lakebase_search._fetch_lakebase_columns"
+        ) as mock_fetch:
+            create_lakebase_search_tool(retriever=retriever)
+            mock_fetch.assert_not_called()
+
+    def test_mode_b_bare_strings_calls_postgres_for_enrichment(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        from dao_ai.tools import create_lakebase_search_tool
+
+        # metadata_columns declares bare strings; ColumnInfo count == 0.
+        with patch(
+            "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+            return_value=[
+                ("category", "string", "cat comment"),
+                ("priority", "number", None),
+            ],
+        ) as mock_fetch:
+            create_lakebase_search_tool(vector_store=vector_store.model_dump())
+            mock_fetch.assert_called_once()
+
+    def test_mode_c_empty_metadata_columns_uses_discovery(self) -> None:
+        from dao_ai.tools import create_lakebase_search_tool
+
+        vs = LakebaseVectorStoreModel(**_vs_dict(metadata_columns=[]))
+        with patch(
+            "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+            return_value=[("discovered_col", "string", None)],
+        ) as mock_fetch:
+            tool = create_lakebase_search_tool(vector_store=vs.model_dump())
+            mock_fetch.assert_called_once()
+
+        # args_schema should be the dynamic subclass with `discovered_col`
+        # accepted as a key.
+        inst = tool.args_schema.model_validate(
+            {
+                "query": "hi",
+                "filters": [{"key": "discovered_col", "value": "x"}],
+            }
+        )
+        assert len(inst.filters) == 1
+
+    def test_mode_c_falls_back_to_metadata_columns_on_pg_error(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        from dao_ai.tools import create_lakebase_search_tool
+
+        # metadata_columns is set; simulate Postgres discovery failing.
+        with patch(
+            "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+            return_value=None,
+        ):
+            tool = create_lakebase_search_tool(vector_store=vector_store.model_dump())
+
+        # Enum built from declared metadata_columns.
+        inst = tool.args_schema.model_validate(
+            {
+                "query": "hi",
+                "filters": [{"key": "category", "value": "faq"}],
+            }
+        )
+        assert len(inst.filters) == 1
+
+    def test_array_column_narrowed_to_equality_only(self) -> None:
+        """When Postgres reports an ARRAY column type, the factory adds an
+        operator override so only equality is exposed on the LLM enum."""
+        from pydantic import ValidationError
+
+        from dao_ai.tools import create_lakebase_search_tool
+
+        vs = LakebaseVectorStoreModel(**_vs_dict(metadata_columns=[]))
+        with patch(
+            "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+            return_value=[("tags", "array", None)],
+        ):
+            tool = create_lakebase_search_tool(vector_store=vs.model_dump())
+
+        # Equality on the array column is fine.
+        tool.args_schema.model_validate(
+            {"query": "hi", "filters": [{"key": "tags", "value": ["a", "b"]}]}
+        )
+        # LIKE on an array column is NOT valid.
+        with pytest.raises(ValidationError):
+            tool.args_schema.model_validate(
+                {"query": "hi", "filters": [{"key": "tags LIKE", "value": "%x%"}]}
+            )

--- a/tests/dao_ai/test_lakebase_search_live.py
+++ b/tests/dao_ai/test_lakebase_search_live.py
@@ -565,3 +565,152 @@ class TestToolFactory:
         )
         raw = tool.invoke({"query": "password"})
         assert json.loads(raw)
+
+
+# ---------------------------------------------------------------------------
+# Rerank (PR A)
+# ---------------------------------------------------------------------------
+
+
+class TestRerank:
+    """Live coverage for FlashRank reranking on lakebase_search output.
+
+    FlashRank is a local cross-encoder — no serving endpoint required.
+    First-time run downloads the model to `~/.dao_ai/cache/flashrank/`
+    (or `/tmp/dao_ai/cache/flashrank` under Model Serving).
+    """
+
+    def test_reranker_score_populated_on_every_doc(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        retriever = LakebaseRetrieverModel(
+            vector_store=vector_store,
+            rerank=True,  # default FlashRank model
+            search_parameters=SearchParametersModel(
+                query_type="ANN", num_results=10
+            ),
+        )
+        tool = create_lakebase_search_tool(retriever=retriever)
+        raw = tool.invoke({"query": "how do I reset my password?"})
+        parsed = json.loads(raw)
+        assert parsed
+        for d in parsed:
+            assert "reranker_score" in d["metadata"], d["metadata"]
+
+    def test_top_n_truncates(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        from dao_ai.config import RerankParametersModel
+
+        retriever = LakebaseRetrieverModel(
+            vector_store=vector_store,
+            rerank=RerankParametersModel(
+                model="ms-marco-MiniLM-L-12-v2", top_n=3
+            ),
+            search_parameters=SearchParametersModel(
+                query_type="ANN", num_results=10
+            ),
+        )
+        tool = create_lakebase_search_tool(retriever=retriever)
+        raw = tool.invoke({"query": "password"})
+        parsed = json.loads(raw)
+        assert len(parsed) == 3, f"top_n=3 → 3 docs, got {len(parsed)}"
+
+    def test_rerank_orders_by_score_descending(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        retriever = LakebaseRetrieverModel(
+            vector_store=vector_store,
+            rerank=True,
+            search_parameters=SearchParametersModel(
+                query_type="ANN", num_results=10
+            ),
+        )
+        tool = create_lakebase_search_tool(retriever=retriever)
+        raw = tool.invoke({"query": "password reset"})
+        parsed = json.loads(raw)
+        assert len(parsed) >= 2
+        scores = [d["metadata"]["reranker_score"] for d in parsed]
+        # Non-increasing order.
+        assert scores == sorted(scores, reverse=True), scores
+
+    def test_rerank_promotes_topically_relevant_top_1(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """Query 'password reset' → the seeded doc explicitly about
+        resetting passwords should rank #1 after FlashRank, even if the
+        raw ANN top-1 was a related-but-less-direct doc."""
+        retriever = LakebaseRetrieverModel(
+            vector_store=vector_store,
+            rerank=True,
+            search_parameters=SearchParametersModel(
+                query_type="ANN", num_results=10
+            ),
+        )
+        tool = create_lakebase_search_tool(retriever=retriever)
+        raw = tool.invoke({"query": "how do I reset my password?"})
+        parsed = json.loads(raw)
+        assert parsed
+        top_content = parsed[0]["page_content"].lower()
+        # Seeded doc d01: "To reset your password, go to Settings..."
+        # or d12: "Password reset links expire..." — either is a
+        # topically direct hit.
+        assert "reset" in top_content and "password" in top_content
+
+    def test_rerank_works_with_bm25(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        retriever = LakebaseRetrieverModel(
+            vector_store=vector_store,
+            rerank=True,
+            search_parameters=SearchParametersModel(
+                query_type="BM25", num_results=5
+            ),
+        )
+        tool = create_lakebase_search_tool(retriever=retriever)
+        raw = tool.invoke({"query": "password reset"})
+        parsed = json.loads(raw)
+        assert parsed
+        for d in parsed:
+            assert "reranker_score" in d["metadata"]
+
+    def test_rerank_works_with_hybrid(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        retriever = LakebaseRetrieverModel(
+            vector_store=vector_store,
+            rerank=True,
+            search_parameters=SearchParametersModel(
+                query_type="HYBRID", num_results=5
+            ),
+        )
+        tool = create_lakebase_search_tool(retriever=retriever)
+        raw = tool.invoke({"query": "reset my forgotten password"})
+        parsed = json.loads(raw)
+        assert parsed
+        for d in parsed:
+            assert "reranker_score" in d["metadata"]
+
+    def test_rerank_preserves_document_metadata(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """The rerank pass adds `reranker_score` on top of the retriever's
+        existing metadata — id, category, and per-mode score/distance
+        should still be there."""
+        retriever = LakebaseRetrieverModel(
+            vector_store=vector_store,
+            rerank=True,
+            search_parameters=SearchParametersModel(
+                query_type="ANN", num_results=5
+            ),
+        )
+        tool = create_lakebase_search_tool(retriever=retriever)
+        raw = tool.invoke({"query": "password"})
+        parsed = json.loads(raw)
+        assert parsed
+        for d in parsed:
+            m = d["metadata"]
+            assert "id" in m, m
+            assert "category" in m, m
+            assert "_distance" in m, m  # ANN metric
+            assert "reranker_score" in m, m

--- a/tests/dao_ai/test_lakebase_search_live.py
+++ b/tests/dao_ai/test_lakebase_search_live.py
@@ -219,6 +219,12 @@ def _retriever(
     filters: dict[str, Any] | None = None,
     k: int = 5,
 ) -> LakebaseRetriever:
+    """Build a retriever with static suffixed-key filters (config-time shape).
+
+    ``filters`` uses the ai_search-aligned dict form: keys are column names
+    optionally suffixed with an operator (``"col LIKE"``, ``"col >="``);
+    values may be scalars or lists (list ⇒ IN semantics).
+    """
     return LakebaseRetriever(
         vector_store=vs,
         search_parameters=SearchParametersModel(
@@ -292,7 +298,12 @@ class TestQueryTypes:
 
 
 class TestFilters:
-    """Live coverage for the operator allowlist in ``_build_where``."""
+    """Live coverage for the suffix-based operator convention in ``_build_where``.
+
+    Uses ai_search's suffixed-key dict shape (``"col LIKE"``, ``"col >="``,
+    plain ``"col"`` for equality, list value for IN). The LLM-facing
+    FilterItem list variant is exercised in :class:`TestToolFactory`.
+    """
 
     def test_scalar_equality(self, vector_store: LakebaseVectorStoreModel) -> None:
         docs = _retriever(
@@ -301,21 +312,25 @@ class TestFilters:
         assert docs
         assert all(d.metadata["category"] == "billing" for d in docs)
 
-    def test_in_operator(self, vector_store: LakebaseVectorStoreModel) -> None:
+    def test_in_via_list_value(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
         docs = _retriever(
             vector_store,
             "ANN",
-            filters={"category": {"op": "in", "values": ["returns", "shipping"]}},
+            filters={"category": ["returns", "shipping"]},
             k=10,
         ).invoke("order")
         assert docs
         assert all(d.metadata["category"] in {"returns", "shipping"} for d in docs)
 
-    def test_not_in_operator(self, vector_store: LakebaseVectorStoreModel) -> None:
+    def test_not_in_via_list_value_and_not_suffix(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
         docs = _retriever(
             vector_store,
             "ANN",
-            filters={"category": {"op": "not_in", "values": ["auth"]}},
+            filters={"category NOT": ["auth"]},
             k=10,
         ).invoke("account")
         assert docs
@@ -327,7 +342,7 @@ class TestFilters:
         docs = _retriever(
             vector_store,
             "ANN",
-            filters={"priority": {"op": ">=", "value": 2}},
+            filters={"priority >=": 2},
             k=10,
         ).invoke("service")
         assert docs
@@ -339,31 +354,49 @@ class TestFilters:
         docs = _retriever(
             vector_store,
             "ANN",
-            filters={"priority": {"op": "<", "value": 2}},
+            filters={"priority <": 2},
             k=10,
         ).invoke("service")
         assert docs
         assert all(d.metadata["priority"] < 2 for d in docs)
 
-    def test_not_equal(self, vector_store: LakebaseVectorStoreModel) -> None:
+    def test_not_equal_via_not_suffix(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
         docs = _retriever(
             vector_store,
             "ANN",
-            filters={"category": {"op": "!=", "value": "billing"}},
+            filters={"category NOT": "billing"},
             k=10,
         ).invoke("customer")
         assert docs
         assert all(d.metadata["category"] != "billing" for d in docs)
 
-    def test_ilike_operator(self, vector_store: LakebaseVectorStoreModel) -> None:
+    def test_like_is_case_insensitive(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """LIKE translates to ILIKE at the SQL layer — mixed-case pattern
+        still matches lower-case data."""
         docs = _retriever(
             vector_store,
             "ANN",
-            filters={"category": {"op": "ilike", "value": "ship%"}},
+            filters={"category LIKE": "SHIP%"},
             k=10,
         ).invoke("delivery")
         assert docs
         assert all(d.metadata["category"] == "shipping" for d in docs)
+
+    def test_not_like_excludes_matches(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        docs = _retriever(
+            vector_store,
+            "ANN",
+            filters={"category NOT LIKE": "auth%"},
+            k=10,
+        ).invoke("service")
+        assert docs
+        assert all(d.metadata["category"] != "auth" for d in docs)
 
     def test_filters_work_with_bm25(
         self, vector_store: LakebaseVectorStoreModel
@@ -383,7 +416,7 @@ class TestFilters:
         docs = _retriever(
             vector_store,
             "HYBRID",
-            filters={"category": {"op": "in", "values": ["returns", "billing"]}},
+            filters={"category": ["returns", "billing"]},
             k=5,
         ).invoke("get a refund")
         assert docs
@@ -395,6 +428,24 @@ class TestFilters:
         with pytest.raises(ValueError, match="Unknown filter column"):
             _retriever(
                 vector_store, "ANN", filters={"nonexistent_col": "x"}, k=3
+            ).invoke("anything")
+
+    def test_stage1_op_form_no_longer_supported(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """Stage-1 ``{op, value}`` dict values are no longer supported at
+        the retriever layer — the shape is treated as an unknown scalar
+        (which the DB then rejects). Regression guard so nobody
+        accidentally puts the Stage-1 form back on a static config and
+        gets a silent success."""
+        # Retriever accepts the shape as an "equality against a dict" and
+        # Postgres rejects at execute time. Assert we surface *some* error.
+        with pytest.raises(Exception):
+            _retriever(
+                vector_store,
+                "ANN",
+                filters={"category": {"op": "in", "values": ["faq"]}},
+                k=3,
             ).invoke("anything")
 
 
@@ -424,9 +475,11 @@ class TestToolFactory:
             assert "metadata" in item
             assert "id" in item["metadata"]
 
-    def test_tool_hybrid_with_filters(
+    def test_tool_hybrid_with_filter_item_list(
         self, vector_store: LakebaseVectorStoreModel
     ) -> None:
+        """LLM-facing FilterItem list is converted to a suffixed dict at the
+        tool boundary and reaches Postgres correctly."""
         tool = create_lakebase_search_tool(
             retriever=LakebaseRetrieverModel(
                 vector_store=vector_store,
@@ -438,9 +491,9 @@ class TestToolFactory:
         raw = tool.invoke(
             {
                 "query": "how do I get a refund?",
-                "filters": {
-                    "category": {"op": "in", "values": ["returns", "billing"]}
-                },
+                "filters": [
+                    {"key": "category", "value": ["returns", "billing"]},
+                ],
             }
         )
         parsed = json.loads(raw)
@@ -448,6 +501,51 @@ class TestToolFactory:
         assert all(
             item["metadata"]["category"] in {"returns", "billing"} for item in parsed
         )
+
+    def test_tool_dynamic_schema_rejects_unlisted_key(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """The tool's per-tool args_schema narrows filters[].key to a
+        Literal — an unlisted column is rejected by Pydantic before any
+        Postgres call happens."""
+        tool = create_lakebase_search_tool(
+            retriever=LakebaseRetrieverModel(
+                vector_store=vector_store,
+                search_parameters=SearchParametersModel(
+                    query_type="ANN", num_results=3
+                ),
+            )
+        )
+        with pytest.raises(Exception):
+            tool.invoke(
+                {
+                    "query": "hi",
+                    "filters": [{"key": "does_not_exist_col", "value": "x"}],
+                }
+            )
+
+    def test_tool_like_is_case_insensitive(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """End-to-end via the tool: LIKE with mixed-case pattern matches
+        lower-case data, proving LIKE→ILIKE flows through the whole stack."""
+        tool = create_lakebase_search_tool(
+            retriever=LakebaseRetrieverModel(
+                vector_store=vector_store,
+                search_parameters=SearchParametersModel(
+                    query_type="ANN", num_results=10
+                ),
+            )
+        )
+        raw = tool.invoke(
+            {
+                "query": "delivery",
+                "filters": [{"key": "category LIKE", "value": "SHIP%"}],
+            }
+        )
+        parsed = json.loads(raw)
+        assert parsed
+        assert all(item["metadata"]["category"] == "shipping" for item in parsed)
 
     def test_tool_from_vector_store_dict(
         self, database: DatabaseModel, seeded_table: None

--- a/tests/dao_ai/test_lakebase_search_rerank.py
+++ b/tests/dao_ai/test_lakebase_search_rerank.py
@@ -1,0 +1,429 @@
+"""Unit tests for lakebase_search's FlashRank rerank integration.
+
+Covers:
+- Config: `rerank: true` coerces to default FlashRank model; explicit
+  `RerankParametersModel` passes through; `rerank: false` and unset both
+  disable reranking.
+- Factory: `build_flashrank_ranker` invoked at factory init when rerank
+  is set; skipped when unset.
+- End-to-end (mocked): `rerank_documents` is called after retrieval;
+  `reranker_score` lands in each Document.metadata; ordering matches
+  the mocked ranker output; `top_n` truncation is honored.
+- Regression: factory works unchanged when `rerank` is unset (Stage 1
+  tests continue to pass — asserted by a null-rerank path here).
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dao_ai.config import (
+    LakebaseRetrieverModel,
+    LakebaseVectorStoreModel,
+    RerankParametersModel,
+    SearchParametersModel,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _vs_dict(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "database": {"project": "test-lakebase"},
+        "table": "kb_articles",
+        "content_column": "passage",
+        "embedding_column": "embedding",
+        "tsvector_column": "passage_tsv",
+        "embedding_model": "databricks-gte-large-en",
+        "metadata_columns": ["category"],
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture()
+def vector_store() -> LakebaseVectorStoreModel:
+    return LakebaseVectorStoreModel(**_vs_dict())
+
+
+# Mocked psycopg pool for the E2E rerank test path.
+class _MockCursor:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+        self.executed: list[tuple[Any, Any]] = []
+
+    def __enter__(self) -> "_MockCursor":
+        return self
+
+    def __exit__(self, *a: Any) -> None:
+        pass
+
+    def execute(self, stmt: Any, params: Any) -> None:
+        self.executed.append((stmt, params))
+
+    def fetchall(self) -> list[dict[str, Any]]:
+        return self._rows
+
+
+class _MockConn:
+    def __init__(self, cursor: _MockCursor) -> None:
+        self._cursor = cursor
+
+    def __enter__(self) -> "_MockConn":
+        return self
+
+    def __exit__(self, *a: Any) -> None:
+        pass
+
+    def cursor(self, **_kw: Any) -> _MockCursor:
+        return self._cursor
+
+
+class _MockPool:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.cursor = _MockCursor(rows)
+
+    @contextmanager
+    def connection(self):
+        yield _MockConn(self.cursor)
+
+
+# ---------------------------------------------------------------------------
+# Config coercion
+# ---------------------------------------------------------------------------
+
+
+class TestRerankConfig:
+    def test_rerank_true_coerces_to_default_model(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        r = LakebaseRetrieverModel(vector_store=vector_store, rerank=True)
+        assert isinstance(r.rerank, RerankParametersModel)
+        assert r.rerank.model == "ms-marco-MiniLM-L-12-v2"
+
+    def test_rerank_false_stays_false(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        r = LakebaseRetrieverModel(vector_store=vector_store, rerank=False)
+        assert r.rerank is False
+
+    def test_rerank_none_default(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        r = LakebaseRetrieverModel(vector_store=vector_store)
+        assert r.rerank is None
+
+    def test_explicit_rerank_params_pass_through(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        params = RerankParametersModel(
+            model="ms-marco-TinyBERT-L-2-v2", top_n=3
+        )
+        r = LakebaseRetrieverModel(vector_store=vector_store, rerank=params)
+        assert r.rerank is params
+        assert r.rerank.model == "ms-marco-TinyBERT-L-2-v2"
+        assert r.rerank.top_n == 3
+
+    def test_yaml_dict_form_validates(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """YAML-friendly dict form on the rerank field."""
+        r = LakebaseRetrieverModel.model_validate(
+            {
+                "vector_store": vector_store.model_dump(),
+                "rerank": {"model": "ms-marco-MiniLM-L-12-v2", "top_n": 5},
+            }
+        )
+        assert isinstance(r.rerank, RerankParametersModel)
+        assert r.rerank.top_n == 5
+
+
+# ---------------------------------------------------------------------------
+# Factory: build_flashrank_ranker is invoked when configured
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryRankerInit:
+    def test_ranker_built_when_rerank_set(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        from dao_ai.tools import create_lakebase_search_tool
+
+        retriever = LakebaseRetrieverModel(vector_store=vector_store, rerank=True)
+        with (
+            patch(
+                "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+                return_value=None,
+            ),
+            patch(
+                "dao_ai.tools.lakebase_search.build_flashrank_ranker"
+            ) as mock_builder,
+        ):
+            mock_builder.return_value = MagicMock(name="Ranker")
+            create_lakebase_search_tool(retriever=retriever)
+            mock_builder.assert_called_once()
+            # Passed the coerced RerankParametersModel, not the raw bool.
+            (arg,) = mock_builder.call_args.args
+            assert isinstance(arg, RerankParametersModel)
+
+    def test_ranker_skipped_when_rerank_unset(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        from dao_ai.tools import create_lakebase_search_tool
+
+        retriever = LakebaseRetrieverModel(vector_store=vector_store)  # no rerank
+        with (
+            patch(
+                "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+                return_value=None,
+            ),
+            patch(
+                "dao_ai.tools.lakebase_search.build_flashrank_ranker"
+            ) as mock_builder,
+        ):
+            create_lakebase_search_tool(retriever=retriever)
+            # Called with None → returns None internally; no ranker built.
+            mock_builder.assert_called_once_with(None)
+
+    def test_ranker_skipped_when_rerank_false(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        from dao_ai.tools import create_lakebase_search_tool
+
+        retriever = LakebaseRetrieverModel(vector_store=vector_store, rerank=False)
+        with (
+            patch(
+                "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+                return_value=None,
+            ),
+            patch(
+                "dao_ai.tools.lakebase_search.build_flashrank_ranker"
+            ) as mock_builder,
+        ):
+            create_lakebase_search_tool(retriever=retriever)
+            mock_builder.assert_called_once_with(None)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: rerank actually reorders the retriever's output
+# ---------------------------------------------------------------------------
+
+
+class TestRerankEndToEnd:
+    def test_rerank_reorders_and_annotates(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """Retriever returns 3 docs in ANN order; ranker returns a
+        different order with scores; final output reflects the ranker
+        order and every doc has reranker_score in its metadata."""
+        from dao_ai.retrievers.lakebase import LakebaseRetriever
+        from dao_ai.tools import create_lakebase_search_tool
+
+        rows = [
+            {"id": "d1", "passage": "First doc", "category": "a", "_distance": 0.1},
+            {"id": "d2", "passage": "Second doc", "category": "b", "_distance": 0.2},
+            {"id": "d3", "passage": "Third doc", "category": "c", "_distance": 0.3},
+        ]
+        pool = _MockPool(rows)
+
+        # Fake ranker: reverses the input order + attaches scores.
+        fake_ranker = MagicMock(name="Ranker")
+
+        def fake_rerank(request):
+            # Return passages in reverse order with descending scores.
+            reversed_passages = list(reversed(request.passages))
+            for i, p in enumerate(reversed_passages):
+                p["score"] = 0.9 - (i * 0.1)
+            return reversed_passages
+
+        fake_ranker.rerank = fake_rerank
+
+        retriever = LakebaseRetrieverModel(
+            vector_store=vector_store,
+            rerank=True,
+            search_parameters=SearchParametersModel(query_type="ANN", num_results=3),
+        )
+
+        with (
+            patch(
+                "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+                return_value=None,
+            ),
+            patch(
+                "dao_ai.tools.lakebase_search.build_flashrank_ranker",
+                return_value=fake_ranker,
+            ),
+            patch.object(LakebaseRetriever, "_sync_pool", return_value=pool),
+            patch.object(LakebaseRetriever, "_embed", return_value=[0.0] * 1024),
+        ):
+            tool = create_lakebase_search_tool(retriever=retriever)
+            output = tool.invoke({"query": "anything"})
+
+        parsed = json.loads(output)
+        # 3 docs, reversed from retriever order.
+        ids = [d["metadata"]["id"] for d in parsed]
+        assert ids == ["d3", "d2", "d1"], f"expected reversed, got {ids}"
+        # Every doc has reranker_score.
+        for d in parsed:
+            assert "reranker_score" in d["metadata"], d["metadata"]
+        assert parsed[0]["metadata"]["reranker_score"] == pytest.approx(0.9)
+
+    def test_rerank_top_n_truncates(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """rerank.top_n limits the returned doc count."""
+        from dao_ai.retrievers.lakebase import LakebaseRetriever
+        from dao_ai.tools import create_lakebase_search_tool
+
+        rows = [
+            {"id": f"d{i}", "passage": f"Doc {i}", "category": "x", "_distance": i / 10}
+            for i in range(5)
+        ]
+        pool = _MockPool(rows)
+
+        fake_ranker = MagicMock(name="Ranker")
+
+        def fake_rerank(request):
+            for i, p in enumerate(request.passages):
+                p["score"] = 1.0 - (i * 0.1)
+            return request.passages
+
+        fake_ranker.rerank = fake_rerank
+
+        retriever = LakebaseRetrieverModel(
+            vector_store=vector_store,
+            rerank=RerankParametersModel(model="ms-marco-MiniLM-L-12-v2", top_n=2),
+            search_parameters=SearchParametersModel(query_type="ANN", num_results=5),
+        )
+
+        with (
+            patch(
+                "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+                return_value=None,
+            ),
+            patch(
+                "dao_ai.tools.lakebase_search.build_flashrank_ranker",
+                return_value=fake_ranker,
+            ),
+            patch.object(LakebaseRetriever, "_sync_pool", return_value=pool),
+            patch.object(LakebaseRetriever, "_embed", return_value=[0.0] * 1024),
+        ):
+            tool = create_lakebase_search_tool(retriever=retriever)
+            output = tool.invoke({"query": "x"})
+
+        parsed = json.loads(output)
+        assert len(parsed) == 2, f"top_n=2 should truncate, got {len(parsed)}"
+
+    def test_no_rerank_when_docs_empty(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """When retriever returns no docs, the ranker is not invoked."""
+        from dao_ai.retrievers.lakebase import LakebaseRetriever
+        from dao_ai.tools import create_lakebase_search_tool
+
+        pool = _MockPool([])  # empty result set
+        fake_ranker = MagicMock(name="Ranker")
+
+        retriever = LakebaseRetrieverModel(vector_store=vector_store, rerank=True)
+
+        with (
+            patch(
+                "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+                return_value=None,
+            ),
+            patch(
+                "dao_ai.tools.lakebase_search.build_flashrank_ranker",
+                return_value=fake_ranker,
+            ),
+            patch.object(LakebaseRetriever, "_sync_pool", return_value=pool),
+            patch.object(LakebaseRetriever, "_embed", return_value=[0.0] * 1024),
+        ):
+            tool = create_lakebase_search_tool(retriever=retriever)
+            output = tool.invoke({"query": "x"})
+
+        parsed = json.loads(output)
+        assert parsed == []
+        fake_ranker.rerank.assert_not_called()
+
+    def test_no_rerank_when_ranker_init_failed(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """When build_flashrank_ranker returns None (init failed), the
+        retriever still returns docs — just without rerank scores."""
+        from dao_ai.retrievers.lakebase import LakebaseRetriever
+        from dao_ai.tools import create_lakebase_search_tool
+
+        rows = [
+            {"id": "d1", "passage": "hello", "category": "a", "_distance": 0.1}
+        ]
+        pool = _MockPool(rows)
+
+        retriever = LakebaseRetrieverModel(vector_store=vector_store, rerank=True)
+
+        with (
+            patch(
+                "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+                return_value=None,
+            ),
+            patch(
+                "dao_ai.tools.lakebase_search.build_flashrank_ranker",
+                return_value=None,  # simulate init failure
+            ),
+            patch.object(LakebaseRetriever, "_sync_pool", return_value=pool),
+            patch.object(LakebaseRetriever, "_embed", return_value=[0.0] * 1024),
+        ):
+            tool = create_lakebase_search_tool(retriever=retriever)
+            output = tool.invoke({"query": "x"})
+
+        parsed = json.loads(output)
+        assert len(parsed) == 1
+        assert "reranker_score" not in parsed[0]["metadata"]
+
+
+# ---------------------------------------------------------------------------
+# Regression: unset rerank behaves exactly like Stage 1
+# ---------------------------------------------------------------------------
+
+
+class TestNoRegressionWhenRerankUnset:
+    def test_stage1_path_unchanged(
+        self, vector_store: LakebaseVectorStoreModel
+    ) -> None:
+        """When `rerank` is unset the factory + invocation path matches
+        pre-PR-A behavior (docs returned as-is, no reranker_score)."""
+        from dao_ai.retrievers.lakebase import LakebaseRetriever
+        from dao_ai.tools import create_lakebase_search_tool
+
+        rows = [
+            {"id": "d1", "passage": "One", "category": "a", "_distance": 0.1},
+            {"id": "d2", "passage": "Two", "category": "b", "_distance": 0.2},
+        ]
+        pool = _MockPool(rows)
+
+        # No rerank param.
+        retriever = LakebaseRetrieverModel(vector_store=vector_store)
+
+        with (
+            patch(
+                "dao_ai.tools.lakebase_search._fetch_lakebase_columns",
+                return_value=None,
+            ),
+            patch.object(LakebaseRetriever, "_sync_pool", return_value=pool),
+            patch.object(LakebaseRetriever, "_embed", return_value=[0.0] * 1024),
+        ):
+            tool = create_lakebase_search_tool(retriever=retriever)
+            output = tool.invoke({"query": "x"})
+
+        parsed = json.loads(output)
+        # Original retriever order, no reranker_score annotation.
+        assert [d["metadata"]["id"] for d in parsed] == ["d1", "d2"]
+        for d in parsed:
+            assert "reranker_score" not in d["metadata"]

--- a/tests/dao_ai/test_reranking.py
+++ b/tests/dao_ai/test_reranking.py
@@ -7,7 +7,7 @@ from conftest import add_databricks_resource_attrs
 
 from dao_ai.config import (
     RerankParametersModel,
-    RetrieverModel,
+    AiSearchRetrieverModel,
     SchemaModel,
     TableModel,
     VectorStoreModel,
@@ -67,13 +67,13 @@ def create_mock_vector_store() -> Mock:
 
 @pytest.mark.unit
 class TestRetrieverModelWithReranker:
-    """Unit tests for RetrieverModel with reranking configuration."""
+    """Unit tests for AiSearchRetrieverModel with reranking configuration."""
 
     def test_rerank_as_bool_true(self) -> None:
         """Test that rerank=True is converted to RerankParametersModel with FlashRank default."""
         vector_store = create_mock_vector_store()
 
-        retriever = RetrieverModel(vector_store=vector_store, rerank=True)
+        retriever = AiSearchRetrieverModel(vector_store=vector_store, rerank=True)
 
         assert isinstance(retriever.rerank, RerankParametersModel)
         # When rerank=True, the default FlashRank model is set
@@ -84,7 +84,7 @@ class TestRetrieverModelWithReranker:
         """Test that rerank=False remains False."""
         vector_store = create_mock_vector_store()
 
-        retriever = RetrieverModel(vector_store=vector_store, rerank=False)
+        retriever = AiSearchRetrieverModel(vector_store=vector_store, rerank=False)
 
         assert retriever.rerank is False
 
@@ -93,7 +93,7 @@ class TestRetrieverModelWithReranker:
         vector_store = create_mock_vector_store()
 
         rerank_config = RerankParametersModel(model="ms-marco-MiniLM-L-6-v2", top_n=3)
-        retriever = RetrieverModel(vector_store=vector_store, rerank=rerank_config)
+        retriever = AiSearchRetrieverModel(vector_store=vector_store, rerank=rerank_config)
 
         assert isinstance(retriever.rerank, RerankParametersModel)
         assert retriever.rerank.model == "ms-marco-MiniLM-L-6-v2"
@@ -103,7 +103,7 @@ class TestRetrieverModelWithReranker:
         """Test that rerank=None remains None."""
         vector_store = create_mock_vector_store()
 
-        retriever = RetrieverModel(vector_store=vector_store, rerank=None)
+        retriever = AiSearchRetrieverModel(vector_store=vector_store, rerank=None)
 
         assert retriever.rerank is None
 
@@ -116,7 +116,7 @@ class TestVectorSearchToolCreation:
     def test_creates_tool_without_reranker(self, mock_vector_search: MagicMock) -> None:
         """Test that tool is created without reranker when not configured."""
         # Create mock retriever config without reranking
-        retriever_config = Mock(spec=RetrieverModel)
+        retriever_config = Mock(spec=AiSearchRetrieverModel)
         retriever_config.rerank = None
         retriever_config.instructed = None
         retriever_config.columns = ["text"]
@@ -208,7 +208,7 @@ class TestVectorSearchToolCreation:
     ) -> None:
         """Test that validation fails when both retriever and vector_store are provided."""
         # Create mock retriever and vector store
-        retriever_config = Mock(spec=RetrieverModel)
+        retriever_config = Mock(spec=AiSearchRetrieverModel)
         vector_store_config = Mock(spec=VectorStoreModel)
 
         with pytest.raises(
@@ -226,7 +226,7 @@ class TestVectorSearchToolCreation:
             model="ms-marco-MiniLM-L-6-v2", top_n=5, cache_dir="/tmp/test"
         )
 
-        retriever_config = Mock(spec=RetrieverModel)
+        retriever_config = Mock(spec=AiSearchRetrieverModel)
         retriever_config.rerank = reranker_config
         retriever_config.instructed = None
         retriever_config.columns = ["text"]
@@ -316,7 +316,7 @@ class TestRerankingE2E:
     ) -> None:
         """Test that create_vector_search_tool returns a callable tool."""
         # Create mock retriever config
-        retriever_config = Mock(spec=RetrieverModel)
+        retriever_config = Mock(spec=AiSearchRetrieverModel)
         retriever_config.rerank = RerankParametersModel()
         retriever_config.instructed = None
         retriever_config.columns = ["text"]

--- a/tests/dao_ai/test_reranking_integration.py
+++ b/tests/dao_ai/test_reranking_integration.py
@@ -20,7 +20,7 @@ from langchain_core.messages import ToolMessage
 from dao_ai.config import (
     IndexModel,
     RerankParametersModel,
-    RetrieverModel,
+    AiSearchRetrieverModel,
     SchemaModel,
     SearchParametersModel,
     TableModel,
@@ -153,7 +153,7 @@ class TestRerankingWithRealIndex:
             ],
         )
 
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vector_store,
             search_parameters=SearchParametersModel(num_results=10),
         )
@@ -219,7 +219,7 @@ class TestRerankingWithRealIndex:
             ],
         )
 
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vector_store,
             search_parameters=SearchParametersModel(num_results=20),
             rerank=True,  # Enable with defaults
@@ -286,7 +286,7 @@ class TestRerankingWithRealIndex:
             ],
         )
 
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vector_store,
             search_parameters=SearchParametersModel(num_results=50),
             rerank=RerankParametersModel(
@@ -361,7 +361,7 @@ class TestRerankingWithRealIndex:
         )
 
         # Search without reranking
-        retriever_no_rerank = RetrieverModel(
+        retriever_no_rerank = AiSearchRetrieverModel(
             vector_store=vector_store,
             search_parameters=SearchParametersModel(num_results=10),
         )
@@ -372,7 +372,7 @@ class TestRerankingWithRealIndex:
         )
 
         # Search with reranking
-        retriever_with_rerank = RetrieverModel(
+        retriever_with_rerank = AiSearchRetrieverModel(
             vector_store=vector_store,
             search_parameters=SearchParametersModel(num_results=20),
             rerank=RerankParametersModel(top_n=10),

--- a/tests/dao_ai/test_retriever_model_hierarchy.py
+++ b/tests/dao_ai/test_retriever_model_hierarchy.py
@@ -1,0 +1,240 @@
+"""Tests for the BaseRetrieverModel hierarchy + AnyRetriever discriminated union.
+
+Covers:
+- The class hierarchy (`AiSearchRetrieverModel` and `LakebaseRetrieverModel` both
+  subclass `BaseRetrieverModel`).
+- `AppConfig.retrievers` dispatches heterogeneous entries via `AnyRetriever`.
+- The callable discriminator defaults missing ``type`` to ``"ai_search"`` so
+  existing YAMLs that never wrote ``type:`` continue to parse.
+- Both concrete models implement `as_tools()` and return the correct tool.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from dao_ai.config import (
+    AiSearchIndexModel,
+    AiSearchRetrieverModel,
+    AnyRetriever,
+    AppConfig,
+    BaseRetrieverModel,
+    IndexModel,
+    LakebaseRetrieverModel,
+    LakebaseVectorStoreModel,
+    RetrieverType,
+    SchemaModel,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _ai_search_dict() -> dict[str, Any]:
+    return {
+        "vector_store": {
+            "index": {
+                "schema": {"catalog_name": "cat", "schema_name": "sch"},
+                "name": "products_ix",
+            }
+        }
+    }
+
+
+def _lakebase_dict() -> dict[str, Any]:
+    return {
+        "type": "lakebase_search",
+        "vector_store": {
+            "database": {"project": "my-lakebase"},
+            "table": "kb_articles",
+            "content_column": "passage",
+            "embedding_column": "embedding",
+            "embedding_model": "databricks-gte-large-en",
+            "metadata_columns": ["category"],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Class hierarchy
+# ---------------------------------------------------------------------------
+
+
+class TestHierarchy:
+    def test_ai_search_retriever_is_base(self) -> None:
+        assert issubclass(AiSearchRetrieverModel, BaseRetrieverModel)
+
+    def test_lakebase_retriever_is_base(self) -> None:
+        assert issubclass(LakebaseRetrieverModel, BaseRetrieverModel)
+
+    def test_base_is_abstract(self) -> None:
+        """BaseRetrieverModel cannot be instantiated directly — as_tools is abstract."""
+        with pytest.raises(TypeError):
+            BaseRetrieverModel()  # type: ignore[abstract]
+
+    def test_shared_fields_on_base(self) -> None:
+        """columns + search_parameters live on the base."""
+        assert "columns" in BaseRetrieverModel.model_fields
+        assert "search_parameters" in BaseRetrieverModel.model_fields
+
+
+# ---------------------------------------------------------------------------
+# Discriminator dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestDiscriminator:
+    def _adapter(self) -> TypeAdapter[AnyRetriever]:
+        return TypeAdapter(AnyRetriever)
+
+    def test_missing_type_defaults_to_ai_search(self) -> None:
+        adapter = self._adapter()
+        r = adapter.validate_python(_ai_search_dict())
+        assert isinstance(r, AiSearchRetrieverModel)
+        assert r.type == RetrieverType.AI_SEARCH.value
+
+    def test_explicit_ai_search_type(self) -> None:
+        adapter = self._adapter()
+        r = adapter.validate_python({"type": "ai_search", **_ai_search_dict()})
+        assert isinstance(r, AiSearchRetrieverModel)
+
+    def test_explicit_lakebase_search_type(self) -> None:
+        adapter = self._adapter()
+        r = adapter.validate_python(_lakebase_dict())
+        assert isinstance(r, LakebaseRetrieverModel)
+        assert r.type == RetrieverType.LAKEBASE_SEARCH.value
+
+    def test_unknown_type_rejected(self) -> None:
+        adapter = self._adapter()
+        with pytest.raises(ValidationError):
+            adapter.validate_python({"type": "not_a_real_retriever", **_ai_search_dict()})
+
+    def test_lakebase_shape_without_type_field_dispatches_wrong(self) -> None:
+        """If someone writes lakebase shape but forgets `type: lakebase_search`,
+        the default AI Search dispatch will reject the shape at validation.
+        This is expected behavior — the discriminator can't infer intent from
+        vector_store shape (that's why we default to ai_search)."""
+        adapter = self._adapter()
+        # Same as _lakebase_dict but with `type` removed. Falls through to
+        # AiSearchRetrieverModel which will reject the Lakebase-shaped
+        # vector_store.
+        raw = _lakebase_dict()
+        del raw["type"]
+        with pytest.raises(ValidationError):
+            adapter.validate_python(raw)
+
+
+# ---------------------------------------------------------------------------
+# AppConfig.retrievers heterogeneous dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestAppConfigRetrievers:
+    def test_heterogeneous_retrievers(self) -> None:
+        cfg = AppConfig.model_validate(
+            {
+                "resources": {},
+                "retrievers": {
+                    "ai": _ai_search_dict(),
+                    "lb": _lakebase_dict(),
+                },
+            }
+        )
+        assert isinstance(cfg.retrievers["ai"], AiSearchRetrieverModel)
+        assert isinstance(cfg.retrievers["lb"], LakebaseRetrieverModel)
+
+    def test_legacy_yaml_without_type_still_parses(self) -> None:
+        """Existing YAMLs that never wrote `type:` on retriever entries
+        continue to dispatch to AiSearchRetrieverModel (backward compat)."""
+        cfg = AppConfig.model_validate(
+            {
+                "resources": {},
+                "retrievers": {
+                    "products": {
+                        "vector_store": {
+                            "index": {
+                                "schema": {
+                                    "catalog_name": "c",
+                                    "schema_name": "s",
+                                },
+                                "name": "products_ix",
+                            }
+                        },
+                        "columns": ["product_id", "name"],
+                    }
+                },
+            }
+        )
+        assert isinstance(cfg.retrievers["products"], AiSearchRetrieverModel)
+
+
+# ---------------------------------------------------------------------------
+# as_tools() implementation
+# ---------------------------------------------------------------------------
+
+
+class TestAsTools:
+    def test_ai_search_retriever_as_tools_delegates_to_factory(self) -> None:
+        """`AiSearchRetrieverModel.as_tools()` calls `create_ai_search_tool`.
+        We don't fully build the tool here (that needs UC lookups) — just
+        verify the method exists and returns a list."""
+        from unittest.mock import patch
+
+        vs = AiSearchIndexModel(
+            index=IndexModel(
+                schema=SchemaModel(catalog_name="c", schema_name="s"),
+                name="ix",
+            )
+        )
+        retriever = AiSearchRetrieverModel(vector_store=vs)
+
+        with patch(
+            "dao_ai.tools.create_ai_search_tool",
+            return_value="STUB_TOOL",
+        ) as mock_factory:
+            tools = retriever.as_tools()
+
+        assert tools == ["STUB_TOOL"]
+        mock_factory.assert_called_once()
+        # The retriever is passed by keyword.
+        assert mock_factory.call_args.kwargs["retriever"] is retriever
+
+    def test_lakebase_retriever_as_tools_delegates_to_factory(self) -> None:
+        from unittest.mock import patch
+
+        vs = LakebaseVectorStoreModel(**_lakebase_dict()["vector_store"])
+        retriever = LakebaseRetrieverModel(vector_store=vs)
+
+        with patch(
+            "dao_ai.tools.create_lakebase_search_tool",
+            return_value="STUB_TOOL",
+        ) as mock_factory:
+            tools = retriever.as_tools()
+
+        assert tools == ["STUB_TOOL"]
+        mock_factory.assert_called_once()
+        assert mock_factory.call_args.kwargs["retriever"] is retriever
+
+
+# ---------------------------------------------------------------------------
+# Rename regression — the old symbol name must be gone from the public API.
+# ---------------------------------------------------------------------------
+
+
+class TestRenameRegression:
+    def test_old_symbol_removed(self) -> None:
+        """`RetrieverModel` was renamed to `AiSearchRetrieverModel`. Ensure
+        no back-compat alias slipped in — the codebase should import the
+        new name explicitly."""
+        import dao_ai.config as cfg
+
+        assert not hasattr(cfg, "RetrieverModel"), (
+            "RetrieverModel should be renamed to AiSearchRetrieverModel; "
+            "no back-compat alias per the plan."
+        )
+        assert hasattr(cfg, "AiSearchRetrieverModel")

--- a/tests/dao_ai/test_vector_search.py
+++ b/tests/dao_ai/test_vector_search.py
@@ -361,12 +361,12 @@ def test_create_vector_search_tool_obo_passes_context_to_workspace_client_from()
     the user's x-forwarded-access-token flows through to the VS query."""
     from langgraph.runtime import Runtime
 
-    from dao_ai.config import RetrieverModel
+    from dao_ai.config import AiSearchRetrieverModel
     from dao_ai.state import Context
     from dao_ai.tools.vector_search import create_vector_search_tool
 
     vs_model = _make_obo_vector_store_mock()
-    retriever = RetrieverModel(vector_store=vs_model)
+    retriever = AiSearchRetrieverModel(vector_store=vs_model)
 
     with patch("dao_ai.tools.vector_search.DatabricksVectorSearch") as MockDVS:
         mock_vs_client = MagicMock()
@@ -407,13 +407,13 @@ def test_create_vector_search_tool_obo_off_does_not_use_context_headers() -> Non
     not crash even when headers are absent."""
     from langgraph.runtime import Runtime
 
-    from dao_ai.config import RetrieverModel
+    from dao_ai.config import AiSearchRetrieverModel
     from dao_ai.state import Context
     from dao_ai.tools.vector_search import create_vector_search_tool
 
     vs_model = _make_obo_vector_store_mock()
     vs_model.on_behalf_of_user = False  # OBO off
-    retriever = RetrieverModel(vector_store=vs_model)
+    retriever = AiSearchRetrieverModel(vector_store=vs_model)
 
     with patch("dao_ai.tools.vector_search.DatabricksVectorSearch") as MockDVS:
         MockDVS.return_value.similarity_search.return_value = []
@@ -509,12 +509,12 @@ def _capture_client_args_and_invoke(
     """
     from langgraph.runtime import Runtime
 
-    from dao_ai.config import RetrieverModel
+    from dao_ai.config import AiSearchRetrieverModel
     from dao_ai.state import Context
     from dao_ai.tools.vector_search import create_vector_search_tool
 
     vs_model.workspace_client_from.return_value = wc
-    retriever = RetrieverModel(vector_store=vs_model)
+    retriever = AiSearchRetrieverModel(vector_store=vs_model)
 
     captured: dict[str, Any] = {}
     with patch("dao_ai.tools.vector_search.DatabricksVectorSearch") as MockDVS, \

--- a/tests/dao_ai/test_vector_search_dynamic_schema.py
+++ b/tests/dao_ai/test_vector_search_dynamic_schema.py
@@ -1483,3 +1483,106 @@ class TestArrayInColumnsDescription:
             ["tags"], {"tags": "array<string>"}, {}
         )
         assert "Array columns match via element containment" in block
+
+
+@pytest.mark.unit
+class TestFactoryToolNameShadowing:
+    """Regression guard for the ``name`` param being clobbered by a
+    ``for name in ...`` column-discovery loop.
+
+    Before the fix, Mode B (bare-string columns + UC enrichment) and
+    Mode C (empty declared + UC discovery) both iterated over discovered
+    columns with a ``for name in declared_names:`` / ``for name, t, c in
+    index_cols:`` loop that shadowed the outer function's ``name``
+    parameter. After the loop, ``tool_name = name or ...`` would pick up
+    the *last* column name — silently mis-labelling the tool
+    (span/metric/log key) with whatever appeared last in the schema.
+    """
+
+    def _make_vs(self) -> VectorStoreModel:
+        return VectorStoreModel(
+            index=IndexModel(
+                schema=SchemaModel(
+                    catalog_name="retail_consumer_goods",
+                    schema_name="commerce_swarm",
+                ),
+                name="products_description_index",
+            ),
+            endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
+        )
+
+    def test_mode_b_bare_strings_do_not_leak_column_name_onto_tool(
+        self,
+    ) -> None:
+        """Mode B: bare-string declared columns + UC returns column info.
+
+        Discovery loop MUST NOT shadow ``name``. Tool name is whatever the
+        caller passed; ``product_vector_search_tool`` here.
+        """
+        vs = self._make_vs()
+        retriever = AiSearchRetrieverModel(
+            vector_store=vs,
+            columns=["product_id", "sku", "description"],  # last col = 'description'
+        )
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch.object(
+            VectorStoreModel, "refresh", autospec=True, return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._fetch_index_columns",
+            return_value=[
+                ("product_id", "STRING", None),
+                ("sku", "STRING", "SKU column"),
+                ("description", "STRING", "Product description"),
+            ],
+        ):
+            tool = create_vector_search_tool(
+                retriever=retriever, name="product_vector_search_tool"
+            )
+        # Would be 'description' before the fix.
+        assert tool.name == "product_vector_search_tool"
+
+    def test_mode_c_discovery_does_not_leak_column_name_onto_tool(self) -> None:
+        """Mode C: nothing declared → UC discovery drives the enum.
+
+        Same shadowing risk. Assert tool name is preserved.
+        """
+        vs = self._make_vs()
+        retriever = AiSearchRetrieverModel(vector_store=vs)  # no declared columns
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch.object(
+            VectorStoreModel, "refresh", autospec=True, return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._fetch_index_columns",
+            return_value=[
+                ("product_id", "STRING", None),
+                ("description", "STRING", None),  # last col
+            ],
+        ):
+            tool = create_vector_search_tool(retriever=retriever, name="my_tool")
+        assert tool.name == "my_tool"
+
+    def test_array_narrowing_loop_does_not_leak_column_name_onto_tool(
+        self,
+    ) -> None:
+        """The ``for col_name, uc_type in description_types.items():``
+        array-narrowing loop is the last place ``name`` could be re-shadowed
+        before ``tool_name = name or ...``. Assert it doesn't."""
+        vs = self._make_vs()
+        retriever = AiSearchRetrieverModel(
+            vector_store=vs,
+            columns=[
+                ColumnInfo(name="tags", type="array"),
+                ColumnInfo(name="brand", type="string"),
+            ],
+        )
+        with patch(
+            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
+        ), patch.object(
+            VectorStoreModel, "refresh", autospec=True, return_value=None
+        ), patch(
+            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
+        ):
+            tool = create_vector_search_tool(retriever=retriever, name="my_tool")
+        assert tool.name == "my_tool"

--- a/tests/dao_ai/test_vector_search_dynamic_schema.py
+++ b/tests/dao_ai/test_vector_search_dynamic_schema.py
@@ -32,7 +32,7 @@ from dao_ai.config import (
     ColumnInfo,
     FilterItem,
     IndexModel,
-    RetrieverModel,
+    AiSearchRetrieverModel,
     SchemaModel,
     VectorSearchEndpoint,
     VectorStoreModel,
@@ -241,7 +241,7 @@ class TestFactoryColumnHydration:
             autospec=True,
             side_effect=lambda self, **kw: original_refresh(self, details=payload),
         ) as mocked_refresh:
-            retriever = RetrieverModel(vector_store=vs)
+            retriever = AiSearchRetrieverModel(vector_store=vs)
             tool = create_vector_search_tool(retriever=retriever, name="product_search")
 
         mocked_refresh.assert_called_once()
@@ -264,7 +264,7 @@ class TestFactoryColumnHydration:
         the live index. The result is declared ∩ index (in declaration order).
         """
         vs = self._make_vs(with_columns=False)
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vs,
             columns=["product_id", "product_name", "price"],
         )
@@ -299,7 +299,7 @@ class TestFactoryColumnHydration:
         filter at query time. Users who want authoritative schema control
         should declare ColumnInfo instead."""
         vs = self._make_vs(with_columns=False)
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vs,
             columns=["product_id", "product_name", "nonexistent_col_xyz"],
         )
@@ -334,7 +334,7 @@ class TestFactoryColumnHydration:
         — but never touch the source table.
         """
         vs = self._make_vs(with_columns=False)
-        retriever = RetrieverModel(vector_store=vs, columns=["product_id"])
+        retriever = AiSearchRetrieverModel(vector_store=vs, columns=["product_id"])
         wc_spy = MagicMock()
         fake_index_table = MagicMock()
         col = MagicMock()
@@ -370,7 +370,7 @@ class TestFactoryColumnHydration:
         declared columns are given, the tool still builds with the
         pre-change free-form ``FilterItem`` schema."""
         vs = self._make_vs(with_columns=False)
-        retriever = RetrieverModel(vector_store=vs)
+        retriever = AiSearchRetrieverModel(vector_store=vs)
         with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch.object(
@@ -394,7 +394,7 @@ class TestFactoryColumnHydration:
         LLM enum is built from declared columns (may hit VS API errors if the
         user made a typo, matching pre-branch behavior)."""
         vs = self._make_vs(with_columns=False)
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vs, columns=["product_id", "product_name"]
         )
         with patch(
@@ -802,7 +802,7 @@ class TestFactoryEntryShapes:
     def test_both_retriever_and_vector_store_raises(self) -> None:
         vs = self._bare_vs()
         vs.columns = ["a"]
-        r = RetrieverModel(vector_store=vs, columns=["a"])
+        r = AiSearchRetrieverModel(vector_store=vs, columns=["a"])
         with pytest.raises(ValueError):
             create_vector_search_tool(retriever=r, vector_store=vs, name="both")
 
@@ -829,7 +829,7 @@ class TestBackwardCompatibility:
             endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
             columns=PRODUCTS_COLUMNS,
         )
-        retriever = RetrieverModel(vector_store=vs, columns=PRODUCTS_COLUMNS)
+        retriever = AiSearchRetrieverModel(vector_store=vs, columns=PRODUCTS_COLUMNS)
         payload = _describe_payload()
         original_refresh = VectorStoreModel.refresh
         with patch(
@@ -860,7 +860,7 @@ class TestBackwardCompatibility:
         gets every operator suffix (permissive fallback). The tool still
         narrows to the declared columns, blocking hallucinated keys."""
         vs = self._bare_vs_no_source()
-        retriever = RetrieverModel(vector_store=vs, columns=["a", "b"])
+        retriever = AiSearchRetrieverModel(vector_store=vs, columns=["a", "b"])
         with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
@@ -908,7 +908,7 @@ class TestMcpAdapterEntryPoint:
             endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
             columns=PRODUCTS_COLUMNS,
         )
-        retriever = RetrieverModel(vector_store=vs, columns=PRODUCTS_COLUMNS)
+        retriever = AiSearchRetrieverModel(vector_store=vs, columns=PRODUCTS_COLUMNS)
         payload = _describe_payload()
         original_refresh = VectorStoreModel.refresh
 
@@ -979,7 +979,7 @@ class TestIndexScopedTypeLookup:
             ),
             endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
         )
-        retriever = RetrieverModel(vector_store=vs)
+        retriever = AiSearchRetrieverModel(vector_store=vs)
         with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
@@ -1025,7 +1025,7 @@ class TestIndexScopedTypeLookup:
             ),
             endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
         )
-        retriever = RetrieverModel(vector_store=vs)
+        retriever = AiSearchRetrieverModel(vector_store=vs)
 
         with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
@@ -1154,7 +1154,7 @@ class TestHandDeclaredColumnInfoInFactory:
         """When any ColumnInfo is in the list, no UC Tables call is made
         at build time — hand-declaration is authoritative."""
         vs = self._bare_vs()
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vs,
             columns=[
                 ColumnInfo(name="brand", type="string", description="Brand"),
@@ -1174,7 +1174,7 @@ class TestHandDeclaredColumnInfoInFactory:
 
     def test_hand_declared_operators_narrow_enum(self) -> None:
         vs = self._bare_vs()
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vs,
             columns=[
                 ColumnInfo(
@@ -1203,7 +1203,7 @@ class TestHandDeclaredColumnInfoInFactory:
         """ColumnInfo without explicit operators → the default full-list
         signals 'don't restrict', so all 8 suffixes apply."""
         vs = self._bare_vs()
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vs,
             columns=[ColumnInfo(name="brand", type="string")],
         )
@@ -1221,7 +1221,7 @@ class TestHandDeclaredColumnInfoInFactory:
 
     def test_hand_declared_description_appears_in_tool_description(self) -> None:
         vs = self._bare_vs()
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vs,
             columns=[
                 ColumnInfo(
@@ -1242,7 +1242,7 @@ class TestHandDeclaredColumnInfoInFactory:
 
     def test_mixed_str_and_column_info_both_in_enum(self) -> None:
         vs = self._bare_vs()
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vs,
             columns=[
                 "product_id",
@@ -1268,7 +1268,7 @@ class TestHandDeclaredColumnInfoInFactory:
         """Mode B: bare-string columns declared → UC call is still made
         best-effort for description enrichment (types + comments)."""
         vs = self._bare_vs()
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vs, columns=["brand", "price"]
         )
         with patch(
@@ -1346,7 +1346,7 @@ class TestArrayColumnInFactory:
         """ColumnInfo(name='tags', type='array') → enum has only 'tags',
         no operator suffixes. This is the Do It Best hardware-iq use case."""
         vs = self._bare_vs()
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vs,
             columns=[
                 ColumnInfo(name="tags", type="array", description="Product tags"),
@@ -1375,7 +1375,7 @@ class TestArrayColumnInFactory:
     def test_hand_declared_array_with_explicit_operators_wins(self) -> None:
         """User explicit operators override the array-type default."""
         vs = self._bare_vs()
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vs,
             columns=[
                 ColumnInfo(name="tags", type="array", operators=["", "NOT"]),
@@ -1397,7 +1397,7 @@ class TestArrayColumnInFactory:
         """Mode C: nothing declared. `_fetch_index_columns` returns an
         array column → factory adds equality-only override."""
         vs = self._bare_vs()
-        retriever = RetrieverModel(vector_store=vs)
+        retriever = AiSearchRetrieverModel(vector_store=vs)
         with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
@@ -1416,7 +1416,7 @@ class TestArrayColumnInFactory:
         """Auto-discovery with a mix: array column narrowed, scalar
         columns keep full 8 suffixes."""
         vs = self._bare_vs()
-        retriever = RetrieverModel(vector_store=vs)
+        retriever = AiSearchRetrieverModel(vector_store=vs)
         with patch(
             "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
         ), patch(
@@ -1441,7 +1441,7 @@ class TestArrayColumnInFactory:
         """When an array column is present, the tool description
         includes the array-contains hint."""
         vs = self._bare_vs()
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vs,
             columns=[
                 ColumnInfo(name="tags", type="array", description="Product tags"),

--- a/tests/dao_ai/test_vector_search_fevm_integration.py
+++ b/tests/dao_ai/test_vector_search_fevm_integration.py
@@ -39,7 +39,7 @@ from langchain_core.messages import ToolMessage
 
 from dao_ai.config import (
     IndexModel,
-    RetrieverModel,
+    AiSearchRetrieverModel,
     SchemaModel,
     SearchParametersModel,
     VectorSearchEndpoint,
@@ -85,12 +85,12 @@ def _extract_documents(result):
     return result
 
 
-def _products_retriever() -> RetrieverModel:
+def _products_retriever() -> AiSearchRetrieverModel:
     schema = SchemaModel(
         catalog_name="retail_consumer_goods",
         schema_name="dao_ai_phase2",
     )
-    return RetrieverModel(
+    return AiSearchRetrieverModel(
         vector_store=VectorStoreModel(
             index=IndexModel(name="products_index", schema=schema),
             endpoint=VectorSearchEndpoint(name="dao_ai_workshop_vs"),
@@ -102,12 +102,12 @@ def _products_retriever() -> RetrieverModel:
     )
 
 
-def _kb_retriever() -> RetrieverModel:
+def _kb_retriever() -> AiSearchRetrieverModel:
     schema = SchemaModel(
         catalog_name="retail_consumer_goods",
         schema_name="dao_ai_phase2",
     )
-    return RetrieverModel(
+    return AiSearchRetrieverModel(
         vector_store=VectorStoreModel(
             index=IndexModel(name="kb_articles_index", schema=schema),
             endpoint=VectorSearchEndpoint(name="dao_ai_workshop_vs"),
@@ -281,7 +281,7 @@ class TestDynamicSchemaHydration:
     def test_products_columns_discovered_from_live_index(self) -> None:
         vs = _bare_vector_store("products_description_index")
         tool = create_vector_search_tool(
-            retriever=RetrieverModel(vector_store=vs),
+            retriever=AiSearchRetrieverModel(vector_store=vs),
             name="product_search",
         )
         enum = _tool_enum_keys(tool)
@@ -308,7 +308,7 @@ class TestDynamicSchemaHydration:
         pydantic validation, NOT surface to the retriever."""
         vs = _bare_vector_store("products_description_index")
         tool = create_vector_search_tool(
-            retriever=RetrieverModel(vector_store=vs),
+            retriever=AiSearchRetrieverModel(vector_store=vs),
             name="product_search",
         )
         from pydantic import ValidationError
@@ -324,7 +324,7 @@ class TestDynamicSchemaHydration:
     def test_products_valid_filter_reaches_vs_and_returns(self) -> None:
         vs = _bare_vector_store("products_description_index")
         tool = create_vector_search_tool(
-            retriever=RetrieverModel(vector_store=vs),
+            retriever=AiSearchRetrieverModel(vector_store=vs),
             name="product_search",
         )
         tool_call = LCToolCall(
@@ -348,7 +348,7 @@ class TestDynamicSchemaHydration:
     def test_faqs_columns_discovered_from_live_index(self) -> None:
         vs = _bare_vector_store("faqs_index")
         tool = create_vector_search_tool(
-            retriever=RetrieverModel(vector_store=vs),
+            retriever=AiSearchRetrieverModel(vector_store=vs),
             name="faq_search",
         )
         enum = _tool_enum_keys(tool)
@@ -358,7 +358,7 @@ class TestDynamicSchemaHydration:
     def test_policies_columns_discovered_from_live_index(self) -> None:
         vs = _bare_vector_store("policies_index")
         tool = create_vector_search_tool(
-            retriever=RetrieverModel(vector_store=vs),
+            retriever=AiSearchRetrieverModel(vector_store=vs),
             name="policy_search",
         )
         enum = _tool_enum_keys(tool)
@@ -368,7 +368,7 @@ class TestDynamicSchemaHydration:
     def test_multiple_valid_filters_across_types(self) -> None:
         vs = _bare_vector_store("products_description_index")
         tool = create_vector_search_tool(
-            retriever=RetrieverModel(vector_store=vs),
+            retriever=AiSearchRetrieverModel(vector_store=vs),
             name="product_search",
         )
         tool_call = LCToolCall(

--- a/tests/dao_ai/test_vector_search_hardware_store_fevm.py
+++ b/tests/dao_ai/test_vector_search_hardware_store_fevm.py
@@ -28,7 +28,7 @@ from pydantic import ValidationError
 
 from dao_ai.config import (
     IndexModel,
-    RetrieverModel,
+    AiSearchRetrieverModel,
     SchemaModel,
     SearchParametersModel,
     VectorSearchEndpoint,
@@ -73,14 +73,14 @@ HARDWARE_STORE_COLUMNS = [
 
 def _hardware_store_retriever(
     *, columns: list[str] | None = HARDWARE_STORE_COLUMNS
-) -> RetrieverModel:
+) -> AiSearchRetrieverModel:
     """Build a retriever mirroring ``hardware_store.yaml`` — same index,
     endpoint, primary_key, and (by default) column set."""
     schema = SchemaModel(
         catalog_name="retail_consumer_goods",
         schema_name="hardware_store",
     )
-    return RetrieverModel(
+    return AiSearchRetrieverModel(
         vector_store=VectorStoreModel(
             index=IndexModel(name="products_index", schema=schema),
             endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),

--- a/tests/dao_ai/test_vector_search_instructed.py
+++ b/tests/dao_ai/test_vector_search_instructed.py
@@ -17,7 +17,7 @@ from dao_ai.config import (
     FilterItem,
     InstructedRetrieverModel,
     LLMModel,
-    RetrieverModel,
+    AiSearchRetrieverModel,
     RouterModel,
     SearchQuery,
     VectorStoreModel,
@@ -93,7 +93,7 @@ class TestEmptyResultFallback:
         vector_store = _create_mock_vector_store()
         llm_model = LLMModel(name="test-decomp-model")
         instructed = _make_instructed(llm_model, max_subqueries=2)
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vector_store,
             instructed=instructed,
         )
@@ -152,7 +152,7 @@ class TestEmptyResultFallback:
         vector_store = _create_mock_vector_store()
         llm_model = LLMModel(name="test-decomp-model")
         instructed = _make_instructed(llm_model)
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vector_store,
             instructed=instructed,
         )
@@ -211,7 +211,7 @@ class TestVerificationRetryLoop:
             max_retries=1,
         )
         instructed = _make_instructed(llm_model, verifier=verifier)
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vector_store,
             instructed=instructed,
         )
@@ -289,7 +289,7 @@ class TestVerificationRetryLoop:
             max_retries=3,
         )
         instructed = _make_instructed(llm_model, verifier=verifier)
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vector_store,
             instructed=instructed,
         )
@@ -345,7 +345,7 @@ class TestVerificationRetryLoop:
             max_retries=1,
         )
         instructed = _make_instructed(llm_model, verifier=verifier)
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vector_store,
             instructed=instructed,
         )
@@ -406,7 +406,7 @@ class TestStandardModeNoRetry:
         # Router with auto_bypass=False so verification actually runs in standard mode
         router = RouterModel(auto_bypass=False)
         instructed = _make_instructed(llm_model, verifier=verifier, router=router)
-        retriever = RetrieverModel(
+        retriever = AiSearchRetrieverModel(
             vector_store=vector_store,
             instructed=instructed,
         )


### PR DESCRIPTION
Stage 2 PR A of the lakebase_search rerank + instructed retrieval work. Adds the `rerank` field to `LakebaseRetrieverModel` matching `AiSearchRetrieverModel`'s shape exactly.

## Summary

- `LakebaseRetrieverModel.rerank: Optional[RerankParametersModel | bool]` — same field, same validator (`rerank: true` → `RerankParametersModel(model="ms-marco-MiniLM-L-12-v2")`), same runtime semantics as ai_search.
- Extracted `build_flashrank_ranker(rerank_config) -> Optional[Ranker]` and renamed `_rerank_documents` → `rerank_documents` (dropped leading underscore) in `dao_ai/tools/vector_search.py`. Both factories import the shared helpers — DRY.
- `create_lakebase_search_tool` invokes `rerank_documents` after `lb_retriever.invoke()` returns. Every returned `Document.metadata` gets a `reranker_score` field; `top_n` truncation is honored. Applies uniformly to ANN / BM25 / HYBRID output.

## Depends on

- #158 (filter parity)
- #159 (base class + discriminator + `col_name` shadowing fix)

Base branch is `feat/retriever-model-base`.

## Test plan

- [x] **13/13 unit tests** in new `test_lakebase_search_rerank.py`: config coercion (all 4 rerank shapes), factory ranker init (built when set, skipped when unset/false), end-to-end with mocked `Ranker` + mocked psycopg pool (reorders + adds scores; top_n truncates; empty docs skip ranker; ranker-init failure soft-falls back), regression test for the Stage 1 unset-rerank path.
- [x] **7/7 live tests** in `test_lakebase_search_live.py::TestRerank` (`-m integration`) against `retail-consumer-goods`: `reranker_score` on every doc, top_n truncates, scores descending, top-1 topically relevant, works with BM25 + HYBRID, metadata preserved through rerank.
- [x] **76/76 existing lakebase tests** green (Stage 1-4 unchanged when `rerank` is unset).
- [x] **Live-app trace verification** — redeployed `dao-ai-lakebase-e2e-03` on FEVM with `rerank: true`; queried `retail_consumer_goods.default.lakebase_e2e_03_otel_spans` for the tool span outputs. Verified every returned doc has `reranker_score` in metadata, scores descending (top-1 ≈ 0.9999, bottom ≈ 0.0000 — canonical FlashRank distribution). Proof rerank is running inside the deployed runtime.
- [x] Pre-existing 4 test failures in `test_reranking.py` unchanged (same as on `main`; unrelated to this PR — verified via `git stash` earlier).

## Docs

- New [`config/examples/21_lakebase_search/reranked.yaml`](../blob/feat/lakebase-rerank/config/examples/21_lakebase_search/reranked.yaml) — full example with both `rerank: true` shorthand and explicit `RerankParametersModel`.
- Extended `21_lakebase_search/README.md` with a Reranking section.
- Added a parity note to `docs/key-capabilities.md` §5 pointing at the new example.

## Not in this PR

- **Instructed retrieval on lakebase_search** — Stage 2 PR B. Requires extracting the pipeline from `create_ai_search_tool` into a shared module and threading a backend-adapter callable through.
- **DatabricksReranker** (server-side reranking via `rerank.columns`) — currently ai_search-only; can wait for a real request.

This pull request and its description were written by Isaac.