### PR TITLE
feat(retrievers): type-safe filter defaults + LLM filter value coercion

### DIFF
--- a/src/dao_ai/tools/instructed_pipeline.py
+++ b/src/dao_ai/tools/instructed_pipeline.py
@@ -68,6 +68,115 @@ RunSearch = Callable[[str, dict[str, Any]], list[Document]]
 Mode = Literal["standard", "instructed"]
 
 
+# Base column name from a suffixed filter key ("priority >=" → "priority").
+# Suffixes are exactly the ones defined by _FILTER_OPERATOR_SUFFIXES in
+# vector_search.py — kept as a local tuple to avoid a cross-module import.
+_FILTER_KEY_SUFFIXES: tuple[str, ...] = (
+    " NOT LIKE",
+    " LIKE",
+    " NOT",
+    " <=",
+    " >=",
+    " <",
+    " >",
+)
+
+
+def _base_column_name(key: str) -> str:
+    """Strip a trailing operator suffix from a filter key."""
+    for suffix in _FILTER_KEY_SUFFIXES:
+        if key.endswith(suffix):
+            return key[: -len(suffix)]
+    return key
+
+
+def _coerce_scalar(value: Any, col_type: str) -> Any:
+    """Coerce a single scalar to the column's declared type.
+
+    Raises ValueError on failure so the caller can drop-and-warn. Returns
+    the value untouched when it's already type-compatible or when
+    ``col_type`` is ``string`` / ``array`` (no coercion needed).
+    """
+    from datetime import datetime
+
+    if col_type == "string" or col_type == "array":
+        return value
+    if col_type == "number":
+        if isinstance(value, bool):
+            raise ValueError(f"bool {value!r} not accepted as number")
+        if isinstance(value, (int, float)):
+            return value
+        s = str(value).strip()
+        # Prefer int when the string has no fractional part.
+        try:
+            return int(s)
+        except ValueError:
+            pass
+        return float(s)  # raises ValueError on bad input
+    if col_type == "boolean":
+        if isinstance(value, bool):
+            return value
+        s = str(value).strip().lower()
+        if s in {"true", "1", "yes"}:
+            return True
+        if s in {"false", "0", "no"}:
+            return False
+        raise ValueError(f"{value!r} not a boolean")
+    if col_type == "datetime":
+        if isinstance(value, datetime):
+            return value.isoformat()
+        # Accept anything datetime.fromisoformat can parse; keep the
+        # canonical ISO string on the wire so backends can render it into
+        # SQL / VS filter unchanged.
+        datetime.fromisoformat(str(value))
+        return str(value)
+    return value
+
+
+def coerce_filter_values(
+    filters: dict[str, Any],
+    columns: list["ColumnInfo"],
+) -> dict[str, Any]:
+    """Coerce LLM-emitted filter values to their column-declared type.
+
+    Trims a common LLM failure mode: decomposition emits
+    ``{"priority": "high"}`` on an integer column, Postgres 500s. Coerces
+    strings to ``int`` / ``float`` / ``bool`` / ``datetime`` per
+    ``ColumnInfo.type``; on failure drops the entry and logs a warning
+    tagged ``dao_ai.filter.coercion_failed`` so the query still runs
+    (degraded — one filter fewer — rather than hard-failing the tool call).
+
+    Suffixed keys (``"priority >="``) resolve to the base column via
+    :func:`_base_column_name`. Unknown columns pass through untouched
+    (the backend will reject them if invalid). List values coerce
+    element-wise; the whole entry is dropped if any element fails.
+    """
+    if not filters or not columns:
+        return filters
+    by_name: dict[str, ColumnInfo] = {c.name: c for c in columns}
+    coerced: dict[str, Any] = {}
+    for key, value in filters.items():
+        col = by_name.get(_base_column_name(key))
+        if col is None:
+            coerced[key] = value
+            continue
+        try:
+            if isinstance(value, list):
+                coerced[key] = [_coerce_scalar(v, col.type) for v in value]
+            else:
+                coerced[key] = _coerce_scalar(value, col.type)
+        except (ValueError, TypeError) as e:
+            logger.warning(
+                "dao_ai.filter.coercion_failed | col={} type={} value={!r} err={}: {} — dropping filter",
+                col.name,
+                col.type,
+                value,
+                type(e).__name__,
+                e,
+            )
+    return coerced
+
+
 def _normalize_filter_values(
     filters: dict[str, Any], case: Optional[str]
 ) -> dict[str, Any]:
