### PR TITLE
feat(lakebase-search): instructed retrieval + pipeline extraction (Stage 2 PR B)

### DIFF
--- a/config/examples/21_lakebase_search/README.md
+++ b/config/examples/21_lakebase_search/README.md
@@ -68,6 +68,7 @@ flowchart TB
 | [`filters_and_traces.yaml`](./filters_and_traces.yaml) | HYBRID | Static filters (equality / IN / comparison / LIKE) + `trace_location` to UC OTEL tables |
 | [`dynamic_schema.yaml`](./dynamic_schema.yaml) | HYBRID | Hand-declared `ColumnInfo` with per-column operator narrowing + LLM-facing descriptions (Mode A discovery) |
 | [`reranked.yaml`](./reranked.yaml) | HYBRID / ANN | FlashRank cross-encoder reranking (`rerank: true` shorthand + full `RerankParametersModel` form) |
+| [`instructed.yaml`](./instructed.yaml) | HYBRID | Full instructed-retrieval pipeline — router → LLM query decomposition → parallel search → RRF merge → instruction-aware LLM rerank → verifier |
 
 ## Prerequisites
 
@@ -282,3 +283,46 @@ weights download once to `~/.dao_ai/cache/flashrank/` (or
 against `retail-consumer-goods`.
 
 See [`reranked.yaml`](./reranked.yaml) for a full config.
+
+## Instructed retrieval
+
+Same shape `ai_search`'s `instructed:` field uses — the full pipeline
+(router → LLM query decomposition → parallel subquery search → RRF merge
+→ instruction-aware LLM rerank → verifier retry loop) lives in a shared
+module and works identically on Lakebase output.
+
+```yaml
+retrievers:
+  kb_instructed:
+    type: lakebase_search
+    vector_store: *kb_vs
+    search_parameters:
+      query_type: HYBRID
+      num_results: 20                # broad recall; pipeline narrows
+    instructed:
+      columns:
+        - name: category
+          type: string
+          description: "Article category"
+        - name: priority
+          type: number
+      constraints: ["Prefer priority <= 2 when the user asks for top info"]
+      decomposition: { model: *fast_llm, max_subqueries: 3, rrf_k: 60 }
+      rerank: { model: *fast_llm, top_n: 5 }
+      router: { model: *fast_llm, default_mode: instructed, auto_bypass: true }
+      verifier: { model: *fast_llm, on_failure: warn, max_retries: 1 }
+```
+
+**All fields are independent.** Omit `router` to always run instructed;
+omit `verifier` to skip the retry loop; combine with the top-level
+`rerank:` field to layer FlashRank cross-encoder rerank on top of the LLM
+rerank.
+
+**Verified live end-to-end** against `retail-consumer-goods` — trace
+inspection confirmed the pipeline spans (`decompose_query`,
+`lakebase_ann_search` / `lakebase_bm25_search` / `lakebase_hybrid_search`
+per subquery, `instruction_aware_rerank`, `verify_results`) all appear
+under the outer `lakebase_search` tool span, matching the shape
+`ai_search` produces.
+
+See [`instructed.yaml`](./instructed.yaml) for a full config.

--- a/config/examples/21_lakebase_search/ann_only.yaml
+++ b/config/examples/21_lakebase_search/ann_only.yaml
@@ -28,6 +28,42 @@ parameters:
   table_name:
     description: Table with vector + text columns
     default: kb_articles
+  # Lakebase currently requires SP credentials for programmatic access
+  # inside a Databricks App. Configure the secret scope + keys here so the
+  # deployed App reads the SP creds from a Databricks secret scope; env-var
+  # fallbacks are used for local dev.
+  secret_scope:
+    description: Databricks secret scope holding the SP client id / secret / host
+    default: my_secret_scope
+  sp_client_id_key:
+    description: Secret-scope key for the SP client id
+    default: SP_CLIENT_ID
+  sp_client_secret_key:
+    description: Secret-scope key for the SP client secret
+    default: SP_CLIENT_SECRET
+  workspace_host_key:
+    description: Secret-scope key for the Databricks workspace host URL
+    default: DATABRICKS_HOST
+
+# Anchored option lists — dao-ai's ``value_of`` picks the first option that
+# resolves. Prefer secret scope (deploy path); fall back to env var (local
+# dev). Any option may be null; unresolved options are skipped.
+variables:
+  client_id: &client_id
+    options:
+      - scope: ${var.secret_scope}
+        secret: ${var.sp_client_id_key}
+      - env: ${var.sp_client_id_key}
+  client_secret: &client_secret
+    options:
+      - scope: ${var.secret_scope}
+        secret: ${var.sp_client_secret_key}
+      - env: ${var.sp_client_secret_key}
+  workspace_host: &workspace_host
+    options:
+      - scope: ${var.secret_scope}
+        secret: ${var.workspace_host_key}
+      - env: ${var.workspace_host_key}
 
 resources:
   models:
@@ -37,23 +73,34 @@ resources:
   databases:
     kb_lakebase: &kb_lakebase
       project: ${var.lakebase_project}
+      client_id: *client_id
+      client_secret: *client_secret
+      workspace_host: *workspace_host
+
+# Top-level retrievers block — same shape ai_search uses. Tools reference
+# these by anchor rather than inlining the retriever config into
+# ``function.retriever``.
+retrievers:
+  kb_ann: &kb_ann
+    type: lakebase_search
+    vector_store:
+      database: *kb_lakebase
+      schema_name: ${var.schema_name}
+      table: ${var.table_name}
+      content_column: passage
+      embedding_column: embedding
+      embedding_model: databricks-gte-large-en   # string shorthand → InferenceEndpointModel
+      metadata_columns:
+        - category
+        - source_url
+      distance_metric: cosine                    # cosine | l2 | ip
 
 tools:
   kb_search: &kb_search
     name: kb_search
     function:
       type: lakebase_search
-      vector_store:
-        database: *kb_lakebase
-        schema_name: ${var.schema_name}
-        table: ${var.table_name}
-        content_column: passage
-        embedding_column: embedding
-        embedding_model: databricks-gte-large-en   # string shorthand → InferenceEndpointModel
-        metadata_columns:
-          - category
-          - source_url
-        distance_metric: cosine                    # cosine | l2 | ip
+      retriever: *kb_ann
 
 agents:
   kb_agent:

--- a/config/examples/21_lakebase_search/bm25_only.yaml
+++ b/config/examples/21_lakebase_search/bm25_only.yaml
@@ -12,14 +12,36 @@
 
 parameters:
   lakebase_project:
-    description: Lakebase autoscaling Postgres project id
     default: my-lakebase-project
   schema_name:
-    description: Postgres schema holding the KB table
     default: dao_ai_kb
   table_name:
-    description: Table with tsvector column
     default: kb_articles
+  secret_scope:
+    default: my_secret_scope
+  sp_client_id_key:
+    default: SP_CLIENT_ID
+  sp_client_secret_key:
+    default: SP_CLIENT_SECRET
+  workspace_host_key:
+    default: DATABRICKS_HOST
+
+variables:
+  client_id: &client_id
+    options:
+      - scope: ${var.secret_scope}
+        secret: ${var.sp_client_id_key}
+      - env: ${var.sp_client_id_key}
+  client_secret: &client_secret
+    options:
+      - scope: ${var.secret_scope}
+        secret: ${var.sp_client_secret_key}
+      - env: ${var.sp_client_secret_key}
+  workspace_host: &workspace_host
+    options:
+      - scope: ${var.secret_scope}
+        secret: ${var.workspace_host_key}
+      - env: ${var.workspace_host_key}
 
 resources:
   models:
@@ -29,26 +51,33 @@ resources:
   databases:
     kb_lakebase: &kb_lakebase
       project: ${var.lakebase_project}
+      client_id: *client_id
+      client_secret: *client_secret
+      workspace_host: *workspace_host
+
+retrievers:
+  kb_bm25: &kb_bm25
+    type: lakebase_search
+    vector_store:
+      database: *kb_lakebase
+      schema_name: ${var.schema_name}
+      table: ${var.table_name}
+      content_column: passage
+      embedding_column: embedding             # required by schema, unused at query time
+      tsvector_column: passage_tsv            # required for BM25
+      embedding_model: databricks-gte-large-en
+      metadata_columns:
+        - category
+    search_parameters:
+      query_type: BM25
+      num_results: 5
 
 tools:
   kb_lexical: &kb_lexical
     name: kb_lexical
     function:
       type: lakebase_search
-      retriever:
-        vector_store:
-          database: *kb_lakebase
-          schema_name: ${var.schema_name}
-          table: ${var.table_name}
-          content_column: passage
-          embedding_column: embedding             # required by schema, unused at query time
-          tsvector_column: passage_tsv            # required for BM25
-          embedding_model: databricks-gte-large-en
-          metadata_columns:
-            - category
-        search_parameters:
-          query_type: BM25
-          num_results: 5
+      retriever: *kb_bm25
 
 agents:
   lexical_agent:

--- a/config/examples/21_lakebase_search/dynamic_schema.yaml
+++ b/config/examples/21_lakebase_search/dynamic_schema.yaml
@@ -18,12 +18,36 @@
 
 parameters:
   lakebase_project:
-    description: Lakebase autoscaling Postgres project id
     default: my-lakebase-project
   schema_name:
     default: dao_ai_kb
   table_name:
     default: kb_articles
+  secret_scope:
+    default: my_secret_scope
+  sp_client_id_key:
+    default: SP_CLIENT_ID
+  sp_client_secret_key:
+    default: SP_CLIENT_SECRET
+  workspace_host_key:
+    default: DATABRICKS_HOST
+
+variables:
+  client_id: &client_id
+    options:
+      - scope: ${var.secret_scope}
+        secret: ${var.sp_client_id_key}
+      - env: ${var.sp_client_id_key}
+  client_secret: &client_secret
+    options:
+      - scope: ${var.secret_scope}
+        secret: ${var.sp_client_secret_key}
+      - env: ${var.sp_client_secret_key}
+  workspace_host: &workspace_host
+    options:
+      - scope: ${var.secret_scope}
+        secret: ${var.workspace_host_key}
+      - env: ${var.workspace_host_key}
 
 resources:
   models:
@@ -33,51 +57,58 @@ resources:
   databases:
     kb_lakebase: &kb_lakebase
       project: ${var.lakebase_project}
+      client_id: *client_id
+      client_secret: *client_secret
+      workspace_host: *workspace_host
+
+retrievers:
+  scoped_kb_retriever: &scoped_kb_retriever
+    type: lakebase_search
+    vector_store:
+      database: *kb_lakebase
+      schema_name: ${var.schema_name}
+      table: ${var.table_name}
+      content_column: passage
+      embedding_column: embedding
+      tsvector_column: passage_tsv
+      embedding_model: databricks-gte-large-en
+      # metadata_columns still set for Document.metadata surfacing;
+      # columns below is what drives the LLM args_schema.
+      metadata_columns:
+        - category
+        - priority
+        - source_url
+    # Hand-declared columns (Mode A — no Postgres discovery call).
+    columns:
+      - name: category
+        type: string
+        operators:                   # locked to a subset of the 8 defaults
+          - ""
+          - LIKE
+        description: "Article category: auth, billing, shipping, returns"
+      - name: priority
+        type: number
+        operators:                   # comparison-only — LIKE makes no sense on an int
+          - ""
+          - "<"
+          - "<="
+          - ">"
+          - ">="
+        description: "Priority tier 1 (highest) - 5 (lowest)"
+      - name: source_url
+        type: string
+        description: "Canonical documentation URL"
+        # `operators` omitted → all 8 suffixes are legal (default).
+    search_parameters:
+      query_type: HYBRID
+      num_results: 5
 
 tools:
   scoped_kb: &scoped_kb
     name: scoped_kb
     function:
       type: lakebase_search
-      retriever:
-        vector_store:
-          database: *kb_lakebase
-          schema_name: ${var.schema_name}
-          table: ${var.table_name}
-          content_column: passage
-          embedding_column: embedding
-          tsvector_column: passage_tsv
-          embedding_model: databricks-gte-large-en
-          # metadata_columns still set for Document.metadata surfacing;
-          # columns below is what drives the LLM args_schema.
-          metadata_columns:
-            - category
-            - priority
-            - source_url
-        # Hand-declared columns (Mode A — no Postgres discovery call).
-        columns:
-          - name: category
-            type: string
-            operators:                   # locked to a subset of the 8 defaults
-              - ""
-              - LIKE
-            description: "Article category: auth, billing, shipping, returns"
-          - name: priority
-            type: number
-            operators:                   # comparison-only — LIKE makes no sense on an int
-              - ""
-              - "<"
-              - "<="
-              - ">"
-              - ">="
-            description: "Priority tier 1 (highest) - 5 (lowest)"
-          - name: source_url
-            type: string
-            description: "Canonical documentation URL"
-            # `operators` omitted → all 8 suffixes are legal (default).
-        search_parameters:
-          query_type: HYBRID
-          num_results: 5
+      retriever: *scoped_kb_retriever
 
 agents:
   scoped_agent:

--- a/config/examples/21_lakebase_search/filters_and_traces.yaml
+++ b/config/examples/21_lakebase_search/filters_and_traces.yaml
@@ -68,48 +68,51 @@ resources:
       client_secret: *client_secret
       workspace_host: *workspace_host
 
-tools:
+retrievers:
   # Only surface published, high-priority auth-related docs to the agent.
   # Filter columns must appear in vector_store.metadata_columns (allowlist).
-  # Supported operators: =, !=, <, <=, >, >=, in, not_in, like, ilike, is_null.
+  active_auth_retriever: &active_auth_retriever
+    type: lakebase_search
+    vector_store:
+      database: *kb_lakebase
+      schema_name: ${var.schema_name}
+      table: ${var.table_name}
+      content_column: passage
+      embedding_column: embedding
+      tsvector_column: passage_tsv
+      embedding_model: databricks-gte-large-en
+      metadata_columns:
+        - category
+        - status
+        - priority
+        - source_url
+    search_parameters:
+      query_type: HYBRID
+      num_results: 5
+      # Filter keys follow ai_search's suffixed-key convention. The
+      # bare column name means equality; the LLM-facing FilterItem
+      # list uses the exact same suffix language.
+      #
+      # Supported suffixes (identical to ai_search):
+      #   ""          equality             ("col": <value>)
+      #   " NOT"      not-equals / not-in  ("col NOT": <value|list>)
+      #   " <" " <=" " >" " >="  comparisons
+      #   " LIKE"     case-insensitive     ("col LIKE": "pattern%")
+      #   " NOT LIKE" case-insensitive not ("col NOT LIKE": "pattern")
+      #
+      # A list value with the bare / NOT suffix triggers IN / NOT IN.
+      filters:
+        category: auth                          # equality
+        "status": [published, reviewed]         # list value → IN
+        "priority >=": 2                        # comparison
+        "source_url LIKE": "https://docs.%.com/%"   # LIKE (Postgres ILIKE)
+
+tools:
   active_auth_kb: &active_auth_kb
     name: active_auth_kb
     function:
       type: lakebase_search
-      retriever:
-        vector_store:
-          database: *kb_lakebase
-          schema_name: ${var.schema_name}
-          table: ${var.table_name}
-          content_column: passage
-          embedding_column: embedding
-          tsvector_column: passage_tsv
-          embedding_model: databricks-gte-large-en
-          metadata_columns:
-            - category
-            - status
-            - priority
-            - source_url
-        search_parameters:
-          query_type: HYBRID
-          num_results: 5
-          # Filter keys follow ai_search's suffixed-key convention. The
-          # bare column name means equality; the LLM-facing FilterItem
-          # list uses the exact same suffix language.
-          #
-          # Supported suffixes (identical to ai_search):
-          #   ""          equality             ("col": <value>)
-          #   " NOT"      not-equals / not-in  ("col NOT": <value|list>)
-          #   " <" " <=" " >" " >="  comparisons
-          #   " LIKE"     case-insensitive     ("col LIKE": "pattern%")
-          #   " NOT LIKE" case-insensitive not ("col NOT LIKE": "pattern")
-          #
-          # A list value with the bare / NOT suffix triggers IN / NOT IN.
-          filters:
-            category: auth                          # equality
-            "status": [published, reviewed]         # list value → IN
-            "priority >=": 2                        # comparison
-            "source_url LIKE": "https://docs.%.com/%"   # LIKE (Postgres ILIKE)
+      retriever: *active_auth_retriever
 
 agents:
   auth_agent:

--- a/config/examples/21_lakebase_search/hybrid_rrf.yaml
+++ b/config/examples/21_lakebase_search/hybrid_rrf.yaml
@@ -19,11 +19,35 @@ parameters:
     description: Lakebase autoscaling Postgres project id
     default: my-lakebase-project
   schema_name:
-    description: Postgres schema holding the KB table
     default: dao_ai_kb
   table_name:
-    description: Table with vector + tsvector columns
     default: kb_articles
+  secret_scope:
+    description: Databricks secret scope holding the SP client id / secret / host
+    default: my_secret_scope
+  sp_client_id_key:
+    default: SP_CLIENT_ID
+  sp_client_secret_key:
+    default: SP_CLIENT_SECRET
+  workspace_host_key:
+    default: DATABRICKS_HOST
+
+variables:
+  client_id: &client_id
+    options:
+      - scope: ${var.secret_scope}
+        secret: ${var.sp_client_id_key}
+      - env: ${var.sp_client_id_key}
+  client_secret: &client_secret
+    options:
+      - scope: ${var.secret_scope}
+        secret: ${var.sp_client_secret_key}
+      - env: ${var.sp_client_secret_key}
+  workspace_host: &workspace_host
+    options:
+      - scope: ${var.secret_scope}
+        secret: ${var.workspace_host_key}
+      - env: ${var.workspace_host_key}
 
 resources:
   models:
@@ -33,30 +57,37 @@ resources:
   databases:
     kb_lakebase: &kb_lakebase
       project: ${var.lakebase_project}
+      client_id: *client_id
+      client_secret: *client_secret
+      workspace_host: *workspace_host
+
+retrievers:
+  kb_hybrid_retriever: &kb_hybrid_retriever
+    type: lakebase_search
+    vector_store:
+      database: *kb_lakebase
+      schema_name: ${var.schema_name}
+      table: ${var.table_name}
+      content_column: passage
+      embedding_column: embedding
+      tsvector_column: passage_tsv            # required for HYBRID / BM25
+      # bm25_index_name auto-derives from
+      #   <schema_name>.<table>_<tsvector_column>_bm25
+      # Set it explicitly here to override that convention.
+      embedding_model: databricks-gte-large-en
+      metadata_columns:
+        - category
+        - source_url
+    search_parameters:
+      query_type: HYBRID                      # ANN | BM25 | HYBRID
+      num_results: 5
 
 tools:
   kb_hybrid: &kb_hybrid
     name: kb_hybrid
     function:
       type: lakebase_search
-      retriever:
-        vector_store:
-          database: *kb_lakebase
-          schema_name: ${var.schema_name}
-          table: ${var.table_name}
-          content_column: passage
-          embedding_column: embedding
-          tsvector_column: passage_tsv            # required for HYBRID / BM25
-          # bm25_index_name auto-derives from
-          #   <schema_name>.<table>_<tsvector_column>_bm25
-          # Set it explicitly here to override that convention.
-          embedding_model: databricks-gte-large-en
-          metadata_columns:
-            - category
-            - source_url
-        search_parameters:
-          query_type: HYBRID                      # ANN | BM25 | HYBRID
-          num_results: 5
+      retriever: *kb_hybrid_retriever
 
 agents:
   kb_agent:

--- a/config/examples/21_lakebase_search/instructed.yaml
+++ b/config/examples/21_lakebase_search/instructed.yaml
@@ -1,0 +1,139 @@
+# yaml-language-server: $schema=../../../schemas/model_config_schema.json
+
+# Lakebase Search with instructed retrieval — parity with ai_search's
+# `instructed:` field. The full pipeline:
+#
+#   1. Router picks "standard" or "instructed" mode from the query text.
+#   2. If instructed: an LLM decomposes the user query into 1–3
+#      constraint-aware subqueries (with structured filters).
+#   3. Each subquery runs in parallel against Lakebase (ANN / BM25 /
+#      HYBRID — whichever query_type is configured).
+#   4. Results merged via Reciprocal Rank Fusion.
+#   5. Optional FlashRank cross-encoder rerank.
+#   6. LLM instruction-aware rerank scores each doc against the user's
+#      constraints.
+#   7. Optional verifier LLM checks the results; on failure, retries with
+#      feedback (up to max_retries).
+#
+# All of this is backend-agnostic — the same pipeline runs for ai_search.
+# Only the search call itself is Lakebase-specific.
+
+parameters:
+  lakebase_project:
+    default: my-lakebase-project
+  schema_name:
+    default: dao_ai_kb
+  table_name:
+    default: kb_articles
+  secret_scope:
+    default: my_secret_scope
+  sp_client_id_key:
+    default: SP_CLIENT_ID
+  sp_client_secret_key:
+    default: SP_CLIENT_SECRET
+  workspace_host_key:
+    default: DATABRICKS_HOST
+
+variables:
+  client_id: &client_id
+    options:
+      - scope: ${var.secret_scope}
+        secret: ${var.sp_client_id_key}
+      - env: ${var.sp_client_id_key}
+  client_secret: &client_secret
+    options:
+      - scope: ${var.secret_scope}
+        secret: ${var.sp_client_secret_key}
+      - env: ${var.sp_client_secret_key}
+  workspace_host: &workspace_host
+    options:
+      - scope: ${var.secret_scope}
+        secret: ${var.workspace_host_key}
+      - env: ${var.workspace_host_key}
+
+resources:
+  models:
+    default_llm: &default_llm
+      name: databricks-claude-sonnet-4-5
+    # Fast, low-latency model for router / decomposition / verify.
+    fast_llm: &fast_llm
+      name: databricks-claude-sonnet-4-5
+
+  databases:
+    kb_lakebase: &kb_lakebase
+      project: ${var.lakebase_project}
+      client_id: *client_id
+      client_secret: *client_secret
+      workspace_host: *workspace_host
+
+retrievers:
+  kb_instructed_retriever: &kb_instructed_retriever
+    type: lakebase_search
+    vector_store:
+      database: *kb_lakebase
+      schema_name: ${var.schema_name}
+      table: ${var.table_name}
+      content_column: passage
+      embedding_column: embedding
+      tsvector_column: passage_tsv
+      embedding_model: databricks-gte-large-en
+      metadata_columns:
+        - category
+        - priority
+    search_parameters:
+      query_type: HYBRID
+      num_results: 20
+    instructed:
+      columns:
+        - name: category
+          type: string
+          description: "Article category (auth, billing, shipping, returns)"
+        - name: priority
+          type: number
+          description: "Priority tier 1 (highest) through 5 (lowest)"
+      constraints:
+        - "Prefer high-priority articles (priority <= 2) when the user asks for the most important info."
+      decomposition:
+        model: *fast_llm
+        max_subqueries: 3
+        rrf_k: 60
+      rerank:
+        model: *fast_llm
+        instructions: "Prioritize articles that directly answer the user's question."
+        top_n: 5
+      router:
+        model: *fast_llm
+        default_mode: instructed
+        auto_bypass: true
+      verifier:
+        model: *fast_llm
+        on_failure: warn
+        max_retries: 1
+
+tools:
+  kb_instructed: &kb_instructed
+    name: kb_instructed
+    function:
+      type: lakebase_search
+      retriever: *kb_instructed_retriever
+
+agents:
+  kb_agent:
+    name: kb_agent
+    model: *default_llm
+    tools:
+      - *kb_instructed
+    prompt: |
+      You are a knowledge-base assistant. Call kb_instructed to search.
+
+app:
+  name: dao-ai-lb-instructed-example
+  registered_model:
+    name: dao_ai_lb_instructed_example
+  agents:
+    - name: kb_agent
+      model: *default_llm
+      tools:
+        - *kb_instructed
+      prompt: |
+        You are a knowledge-base assistant. Call kb_instructed to search.

--- a/config/examples/21_lakebase_search/reranked.yaml
+++ b/config/examples/21_lakebase_search/reranked.yaml
@@ -17,12 +17,36 @@
 
 parameters:
   lakebase_project:
-    description: Lakebase autoscaling Postgres project id
     default: my-lakebase-project
   schema_name:
     default: dao_ai_kb
   table_name:
     default: kb_articles
+  secret_scope:
+    default: my_secret_scope
+  sp_client_id_key:
+    default: SP_CLIENT_ID
+  sp_client_secret_key:
+    default: SP_CLIENT_SECRET
+  workspace_host_key:
+    default: DATABRICKS_HOST
+
+variables:
+  client_id: &client_id
+    options:
+      - scope: ${var.secret_scope}
+        secret: ${var.sp_client_id_key}
+      - env: ${var.sp_client_id_key}
+  client_secret: &client_secret
+    options:
+      - scope: ${var.secret_scope}
+        secret: ${var.sp_client_secret_key}
+      - env: ${var.sp_client_secret_key}
+  workspace_host: &workspace_host
+    options:
+      - scope: ${var.secret_scope}
+        secret: ${var.workspace_host_key}
+      - env: ${var.workspace_host_key}
 
 resources:
   models:
@@ -32,50 +56,60 @@ resources:
   databases:
     kb_lakebase: &kb_lakebase
       project: ${var.lakebase_project}
+      client_id: *client_id
+      client_secret: *client_secret
+      workspace_host: *workspace_host
+
+retrievers:
+  # Cast a wide net, then rerank down to the top 5 most relevant.
+  kb_reranked_retriever: &kb_reranked_retriever
+    type: lakebase_search
+    vector_store:
+      database: *kb_lakebase
+      schema_name: ${var.schema_name}
+      table: ${var.table_name}
+      content_column: passage
+      embedding_column: embedding
+      tsvector_column: passage_tsv
+      embedding_model: databricks-gte-large-en
+      metadata_columns: [category, priority]
+    search_parameters:
+      query_type: HYBRID
+      num_results: 20                # broad recall — cast the wide net
+    rerank:
+      model: ms-marco-MiniLM-L-12-v2
+      top_n: 5                       # narrow to top-5 after reranking
+
+  # Simpler variant — bool defaults to ms-marco-MiniLM-L-12-v2, no top_n
+  # (returns all num_results docs, just reordered by rerank score).
+  kb_reranked_default_retriever: &kb_reranked_default_retriever
+    type: lakebase_search
+    vector_store:
+      database: *kb_lakebase
+      schema_name: ${var.schema_name}
+      table: ${var.table_name}
+      content_column: passage
+      embedding_column: embedding
+      tsvector_column: passage_tsv
+      embedding_model: databricks-gte-large-en
+      metadata_columns: [category]
+    search_parameters:
+      query_type: ANN
+      num_results: 5
+    rerank: true                     # shorthand → default FlashRank model
 
 tools:
-  # Cast a wide net, then rerank down to the top 5 most relevant.
   kb_reranked: &kb_reranked
     name: kb_reranked
     function:
       type: lakebase_search
-      retriever:
-        vector_store:
-          database: *kb_lakebase
-          schema_name: ${var.schema_name}
-          table: ${var.table_name}
-          content_column: passage
-          embedding_column: embedding
-          tsvector_column: passage_tsv
-          embedding_model: databricks-gte-large-en
-          metadata_columns: [category, priority]
-        search_parameters:
-          query_type: HYBRID
-          num_results: 20                # broad recall — cast the wide net
-        rerank:
-          model: ms-marco-MiniLM-L-12-v2
-          top_n: 5                       # narrow to top-5 after reranking
+      retriever: *kb_reranked_retriever
 
-  # Simpler variant — bool defaults to ms-marco-MiniLM-L-12-v2, no top_n
-  # (returns all num_results docs, just reordered by rerank score).
   kb_reranked_default: &kb_reranked_default
     name: kb_reranked_default
     function:
       type: lakebase_search
-      retriever:
-        vector_store:
-          database: *kb_lakebase
-          schema_name: ${var.schema_name}
-          table: ${var.table_name}
-          content_column: passage
-          embedding_column: embedding
-          tsvector_column: passage_tsv
-          embedding_model: databricks-gte-large-en
-          metadata_columns: [category]
-        search_parameters:
-          query_type: ANN
-          num_results: 5
-        rerank: true                     # shorthand → default FlashRank model
+      retriever: *kb_reranked_default_retriever
 
 agents:
   kb_agent:

--- a/docs/key-capabilities.md
+++ b/docs/key-capabilities.md
@@ -500,6 +500,13 @@ rerank:
 
 ### Instructed Retrieval
 
+> **`lakebase_search` parity (Stage 2, PR B):** the same `instructed:` field
+> works on `LakebaseRetrieverModel`. The pipeline (router → decomposition
+> → parallel search → RRF merge → instruction rerank → verifier retry loop)
+> is shared via `dao_ai.tools.instructed_pipeline` — both retrievers pass a
+> backend adapter callable. See
+> [config/examples/21_lakebase_search/instructed.yaml](../config/examples/21_lakebase_search/instructed.yaml).
+
 **The problem:** Standard AI Search ignores metadata constraints entirely. When a user asks "Milwaukee power drills under $200 from last month", semantic similarity alone can't enforce brand, price, or recency constraints. Queries with multiple intents or exclusions ("cordless tools excluding DeWalt") fare even worse.
 
 **The solution:** Instructed Retrieval extends basic RAG by automatically translating natural language constraints into executable metadata filters. An LLM decomposes complex queries into focused subqueries with filters, executes them in parallel, and merges results using Reciprocal Rank Fusion (RRF).

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -4729,6 +4729,18 @@ class LakebaseRetrieverModel(BaseRetrieverModel):
             "instead."
         ),
     )
