### PR TITLE
feat(cli): dao-ai link-trace-destination — post-deploy UC trace linkage

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,8 @@ databricks grants update schema <catalog>.<schema> -p <profile> \
   --json "{\"changes\":[{\"principal\":\"$SP\",\"add\":[\"USE_SCHEMA\",\"CREATE_TABLE\",\"MODIFY\",\"SELECT\"]}]}"
 ```
 
+**Run `dao-ai link-trace-destination` between `bundle deploy` and `bundle run`** so the UC linkage is established from your machine on a fresh (0-traces) experiment — the app's own runtime link attempt is rejected on re-deploys with `already contains traces`, which causes silent trace loss. `generate-bundle` prints a one-line reminder in its "Next steps" when `trace_location` is set. See [`docs/cli-reference.md#link-trace-destination`](docs/cli-reference.md#link-trace-destination) for details, including the migration playbook (Databricks does not allow un-linking or changing a UC destination once set — moving traces to a different `catalog` / `schema` / `table_prefix` requires a fresh experiment).
+
 When `trace_location` is unset, `generate-bundle` emits a loud warning. Local notebook/CLI runs and Model Serving deploys are unaffected and continue to use the default control-plane path. See `config/examples/01_getting_started/ai_gateway.yaml` for a commented example.
 
 ### Multi-Cloud Deployment

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -265,13 +265,14 @@ If none of the above resolves, the CLI prints the candidates and exits 1.
 
 **1. You must restart the app after linking.** MLflow's OTEL exporter binds the trace destination at **process startup**. Running `link-trace-destination` while the app is up does not retroactively route in-flight traces to the new location — the running exporter is already bound to whatever destination was in effect when it started. Trigger `databricks apps restart <name>` (or any bundle re-deploy) so the app picks up the fresh linkage.
 
-**2. Changing a UC trace destination is restricted.** MLflow *does* expose `mlflow.tracing.unset_experiment_trace_location(location, experiment_id=...)` for un-linking (OSS API, `tracing/enablement.py:115-163`), and `mlflow.tracing.set_experiment_trace_location(...)` for the follow-up re-link — the OSS-supported swap is `unset → set`. On Databricks, though:
+**2. A UC-linked experiment is permanently bound to that destination on Databricks.** Verified against a live Databricks workspace (MLflow 3.11):
 
-- **Re-linking to the *same* tuple** — safe (idempotent, returns existing).
-- **Un-linking + re-linking to a *different* tuple** — MLflow's own client-side guard is based on the `mlflow.experiment.databricksTraceDestinationPath` tag, not on trace count; after `unset`, the tag is removed so a fresh `set` should be accepted. However, the Databricks control plane may still reject with `already contains traces` when the experiment has existing spans — the exact policy depends on backend version. **Untested against a live Databricks workspace as of this doc; verify on your workspace before scripting a migration.**
-- **`table_prefix` / `catalog` / `schema` change without un-linking first** — always rejected.
+- **Re-linking to the *same* destination** — safe (idempotent, no error).
+- **`mlflow.tracing.unset_experiment_trace_location(...)`** — the OSS API exists (`tracing/enablement.py:115-163`), but the Databricks control plane explicitly rejects it:
+  > `BAD_REQUEST: Unlinking an experiment from a Unity Catalog trace location is not allowed. Once linked, an experiment cannot be unlinked from its trace location.`
+- **Changing `table_prefix` / `catalog` / `schema`** — impossible, since you can't un-link first. The `unset → set` swap that OSS MLflow supports does not work here.
 
-If you need to change the destination and the swap path is blocked by the backend, fall back to the migration playbook below (create a fresh experiment).
+There is no `force`, `replace`, or delete-and-recreate-linkage flag anywhere in the client or server API. The only recovery path is the fresh-experiment migration playbook below.
 
 ### Migration playbook — moving traces to a new UC destination
 
@@ -312,7 +313,7 @@ databricks bundle run <new-app-name> --target dev -p <profile>
 databricks apps restart <new-app-name> -p <profile>
 ```
 
-The **old** experiment can be un-linked from its UC destination via `mlflow.tracing.unset_experiment_trace_location(location, experiment_id=<old-id>)` (subject to the Databricks-backend caveat above), or deleted outright via `mlflow.delete_experiment(<old-id>)` / the workspace UI (soft-delete; hard purge is a workspace cleanup job).
+The **old** experiment stays linked to its original destination — Databricks does not allow un-linking. If you no longer need the old data, delete the experiment outright via `mlflow.delete_experiment(<old-id>)` (or the workspace UI). That's a soft-delete; a hard purge is a workspace cleanup job. The OTEL Delta tables the old experiment wrote to are not affected by experiment deletion — drop them separately if you want the storage back.
 
 ## Interactive Chat
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -169,6 +169,24 @@ When `trace_location` is unset, `generate-bundle` emits a `⚠` warning to alert
 
 See `config/examples/01_getting_started/ai_gateway.yaml` for a drop-in example.
 
+#### Linking the UC trace destination — run `dao-ai link-trace-destination` between deploy and run
+
+MLflow requires the UC trace-destination link to be established on an experiment **before** that experiment receives any traces. On a re-deploy (or after a `trace_location` change), the experiment already has traces from prior runs, so the app's runtime attempt to link is rejected with `already contains traces` and every subsequent trace silently drops with `TABLE_DOES_NOT_EXIST`.
+
+The fix is a standalone CLI verb that links from **your** machine (operator credentials, deterministic timing) instead of relying on the running app to link itself:
+
+```bash
+databricks bundle deploy --target dev -p <profile>
+dao-ai link-trace-destination -c my_config.yaml -p <profile>
+databricks bundle run <app-name> --target dev -p <profile>
+# then restart to pick up the freshly-linked destination:
+databricks apps restart <app-name> -p <profile>
+```
+
+The verb is idempotent — safe on every deploy — but load-bearing on re-deploys and after `trace_location` changes. `generate-bundle` prints a one-line reminder in its "Next steps" when `trace_location` is configured.
+
+See [Link Trace Destination](#link-trace-destination) for full flag reference and the migration playbook for moving traces between destinations.
+
 ### Overwriting Existing Files
 
 If the output directory already contains generated files, they are skipped by default. Use `--force` to overwrite:
@@ -210,6 +228,91 @@ uv sync
 databricks bundle deploy --target dev
 databricks bundle run <app-name> --target dev
 ```