@@ -153,6 +262,9 @@ def _execute_instructed_search(
             if sq.filters:
                 for item in sq.filters:
                     sq_filters_dict[item.key] = item.value
+            sq_filters_dict = coerce_filter_values(
+                sq_filters_dict, instructed_columns
+            )
             sq_filters = _normalize_filter_values(
                 sq_filters_dict, decomposition_config.normalize_filter_case
             )

--- a/src/dao_ai/tools/vector_search.py
+++ b/src/dao_ai/tools/vector_search.py
@@ -190,6 +190,24 @@ _FILTER_OPERATOR_SUFFIXES: tuple[str, ...] = (
 )
 
 
+# Per-type default operator whitelist for ColumnInfo entries whose
+# `operators` field wasn't hand-set. Applied by
+# `_normalize_declared_columns` when the user declares only `type`.
+# User-set `operators` always wins.
+#
+# - string:   full 8 (equality + IN + comparisons + LIKE + negations)
+# - number:   drop LIKE/NOT LIKE (nonsensical on numerics)
+# - boolean:  equality + NOT only (comparisons + LIKE are meaningless)
+# - datetime: drop LIKE/NOT LIKE (comparisons are the useful range ops)
+# - array:    equality only (VS rejects everything else on array cols)
+_DEFAULT_OPERATORS_BY_TYPE: dict[str, list[str]] = {
+    "number": ["", "NOT", "<", "<=", ">", ">="],
+    "boolean": ["", "NOT"],
+    "datetime": ["", "NOT", "<", "<=", ">", ">="],
+    "array": [""],
+}
+
+
 def _legal_filter_keys(
     columns: list[str],
     operator_overrides: dict[str, list[str]] | None = None,
@@ -434,17 +452,15 @@ def _normalize_declared_columns(
             types[name] = type_label
             if item.description:
                 descriptions[name] = item.description
-            # Only treat operators as an override when the user explicitly
-            # set them (Pydantic tracks this via model_fields_set). If the
-            # field defaulted to the full 8-op list, we let the standard
-            # `_legal_filter_keys` cross-product apply — same as bare
-            # strings — for consistency. Exception: type=="array" narrows
-            # to equality-only ("") by default, since VS rejects every
-            # other operator on array columns.
+            # User-set operators always win (tracked via Pydantic
+            # `model_fields_set`). Otherwise apply the per-type default
+            # from `_DEFAULT_OPERATORS_BY_TYPE` — number/boolean/datetime/
+            # array get narrower whitelists; string falls through to the
+            # full 8-operator cross-product at `_legal_filter_keys` time.
             if "operators" in item.model_fields_set:
                 operator_overrides[name] = list(item.operators)
-            elif item.type == "array":
-                operator_overrides[name] = [""]
+            elif item.type in _DEFAULT_OPERATORS_BY_TYPE:
+                operator_overrides[name] = list(_DEFAULT_OPERATORS_BY_TYPE[item.type])
         elif isinstance(item, str):
             names.append(item)
         else:

--- a/tests/dao_ai/test_coerce_filter_values.py
+++ b/tests/dao_ai/test_coerce_filter_values.py
@@ -1,0 +1,180 @@
+"""Unit tests for `coerce_filter_values` — the LLM-filter-robustness helper.
+
+Covers the common failure mode where LLM decomposition emits a string value
+on a non-string column (e.g. `{"priority": "high"}` on an int column) —
+Postgres 500s in the raw path; this helper coerces where possible and drops
+the entry with a warning where not, so the query still runs.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from dao_ai.config import ColumnInfo
+from dao_ai.tools.instructed_pipeline import (
+    _base_column_name,
+    coerce_filter_values,
+)
+
+
+@pytest.mark.unit
+class TestBaseColumnName:
+    def test_bare_column(self) -> None:
+        assert _base_column_name("priority") == "priority"
+
+    def test_suffix_stripped(self) -> None:
+        assert _base_column_name("priority >=") == "priority"
+        assert _base_column_name("priority NOT") == "priority"
+        assert _base_column_name("brand LIKE") == "brand"
+        assert _base_column_name("brand NOT LIKE") == "brand"
+
+    def test_column_containing_suffix_word_preserved(self) -> None:
+        # "note" doesn't end in " NOT" (space matters).
+        assert _base_column_name("note") == "note"
+
+
+@pytest.mark.unit
+class TestCoerceNumber:
+    cols = [ColumnInfo(name="priority", type="number")]
+
+    def test_int_string_to_int(self) -> None:
+        assert coerce_filter_values({"priority": "3"}, self.cols) == {"priority": 3}
+
+    def test_float_string_to_float(self) -> None:
+        assert coerce_filter_values({"priority": "3.14"}, self.cols) == {
+            "priority": 3.14
+        }
+
+    def test_int_passes_through(self) -> None:
+        assert coerce_filter_values({"priority": 5}, self.cols) == {"priority": 5}
+
+    def test_float_passes_through(self) -> None:
+        assert coerce_filter_values({"priority": 1.5}, self.cols) == {"priority": 1.5}
+
+    def test_bad_string_dropped(self, caplog) -> None:
+        out = coerce_filter_values({"priority": "high"}, self.cols)
+        assert out == {}
+
+    def test_suffixed_key_coerced(self) -> None:
+        assert coerce_filter_values({"priority >=": "3"}, self.cols) == {
+            "priority >=": 3
+        }
+
+    def test_list_of_int_strings(self) -> None:
+        assert coerce_filter_values({"priority": ["1", "2", "3"]}, self.cols) == {
+            "priority": [1, 2, 3]
+        }
+
+    def test_list_with_bad_element_drops_entire_entry(self) -> None:
+        out = coerce_filter_values({"priority": ["1", "high", "3"]}, self.cols)
+        assert out == {}
+
+    def test_bool_rejected_as_number(self) -> None:
+        # bool is technically int subclass in Python — reject to avoid
+        # sending True/False into a numeric column.
+        assert coerce_filter_values({"priority": True}, self.cols) == {}
+
+
+@pytest.mark.unit
+class TestCoerceBoolean:
+    cols = [ColumnInfo(name="active", type="boolean")]
+
+    def test_true_string(self) -> None:
+        assert coerce_filter_values({"active": "true"}, self.cols) == {"active": True}
+        assert coerce_filter_values({"active": "TRUE"}, self.cols) == {"active": True}
+
+    def test_false_string(self) -> None:
+        assert coerce_filter_values({"active": "false"}, self.cols) == {
+            "active": False
+        }
+
+    def test_numeric_string(self) -> None:
+        assert coerce_filter_values({"active": "1"}, self.cols) == {"active": True}
+        assert coerce_filter_values({"active": "0"}, self.cols) == {"active": False}
+
+    def test_yes_no(self) -> None:
+        assert coerce_filter_values({"active": "yes"}, self.cols) == {"active": True}
+        assert coerce_filter_values({"active": "no"}, self.cols) == {"active": False}
+
+    def test_bool_passes_through(self) -> None:
+        assert coerce_filter_values({"active": True}, self.cols) == {"active": True}
+
+    def test_unknown_dropped(self) -> None:
+        assert coerce_filter_values({"active": "maybe"}, self.cols) == {}
+
+
+@pytest.mark.unit
+class TestCoerceDatetime:
+    cols = [ColumnInfo(name="ts", type="datetime")]
+
+    def test_iso_date_kept(self) -> None:
+        assert coerce_filter_values({"ts": "2026-07-09"}, self.cols) == {
+            "ts": "2026-07-09"
+        }
+
+    def test_iso_datetime_kept(self) -> None:
+        assert coerce_filter_values({"ts": "2026-07-09T10:30:00"}, self.cols) == {
+            "ts": "2026-07-09T10:30:00"
+        }
+
+    def test_datetime_instance_becomes_iso(self) -> None:
+        dt = datetime(2026, 7, 9, 10, 30)
+        assert coerce_filter_values({"ts": dt}, self.cols) == {
+            "ts": "2026-07-09T10:30:00"
+        }
+
+    def test_unparseable_dropped(self) -> None:
+        assert coerce_filter_values({"ts": "yesterday"}, self.cols) == {}
+
+
+@pytest.mark.unit
+class TestCoercePassthroughs:
+    def test_string_untouched(self) -> None:
+        cols = [ColumnInfo(name="brand", type="string")]
+        assert coerce_filter_values({"brand": "DEWALT"}, cols) == {"brand": "DEWALT"}
+        # Integer on a string column stays an integer (no coercion for
+        # string type — the backend will str-coerce or reject).
+        assert coerce_filter_values({"brand": 5}, cols) == {"brand": 5}
+
+    def test_array_untouched(self) -> None:
+        cols = [ColumnInfo(name="tags", type="array")]
+        assert coerce_filter_values(
+            {"tags": ["cordless", "brushless"]}, cols
+        ) == {"tags": ["cordless", "brushless"]}
+
+    def test_unknown_column_passes_through(self) -> None:
+        cols = [ColumnInfo(name="brand", type="string")]
+        # The LLM might invent a column; let the backend reject.
+        assert coerce_filter_values({"invented_col": "x"}, cols) == {
+            "invented_col": "x"
+        }
+
+    def test_empty_filters(self) -> None:
+        assert coerce_filter_values({}, [ColumnInfo(name="x", type="number")]) == {}
+
+    def test_empty_columns(self) -> None:
+        # No columns declared → passthrough (nothing to coerce against).
+        assert coerce_filter_values({"anything": "value"}, []) == {"anything": "value"}
+
+
+@pytest.mark.unit
+class TestCoerceMixed:
+    def test_multi_column_filter(self) -> None:
+        cols = [
+            ColumnInfo(name="brand", type="string"),
+            ColumnInfo(name="price", type="number"),
+            ColumnInfo(name="in_stock", type="boolean"),
+        ]
+        out = coerce_filter_values(
+            {"brand": "DEWALT", "price": "99.99", "in_stock": "true"},
+            cols,
+        )
+        assert out == {"brand": "DEWALT", "price": 99.99, "in_stock": True}
+
+    def test_one_bad_entry_dropped_others_kept(self) -> None:
+        cols = [
+            ColumnInfo(name="brand", type="string"),
+            ColumnInfo(name="price", type="number"),
+        ]
+        out = coerce_filter_values({"brand": "DEWALT", "price": "cheap"}, cols)
+        assert out == {"brand": "DEWALT"}

--- a/tests/dao_ai/test_instructed_pipeline.py
+++ b/tests/dao_ai/test_instructed_pipeline.py
@@ -232,6 +232,94 @@ class TestInstructedMode:
             "result_for_sub2",
         }
 
+    def test_bad_type_filter_coerced_before_dispatch(
+        self, instructed_cfg: InstructedRetrieverModel
+    ) -> None:
+        """Regression: LLM emits `{priority: "3"}` (string) on int column.
+
+        The pipeline must coerce "3" → 3 BEFORE calling run_search — the
+        earlier lakebase failure was decomposition returning a string
+        value and Postgres 500'ing on the numeric column.
+        """
+        captured: list[dict[str, Any]] = []
+
+        def run_search(q: str, f: dict[str, Any]) -> list[Document]:
+            captured.append(dict(f))
+            return _docs("ok")
+
+        with (
+            patch(
+                "dao_ai.tools.instructed_pipeline._get_cached_llm"
+            ) as mock_llm,
+            patch(
+                "dao_ai.tools.instructed_pipeline.decompose_query"
+            ) as mock_decompose,
+        ):
+            mock_llm.return_value = MagicMock()
+            mock_decompose.return_value = [
+                SearchQuery(
+                    text="high priority",
+                    filters=[FilterItem(key="priority", value="3")],
+                ),
+            ]
+            execute_instructed_pipeline(
+                run_search=run_search,
+                query="q",
+                base_filters={},
+                instructed_config=instructed_cfg,
+                router_config=None,
+                verifier_config=None,
+                decomposition_config=instructed_cfg.decomposition,
+                instruction_rerank_config=None,
+                instructed_columns=instructed_cfg.columns,
+            )
+        # Coerced from "3" → 3 before dispatch.
+        assert captured == [{"priority": 3}]
+
+    def test_uncoercible_filter_dropped_and_search_continues(
+        self, instructed_cfg: InstructedRetrieverModel
+    ) -> None:
+        """Regression of the earlier lakebase 500: `{priority: "high"}`
+        on an int col is dropped-and-warned so the search still runs
+        (degraded, one fewer filter) rather than hard-failing."""
+        captured: list[dict[str, Any]] = []
+
+        def run_search(q: str, f: dict[str, Any]) -> list[Document]:
+            captured.append(dict(f))
+            return _docs("ok")
+
+        with (
+            patch(
+                "dao_ai.tools.instructed_pipeline._get_cached_llm"
+            ) as mock_llm,
+            patch(
+                "dao_ai.tools.instructed_pipeline.decompose_query"
+            ) as mock_decompose,
+        ):
+            mock_llm.return_value = MagicMock()
+            mock_decompose.return_value = [
+                SearchQuery(
+                    text="most important",
+                    filters=[
+                        FilterItem(key="category", value="auth"),
+                        FilterItem(key="priority", value="high"),  # bad
+                    ],
+                ),
+            ]
+            execute_instructed_pipeline(
+                run_search=run_search,
+                query="q",
+                base_filters={},
+                instructed_config=instructed_cfg,
+                router_config=None,
+                verifier_config=None,
+                decomposition_config=instructed_cfg.decomposition,
+                instruction_rerank_config=None,
+                instructed_columns=instructed_cfg.columns,
+            )
+        # `priority: "high"` dropped; `category: "auth"` kept.
+        assert captured == [{"category": "auth"}]
+
     def test_empty_decomposition_falls_back(
         self, instructed_cfg: InstructedRetrieverModel
     ) -> None:

--- a/tests/dao_ai/test_vector_search_dynamic_schema.py
+++ b/tests/dao_ai/test_vector_search_dynamic_schema.py
@@ -1070,7 +1070,9 @@ class TestNormalizeDeclaredColumns:
         assert names == ["brand", "price"]
         assert types == {"brand": "STRING", "price": "NUMBER"}
         assert descs == {"brand": "Brand name"}  # only where set
-        assert ops == {}  # neither set operators explicitly
+        # `string` falls through to the full 8-op default; `number` gets
+        # the per-type default (drops LIKE / NOT LIKE).
+        assert ops == {"price": ["", "NOT", "<", "<=", ">", ">="]}
         assert any_hand is True
 
     def test_column_info_explicit_operators(self) -> None:
@@ -1094,6 +1096,35 @@ class TestNormalizeDeclaredColumns:
         assert descs == {"brand": "Brand"}
         assert ops == {}
         assert any_hand is True
+
+    def test_type_driven_operator_defaults(self) -> None:
+        """Per-type default operator whitelist when `operators` not hand-set."""
+        items = [
+            ColumnInfo(name="name", type="string"),
+            ColumnInfo(name="qty", type="number"),
+            ColumnInfo(name="active", type="boolean"),
+            ColumnInfo(name="ts", type="datetime"),
+            ColumnInfo(name="tags", type="array"),
+        ]
+        _, _, _, ops, _ = _normalize_declared_columns(items)
+        # string → no override (falls through to full 8-op default)
+        assert "name" not in ops
+        # number / datetime → equality + NOT + comparisons (no LIKE)
+        assert ops["qty"] == ["", "NOT", "<", "<=", ">", ">="]
+        assert ops["ts"] == ["", "NOT", "<", "<=", ">", ">="]
+        # boolean → equality + NOT only
+        assert ops["active"] == ["", "NOT"]
+        # array → equality only (VS rejects everything else)
+        assert ops["tags"] == [""]
+
+    def test_hand_set_operators_win_over_type_default(self) -> None:
+        """Explicit `operators` always wins, even for non-string types."""
+        items = [
+            ColumnInfo(name="qty", type="number", operators=["", "LIKE"]),
+        ]
+        _, _, _, ops, _ = _normalize_declared_columns(items)
+        # Nonsensical for a number, but the user asked for it.
+        assert ops["qty"] == ["", "LIKE"]
 
     def test_empty_list(self) -> None:
         names, types, descs, ops, any_hand = _normalize_declared_columns([])
@@ -1194,10 +1225,12 @@ class TestHandDeclaredColumnInfoInFactory:
         enum = tool.args_schema.model_json_schema()["$defs"][
             "DynamicFilterItem"
         ]["properties"]["key"]["enum"]
-        # brand is locked to 2 ops; price gets full 8.
+        # brand is hand-locked to 2 ops; price falls to the per-type
+        # numeric default (equality + NOT + comparisons, no LIKE).
         assert "brand" in enum and "brand LIKE" in enum
         assert "brand NOT" not in enum and "brand <" not in enum
-        assert "price" in enum and "price LIKE" in enum and "price <" in enum
+        assert "price" in enum and "price <" in enum
+        assert "price LIKE" not in enum and "price NOT LIKE" not in enum
 
     def test_hand_declared_default_operators_gets_all_suffixes(self) -> None:
         """ColumnInfo without explicit operators → the default full-list


### PR DESCRIPTION
## Summary

Two complementary robustness fixes for filter handling — shared by `ai_search` and `lakebase_search` since both retrievers already share the pipeline and tool-schema builder.

### A — Type-driven operator whitelist

Default `ColumnInfo.operators` from the column's declared `type` when the user doesn't hand-set them:
- **string** → full 8 (unchanged)
- **number** → drop LIKE / NOT LIKE
- **boolean** → equality + NOT only
- **datetime** → drop LIKE / NOT LIKE
- **array** → equality only (unchanged)

User-set `operators` still wins. The LLM's tool-schema `Literal[...]` on the filter-key field is narrower per column, so nonsensical operators (like `priority LIKE`) don't reach the backend and the LLM sees fewer bad options.

### B — LLM filter value coercion

New `coerce_filter_values(filters, columns)` in `instructed_pipeline.py` coerces string values to the column's declared type before dispatch:
- `int` / `float` / `bool` / `datetime.fromisoformat`
- On coercion failure → drop the entry, log `dao_ai.filter.coercion_failed`, continue

Regression of the earlier lakebase deploy where LLM decomposition emitted `{"priority": "high"}` on an integer column and Postgres 500'd. Now: coerce where possible, drop-and-warn where not, search always completes.

## Impact

- **Context**: A slightly *shrinks* the tool JSON schema (fewer Literal entries per column). B is invisible to the LLM.
- **DB overhead**: Zero. Both use the column-metadata read already performed at tool-factory init.
- **Latency**: A one-time at init. B microseconds per filter item.
- **Backwards compat**: hand-set `operators` always wins; string columns unchanged; existing pipelines continue to work.

## Test plan

- [x] `test_coerce_filter_values.py` (new, 29 tests): scalar + list coercion for all types, suffixed-key resolution, unknown-column passthrough, bad-element-drops-entry, empty/list edge cases.
- [x] `test_vector_search_dynamic_schema.py`: 2 new tests for per-type operator defaults + hand-set-wins; updated 2 pre-existing assertions that assumed number columns got the full 8-op set.
- [x] `test_instructed_pipeline.py`: 2 new regression tests reproducing the lakebase priority-int bug (coerce-and-continue + drop-and-continue).
- [x] `uv run pytest tests/dao_ai/test_coerce_filter_values.py tests/dao_ai/test_vector_search_dynamic_schema.py tests/dao_ai/test_instructed_pipeline.py tests/dao_ai/test_instructed_retriever.py tests/dao_ai/test_lakebase_search.py tests/dao_ai/test_vector_search_instructed.py tests/dao_ai/test_router.py tests/dao_ai/test_verifier.py tests/dao_ai/test_retriever_model_hierarchy.py` — **295 pass, 2 skipped**.
- [x] **Live regression on lakebase** (`dao-ai-lb-instructed` app, fevm workspace): sent `"Give me the most important auth articles — high priority only."` — HTTP 200, 28 OTEL spans, every one `STATUS_CODE_OK`. Pre-fix, the same query 500'd inside `lakebase_hybrid_search` with `invalid input syntax for type integer`. Trace confirmed via `retail_consumer_goods.default.lb_instructed_otel_spans`.

## Known gap (follow-up)

Fix A doesn't reach the decomposition schema — `create_decomposition_schema` in `instructed_retriever.py` still shows all 8 operators on the LLM's structured-output schema because it reads `col.operators` directly from `ColumnInfo` (whose default is all 8). To close that gap, `ColumnInfo` needs a validator that narrows its own `operators` default from `type`. Small follow-up.

This pull request and its description were written by Isaac.