+    instructed: Optional[InstructedRetrieverModel] = Field(
+        default=None,
+        description=(
+            "Optional instructed-retrieval pipeline: LLM decomposes the "
+            "query into constraint-aware subqueries, runs them in parallel "
+            "against the Lakebase retriever, RRF-merges results, applies "
+            "an LLM instruction-aware rerank, and (optionally) verifies + "
+            "retries. Same semantics as ``AiSearchRetrieverModel.instructed`` "
+            "— shares the pipeline implementation in "
+            "``dao_ai.tools.instructed_pipeline``."
+        ),
+    )
 
     # Note: ``columns`` and ``search_parameters`` are inherited from
     # ``BaseRetrieverModel``. Description below repurposes the inherited

--- a/src/dao_ai/tools/instructed_pipeline.py
+++ b/src/dao_ai/tools/instructed_pipeline.py
@@ -1,0 +1,486 @@
+"""Backend-agnostic instructed-retrieval pipeline.
+
+Extracted from ``create_ai_search_tool``'s closure so ``lakebase_search``
+(and any future retriever) can share the exact same pipeline logic:
+
+    router mode selection
+      → (standard search | instructed: decompose → parallel → RRF)
+        → FlashRank reranking
+          → instruction-aware LLM reranking
+            → verifier retry loop
+
+The only backend-coupled piece is the search call. Callers pass a
+``run_search: Callable[[str, dict[str, Any]], list[Document]]`` adapter
+that encapsulates their backend (AI Search's ``vs.similarity_search`` /
+Lakebase's mode-specific ``_run_*_sync``), including ``k``, ``query_type``,
+embedding, and any other retriever-specific state.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable, Literal, Optional, TYPE_CHECKING
+
+import mlflow
+from flashrank import Ranker
+from langchain_core.documents import Document
+from loguru import logger
+from mlflow.entities import SpanType
+
+from dao_ai.config import (
+    ColumnInfo,
+    DecompositionModel,
+    InstructedRetrieverModel,
+    InstructionAwareRerankModel,
+    RerankParametersModel,
+    RouterModel,
+    SearchQuery,
+    VerifierModel,
+)
+from dao_ai._tracing import in_caller_context
+from dao_ai.tools.instructed_retriever import (
+    _get_cached_llm,
+    decompose_query,
+    rrf_merge,
+)
+from dao_ai.tools.instruction_reranker import instruction_aware_rerank
+from dao_ai.tools.router import route_query
+from dao_ai.tools.tracing import (
+    ATTR_ROUTER_BYPASSED,
+    ATTR_ROUTER_FALLBACK,
+    ATTR_ROUTER_MODE,
+    ATTR_VERIFIER_OUTCOME,
+    ATTR_VERIFIER_RETRIES,
+    ResourceInfo,
+)
+from dao_ai.tools.verifier import add_verification_metadata, verify_results
+
+if TYPE_CHECKING:
+    from dao_ai.state import Context
+
+
+# Type alias — the backend adapter callable. Given a query string and a
+# suffixed-key filter dict, return the top-k documents from the backend.
+# The retriever tool captures k, query_type, embedding, etc. in the closure.
+RunSearch = Callable[[str, dict[str, Any]], list[Document]]
+
+
+Mode = Literal["standard", "instructed"]
+
+
+def _normalize_filter_values(
+    filters: dict[str, Any], case: Optional[str]
+) -> dict[str, Any]:
+    """Normalize string filter values to specified case (uppercase/lowercase).
+
+    Lifted verbatim from ``create_ai_search_tool`` — used when
+    ``DecompositionModel.normalize_filter_case`` is set. No case normalization
+    is applied when ``case`` is ``None``.
+    """
+    if not case or not filters:
+        return filters
+    normalized: dict[str, Any] = {}
+    for key, value in filters.items():
+        if isinstance(value, str):
+            normalized[key] = value.upper() if case == "uppercase" else value.lower()
+        elif isinstance(value, list):
+            normalized[key] = [
+                v.upper() if case == "uppercase" else v.lower() if isinstance(v, str) else v
+                for v in value
+            ]
+        else:
+            normalized[key] = value
+    return normalized
+
+
+@mlflow.trace(name="execute_instructed_retrieval", span_type=SpanType.RETRIEVER)
+def _execute_instructed_search(
+    *,
+    run_search: RunSearch,
+    query: str,
+    base_filters: dict[str, Any],
+    instructed_config: InstructedRetrieverModel,
+    decomposition_config: DecompositionModel,
+    instructed_columns: list[ColumnInfo],
+    primary_key: Optional[str],
+    previous_feedback: Optional[str] = None,
+    context: Optional["Context"] = None,
+) -> list[Document]:
+    """Decompose → parallel search → RRF merge.
+
+    Backend-agnostic — takes the backend adapter as ``run_search``. Falls
+    back to a single unfiltered ``run_search(query, base_filters)`` call
+    when decomposition yields no subqueries, all subqueries return empty
+    results, or any exception is raised inside decomposition / merge.
+
+    Matches the shape of the closure that used to live inside
+    ``create_ai_search_tool`` at ``vector_search.py:1094-1254``.
+    """
+    logger.trace(
+        "Executing instructed retrieval", query=query, base_filters=base_filters
+    )
+    try:
+        decomposition_llm = _get_cached_llm(decomposition_config.model, context)
+
+        subqueries: list[SearchQuery] = decompose_query(
+            llm=decomposition_llm,
+            query=query,
+            columns=instructed_columns,
+            constraints=instructed_config.constraints,
+            max_subqueries=decomposition_config.max_subqueries,
+            examples=decomposition_config.examples,
+            previous_feedback=previous_feedback,
+            resource_info=ResourceInfo(
+                "model_serving",
+                decomposition_config.model.on_behalf_of_user,
+                decomposition_config.model.name,
+            ),
+        )
+
+        if not subqueries:
+            logger.warning(
+                "Query decomposition returned no subqueries, using original"
+            )
+            return run_search(query, base_filters)
+
+        normalized_base_filters = _normalize_filter_values(
+            base_filters, decomposition_config.normalize_filter_case
+        )
+
+        def execute_search(sq: SearchQuery) -> list[Document]:
+            logger.trace("Executing search", query=sq.text, filters=sq.filters)
+            sq_filters_dict: dict[str, Any] = {}
+            if sq.filters:
+                for item in sq.filters:
+                    sq_filters_dict[item.key] = item.value
+            sq_filters = _normalize_filter_values(
+                sq_filters_dict, decomposition_config.normalize_filter_case
+            )
+            # Decomposed filters take precedence over base filters
+            combined_filters: dict[str, Any] = {
+                **normalized_base_filters,
+                **sq_filters,
+            }
+            logger.trace(
+                "Executing search",
+                query=sq.text,
+                filters=combined_filters,
+            )
+            return run_search(sq.text, combined_filters)
+
+        logger.debug(
+            "Executing parallel searches",
+            num_subqueries=len(subqueries),
+            queries=[sq.text[:50] for sq in subqueries],
+        )
+
+        with ThreadPoolExecutor(
+            max_workers=decomposition_config.max_subqueries
+        ) as executor:
+            # Wrap once so per-subquery threads inherit the parent
+            # MLflow active-span ContextVar (span nesting).
+            all_results = list(
+                executor.map(in_caller_context(execute_search), subqueries)
+            )
+
+        merged = rrf_merge(
+            all_results,
+            k=decomposition_config.rrf_k,
+            primary_key=primary_key,
+        )
+
+        logger.debug(
+            "Instructed retrieval complete",
+            num_subqueries=len(subqueries),
+            total_results=sum(len(r) for r in all_results),
+            merged_results=len(merged),
+        )
+
+        if not merged:
+            logger.warning(
+                "All instructed subqueries returned empty results, "
+                "falling back to standard unfiltered search",
+                num_subqueries=len(subqueries),
+            )
+            return run_search(query, base_filters)
+
+        return merged
+
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "Instructed retrieval failed, falling back to standard search",
+            error=str(e),
+        )
+        return run_search(query, base_filters)
+
+
+@mlflow.trace(name="apply_post_processing", span_type=SpanType.RETRIEVER)
+def _apply_post_processing(
+    *,
+    documents: list[Document],
+    query: str,
+    mode: Mode,
+    auto_bypass: bool,
+    instructed_config: Optional[InstructedRetrieverModel],
+    instruction_rerank_config: Optional[InstructionAwareRerankModel],
+    instructed_columns: list[ColumnInfo],
+    context: Optional["Context"] = None,
+) -> list[Document]:
+    """Instruction-aware LLM reranking (post-FlashRank).
+
+    Skipped when ``mode == "standard"`` and ``auto_bypass`` is true — that's
+    the router's opt-out for simple queries where LLM re-scoring adds no
+    value. Lifted from ``vector_search.py:1271-1312``.
+    """
+    if mode == "standard" and auto_bypass:
+        span = mlflow.get_current_active_span()
+        if span:
+            span.set_attribute(ATTR_ROUTER_BYPASSED, True)
+        return documents
+
+    if instruction_rerank_config and instructed_config:
+        instruction_llm = (
+            _get_cached_llm(instruction_rerank_config.model, context)
+            if instruction_rerank_config.model
+            else None
+        )
+        if instruction_llm:
+            documents = instruction_aware_rerank(
+                llm=instruction_llm,
+                query=query,
+                documents=documents,
+                instructions=instruction_rerank_config.instructions,
+                columns=instructed_columns,
+                top_n=instruction_rerank_config.top_n,
+                resource_info=ResourceInfo(
+                    "model_serving",
+                    instruction_rerank_config.model.on_behalf_of_user,
+                    instruction_rerank_config.model.name,
+                )
+                if instruction_rerank_config.model
+                else None,
+            )
+    return documents
+
+
+def _decide_mode(
+    *,
+    query: str,
+    router_config: Optional[RouterModel],
+    instructed_config: Optional[InstructedRetrieverModel],
+    instructed_columns: list[ColumnInfo],
+    context: Optional["Context"] = None,
+) -> tuple[Mode, bool]:
+    """Route the query to ``"standard"`` or ``"instructed"``.
+
+    Returns ``(mode, auto_bypass)``. When there's no router but instructed
+    config exists, mode is ``"instructed"`` with ``auto_bypass=False``.
+    When neither is set, mode is ``"standard"`` with ``auto_bypass=True``.
+    """
+    mode: Mode = "standard"
+    auto_bypass = True
+
+    if router_config:
+        router_llm = (
+            _get_cached_llm(router_config.model, context)
+            if router_config.model
+            else None
+        )
+        auto_bypass = router_config.auto_bypass
+
+        if router_llm and instructed_config:
+            try:
+                mode = route_query(
+                    llm=router_llm,
+                    query=query,
+                    columns=instructed_columns,
+                    resource_info=ResourceInfo(
+                        "model_serving",
+                        router_config.model.on_behalf_of_user,
+                        router_config.model.name,
+                    ),
+                )
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "Router failed, defaulting to configured default", error=str(e)
+                )
+                span = mlflow.get_current_active_span()
+                if span:
+                    span.set_attribute(ATTR_ROUTER_FALLBACK, True)
+                mode = router_config.default_mode
+        else:
+            mode = router_config.default_mode
+    elif instructed_config:
+        # No router but instructed config is set — always run instructed.
+        mode = "instructed"
+        auto_bypass = False
+
+    return mode, auto_bypass
+
+
+def execute_instructed_pipeline(
+    *,
+    run_search: RunSearch,
+    query: str,
+    base_filters: dict[str, Any],
+    instructed_config: Optional[InstructedRetrieverModel],
+    router_config: Optional[RouterModel],
+    verifier_config: Optional[VerifierModel],
+    decomposition_config: Optional[DecompositionModel],
+    instruction_rerank_config: Optional[InstructionAwareRerankModel],
+    instructed_columns: list[ColumnInfo],
+    primary_key: Optional[str] = None,
+    ranker: Optional[Ranker] = None,
+    rerank_config: Optional[RerankParametersModel] = None,
+    context: Optional["Context"] = None,
+) -> list[Document]:
+    """Backend-agnostic full instructed-retrieval pipeline.
+
+    Orchestrates: router mode selection → (standard | instructed search) →
+    FlashRank cross-encoder rerank → instruction-aware LLM rerank →
+    verifier retry loop.
+
+    ``run_search`` is the only backend-coupled input. It receives
+    ``(query, filters)`` and returns the top-k documents from the
+    caller's retriever. The pipeline never touches ``vs.similarity_search``
+    directly.
+
+    All pipeline stages are optional:
+
+    - ``router_config``: if ``None`` and ``instructed_config`` is set, always
+      runs instructed mode; otherwise standard.
+    - ``instructed_config`` / ``decomposition_config``: if either is ``None``,
+      instructed mode degrades to standard (single ``run_search`` call).
+    - ``ranker`` / ``rerank_config``: skipped if either is ``None``.
+    - ``instruction_rerank_config``: skipped when standard + auto_bypass.
+    - ``verifier_config``: skipped if ``None``; retry loop is a no-op.
+
+    Returns the final ``list[Document]``. Serialization is the caller's
+    responsibility.
+    """
+    from dao_ai.tools.vector_search import rerank_documents
+
+    # Router / mode decision.
+    mode, auto_bypass = _decide_mode(
+        query=query,
+        router_config=router_config,
+        instructed_config=instructed_config,
+        instructed_columns=instructed_columns,
+        context=context,
+    )
+    logger.trace("Routing mode", mode=mode, auto_bypass=auto_bypass)
+    span = mlflow.get_current_active_span()
+    if span:
+        span.set_attribute(ATTR_ROUTER_MODE, mode)
+
+    retry_count = 0
+    max_retries = verifier_config.max_retries if verifier_config else 0
+    previous_feedback: Optional[str] = None
+    documents: list[Document] = []
+
+    while True:
+        # 1. Search (standard or instructed).
+        if mode == "instructed" and instructed_config and decomposition_config:
+            documents = _execute_instructed_search(
+                run_search=run_search,
+                query=query,
+                base_filters=base_filters,
+                instructed_config=instructed_config,
+                decomposition_config=decomposition_config,
+                instructed_columns=instructed_columns,
+                primary_key=primary_key,
+                previous_feedback=previous_feedback,
+                context=context,
+            )
+        else:
+            documents = run_search(query, base_filters)
+
+        # 2. FlashRank cross-encoder pass.
+        if ranker and rerank_config and documents:
+            logger.debug("Applying FlashRank reranking")
+            documents = rerank_documents(query, documents, ranker, rerank_config)
+
+        # 3. Instruction-aware LLM rerank.
+        documents = _apply_post_processing(
+            documents=documents,
+            query=query,
+            mode=mode,
+            auto_bypass=auto_bypass,
+            instructed_config=instructed_config,
+            instruction_rerank_config=instruction_rerank_config,
+            instructed_columns=instructed_columns,
+            context=context,
+        )
+
+        # 4. Verifier (optional).
+        if not verifier_config:
+            break
+        if mode == "standard" and auto_bypass:
+            break
+
+        verifier_llm = (
+            _get_cached_llm(verifier_config.model, context)
+            if verifier_config.model
+            else None
+        )
+        if not verifier_llm:
+            break
+
+        constraints = instructed_config.constraints if instructed_config else None
+
+        verification_result = verify_results(
+            llm=verifier_llm,
+            query=query,
+            documents=documents,
+            columns=instructed_columns,
+            constraints=constraints,
+            previous_feedback=previous_feedback,
+            resource_info=ResourceInfo(
+                "model_serving",
+                verifier_config.model.on_behalf_of_user,
+                verifier_config.model.name,
+            )
+            if verifier_config.model
+            else None,
+        )
+
+        _span = mlflow.get_current_active_span()
+        if verification_result.passed:
+            if _span:
+                _span.set_attribute(ATTR_VERIFIER_OUTCOME, "passed")
+                _span.set_attribute(ATTR_VERIFIER_RETRIES, retry_count)
+            break
+
+        # Warn-only: annotate and stop.
+        if verifier_config.on_failure == "warn":
+            if _span:
+                _span.set_attribute(ATTR_VERIFIER_OUTCOME, "warned")
+            documents = add_verification_metadata(documents, verification_result)
+            break
+
+        # Retries exhausted.
+        if retry_count >= max_retries:
+            if _span:
+                _span.set_attribute(ATTR_VERIFIER_OUTCOME, "exhausted")
+                _span.set_attribute(ATTR_VERIFIER_RETRIES, retry_count)
+            documents = add_verification_metadata(
+                documents, verification_result, exhausted=True
+            )
+            break
+
+        # Standard mode can't meaningfully retry (no decomposition to adjust).
+        if mode != "instructed":
+            if _span:
+                _span.set_attribute(ATTR_VERIFIER_OUTCOME, "warned")
+            documents = add_verification_metadata(documents, verification_result)
+            break
+
+        # Retry: re-execute with the verifier feedback.
+        retry_count += 1
+        previous_feedback = verification_result.feedback
+        logger.debug(
+            "Retrying search with verification feedback",
+            retry=retry_count,
+        )
+
+    return documents

--- a/src/dao_ai/tools/lakebase_search.py
+++ b/src/dao_ai/tools/lakebase_search.py
@@ -14,6 +14,7 @@ import json
 from typing import Any, Optional
 
 import mlflow
+from langchain_core.documents import Document
 from langchain_core.tools import StructuredTool
 from loguru import logger
 from mlflow.entities import SpanType
@@ -347,18 +348,60 @@ def create_lakebase_search_tool(
         static_dict = dict(retriever_model.search_parameters.filters or {})
         merged: dict[str, Any] = {**static_dict, **runtime_dict}
 
-        effective_params = retriever_model.search_parameters.model_copy(
-            update={"filters": merged}
-        )
-        lb_retriever.search_parameters = effective_params
+        # If instructed retrieval is configured, route through the shared
+        # pipeline (router → decompose → parallel → RRF → FlashRank →
+        # instruction rerank → verifier). Fast path below runs the raw
+        # retriever + optional FlashRank when no instructed config is set.
+        if retriever_model.instructed is not None:
+            from dao_ai.tools.instructed_pipeline import (
+                execute_instructed_pipeline,
+            )
 
-        docs = lb_retriever.invoke(query)
+            # Backend adapter — fresh LakebaseRetriever per subquery so
+            # concurrent ThreadPoolExecutor calls inside the pipeline are
+            # thread-safe (no shared search_parameters mutation).
+            def _run_search(qtxt: str, flt: dict[str, Any]) -> list[Document]:
+                sub_params = retriever_model.search_parameters.model_copy(
+                    update={"filters": flt or {}}
+                )
+                sub_retriever = LakebaseRetriever(
+                    vector_store=vs,
+                    search_parameters=sub_params,
+                )
+                return list(sub_retriever.invoke(qtxt))
 
-        # Optional FlashRank cross-encoder pass. Same helper ai_search
-        # uses — reranker_score lands in each Document.metadata.
-        if ranker is not None and rerank_config is not None and docs:
-            logger.debug("Applying FlashRank reranking to Lakebase results")
-            docs = rerank_documents(query, docs, ranker, rerank_config)
+            inst = retriever_model.instructed
+            docs = execute_instructed_pipeline(
+                run_search=_run_search,
+                query=query,
+                base_filters=merged,
+                instructed_config=inst,
+                router_config=inst.router,
+                verifier_config=inst.verifier,
+                decomposition_config=inst.decomposition,
+                instruction_rerank_config=inst.rerank,
+                instructed_columns=inst.columns,
+                primary_key=vs.id_column,
+                ranker=ranker,
+                rerank_config=rerank_config,
+            )
+        else:
+            # Fast path — no instructed pipeline. Mutation of
+            # search_parameters is safe here since this thread is the only
+            # caller (unlike the ThreadPoolExecutor fan-out above).
+            effective_params = retriever_model.search_parameters.model_copy(
+                update={"filters": merged}
+            )
+            lb_retriever.search_parameters = effective_params
+
+            docs = lb_retriever.invoke(query)
+
+            # Optional FlashRank cross-encoder pass. Same helper
+            # ai_search uses — reranker_score lands in each
+            # Document.metadata.
+            if ranker is not None and rerank_config is not None and docs:
+                logger.debug("Applying FlashRank reranking to Lakebase results")
+                docs = rerank_documents(query, docs, ranker, rerank_config)
 
         serialized = [
             {"page_content": d.page_content, "metadata": _jsonable(d.metadata)}

--- a/src/dao_ai/tools/vector_search.py
+++ b/src/dao_ai/tools/vector_search.py
@@ -1091,225 +1091,11 @@ def create_ai_search_tool(
     else:
         tool_description = base_description
 
-    @mlflow.trace(name="execute_instructed_retrieval", span_type=SpanType.RETRIEVER)
-    def _execute_instructed_retrieval(
-        vs: DatabricksVectorSearch,
-        query: str,
-        base_filters: dict[str, Any],
-        previous_feedback: str | None = None,
-        context: Context | None = None,
-    ) -> list[Document]:
-        """Execute instructed retrieval with query decomposition and RRF merging."""
-        logger.trace(
-            "Executing instructed retrieval", query=query, base_filters=base_filters
-        )
-        try:
-            decomposition_llm = _get_cached_llm(decomposition_config.model, context)
-
-            subqueries: list[SearchQuery] = decompose_query(
-                llm=decomposition_llm,
-                query=query,
-                columns=instructed_columns,
-                constraints=instructed_config.constraints,
-                max_subqueries=decomposition_config.max_subqueries,
-                examples=decomposition_config.examples,
-                previous_feedback=previous_feedback,
-                resource_info=ResourceInfo(
-                    "model_serving",
-                    decomposition_config.model.on_behalf_of_user,
-                    decomposition_config.model.name,
-                ),
-            )
-
-            if not subqueries:
-                logger.warning(
-                    "Query decomposition returned no subqueries, using original"
-                )
-                return vs.similarity_search(
-                    query=query,
-                    k=search_parameters.num_results or 5,
-                    filter=base_filters if base_filters else None,
-                    query_type=search_parameters.query_type or "ANN",
-                )
-
-            def normalize_filter_values(
-                filters: dict[str, Any], case: str | None
-            ) -> dict[str, Any]:
-                """Normalize string filter values to specified case."""
-                logger.trace("Normalizing filter values", filters=filters, case=case)
-                if not case or not filters:
-                    return filters
-                normalized = {}
-                for key, value in filters.items():
-                    if isinstance(value, str):
-                        normalized[key] = (
-                            value.upper() if case == "uppercase" else value.lower()
-                        )
-                    elif isinstance(value, list):
-                        normalized[key] = [
-                            v.upper()
-                            if case == "uppercase"
-                            else v.lower()
-                            if isinstance(v, str)
-                            else v
-                            for v in value
-                        ]
-                    else:
-                        normalized[key] = value
-                return normalized
-
-            # Normalize base_filters once for consistent case matching
-            normalized_base_filters = normalize_filter_values(
-                base_filters, decomposition_config.normalize_filter_case
-            )
-
-            def execute_search(sq: SearchQuery) -> list[Document]:
-                logger.trace("Executing search", query=sq.text, filters=sq.filters)
-                # Convert FilterItem list to dict
-                sq_filters_dict: dict[str, Any] = {}
-                if sq.filters:
-                    for item in sq.filters:
-                        sq_filters_dict[item.key] = item.value
-                sq_filters = normalize_filter_values(
-                    sq_filters_dict, decomposition_config.normalize_filter_case
-                )
-                k: int = search_parameters.num_results or 5
-                query_type: str = search_parameters.query_type or "ANN"
-                # Decomposed filters take precedence over base filters
-                combined_filters: dict[str, Any] = {
-                    **normalized_base_filters,
-                    **sq_filters,
-                }
-                logger.trace(
-                    "Executing search",
-                    query=sq.text,
-                    k=k,
-                    query_type=query_type,
-                    filters=combined_filters,
-                )
-                return vs.similarity_search(
-                    query=sq.text,
-                    k=k,
-                    filter=combined_filters if combined_filters else None,
-                    query_type=query_type,
-                )
-
-            logger.debug(
-                "Executing parallel searches",
-                num_subqueries=len(subqueries),
-                queries=[sq.text[:50] for sq in subqueries],
-            )
-
-            with ThreadPoolExecutor(
-                max_workers=decomposition_config.max_subqueries
-            ) as executor:
-                # Wrap once: every subquery thread runs inside the caller's
-                # captured contextvars so the MLflow active-span ContextVar
-                # propagates and the per-subquery autolog spans nest under
-                # the parent decomposed-retrieval span.
-                all_results = list(
-                    executor.map(in_caller_context(execute_search), subqueries)
-                )
-
-            merged = rrf_merge(
-                all_results,
-                k=decomposition_config.rrf_k,
-                primary_key=vector_store.primary_key,
-            )
-
-            logger.debug(
-                "Instructed retrieval complete",
-                num_subqueries=len(subqueries),
-                total_results=sum(len(r) for r in all_results),
-                merged_results=len(merged),
-            )
-
-            # Fallback when decomposed filters are too restrictive
-            if not merged:
-                logger.warning(
-                    "All instructed subqueries returned empty results, "
-                    "falling back to standard unfiltered search",
-                    num_subqueries=len(subqueries),
-                    queries=[sq.text[:50] for sq in subqueries],
-                )
-                return vs.similarity_search(
-                    query=query,
-                    k=search_parameters.num_results or 5,
-                    filter=base_filters if base_filters else None,
-                    query_type=search_parameters.query_type or "ANN",
-                )
-
-            return merged
-
-        except Exception as e:
-            logger.warning(
-                "Instructed retrieval failed, falling back to standard search",
-                error=str(e),
-            )
-            return vs.similarity_search(
-                query=query,
-                k=search_parameters.num_results or 5,
-                filter=base_filters if base_filters else None,
-                query_type=search_parameters.query_type or "ANN",
-            )
-
-    @mlflow.trace(name="execute_standard_search", span_type=SpanType.RETRIEVER)
-    def _execute_standard_search(
-        vs: DatabricksVectorSearch,
-        query: str,
-        base_filters: dict[str, Any],
-    ) -> list[Document]:
-        """Execute standard single-query search."""
-        logger.trace("Performing standard vector search", query_preview=query[:50])
-        return vs.similarity_search(
-            query=query,
-            k=search_parameters.num_results or 5,
-            filter=base_filters if base_filters else None,
-            query_type=search_parameters.query_type or "ANN",
-        )
-
-    @mlflow.trace(name="apply_post_processing", span_type=SpanType.RETRIEVER)
-    def _apply_post_processing(
-        documents: list[Document],
-        query: str,
-        mode: Literal["standard", "instructed"],
-        auto_bypass: bool,
-        context: Context | None = None,
-    ) -> list[Document]:
-        """Apply instruction-aware reranking based on mode and bypass settings."""
-        # Skip post-processing for standard mode when auto_bypass is enabled
-        if mode == "standard" and auto_bypass:
-            span = mlflow.get_current_active_span()
-            if span:
-                span.set_attribute(ATTR_ROUTER_BYPASSED, True)
-            return documents
-
-        # Apply instruction-aware reranking if configured
-        if instruction_rerank_config and instructed_config:
-            instruction_llm = (
-                _get_cached_llm(instruction_rerank_config.model, context)
-                if instruction_rerank_config.model
-                else None
-            )
-
-            if instruction_llm:
-                documents = instruction_aware_rerank(
-                    llm=instruction_llm,
-                    query=query,
-                    documents=documents,
-                    instructions=instruction_rerank_config.instructions,
-                    columns=instructed_columns,
-                    top_n=instruction_rerank_config.top_n,
-                    resource_info=ResourceInfo(
-                        "model_serving",
-                        instruction_rerank_config.model.on_behalf_of_user,
-                        instruction_rerank_config.model.name,
-                    )
-                    if instruction_rerank_config.model
-                    else None,
-                )
-
-        return documents
+    # Pipeline logic (execute_instructed_retrieval + apply_post_processing +
+    # verifier retry loop) lives in ``dao_ai.tools.instructed_pipeline`` so
+    # ``lakebase_search`` shares the same code path. See ``_run_search``
+    # inside the tool closure below for the backend adapter that wraps
+    # ``vs.similarity_search``.
 
     # Use @tool decorator for proper ToolRuntime injection. args_schema=
     # gives the LLM a structural JSON schema for `filters` (type=array,
@@ -1348,154 +1134,38 @@ def create_ai_search_tool(
             **(search_parameters.filters or {}),
         }
 
-        # Determine execution mode via router or config
-        mode: Literal["standard", "instructed"] = "standard"
-        auto_bypass = True
+        # Backend adapter for the shared instructed pipeline. Captures this
+        # invocation's ``vs`` (which may be OBO-scoped) plus the retriever's
+        # ``k`` + ``query_type``. The pipeline calls this once per subquery
+        # in instructed mode and once with base_filters in standard mode.
+        def _run_search(qtxt: str, flt: dict[str, Any]) -> list[Document]:
+            return vs.similarity_search(
+                query=qtxt,
+                k=search_parameters.num_results or 5,
+                filter=flt if flt else None,
+                query_type=search_parameters.query_type or "ANN",
+            )
 
-        logger.trace("Router configuration", router_config=router_config)
-        logger.trace("Instructed configuration", instructed_config=instructed_config)
-        logger.trace(
-            "Instruction-aware rerank configuration",
-            instruction_aware=instruction_rerank_config,
+        # All routing / decomposition / rerank / verify logic lives in
+        # ``dao_ai.tools.instructed_pipeline`` — same code path
+        # lakebase_search uses.
+        from dao_ai.tools.instructed_pipeline import execute_instructed_pipeline
+
+        documents = execute_instructed_pipeline(
+            run_search=_run_search,
+            query=query,
+            base_filters=base_filters,
+            instructed_config=instructed_config,
+            router_config=router_config,
+            verifier_config=verifier_config,
+            decomposition_config=decomposition_config,
+            instruction_rerank_config=instruction_rerank_config,
+            instructed_columns=instructed_columns,
+            primary_key=vector_store.primary_key,
+            ranker=ranker,
+            rerank_config=rerank_config,
+            context=context,
         )
-
-        if router_config:
-            router_llm = (
-                _get_cached_llm(router_config.model, context)
-                if router_config.model
-                else None
-            )
-            auto_bypass = router_config.auto_bypass
-
-            if router_llm and instructed_config:
-                try:
-                    mode = route_query(
-                        llm=router_llm,
-                        query=query,
-                        columns=instructed_columns,
-                        resource_info=ResourceInfo(
-                            "model_serving",
-                            router_config.model.on_behalf_of_user,
-                            router_config.model.name,
-                        ),
-                    )
-                except Exception as e:
-                    # Router fail-safe: default to standard mode
-                    logger.warning(
-                        "Router failed, defaulting to standard mode", error=str(e)
-                    )
-                    span = mlflow.get_current_active_span()
-                    if span:
-                        span.set_attribute(ATTR_ROUTER_FALLBACK, True)
-                    mode = router_config.default_mode
-            else:
-                mode = router_config.default_mode
-        elif instructed_config:
-            # No router but instructed is configured - use instructed mode
-            mode = "instructed"
-            auto_bypass = False
-
-        logger.trace("Routing mode", mode=mode, auto_bypass=auto_bypass)
-        span = mlflow.get_current_active_span()
-        if span:
-            span.set_attribute(ATTR_ROUTER_MODE, mode)
-
-        # Search + verify loop: re-executes search with feedback on verification failure
-        retry_count = 0
-        max_retries = verifier_config.max_retries if verifier_config else 0
-        previous_feedback: str | None = None
-
-        while True:
-            # Execute search based on mode
-            if mode == "instructed" and instructed_config and decomposition_config:
-                documents = _execute_instructed_retrieval(
-                    vs, query, base_filters, previous_feedback, context=context
-                )
-            else:
-                documents = _execute_standard_search(vs, query, base_filters)
-
-            # Apply FlashRank reranking if configured
-            if ranker and rerank_config and documents:
-                logger.debug("Applying FlashRank reranking")
-                documents = rerank_documents(query, documents, ranker, rerank_config)
-
-            # Apply instruction-aware reranking
-            documents = _apply_post_processing(
-                documents, query, mode, auto_bypass, context=context
-            )
-
-            # Verification (if configured)
-            if not verifier_config:
-                break
-
-            # Skip verification for standard mode when auto_bypass is enabled
-            if mode == "standard" and auto_bypass:
-                break
-
-            verifier_llm = (
-                _get_cached_llm(verifier_config.model, context)
-                if verifier_config.model
-                else None
-            )
-            if not verifier_llm:
-                break
-
-            constraints = instructed_config.constraints if instructed_config else None
-
-            verification_result = verify_results(
-                llm=verifier_llm,
-                query=query,
-                documents=documents,
-                columns=instructed_columns,
-                constraints=constraints,
-                previous_feedback=previous_feedback,
-                resource_info=ResourceInfo(
-                    "model_serving",
-                    verifier_config.model.on_behalf_of_user,
-                    verifier_config.model.name,
-                )
-                if verifier_config.model
-                else None,
-            )
-
-            _span = mlflow.get_current_active_span()
-            if verification_result.passed:
-                if _span:
-                    _span.set_attribute(ATTR_VERIFIER_OUTCOME, "passed")
-                    _span.set_attribute(ATTR_VERIFIER_RETRIES, retry_count)
-                break
-
-            # Warn-only: annotate and stop
-            if verifier_config.on_failure == "warn":
-                if _span:
-                    _span.set_attribute(ATTR_VERIFIER_OUTCOME, "warned")
-                documents = add_verification_metadata(documents, verification_result)
-                break
-
-            # Retries exhausted
-            if retry_count >= max_retries:
-                if _span:
-                    _span.set_attribute(ATTR_VERIFIER_OUTCOME, "exhausted")
-                    _span.set_attribute(ATTR_VERIFIER_RETRIES, retry_count)
-                documents = add_verification_metadata(
-                    documents, verification_result, exhausted=True
-                )
-                break
-
-            # Standard mode can't meaningfully retry (no decomposition to adjust)
-            if mode != "instructed":
-                if _span:
-                    _span.set_attribute(ATTR_VERIFIER_OUTCOME, "warned")
-                documents = add_verification_metadata(documents, verification_result)
-                break
-
-            # Retry: re-execute search with verifier feedback
-            retry_count += 1
-            previous_feedback = verification_result.feedback
-            logger.debug(
-                "Retrying search with verification feedback",
-                retry=retry_count,
-            )
 
         # Serialize documents to JSON format for LLM consumption
         serialized_docs: list[dict[str, Any]] = []

--- a/tests/dao_ai/test_instructed_pipeline.py
+++ b/tests/dao_ai/test_instructed_pipeline.py
@@ -1,0 +1,657 @@
+"""Unit tests for the backend-agnostic instructed-retrieval pipeline.
+
+Covers `execute_instructed_pipeline` with a fake `run_search` fixture:
+- Router mode selection (standard vs instructed, fallback, no-router path).
+- Decompose → parallel search → RRF merge (happy path).
+- Empty decomposition → fallback single call.
+- Exception in decompose → fallback single call.
+- Empty merge → fallback single call.
+- FlashRank invocation position.
+- Instruction-aware rerank called for instructed, skipped for standard+auto_bypass.
+- Verifier retry loop: passed / warn / retry-then-pass / exhausted paths.
+- Standard mode never retries.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.documents import Document
+
+from dao_ai.config import (
+    ColumnInfo,
+    DecompositionModel,
+    FilterItem,
+    InferenceEndpointModel,
+    InstructedRetrieverModel,
+    InstructionAwareRerankModel,
+    RouterModel,
+    SearchQuery,
+    VerificationResult,
+    VerifierModel,
+)
+from dao_ai.tools.instructed_pipeline import (
+    _decide_mode,
+    execute_instructed_pipeline,
+)
+
+
+@pytest.fixture()
+def columns() -> list[ColumnInfo]:
+    return [
+        ColumnInfo(name="category", type="string"),
+        ColumnInfo(name="priority", type="number"),
+    ]
+
+
+@pytest.fixture()
+def llm() -> InferenceEndpointModel:
+    return InferenceEndpointModel(name="databricks-claude-sonnet-4-5")
+
+
+@pytest.fixture()
+def decomposition(llm: InferenceEndpointModel) -> DecompositionModel:
+    return DecompositionModel(model=llm, max_subqueries=2, rrf_k=60)
+
+
+@pytest.fixture()
+def instructed_cfg(
+    llm: InferenceEndpointModel,
+    decomposition: DecompositionModel,
+    columns: list[ColumnInfo],
+) -> InstructedRetrieverModel:
+    return InstructedRetrieverModel(
+        columns=columns, decomposition=decomposition
+    )
+
+
+def _docs(*ids: str) -> list[Document]:
+    return [
+        Document(
+            page_content=f"content of {i}",
+            metadata={"id": i, "primary_key": i},
+        )
+        for i in ids
+    ]
+
+
+class TestDecideMode:
+    def test_no_router_no_instructed_is_standard(self) -> None:
+        mode, bypass = _decide_mode(
+            query="hi",
+            router_config=None,
+            instructed_config=None,
+            instructed_columns=[],
+        )
+        assert mode == "standard"
+        assert bypass is True
+
+    def test_no_router_with_instructed_is_instructed(
+        self, instructed_cfg: InstructedRetrieverModel
+    ) -> None:
+        mode, bypass = _decide_mode(
+            query="hi",
+            router_config=None,
+            instructed_config=instructed_cfg,
+            instructed_columns=instructed_cfg.columns,
+        )
+        assert mode == "instructed"
+        assert bypass is False
+
+    def test_router_no_llm_uses_default_mode(
+        self, instructed_cfg: InstructedRetrieverModel
+    ) -> None:
+        rc = RouterModel(default_mode="instructed", auto_bypass=True)
+        mode, bypass = _decide_mode(
+            query="hi",
+            router_config=rc,
+            instructed_config=instructed_cfg,
+            instructed_columns=instructed_cfg.columns,
+        )
+        assert mode == "instructed"
+        assert bypass is True
+
+    def test_router_llm_success(
+        self,
+        instructed_cfg: InstructedRetrieverModel,
+        llm: InferenceEndpointModel,
+    ) -> None:
+        rc = RouterModel(model=llm, default_mode="standard", auto_bypass=True)
+        with (
+            patch(
+                "dao_ai.tools.instructed_pipeline._get_cached_llm"
+            ) as mock_llm,
+            patch(
+                "dao_ai.tools.instructed_pipeline.route_query",
+                return_value="instructed",
+            ),
+        ):
+            mock_llm.return_value = MagicMock()
+            mode, _ = _decide_mode(
+                query="Milwaukee power tools under $200",
+                router_config=rc,
+                instructed_config=instructed_cfg,
+                instructed_columns=instructed_cfg.columns,
+            )
+        assert mode == "instructed"
+
+    def test_router_llm_failure_falls_back(
+        self,
+        instructed_cfg: InstructedRetrieverModel,
+        llm: InferenceEndpointModel,
+    ) -> None:
+        rc = RouterModel(model=llm, default_mode="instructed", auto_bypass=False)
+        with (
+            patch(
+                "dao_ai.tools.instructed_pipeline._get_cached_llm"
+            ) as mock_llm,
+            patch(
+                "dao_ai.tools.instructed_pipeline.route_query",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            mock_llm.return_value = MagicMock()
+            mode, bypass = _decide_mode(
+                query="hi",
+                router_config=rc,
+                instructed_config=instructed_cfg,
+                instructed_columns=instructed_cfg.columns,
+            )
+        assert mode == "instructed"
+        assert bypass is False
+
+
+class TestStandardMode:
+    def test_standard_runs_one_search(self, columns: list[ColumnInfo]) -> None:
+        calls: list[tuple[str, dict]] = []
+
+        def run_search(q: str, f: dict[str, Any]) -> list[Document]:
+            calls.append((q, f))
+            return _docs("a", "b")
+
+        docs = execute_instructed_pipeline(
+            run_search=run_search,
+            query="hello",
+            base_filters={"category": "x"},
+            instructed_config=None,
+            router_config=None,
+            verifier_config=None,
+            decomposition_config=None,
+            instruction_rerank_config=None,
+            instructed_columns=columns,
+        )
+        assert [d.metadata["id"] for d in docs] == ["a", "b"]
+        assert calls == [("hello", {"category": "x"})]
+
+
+class TestInstructedMode:
+    def test_decomposes_and_merges(
+        self, instructed_cfg: InstructedRetrieverModel
+    ) -> None:
+        calls: list[str] = []
+
+        def run_search(q: str, f: dict[str, Any]) -> list[Document]:
+            calls.append(q)
+            return _docs(f"result_for_{q}")
+
+        with (
+            patch(
+                "dao_ai.tools.instructed_pipeline._get_cached_llm"
+            ) as mock_llm,
+            patch(
+                "dao_ai.tools.instructed_pipeline.decompose_query"
+            ) as mock_decompose,
+        ):
+            mock_llm.return_value = MagicMock()
+            mock_decompose.return_value = [
+                SearchQuery(
+                    text="sub1", filters=[FilterItem(key="category", value="a")]
+                ),
+                SearchQuery(
+                    text="sub2", filters=[FilterItem(key="category", value="b")]
+                ),
+            ]
+            docs = execute_instructed_pipeline(
+                run_search=run_search,
+                query="complex",
+                base_filters={},
+                instructed_config=instructed_cfg,
+                router_config=None,
+                verifier_config=None,
+                decomposition_config=instructed_cfg.decomposition,
+                instruction_rerank_config=None,
+                instructed_columns=instructed_cfg.columns,
+            )
+
+        assert set(calls) == {"sub1", "sub2"}
+        assert len(docs) == 2
+        assert {d.metadata["id"] for d in docs} == {
+            "result_for_sub1",
+            "result_for_sub2",
+        }
+
+    def test_empty_decomposition_falls_back(
+        self, instructed_cfg: InstructedRetrieverModel
+    ) -> None:
+        calls: list[tuple[str, dict]] = []
+
+        def run_search(q: str, f: dict[str, Any]) -> list[Document]:
+            calls.append((q, f))
+            return _docs("fallback")
+
+        with (
+            patch(
+                "dao_ai.tools.instructed_pipeline._get_cached_llm"
+            ) as mock_llm,
+            patch(
+                "dao_ai.tools.instructed_pipeline.decompose_query", return_value=[]
+            ),
+        ):
+            mock_llm.return_value = MagicMock()
+            docs = execute_instructed_pipeline(
+                run_search=run_search,
+                query="hi",
+                base_filters={"a": 1},
+                instructed_config=instructed_cfg,
+                router_config=None,
+                verifier_config=None,
+                decomposition_config=instructed_cfg.decomposition,
+                instruction_rerank_config=None,
+                instructed_columns=instructed_cfg.columns,
+            )
+        assert calls == [("hi", {"a": 1})]
+        assert docs[0].metadata["id"] == "fallback"
+
+    def test_decomposition_exception_falls_back(
+        self, instructed_cfg: InstructedRetrieverModel
+    ) -> None:
+        calls: list[tuple[str, dict]] = []
+
+        def run_search(q: str, f: dict[str, Any]) -> list[Document]:
+            calls.append((q, f))
+            return _docs("fallback")
+
+        with (
+            patch(
+                "dao_ai.tools.instructed_pipeline._get_cached_llm"
+            ) as mock_llm,
+            patch(
+                "dao_ai.tools.instructed_pipeline.decompose_query",
+                side_effect=RuntimeError("LLM down"),
+            ),
+        ):
+            mock_llm.return_value = MagicMock()
+            docs = execute_instructed_pipeline(
+                run_search=run_search,
+                query="hi",
+                base_filters={"cat": "x"},
+                instructed_config=instructed_cfg,
+                router_config=None,
+                verifier_config=None,
+                decomposition_config=instructed_cfg.decomposition,
+                instruction_rerank_config=None,
+                instructed_columns=instructed_cfg.columns,
+            )
+        assert calls == [("hi", {"cat": "x"})]
+        assert docs
+
+    def test_empty_merge_falls_back(
+        self, instructed_cfg: InstructedRetrieverModel
+    ) -> None:
+        calls: list[str] = []
+
+        def run_search(q: str, f: dict[str, Any]) -> list[Document]:
+            calls.append(q)
+            return _docs("x")
+
+        with (
+            patch(
+                "dao_ai.tools.instructed_pipeline._get_cached_llm"
+            ) as mock_llm,
+            patch(
+                "dao_ai.tools.instructed_pipeline.decompose_query"
+            ) as mock_decompose,
+            patch(
+                "dao_ai.tools.instructed_pipeline.rrf_merge", return_value=[]
+            ),
+        ):
+            mock_llm.return_value = MagicMock()
+            mock_decompose.return_value = [
+                SearchQuery(text="sub1", filters=None),
+            ]
+            docs = execute_instructed_pipeline(
+                run_search=run_search,
+                query="original",
+                base_filters={},
+                instructed_config=instructed_cfg,
+                router_config=None,
+                verifier_config=None,
+                decomposition_config=instructed_cfg.decomposition,
+                instruction_rerank_config=None,
+                instructed_columns=instructed_cfg.columns,
+            )
+        assert "sub1" in calls
+        assert "original" in calls
+        assert docs
+
+
+class TestFlashRankPosition:
+    def test_runs_between_search_and_instruction_rerank(
+        self, columns: list[ColumnInfo]
+    ) -> None:
+        def run_search(q: str, f: dict[str, Any]) -> list[Document]:
+            return _docs("a", "b", "c")
+
+        fake_ranker = MagicMock(name="Ranker")
+        with patch(
+            "dao_ai.tools.vector_search.rerank_documents"
+        ) as mock_rerank:
+            mock_rerank.return_value = _docs("c", "b", "a")
+            docs = execute_instructed_pipeline(
+                run_search=run_search,
+                query="q",
+                base_filters={},
+                instructed_config=None,
+                router_config=None,
+                verifier_config=None,
+                decomposition_config=None,
+                instruction_rerank_config=None,
+                instructed_columns=columns,
+                ranker=fake_ranker,
+                rerank_config=MagicMock(),
+            )
+
+        mock_rerank.assert_called_once()
+        called_docs = mock_rerank.call_args.args[1]
+        assert [d.metadata["id"] for d in called_docs] == ["a", "b", "c"]
+        assert [d.metadata["id"] for d in docs] == ["c", "b", "a"]
+
+    def test_skipped_when_ranker_none(self, columns: list[ColumnInfo]) -> None:
+        def run_search(q: str, f: dict[str, Any]) -> list[Document]:
+            return _docs("a")
+
+        with patch(
+            "dao_ai.tools.vector_search.rerank_documents"
+        ) as mock_rerank:
+            execute_instructed_pipeline(
+                run_search=run_search,
+                query="q",
+                base_filters={},
+                instructed_config=None,
+                router_config=None,
+                verifier_config=None,
+                decomposition_config=None,
+                instruction_rerank_config=None,
+                instructed_columns=columns,
+                ranker=None,
+                rerank_config=None,
+            )
+        mock_rerank.assert_not_called()
+
+
+class TestInstructionRerank:
+    def test_skipped_for_standard_auto_bypass(
+        self, columns: list[ColumnInfo], llm: InferenceEndpointModel
+    ) -> None:
+        rc = RouterModel(default_mode="standard", auto_bypass=True)
+        instr_rerank = InstructionAwareRerankModel(model=llm)
+
+        def run_search(q: str, f: dict[str, Any]) -> list[Document]:
+            return _docs("a")
+
+        with patch(
+            "dao_ai.tools.instructed_pipeline.instruction_aware_rerank"
+        ) as mock_iar:
+            execute_instructed_pipeline(
+                run_search=run_search,
+                query="q",
+                base_filters={},
+                instructed_config=InstructedRetrieverModel(
+                    columns=columns, rerank=instr_rerank
+                ),
+                router_config=rc,
+                verifier_config=None,
+                decomposition_config=None,
+                instruction_rerank_config=instr_rerank,
+                instructed_columns=columns,
+            )
+        mock_iar.assert_not_called()
+
+    def test_called_for_instructed_mode(
+        self, columns: list[ColumnInfo], llm: InferenceEndpointModel
+    ) -> None:
+        instr_rerank = InstructionAwareRerankModel(model=llm)
+
+        def run_search(q: str, f: dict[str, Any]) -> list[Document]:
+            return _docs("a")
+
+        with (
+            patch(
+                "dao_ai.tools.instructed_pipeline._get_cached_llm"
+            ) as mock_llm,
+            patch(
+                "dao_ai.tools.instructed_pipeline.decompose_query", return_value=[]
+            ),
+            patch(
+                "dao_ai.tools.instructed_pipeline.instruction_aware_rerank",
+                return_value=_docs("rerank_a"),
+            ) as mock_iar,
+        ):
+            mock_llm.return_value = MagicMock()
+            docs = execute_instructed_pipeline(
+                run_search=run_search,
+                query="q",
+                base_filters={},
+                instructed_config=InstructedRetrieverModel(
+                    columns=columns,
+                    decomposition=DecompositionModel(model=llm),
+                    rerank=instr_rerank,
+                ),
+                router_config=None,
+                verifier_config=None,
+                decomposition_config=DecompositionModel(model=llm),
+                instruction_rerank_config=instr_rerank,
+                instructed_columns=columns,
+            )
+        mock_iar.assert_called_once()
+        assert docs[0].metadata["id"] == "rerank_a"
+
+
+class TestVerifierRetryLoop:
+    def _base(
+        self,
+        columns: list[ColumnInfo],
+        instructed_cfg: InstructedRetrieverModel,
+        run_search,
+    ) -> dict[str, Any]:
+        return dict(
+            run_search=run_search,
+            query="q",
+            base_filters={},
+            instructed_config=instructed_cfg,
+            router_config=None,
+            decomposition_config=instructed_cfg.decomposition,
+            instruction_rerank_config=None,
+            instructed_columns=columns,
+        )
+
+    def test_passed_stops_loop(
+        self,
+        columns: list[ColumnInfo],
+        instructed_cfg: InstructedRetrieverModel,
+        llm: InferenceEndpointModel,
+    ) -> None:
+        def run_search(q: str, f: dict[str, Any]) -> list[Document]:
+            return _docs("a")
+
+        verifier = VerifierModel(model=llm, on_failure="retry", max_retries=3)
+        with (
+            patch(
+                "dao_ai.tools.instructed_pipeline._get_cached_llm"
+            ) as mock_llm,
+            patch(
+                "dao_ai.tools.instructed_pipeline.decompose_query", return_value=[]
+            ),
+            patch(
+                "dao_ai.tools.instructed_pipeline.verify_results"
+            ) as mock_verify,
+        ):
+            mock_llm.return_value = MagicMock()
+            mock_verify.return_value = VerificationResult(passed=True, confidence=0.9)
+            execute_instructed_pipeline(
+                **self._base(columns, instructed_cfg, run_search),
+                verifier_config=verifier,
+            )
+        mock_verify.assert_called_once()
+
+    def test_warn_annotates_and_stops(
+        self,
+        columns: list[ColumnInfo],
+        instructed_cfg: InstructedRetrieverModel,
+        llm: InferenceEndpointModel,
+    ) -> None:
+        def run_search(q: str, f: dict[str, Any]) -> list[Document]:
+            return _docs("a")
+
+        verifier = VerifierModel(model=llm, on_failure="warn", max_retries=3)
+        vr = VerificationResult(passed=False, confidence=0.3, feedback="too broad")
+        with (
+            patch(
+                "dao_ai.tools.instructed_pipeline._get_cached_llm"
+            ) as mock_llm,
+            patch(
+                "dao_ai.tools.instructed_pipeline.decompose_query", return_value=[]
+            ),
+            patch(
+                "dao_ai.tools.instructed_pipeline.verify_results", return_value=vr
+            ) as mock_verify,
+            patch(
+                "dao_ai.tools.instructed_pipeline.add_verification_metadata"
+            ) as mock_annot,
+        ):
+            mock_llm.return_value = MagicMock()
+            mock_annot.return_value = _docs("annotated_a")
+            docs = execute_instructed_pipeline(
+                **self._base(columns, instructed_cfg, run_search),
+                verifier_config=verifier,
+            )
+        assert mock_verify.call_count == 1
+        mock_annot.assert_called_once()
+        assert docs[0].metadata["id"] == "annotated_a"
+
+    def test_retry_re_executes_with_feedback(
+        self,
+        columns: list[ColumnInfo],
+        instructed_cfg: InstructedRetrieverModel,
+        llm: InferenceEndpointModel,
+    ) -> None:
+        def run_search(q: str, f: dict[str, Any]) -> list[Document]:
+            return _docs("a")
+
+        verifier = VerifierModel(model=llm, on_failure="retry", max_retries=3)
+        results = [
+            VerificationResult(passed=False, confidence=0.3, feedback="add brand filter"),
+            VerificationResult(passed=True, confidence=0.9),
+        ]
+
+        with (
+            patch(
+                "dao_ai.tools.instructed_pipeline._get_cached_llm"
+            ) as mock_llm,
+            patch(
+                "dao_ai.tools.instructed_pipeline.decompose_query"
+            ) as mock_decompose,
+            patch(
+                "dao_ai.tools.instructed_pipeline.verify_results", side_effect=results
+            ) as mock_verify,
+        ):
+            mock_llm.return_value = MagicMock()
+            mock_decompose.return_value = [SearchQuery(text="sub1", filters=None)]
+            execute_instructed_pipeline(
+                **self._base(columns, instructed_cfg, run_search),
+                verifier_config=verifier,
+            )
+
+        assert mock_verify.call_count == 2
+        second_kwargs = mock_decompose.call_args_list[1].kwargs
+        assert second_kwargs.get("previous_feedback") == "add brand filter"
+
+    def test_retries_exhausted_annotates(
+        self,
+        columns: list[ColumnInfo],
+        instructed_cfg: InstructedRetrieverModel,
+        llm: InferenceEndpointModel,
+    ) -> None:
+        def run_search(q: str, f: dict[str, Any]) -> list[Document]:
+            return _docs("a")
+
+        verifier = VerifierModel(model=llm, on_failure="retry", max_retries=1)
+        vr = VerificationResult(passed=False, confidence=0.2, feedback="still bad")
+
+        with (
+            patch(
+                "dao_ai.tools.instructed_pipeline._get_cached_llm"
+            ) as mock_llm,
+            patch(
+                "dao_ai.tools.instructed_pipeline.decompose_query"
+            ) as mock_decompose,
+            patch(
+                "dao_ai.tools.instructed_pipeline.verify_results", return_value=vr
+            ) as mock_verify,
+            patch(
+                "dao_ai.tools.instructed_pipeline.add_verification_metadata"
+            ) as mock_annot,
+        ):
+            mock_llm.return_value = MagicMock()
+            mock_decompose.return_value = [SearchQuery(text="sub1", filters=None)]
+            mock_annot.return_value = _docs("exhausted_a")
+            docs = execute_instructed_pipeline(
+                **self._base(columns, instructed_cfg, run_search),
+                verifier_config=verifier,
+            )
+        assert mock_verify.call_count == 2
+        assert mock_annot.call_args.kwargs.get("exhausted") is True
+        assert docs[0].metadata["id"] == "exhausted_a"
+
+    def test_standard_mode_does_not_retry(
+        self,
+        columns: list[ColumnInfo],
+        instructed_cfg: InstructedRetrieverModel,
+        llm: InferenceEndpointModel,
+    ) -> None:
+        rc = RouterModel(default_mode="standard", auto_bypass=False)
+
+        def run_search(q: str, f: dict[str, Any]) -> list[Document]:
+            return _docs("a")
+
+        verifier = VerifierModel(model=llm, on_failure="retry", max_retries=3)
+        vr = VerificationResult(passed=False, confidence=0.4)
+
+        with (
+            patch(
+                "dao_ai.tools.instructed_pipeline._get_cached_llm"
+            ) as mock_llm,
+            patch(
+                "dao_ai.tools.instructed_pipeline.verify_results", return_value=vr
+            ) as mock_verify,
+            patch(
+                "dao_ai.tools.instructed_pipeline.add_verification_metadata"
+            ) as mock_annot,
+        ):
+            mock_llm.return_value = MagicMock()
+            mock_annot.return_value = _docs("annotated")
+            execute_instructed_pipeline(
+                run_search=run_search,
+                query="q",
+                base_filters={},
+                instructed_config=instructed_cfg,
+                router_config=rc,
+                verifier_config=verifier,
+                decomposition_config=instructed_cfg.decomposition,
+                instruction_rerank_config=None,
+                instructed_columns=columns,
+            )
+        assert mock_verify.call_count == 1
+        mock_annot.assert_called_once()

--- a/tests/dao_ai/test_vector_search_instructed.py
+++ b/tests/dao_ai/test_vector_search_instructed.py
@@ -77,9 +77,9 @@ def _make_instructed(
 class TestEmptyResultFallback:
     """Tests that empty instructed retrieval results trigger standard search fallback."""
 
-    @patch("dao_ai.tools.vector_search.rrf_merge")
-    @patch("dao_ai.tools.vector_search.decompose_query")
-    @patch("dao_ai.tools.vector_search._get_cached_llm")
+    @patch("dao_ai.tools.instructed_pipeline.rrf_merge")
+    @patch("dao_ai.tools.instructed_pipeline.decompose_query")
+    @patch("dao_ai.tools.instructed_pipeline._get_cached_llm")
     @patch("dao_ai.tools.vector_search.DatabricksVectorSearch")
     def test_empty_merge_falls_back_to_standard_search(
         self,
@@ -137,9 +137,9 @@ class TestEmptyResultFallback:
         )
         assert fallback_filter is None or fallback_filter == {}
 
-    @patch("dao_ai.tools.vector_search.rrf_merge")
-    @patch("dao_ai.tools.vector_search.decompose_query")
-    @patch("dao_ai.tools.vector_search._get_cached_llm")
+    @patch("dao_ai.tools.instructed_pipeline.rrf_merge")
+    @patch("dao_ai.tools.instructed_pipeline.decompose_query")
+    @patch("dao_ai.tools.instructed_pipeline._get_cached_llm")
     @patch("dao_ai.tools.vector_search.DatabricksVectorSearch")
     def test_nonempty_merge_does_not_fallback(
         self,
@@ -188,10 +188,10 @@ class TestEmptyResultFallback:
 class TestVerificationRetryLoop:
     """Tests that verification failure re-executes instructed search with feedback."""
 
-    @patch("dao_ai.tools.vector_search.verify_results")
-    @patch("dao_ai.tools.vector_search.rrf_merge")
-    @patch("dao_ai.tools.vector_search.decompose_query")
-    @patch("dao_ai.tools.vector_search._get_cached_llm")
+    @patch("dao_ai.tools.instructed_pipeline.verify_results")
+    @patch("dao_ai.tools.instructed_pipeline.rrf_merge")
+    @patch("dao_ai.tools.instructed_pipeline.decompose_query")
+    @patch("dao_ai.tools.instructed_pipeline._get_cached_llm")
     @patch("dao_ai.tools.vector_search.DatabricksVectorSearch")
     def test_retry_re_executes_search_with_feedback(
         self,
@@ -267,10 +267,10 @@ class TestVerificationRetryLoop:
         # verify_results should have been called twice
         assert mock_verify.call_count == 2
 
-    @patch("dao_ai.tools.vector_search.verify_results")
-    @patch("dao_ai.tools.vector_search.rrf_merge")
-    @patch("dao_ai.tools.vector_search.decompose_query")
-    @patch("dao_ai.tools.vector_search._get_cached_llm")
+    @patch("dao_ai.tools.instructed_pipeline.verify_results")
+    @patch("dao_ai.tools.instructed_pipeline.rrf_merge")
+    @patch("dao_ai.tools.instructed_pipeline.decompose_query")
+    @patch("dao_ai.tools.instructed_pipeline._get_cached_llm")
     @patch("dao_ai.tools.vector_search.DatabricksVectorSearch")
     def test_warn_mode_does_not_retry(
         self,
@@ -323,10 +323,10 @@ class TestVerificationRetryLoop:
         # Result should contain verification metadata
         assert result[0]["metadata"]["_verification_status"] == "failed"
 
-    @patch("dao_ai.tools.vector_search.verify_results")
-    @patch("dao_ai.tools.vector_search.rrf_merge")
-    @patch("dao_ai.tools.vector_search.decompose_query")
-    @patch("dao_ai.tools.vector_search._get_cached_llm")
+    @patch("dao_ai.tools.instructed_pipeline.verify_results")
+    @patch("dao_ai.tools.instructed_pipeline.rrf_merge")
+    @patch("dao_ai.tools.instructed_pipeline.decompose_query")
+    @patch("dao_ai.tools.instructed_pipeline._get_cached_llm")
     @patch("dao_ai.tools.vector_search.DatabricksVectorSearch")
     def test_retries_exhausted_annotates_docs(
         self,
@@ -385,8 +385,8 @@ class TestVerificationRetryLoop:
 class TestStandardModeNoRetry:
     """Tests that standard mode never retries verification, even when retry is configured."""
 
-    @patch("dao_ai.tools.vector_search.verify_results")
-    @patch("dao_ai.tools.vector_search._get_cached_llm")
+    @patch("dao_ai.tools.instructed_pipeline.verify_results")
+    @patch("dao_ai.tools.instructed_pipeline._get_cached_llm")
     @patch("dao_ai.tools.vector_search.DatabricksVectorSearch")
     def test_standard_mode_does_not_retry_on_verification_failure(
         self,


### PR DESCRIPTION
Stage 2 PR B — instructed retrieval on `lakebase_search`. Extracts the pipeline from `create_ai_search_tool`'s closure into a shared module both retrievers import via a backend-adapter callable.

## Depends on

- #158 (filter parity)
- #159 (base class + discriminator)
- #160 (rerank on lakebase_search) — this PR is cut off `feat/lakebase-rerank`

## Summary

- **Shared pipeline module** — new `src/dao_ai/tools/instructed_pipeline.py` (`execute_instructed_pipeline`) with backend-agnostic router → decompose → parallel search → RRF merge → FlashRank rerank → instruction-aware LLM rerank → verifier retry loop. Backend coupling reduced to a single `run_search: Callable[[str, dict], list[Document]]` param.
- `LakebaseRetrieverModel.instructed: Optional[InstructedRetrieverModel]` — identical field to `AiSearchRetrieverModel.instructed`. Composable with the top-level `rerank:` field.
- `create_ai_search_tool` now delegates to the shared pipeline; ~150 lines shorter. Span names + attributes unchanged.
- `create_lakebase_search_tool` builds a `run_search` adapter that constructs a **fresh** `LakebaseRetriever` per subquery (thread-safe under the pipeline's `ThreadPoolExecutor` fan-out).
- **All 21_lakebase_search examples refactored** to use a top-level `retrievers:` section referenced from `tools[].function.retriever:` (matches `ai_search` example convention) — per user request.
- **All examples now include client_id/client_secret/workspace_host** on the `DatabaseModel` via anchored `variables:` blocks with secret-scope + env-var fallback chains. Scope and key names are `parameters:` so they're overridable at bundle-gen time.
- New `21_lakebase_search/instructed.yaml` example covering all pipeline knobs.

## Test plan

- [x] **19/19 unit tests** in new `test_instructed_pipeline.py`: router mode selection (5), standard mode single call, instructed decompose+merge, all 3 fallback paths (empty decomposition / decomposition-exception / empty-merge), FlashRank position + skip conditions, instruction rerank called/skipped by mode, verifier retry loop (passed / warn / retry-with-feedback / exhausted / standard-mode-no-retry).
- [x] **Migrated `test_vector_search_instructed.py`** — 6 pre-existing mock-based tests updated to patch `dao_ai.tools.instructed_pipeline.*` instead of `dao_ai.tools.vector_search.*` (helpers moved). All pass.
- [x] **Full ai_search regression**: 257 tests + migrated instructed suite — no new failures. Same 4 pre-existing failures on `test_reranking.py` as `main` (unrelated).
- [x] **All 7 lakebase_search examples validate** after the refactor (ann_only, hybrid_rrf, bm25_only, filters_and_traces, dynamic_schema, reranked, new instructed).
- [x] **Live regression on both backends** (per user request):
    - `hardware-store-instructed` (ai_search) — deployed with `dao_ai-0.1.106-dev6`. Multi-intent DEWALT + Milwaukee query returned grounded product listings.
    - `dao-ai-lb-instructed` (lakebase_search) — deployed. Multi-intent password-reset + MFA query returned grounded KB answers.
- [x] **MLflow trace verification** on the lakebase deployment — queried `retail_consumer_goods.default.lb_instructed_otel_spans`; confirmed the full span tree:
    ```
    2x execute_instructed_retrieval
    2x decompose_query
    2x instruction_aware_rerank
    2x apply_post_processing
    2x lakebase_ann_search (subquery)
    2x lakebase_bm25_search (subquery)
    2x lakebase_hybrid_search
    4x lakebase_search (tool)
    ```
    Every backend-agnostic helper fires; no ai_search-branded span; both backends flow through identical code.

## Files

- **New**: `src/dao_ai/tools/instructed_pipeline.py`, `tests/dao_ai/test_instructed_pipeline.py`, `config/examples/21_lakebase_search/instructed.yaml`
- **Modified**: `src/dao_ai/config.py` (add `instructed` to `LakebaseRetrieverModel`), `src/dao_ai/tools/vector_search.py` (delegate to shared pipeline; -150 lines), `src/dao_ai/tools/lakebase_search.py` (branch on `instructed` with backend adapter), `tests/dao_ai/test_vector_search_instructed.py` (patch path migration)
- **Examples refactored**: all 21_lakebase_search/*.yaml — top-level `retrievers:` refs + SP auth params
- **Docs**: `docs/key-capabilities.md` §5.5 (Instructed Retrieval) parity note, `21_lakebase_search/README.md` new Instructed section + examples table entry

## Not in this PR

- Auto-provisioning (Stage 3) — independent
- `DatabricksReranker` on lakebase — not requested
- Hoisting `rerank` + `instructed` onto `BaseRetrieverModel` — now that both retrievers have identical fields, the extraction is straightforward but out of scope

This pull request and its description were written by Isaac.