+
+## Link Trace Destination
+
+`dao-ai link-trace-destination` attaches an MLflow experiment to its Unity Catalog trace destination declared under `app.trace_location`. Run it as an explicit step **between** `databricks bundle deploy` and `databricks bundle run` — see the [background above](#linking-the-uc-trace-destination--run-dao-ai-link-trace-destination-between-deploy-and-run) for why the app's runtime attempt is unreliable.
+
+### Basic usage
+
+```bash
+databricks bundle deploy --target dev -p <profile>
+dao-ai link-trace-destination -c my_config.yaml -p <profile>
+databricks bundle run <app-name> --target dev -p <profile>
+databricks apps restart <app-name> -p <profile>    # required — see below
+```
+
+### Flags
+
+| Flag | Purpose |
+|---|---|
+| `-c FILE`, `--config FILE` | Config file. Must set `app.trace_location`. |
+| `-p PROFILE`, `--profile PROFILE` | Databricks profile for auth. |
+| `--experiment-id ID` | Skip resolution and use this experiment id directly. |
+| `--param KEY=VALUE` / `--var KEY=VALUE` | Config parameter overrides (repeatable). |
+
+### Experiment resolution
+
+Tries in order:
+
+1. `--experiment-id` explicit override.
+2. `config.app.experiment.resolved_id` when the config sets an explicit `experiment:` block.
+3. Bundle-declared name lookup — tries **both** the plain `/Users/<user>/<app-name>` name AND the DABs `--target dev`-prefixed variant `/Users/<user>/[dev <sanitized-user>] <app-name>`, so the same command works for prod deploys and personal dev deploys.
+
+If none of the above resolves, the CLI prints the candidates and exits 1.
+
+### Two things that surprise operators
+
+**1. You must restart the app after linking.** MLflow's OTEL exporter binds the trace destination at **process startup**. Running `link-trace-destination` while the app is up does not retroactively route in-flight traces to the new location — the running exporter is already bound to whatever destination was in effect when it started. Trigger `databricks apps restart <name>` (or any bundle re-deploy) so the app picks up the fresh linkage.
+
+**2. Changing a UC trace destination is restricted.** MLflow *does* expose `mlflow.tracing.unset_experiment_trace_location(location, experiment_id=...)` for un-linking (OSS API, `tracing/enablement.py:115-163`), and `mlflow.tracing.set_experiment_trace_location(...)` for the follow-up re-link — the OSS-supported swap is `unset → set`. On Databricks, though:
+
+- **Re-linking to the *same* tuple** — safe (idempotent, returns existing).
+- **Un-linking + re-linking to a *different* tuple** — MLflow's own client-side guard is based on the `mlflow.experiment.databricksTraceDestinationPath` tag, not on trace count; after `unset`, the tag is removed so a fresh `set` should be accepted. However, the Databricks control plane may still reject with `already contains traces` when the experiment has existing spans — the exact policy depends on backend version. **Untested against a live Databricks workspace as of this doc; verify on your workspace before scripting a migration.**
+- **`table_prefix` / `catalog` / `schema` change without un-linking first** — always rejected.
+
+If you need to change the destination and the swap path is blocked by the backend, fall back to the migration playbook below (create a fresh experiment).
+
+### Migration playbook — moving traces to a new UC destination
+
+When you actually need to change `table_prefix`, `catalog`, `schema`, or want traces to land somewhere new, you can't mutate the existing experiment — create a fresh one and re-point the app:
+
+```yaml
+# 1. In your config, point at a new experiment. Two options:
+#
+#    (a) Change the experiment name explicitly:
+app:
+  experiment:
+    name: /Users/me@databricks.com/my-app-v2       # new path
+
+#    (b) Rename the app itself (auto-declared experiment path derives
+#        from app.name — a rename gives you a fresh experiment):
+app:
+  name: my-app-v2                                  # was: my-app
+
+# 2. (Optional) update trace_location. `table_prefix` is optional in
+#    dao-ai — if omitted, MLflow uses the experiment id as the prefix,
+#    which is fine (and often preferred) since a fresh experiment
+#    already gives you a fresh table namespace. Only set an explicit
+#    `table_prefix` when you want a human-readable name in the OTEL
+#    Delta tables (e.g. for dashboarding).
+  trace_location:
+    schema: *my_schema
+    warehouse: *my_warehouse
+    # table_prefix: my_app_v2_traces               # optional
+```
+
+```bash
+# 3. Deploy → link → run → restart.
+dao-ai generate-bundle -c my_config.yaml -o ./bundle --force
+cd ./bundle
+databricks bundle deploy --target dev -p <profile>
+dao-ai link-trace-destination -c ../my_config.yaml -p <profile>
+databricks bundle run <new-app-name> --target dev -p <profile>
+databricks apps restart <new-app-name> -p <profile>
+```
+
+The **old** experiment can be un-linked from its UC destination via `mlflow.tracing.unset_experiment_trace_location(location, experiment_id=<old-id>)` (subject to the Databricks-backend caveat above), or deleted outright via `mlflow.delete_experiment(<old-id>)` / the workspace UI (soft-delete; hard purge is a workspace cleanup job).
 
 ## Interactive Chat
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -384,12 +384,28 @@ app:
     max_tokens_before_summary: int | null     # Triggers summarization at this token count
     max_messages_before_summary: int | null   # OR triggers at this message count (mutually exclusive)
 
-  # OTEL trace storage in Unity Catalog Delta tables
+  # OTEL trace storage in Unity Catalog Delta tables.
+  # Requires an explicit post-deploy link step:
+  #   `dao-ai link-trace-destination -c my_config.yaml -p <profile>`
+  # See `docs/cli-reference.md#link-trace-destination` for the flow and
+  # for the migration playbook (changing table_prefix / catalog / schema
+  # requires a fresh experiment — MLflow does not support in-place edits
+  # to a UC trace destination once the experiment has any traces).
   trace_location:
     # Either provide a schema + warehouse (preferred), or pass a single
     # "catalog.schema" string and the warehouse separately.
     schema: *my_schema
     warehouse: *warehouse | string    # WarehouseModel ref OR warehouse-id string
+    table_prefix: string | null       # Prefix for the OTEL tables
+                                      # (<prefix>_otel_{spans,logs,metrics}).
+                                      # null → MLflow uses the experiment id
+                                      # as the prefix (backend-assigned).
+                                      # Changing this on an existing experiment
+                                      # requires the unset → set swap; on some
+                                      # Databricks backends the swap is rejected
+                                      # once the experiment has traces. See
+                                      # `docs/cli-reference.md#link-trace-destination`
+                                      # for the migration playbook.
 
   # Production monitoring via MLflow GenAI scorers
   monitoring:

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -388,9 +388,11 @@ app:
   # Requires an explicit post-deploy link step:
   #   `dao-ai link-trace-destination -c my_config.yaml -p <profile>`
   # See `docs/cli-reference.md#link-trace-destination` for the flow and
-  # for the migration playbook (changing table_prefix / catalog / schema
-  # requires a fresh experiment — MLflow does not support in-place edits
-  # to a UC trace destination once the experiment has any traces).
+  # for the migration playbook. IMPORTANT: once an experiment is linked
+  # to a UC destination, Databricks does NOT allow un-linking or
+  # changing the destination (verified live — the server rejects
+  # `unset_experiment_trace_location`). Changing catalog / schema /
+  # table_prefix requires creating a fresh experiment.
   trace_location:
     # Either provide a schema + warehouse (preferred), or pass a single
     # "catalog.schema" string and the warehouse separately.
@@ -400,12 +402,8 @@ app:
                                       # (<prefix>_otel_{spans,logs,metrics}).
                                       # null → MLflow uses the experiment id
                                       # as the prefix (backend-assigned).
-                                      # Changing this on an existing experiment
-                                      # requires the unset → set swap; on some
-                                      # Databricks backends the swap is rejected
-                                      # once the experiment has traces. See
-                                      # `docs/cli-reference.md#link-trace-destination`
-                                      # for the migration playbook.
+                                      # PERMANENT once linked — see the note
+                                      # above on the trace_location block.
 
   # Production monitoring via MLflow GenAI scorers
   monitoring:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -693,7 +693,7 @@ See [Lab 15 — Background Agents](https://github.com/natefleming/dao-ai-worksho
 
 ### How do I route traces to a UC schema?
 
-Declare `app.trace_location:` on the AppConfig. The dao-ai deploy paths (both Databricks Apps and Model Serving) will call `mlflow.set_experiment(experiment_id=..., trace_location=UnityCatalog(...))` at boot, and MLflow will lazily materialize four Delta tables in the target schema — `<prefix>_otel_spans`, `<prefix>_otel_logs`, `<prefix>_otel_metrics`, `<prefix>_otel_annotations` — on the first trace flush.
+Declare `app.trace_location:` on the AppConfig, then link the experiment to the UC destination as an explicit deploy step. MLflow lazily materializes four Delta tables in the target schema — `<prefix>_otel_spans`, `<prefix>_otel_logs`, `<prefix>_otel_metrics`, `<prefix>_otel_annotations` — on the first trace flush after linking.
 
 ```yaml
 app:
@@ -706,7 +706,22 @@ app:
     table_prefix: hardware_store         # optional; defaults to the experiment_id
 ```
 
-Everything about the wiring is identical for Apps and Model Serving — same `_link_experiment_trace_location` call is invoked from both deploy paths. The only asymmetry is what permissions the endpoint's runtime SP needs on the target schema (see next question).
+**Deploy flow for Databricks Apps** (bundle path):
+
+```bash
+dao-ai generate-bundle -c my_config.yaml -o ./bundle
+cd ./bundle
+databricks bundle deploy --target dev -p <profile>
+dao-ai link-trace-destination -c ../my_config.yaml -p <profile>   # explicit link step
+databricks bundle run <app-name> --target dev -p <profile>
+databricks apps restart <app-name> -p <profile>                   # required
+```
+
+The `link-trace-destination` step is idempotent — safe on every deploy — but load-bearing on re-deploys. It runs from your machine with your credentials, before the app boots. Skipping it (and relying on the app's own runtime link attempt in `dao_ai.apps.handlers`) causes silent trace loss on re-deploys because MLflow rejects re-linking with `already contains traces`.
+
+**Model Serving** deploys via `dao-ai deploy` link automatically inside `deploy_apps_agent` / `deploy_model_serving_agent` (same `link_experiment_trace_location` helper) — no manual step required.
+
+**Important once linked:** Databricks does NOT allow un-linking or changing a UC trace destination. `catalog` / `schema` / `table_prefix` are permanent for that experiment. To move traces to a different destination, create a fresh experiment (new name or id) and re-link it — see [`docs/cli-reference.md#link-trace-destination`](cli-reference.md#link-trace-destination) for the full migration playbook.
 
 See [Lab 24 — UC OTEL Trace Tables](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-24-uc-trace-location) for the walkthrough. **Note:** in-process notebook usage of the same config additionally needs `mlflow.langchain.autolog(run_tracer_inline=True)` + `dao_ai.logging.suppress_autolog_context_warnings()` — the deploy runtime does both automatically at boot, but the notebook flow must do them explicitly.
 

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -906,6 +906,14 @@ def write_bundle(
     print("\nNext steps:")
     print(f"  cd {output_dir}")
     print("  databricks bundle deploy --target dev")
+    if config.app and config.app.trace_location:
+        # Idempotent — safe on every deploy — but load-bearing on
+        # re-deploys and after trace_location changes. See
+        # `dao-ai link-trace-destination --help` for the full story.
+        print(
+            f"  dao-ai link-trace-destination -c <your-config.yaml>"
+            f"   # links UC trace destination for {app_name}"
+        )
     print(f"  databricks bundle run {app_name} --target dev")
     print()
     print("  # Apps' build phase installs deps directly from requirements.txt;")

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -343,6 +343,74 @@ Examples:
         help="Output format (default: text).",
     )
 
+    # Link-trace-destination command
+    link_trace_parser: ArgumentParser = subparsers.add_parser(
+        "link-trace-destination",
+        help="Link an MLflow experiment to its UC trace destination",
+        description="""
+Link an MLflow experiment to the Unity Catalog trace destination
+declared under ``app.trace_location`` in the config. Idempotent — safe
+to run repeatedly.
+
+Run this AFTER ``databricks bundle deploy`` and BEFORE
+``databricks bundle run``. Fixes the case where MLflow rejects the
+runtime link attempt with "already contains traces" on a re-deploy or
+after a trace-location change, which otherwise causes silent trace loss.
+
+Experiment resolution order:
+  1. ``--experiment-id`` flag (explicit override)
+  2. ``config.app.experiment.resolved_id`` if ``experiment:`` is set
+  3. Bundle-declared experiment name (``/Users/<current-user>/<app-name>``)
+     looked up via MlflowClient — matches what dao-ai generate-bundle
+     writes for the auto-declared experiment path.
+
+No-op when ``config.app.trace_location`` is not set.
+        """,
+        epilog="""
+Examples:
+  # Typical bundle flow — insert between deploy and run
+  databricks bundle deploy --target dev -p fevm
+  dao-ai link-trace-destination -c config.yaml -p fevm
+  databricks bundle run my-app --target dev -p fevm
+
+  # Explicit experiment id
+  dao-ai link-trace-destination -c config.yaml --experiment-id 1234567890 -p fevm
+
+Notes:
+  * Restart the app after linking. The MLflow OTEL exporter binds the
+    trace destination at process startup, so linking against a running
+    app won't retroactively route in-flight traces to the new location —
+    trigger `databricks apps restart <name>` (or any bundle re-deploy).
+  * MLflow does NOT support un-linking a UC trace destination or moving
+    an experiment back to control-plane storage. To "reset" traces to a
+    different UC schema, create a fresh experiment (new name or id) and
+    point `MLFLOW_EXPERIMENT_ID` at the new one. The old experiment
+    continues to write to its original UC destination forever.
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    link_trace_parser.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        required=True,
+        metavar="FILE",
+        help="Path to the model configuration file (must set app.trace_location).",
+    )
+    link_trace_parser.add_argument(
+        "-p",
+        "--profile",
+        type=str,
+        help="Databricks profile to use for authentication.",
+    )
+    link_trace_parser.add_argument(
+        "--experiment-id",
+        type=str,
+        metavar="ID",
+        help="Explicit experiment id (skips resolution from config/bundle name).",
+    )
+    _add_var_argument(link_trace_parser)
+
     # Graph command
     graph_parser: ArgumentParser = subparsers.add_parser(
         "graph",
@@ -1175,6 +1243,142 @@ def handle_create_experiment_command(options: Namespace) -> None:
         print(f"name:              {experiment.name}")
         print(f"artifact_location: {experiment.artifact_location}")
         print(f"lifecycle_stage:   {experiment.lifecycle_stage}")
+
+
+def handle_link_trace_destination_command(options: Namespace) -> None:
+    """Link an MLflow experiment to its UC trace destination (idempotent).
+
+    Standalone verb intended to run between ``databricks bundle deploy``
+    and ``databricks bundle run``. Fixes silent trace loss on re-deploys
+    where the runtime's link attempt is rejected with "already contains
+    traces" — this call runs from the operator's machine with their own
+    credentials, so the tag-based idempotency check (or the API call
+    itself, on a truly-first link) can succeed cleanly.
+    """
+    _apply_profile_context(options.profile)
+
+    try:
+        config: AppConfig = AppConfig.from_file(
+            options.config, params=_parse_var_args(options.var)
+        )
+    except ConfigVariableError as e:
+        _print_config_variable_error(e)
+        sys.exit(1)
+
+    if not (config.app and config.app.trace_location):
+        print(
+            "No app.trace_location configured — nothing to link.",
+            file=sys.stderr,
+        )
+        return
+
+    experiment_id: Optional[str] = _resolve_experiment_id_for_link(
+        config, options.experiment_id
+    )
+    if experiment_id is None:
+        sys.exit(1)  # _resolve_* already printed a diagnostic
+
+    from dao_ai.providers.databricks import _link_experiment_trace_location
+
+    try:
+        _link_experiment_trace_location(config, experiment_id)
+    except Exception as e:  # noqa: BLE001
+        print(
+            f"Failed to link experiment {experiment_id} to UC trace destination: "
+            f"{type(e).__name__}: {e}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(
+        f"Linked experiment {experiment_id} to "
+        f"{config.app.trace_location.catalog_name}."
+        f"{config.app.trace_location.schema_name}"
+        + (
+            f" (table_prefix={config.app.trace_location.resolved_table_prefix})"
+            if config.app.trace_location.resolved_table_prefix
+            else ""
+        )
+    )
+
+
+def _resolve_experiment_id_for_link(
+    config: AppConfig,
+    override: Optional[str],
+) -> Optional[str]:
+    """Resolve the MLflow experiment id for link-trace-destination.
+
+    Resolution order:
+      1. ``override`` from ``--experiment-id`` flag.
+      2. ``config.app.experiment.resolved_id`` (path A — user set ``experiment:``).
+      3. Bundle-declared name ``/Users/<current-user>/<app-name>`` looked up
+         via ``MlflowClient.get_experiment_by_name`` (path B — the default
+         auto-declared bundle experiment).
+
+    Returns ``None`` on failure after printing a diagnostic to stderr. The
+    caller exits(1); we don't raise so the CLI's user-facing output stays
+    clean.
+    """
+    if override:
+        return override
+
+    if config.app.experiment is not None:
+        resolved = config.app.experiment.resolved_id
+        if resolved:
+            return resolved
+        print(
+            "app.experiment is set but resolved_id is None — pass "
+            "--experiment-id explicitly or run `dao-ai create-experiment` first.",
+            file=sys.stderr,
+        )
+        return None
+
+    # Path B: mirror bundle.py's deterministic name convention. DABs'
+    # `--target dev` presets prefix bundle-resource names with
+    # `[dev <sanitized-user>]` — try both the unprefixed name (prod-mode
+    # deploys) and the dev-prefixed name (personal dev deploys) so the
+    # CLI works in either mode without the operator having to specify.
+    app_name = config.app.name.lower().replace("_", "-")
+    try:
+        from databricks.sdk import WorkspaceClient
+        from mlflow.tracking import MlflowClient
+
+        current_user = WorkspaceClient().current_user.me().user_name or "unknown"
+        # DABs sanitizes the user for the dev prefix: lowercase, strip the
+        # email domain, replace non-alnum with underscores.
+        dev_tag = current_user.split("@", 1)[0].lower()
+        dev_tag = "".join(c if c.isalnum() else "_" for c in dev_tag)
+        candidates = [
+            f"/Users/{current_user}/{app_name}",
+            f"/Users/{current_user}/[dev {dev_tag}] {app_name}",
+        ]
+        mc = MlflowClient()
+        exp = None
+        for name in candidates:
+            exp = mc.get_experiment_by_name(name)
+            if exp is not None:
+                break
+    except Exception as e:  # noqa: BLE001
+        print(
+            f"Could not look up bundle-declared experiment: "
+            f"{type(e).__name__}: {e}",
+            file=sys.stderr,
+        )
+        return None
+    if exp is None:
+        print(
+            "Experiment not found under any of these names:",
+            file=sys.stderr,
+        )
+        for name in candidates:
+            print(f"  - {name}", file=sys.stderr)
+        print(
+            "Run `databricks bundle deploy` first (which materializes the "
+            "experiment), or pass --experiment-id explicitly.",
+            file=sys.stderr,
+        )
+        return None
+    return exp.experiment_id
 
 
 def handle_graph_command(options: Namespace) -> None:
@@ -2068,6 +2272,8 @@ def main() -> None:
             handle_schema_command(options)
         case "create-experiment":
             handle_create_experiment_command(options)
+        case "link-trace-destination":
+            handle_link_trace_destination_command(options)
         case "validate":
             handle_validate_command(options)
         case "graph":

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -377,15 +377,21 @@ Examples:
   dao-ai link-trace-destination -c config.yaml --experiment-id 1234567890 -p fevm
 
 Notes:
-  * Restart the app after linking. The MLflow OTEL exporter binds the
-    trace destination at process startup, so linking against a running
-    app won't retroactively route in-flight traces to the new location —
-    trigger `databricks apps restart <name>` (or any bundle re-deploy).
-  * MLflow does NOT support un-linking a UC trace destination or moving
-    an experiment back to control-plane storage. To "reset" traces to a
-    different UC schema, create a fresh experiment (new name or id) and
-    point `MLFLOW_EXPERIMENT_ID` at the new one. The old experiment
-    continues to write to its original UC destination forever.
+  * Restart the app after linking. MLflow's tracer provider is
+    initialized once at process startup and caches the resolved UC
+    destination — linking against a running app won't retroactively
+    route in-flight traces to the new location. Trigger
+    `databricks apps restart <name>` (or any bundle re-deploy).
+  * Databricks does NOT allow un-linking a UC trace destination.
+    The OSS `mlflow.tracing.unset_experiment_trace_location` API exists,
+    but the Databricks control plane rejects it with:
+      BAD_REQUEST: Unlinking an experiment from a Unity Catalog trace
+      location is not allowed.
+    Consequently, `catalog` / `schema` / `table_prefix` cannot be
+    changed once the experiment is linked. To move traces to a different
+    UC destination, create a fresh experiment (new name or id), point
+    `MLFLOW_EXPERIMENT_ID` at it, link, then restart. The old experiment
+    continues writing to its original UC destination forever.
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/tests/dao_ai/test_link_trace_destination_cli.py
+++ b/tests/dao_ai/test_link_trace_destination_cli.py
@@ -1,0 +1,233 @@
+"""Unit tests for `dao-ai link-trace-destination` CLI verb.
+
+Focus is on the CLI orchestration: argument parsing, experiment-id
+resolution (explicit override, `app.experiment.resolved_id`, bundle-name
+lookup), and clean stderr output on failure paths. The idempotent linker
+itself is exercised by `test_trace_location_linkage.py` in PR #164.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _cfg_with_trace(
+    catalog: str = "cat",
+    schema: str = "sch",
+    prefix: str | None = None,
+    experiment_resolved_id: str | None = None,
+    app_name: str = "my-app",
+) -> MagicMock:
+    """Build a mock AppConfig for the resolver / handler under test.
+
+    Real AppConfig instantiation drags too many required fields (secrets,
+    resources, etc.); the CLI handler only touches
+    `config.app.{name,trace_location,experiment}`.
+    """
+    cfg = MagicMock()
+    cfg.app = MagicMock()
+    cfg.app.name = app_name
+    cfg.app.trace_location.catalog_name = catalog
+    cfg.app.trace_location.schema_name = schema
+    cfg.app.trace_location.resolved_table_prefix = prefix
+    if experiment_resolved_id is None:
+        cfg.app.experiment = None
+    else:
+        cfg.app.experiment.resolved_id = experiment_resolved_id
+    return cfg
+
+
+@pytest.mark.unit
+class TestResolveExperimentId:
+    def test_override_wins(self) -> None:
+        from dao_ai.cli import _resolve_experiment_id_for_link
+
+        cfg = _cfg_with_trace(experiment_resolved_id="cfg_id")
+        assert _resolve_experiment_id_for_link(cfg, "override_id") == "override_id"
+
+    def test_uses_config_experiment_when_set(self) -> None:
+        from dao_ai.cli import _resolve_experiment_id_for_link
+
+        cfg = _cfg_with_trace(experiment_resolved_id="cfg_id")
+        assert _resolve_experiment_id_for_link(cfg, None) == "cfg_id"
+
+    def test_returns_none_when_experiment_resolved_id_missing(self, capsys) -> None:
+        from dao_ai.cli import _resolve_experiment_id_for_link
+
+        cfg = MagicMock()
+        cfg.app = MagicMock()
+        cfg.app.experiment.resolved_id = None
+        assert _resolve_experiment_id_for_link(cfg, None) is None
+        assert "resolved_id is None" in capsys.readouterr().err
+
+    def test_falls_back_to_bundle_name_lookup_prod(self) -> None:
+        """Prod-mode deploy: unprefixed experiment name matches first."""
+        from dao_ai.cli import _resolve_experiment_id_for_link
+
+        cfg = _cfg_with_trace(app_name="my_app")  # underscore → hyphen
+        exp = MagicMock()
+        exp.experiment_id = "bundle_id"
+        with (
+            patch("databricks.sdk.WorkspaceClient") as wc,
+            patch("mlflow.tracking.MlflowClient") as mc,
+        ):
+            wc.return_value.current_user.me.return_value.user_name = "u@x.com"
+            mc.return_value.get_experiment_by_name.return_value = exp
+            assert _resolve_experiment_id_for_link(cfg, None) == "bundle_id"
+            # First candidate is the unprefixed path.
+            first_call = mc.return_value.get_experiment_by_name.call_args_list[0]
+            assert first_call.args[0] == "/Users/u@x.com/my-app"
+
+    def test_falls_back_to_dev_prefixed_name(self) -> None:
+        """DABs `--target dev` prefix: first lookup misses, second hits."""
+        from dao_ai.cli import _resolve_experiment_id_for_link
+
+        cfg = _cfg_with_trace(app_name="my_app")
+        exp = MagicMock()
+        exp.experiment_id = "dev_bundle_id"
+        with (
+            patch("databricks.sdk.WorkspaceClient") as wc,
+            patch("mlflow.tracking.MlflowClient") as mc,
+        ):
+            wc.return_value.current_user.me.return_value.user_name = "u@x.com"
+            # Return None for unprefixed, actual exp for dev-prefixed.
+            mc.return_value.get_experiment_by_name.side_effect = [None, exp]
+            assert _resolve_experiment_id_for_link(cfg, None) == "dev_bundle_id"
+            calls = mc.return_value.get_experiment_by_name.call_args_list
+            assert calls[0].args[0] == "/Users/u@x.com/my-app"
+            # dev-tag: split '@', lowercase, non-alnum → underscore.
+            assert calls[1].args[0] == "/Users/u@x.com/[dev u] my-app"
+
+    def test_bundle_lookup_missing_returns_none(self, capsys) -> None:
+        from dao_ai.cli import _resolve_experiment_id_for_link
+
+        cfg = _cfg_with_trace()
+        with (
+            patch("databricks.sdk.WorkspaceClient") as wc,
+            patch("mlflow.tracking.MlflowClient") as mc,
+        ):
+            wc.return_value.current_user.me.return_value.user_name = "u@x.com"
+            # Both candidates miss.
+            mc.return_value.get_experiment_by_name.return_value = None
+            assert _resolve_experiment_id_for_link(cfg, None) is None
+        err = capsys.readouterr().err
+        assert "not found" in err
+        assert "databricks bundle deploy" in err
+        # Both candidates surfaced in the diagnostic
+        assert "[dev " in err
+
+    def test_bundle_lookup_error_returns_none(self, capsys) -> None:
+        from dao_ai.cli import _resolve_experiment_id_for_link
+
+        cfg = _cfg_with_trace()
+        with patch("databricks.sdk.WorkspaceClient") as wc:
+            wc.side_effect = RuntimeError("no auth")
+            assert _resolve_experiment_id_for_link(cfg, None) is None
+        assert "RuntimeError: no auth" in capsys.readouterr().err
+
+
+@pytest.mark.unit
+class TestHandleCommand:
+    def test_noop_when_no_trace_location(self, capsys) -> None:
+        from argparse import Namespace
+
+        from dao_ai.cli import handle_link_trace_destination_command
+
+        cfg = MagicMock()
+        cfg.app.trace_location = None
+        with (
+            patch("dao_ai.cli._apply_profile_context"),
+            patch("dao_ai.cli.AppConfig") as ac,
+        ):
+            ac.from_file.return_value = cfg
+            handle_link_trace_destination_command(
+                Namespace(
+                    config="cfg.yaml", profile=None, experiment_id=None, var=None
+                )
+            )
+        assert "nothing to link" in capsys.readouterr().err
+
+    def test_exit_1_when_resolver_returns_none(self) -> None:
+        from argparse import Namespace
+
+        from dao_ai.cli import handle_link_trace_destination_command
+
+        cfg = _cfg_with_trace()
+        with (
+            patch("dao_ai.cli._apply_profile_context"),
+            patch("dao_ai.cli.AppConfig") as ac,
+            patch(
+                "dao_ai.cli._resolve_experiment_id_for_link", return_value=None
+            ),
+        ):
+            ac.from_file.return_value = cfg
+            with pytest.raises(SystemExit) as exc:
+                handle_link_trace_destination_command(
+                    Namespace(
+                        config="cfg.yaml",
+                        profile=None,
+                        experiment_id=None,
+                        var=None,
+                    )
+                )
+        assert exc.value.code == 1
+
+    def test_success_calls_linker_and_prints(self, capsys) -> None:
+        from argparse import Namespace
+
+        from dao_ai.cli import handle_link_trace_destination_command
+
+        cfg = _cfg_with_trace(catalog="cat", schema="sch", prefix="myp")
+        with (
+            patch("dao_ai.cli._apply_profile_context"),
+            patch("dao_ai.cli.AppConfig") as ac,
+            patch(
+                "dao_ai.cli._resolve_experiment_id_for_link", return_value="exp42"
+            ),
+            patch(
+                "dao_ai.providers.databricks._link_experiment_trace_location"
+            ) as link,
+        ):
+            ac.from_file.return_value = cfg
+            handle_link_trace_destination_command(
+                Namespace(
+                    config="cfg.yaml", profile=None, experiment_id=None, var=None
+                )
+            )
+        link.assert_called_once_with(cfg, "exp42")
+        out = capsys.readouterr().out
+        assert "exp42" in out
+        assert "cat.sch" in out
+        assert "table_prefix=myp" in out
+
+    def test_link_failure_exits_1_with_diagnostic(self, capsys) -> None:
+        from argparse import Namespace
+
+        from dao_ai.cli import handle_link_trace_destination_command
+
+        cfg = _cfg_with_trace()
+        with (
+            patch("dao_ai.cli._apply_profile_context"),
+            patch("dao_ai.cli.AppConfig") as ac,
+            patch(
+                "dao_ai.cli._resolve_experiment_id_for_link", return_value="exp42"
+            ),
+            patch(
+                "dao_ai.providers.databricks._link_experiment_trace_location",
+                side_effect=RuntimeError("warehouse timeout"),
+            ),
+        ):
+            ac.from_file.return_value = cfg
+            with pytest.raises(SystemExit) as exc:
+                handle_link_trace_destination_command(
+                    Namespace(
+                        config="cfg.yaml",
+                        profile=None,
+                        experiment_id=None,
+                        var=None,
+                    )
+                )
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "warehouse timeout" in err
+        assert "exp42" in err


### PR DESCRIPTION
## Summary

New CLI verb `dao-ai link-trace-destination` — an explicit, idempotent post-deploy step that links an MLflow experiment to its Unity Catalog trace destination declared under \`app.trace_location\`. Fills the gap between \`databricks bundle deploy\` and \`databricks bundle run\` so the linkage happens from the operator's machine (with their credentials) instead of by the app's runtime, where re-deploys hit MLflow's "already contains traces" invariant and silently drop every future trace.

## Usage

\`\`\`bash
databricks bundle deploy --target dev -p fevm
dao-ai link-trace-destination -c config.yaml -p fevm
databricks bundle run my-app --target dev -p fevm
# → then restart the app (MLflow exporter binds destination at process
#   startup; a running app doesn't pick up a newly-established link):
databricks apps restart my-app -p fevm
\`\`\`

Bundle-gen additionally prints a one-line reminder to run this verb when \`app.trace_location\` is configured — bundle-gen itself stays pure (no workspace calls added).

## Experiment resolution

Tries in order:
1. \`--experiment-id\` explicit override
2. \`config.app.experiment.resolved_id\` (path A — user set \`experiment:\` in config)
3. Bundle-declared name lookup via \`MlflowClient.get_experiment_by_name\` (path B — auto-declared bundle experiment). Tries **both** the unprefixed name and DABs' \`[dev <sanitized-user>] <app-name>\` name to cover \`--target dev\` deploys transparently.

## Operator caveats surfaced in \`--help\` epilog

- **Restart required**: MLflow's OTEL exporter binds the trace destination at process startup. Linking against a running app has no retroactive effect on in-flight traces.
- **No un-link path**: MLflow doesn't support removing a UC trace destination or moving an experiment back to control-plane storage. Recovery from a wrong link means creating a fresh experiment (new name or id) and pointing \`MLFLOW_EXPERIMENT_ID\` at it.

## Live verification

Ran against the deployed \`hardware-store-instructed\` app on fevm:

\`\`\`
$ uv run dao-ai link-trace-destination -c /tmp/hw_instructed_with_traces.yaml -p fevm
Linked experiment 2118001471326798 to retail_consumer_goods.default
\`\`\`

Auto-resolved the DABs-prefixed experiment without any \`--experiment-id\` flag. Idempotent on the second run (existing linkage confirmed).

## Test plan

- [x] \`tests/dao_ai/test_link_trace_destination_cli.py\` — 11 new tests covering:
  - Resolver: override / \`config.experiment\` / bundle-name-prod / bundle-name-dev-prefix / lookup-miss / lookup-error / \`resolved_id=None\`
  - Handler: no-op (no trace_location) / resolver-fail → exit 1 / success prints linkage details / link-fail → exit 1 with diagnostic
- [x] \`uv run pytest tests/dao_ai/test_link_trace_destination_cli.py\` → 11/11 pass
- [x] Regression across \`test_vector_search_dynamic_schema.py\` / \`test_instructed_pipeline.py\` / \`test_lakebase_search.py\` → 174/174 pass
- [x] Live CLI invocation against a real deployed app confirmed the resolver + linker work end-to-end

## Relationship to other PRs

- **PR #164** improves the underlying \`link_experiment_trace_location\` helper to be tag-idempotent and log loudly on real failures. This PR's CLI reuses that helper directly — the two land well in either order.

This pull request and its description were written by Isaac.