### PR TITLE
feat(lakebase): DatabaseModel.execute_sql + LakebaseVectorStoreModel.provision

### DIFF
--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -3793,6 +3793,58 @@ class DatabaseModel(IsDatabricksResource):
             provider.create_lakebase_autoscaling(self)
             provider.create_lakebase_autoscaling_role(self)
 
+    def execute_sql(
+        self,
+        statements: str | Sequence[str],
+        parameters: Sequence[Any] | None = None,
+    ) -> None:
+        """Execute one or more SQL statements against this database.
+
+        Convenience wrapper around the synchronous connection pool
+        (:class:`dao_ai.memory.postgres.PostgresPoolManager`). Runs
+        every statement in a single transaction; commits on success and
+        rolls back on error. Intended for ad-hoc DDL/DML from notebooks
+        and setup scripts — not a substitute for a proper ORM or
+        parameterized bulk-write path.
+
+        Args:
+            statements: A single SQL string OR a sequence of SQL strings.
+                Strings are executed verbatim (no additional splitting
+                on ``;``). When passing a sequence, ``parameters`` must
+                be ``None`` — parameter binding is only supported when
+                a single statement is provided.
+            parameters: Optional positional parameters passed to
+                ``cursor.execute()``. Only valid when ``statements`` is
+                a single string.
+        """
+        from dao_ai.memory.postgres import PostgresPoolManager
+
+        if isinstance(statements, str):
+            stmts: list[str] = [statements]
+        else:
+            stmts = list(statements)
+            if parameters is not None:
+                raise ValueError(
+                    "`parameters` is only supported when `statements` is a "
+                    "single string; got a sequence."
+                )
+        if not stmts:
+            return
+
+        pool = PostgresPoolManager.get_pool(self)
+        with pool.connection() as conn:
+            try:
+                with conn.cursor() as cur:
+                    for stmt in stmts:
+                        if parameters is not None:
+                            cur.execute(stmt, parameters)
+                        else:
+                            cur.execute(stmt)
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+
 
 class GenieLRUCacheParametersModel(BaseModel):
     """Configuration for a simple LRU (Least Recently Used) Genie response cache."""
@@ -4612,9 +4664,10 @@ class AiSearchRetrieverModel(BaseRetrieverModel):
 class LakebaseVectorStoreModel(BaseModel):
     """Configuration for a Databricks Lakebase Postgres table used for retrieval.
 
-    Points at a table that already has ``lakebase_vector`` (and optionally
-    ``lakebase_text``) extensions installed and appropriate indexes built.
-    Stage-1 scope: existing tables only; provisioning is deferred.
+    Points at a table that has ``lakebase_vector`` (and optionally
+    ``lakebase_text``) extensions installed and appropriate indexes
+    built. Call :meth:`provision` to idempotently create the extensions,
+    table, and indexes if they don't exist yet.
 
     Example (existing table, hybrid-ready):
     ```yaml
@@ -4713,6 +4766,106 @@ class LakebaseVectorStoreModel(BaseModel):
                 f"{self.schema_name}.{self.table}_{self.tsvector_column}_bm25"
             )
         return self
+
+    def provision(
+        self,
+        *,
+        dimension: int,
+        metadata_column_types: dict[str, str] | None = None,
+        id_column_type: str = "text",
+    ) -> None:
+        """Idempotently create the Postgres extensions + table + indexes.
+
+        Runs ``CREATE EXTENSION IF NOT EXISTS`` for ``lakebase_vector``
+        (and ``lakebase_text`` when ``tsvector_column`` is configured),
+        then ``CREATE TABLE IF NOT EXISTS`` for the retrieval table with
+        columns matching this vector-store config, then
+        ``CREATE INDEX IF NOT EXISTS`` for the ``lakebase_ann`` index on
+        ``embedding_column`` (and ``lakebase_bm25`` on ``tsvector_column``
+        when configured). Every statement is safe to re-run — no rows or
+        indexes are dropped.
+
+        The generated table has this shape (all columns nullable except
+        the id + content column):
+
+        - ``{id_column} {id_column_type} PRIMARY KEY``
+        - ``{content_column} text NOT NULL``
+        - ``{embedding_column} vector({dimension})``
+        - Optional: ``{tsvector_column} tsvector GENERATED ALWAYS AS
+          (to_tsvector('{tsv_language}', {content_column})) STORED``
+        - Each metadata column typed via ``metadata_column_types``
+          (defaults to ``text`` when unspecified).
+
+        Args:
+            dimension: Vector dimension of the ``embedding_column``. Must
+                match the ``embedding_model`` endpoint's output shape
+                (e.g. ``1024`` for ``databricks-gte-large-en``). No
+                auto-detection — the caller knows the endpoint.
+            metadata_column_types: Optional ``{name: pg_type}`` overrides
+                for entries in ``metadata_columns``. Any name not listed
+                defaults to ``text``. Use standard Postgres type names
+                (``int``, ``bigint``, ``numeric``, ``timestamp``, etc.).
+            id_column_type: Postgres type for the primary-key column.
+                Defaults to ``text`` to match the ``kb_articles`` seed
+                convention; use ``bigint`` / ``uuid`` etc. as needed.
+
+        This method is idempotent. It does NOT drop the existing table
+        or its data — pointing ``provision()`` at an existing table with
+        a different schema is a no-op (Postgres accepts the ``CREATE
+        TABLE IF NOT EXISTS`` silently even when the shape differs). To
+        rebuild from scratch, drop the table manually first.
+        """
+        if dimension <= 0:
+            raise ValueError(
+                f"dimension must be a positive int; got {dimension!r}"
+            )
+        meta_types = metadata_column_types or {}
+        qualified = f"{self.schema_name}.{self.table}"
+
+        stmts: list[str] = ["CREATE EXTENSION IF NOT EXISTS lakebase_vector CASCADE;"]
+        if self.tsvector_column:
+            stmts.append("CREATE EXTENSION IF NOT EXISTS lakebase_text;")
+
+        cols: list[str] = [
+            f"{self.id_column} {id_column_type} PRIMARY KEY",
+            f"{self.content_column} text NOT NULL",
+            f"{self.embedding_column} vector({dimension})",
+        ]
+        for col in self.metadata_columns or []:
+            col_type = meta_types.get(col, "text")
+            cols.append(f"{col} {col_type}")
+        if self.tsvector_column:
+            cols.append(
+                f"{self.tsvector_column} tsvector GENERATED ALWAYS AS "
+                f"(to_tsvector('{self.tsv_language}', {self.content_column})) STORED"
+            )
+        stmts.append(
+            f"CREATE TABLE IF NOT EXISTS {qualified} (\n    "
+            + ",\n    ".join(cols)
+            + "\n);"
+        )
+
+        # ANN index — name follows the same convention the tool uses when
+        # reading back (`<table>_<column>_ann`). vector_cosine_ops matches
+        # the default `distance_metric`; overridden below when needed.
+        ops_map = {
+            "cosine": "vector_cosine_ops",
+            "l2": "vector_l2_ops",
+            "ip": "vector_ip_ops",
+        }
+        ops = ops_map[self.distance_metric]
+        ann_index = f"{self.table}_{self.embedding_column}_ann"
+        stmts.append(
+            f"CREATE INDEX IF NOT EXISTS {ann_index} "
+            f"ON {qualified} USING lakebase_ann ({self.embedding_column} {ops});"
+        )
+        if self.tsvector_column:
+            bm25_index = f"{self.table}_{self.tsvector_column}_bm25"
+            stmts.append(
+                f"CREATE INDEX IF NOT EXISTS {bm25_index} "
+                f"ON {qualified} USING lakebase_bm25 ({self.tsvector_column});"
+            )
+        self.database.execute_sql(stmts)
 
 
 class LakebaseRetrieverModel(BaseRetrieverModel):

--- a/tests/dao_ai/test_lakebase_provision.py
+++ b/tests/dao_ai/test_lakebase_provision.py
@@ -1,0 +1,225 @@
+"""Unit tests for `DatabaseModel.execute_sql` + `LakebaseVectorStoreModel.provision`.
+
+Both helpers wrap `PostgresPoolManager.get_pool(db).connection()`.
+We mock the pool + cursor and assert the exact SQL statements emitted.
+Live Postgres testing is out of scope here — the DDL grammar is verified
+by the Lakebase server at runtime.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dao_ai.config import DatabaseModel, LakebaseVectorStoreModel
+
+
+def _mock_pool(cursor: MagicMock) -> MagicMock:
+    """Build a context-manager pool whose .connection().cursor() → given mock."""
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cursor
+    pool = MagicMock()
+    pool.connection.return_value.__enter__.return_value = conn
+    return pool, conn
+
+
+def _db() -> DatabaseModel:
+    """Build a minimal Lakebase DatabaseModel for the helper tests."""
+    return DatabaseModel(project="my-project", name="my_project_db")
+
+
+@pytest.mark.unit
+class TestExecuteSql:
+    def test_single_statement(self) -> None:
+        cur = MagicMock()
+        pool, conn = _mock_pool(cur)
+        with patch(
+            "dao_ai.memory.postgres.PostgresPoolManager.get_pool",
+            return_value=pool,
+        ):
+            _db().execute_sql("SELECT 1")
+        cur.execute.assert_called_once_with("SELECT 1")
+        conn.commit.assert_called_once()
+        conn.rollback.assert_not_called()
+
+    def test_sequence_runs_all_and_commits_once(self) -> None:
+        cur = MagicMock()
+        pool, conn = _mock_pool(cur)
+        with patch(
+            "dao_ai.memory.postgres.PostgresPoolManager.get_pool",
+            return_value=pool,
+        ):
+            _db().execute_sql(["CREATE EXTENSION x;", "CREATE TABLE y (id int);"])
+        assert cur.execute.call_count == 2
+        cur.execute.assert_any_call("CREATE EXTENSION x;")
+        cur.execute.assert_any_call("CREATE TABLE y (id int);")
+        conn.commit.assert_called_once()
+
+    def test_rollback_on_error(self) -> None:
+        cur = MagicMock()
+        cur.execute.side_effect = RuntimeError("boom")
+        pool, conn = _mock_pool(cur)
+        with patch(
+            "dao_ai.memory.postgres.PostgresPoolManager.get_pool",
+            return_value=pool,
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                _db().execute_sql("bad sql")
+        conn.commit.assert_not_called()
+        conn.rollback.assert_called_once()
+
+    def test_empty_sequence_is_no_op(self) -> None:
+        cur = MagicMock()
+        pool, _ = _mock_pool(cur)
+        with patch(
+            "dao_ai.memory.postgres.PostgresPoolManager.get_pool",
+            return_value=pool,
+        ):
+            _db().execute_sql([])
+        cur.execute.assert_not_called()
+        # No pool acquisition either
+        pool.connection.assert_not_called()
+
+    def test_parameters_forwarded(self) -> None:
+        cur = MagicMock()
+        pool, _ = _mock_pool(cur)
+        with patch(
+            "dao_ai.memory.postgres.PostgresPoolManager.get_pool",
+            return_value=pool,
+        ):
+            _db().execute_sql("SELECT %s", parameters=(42,))
+        cur.execute.assert_called_once_with("SELECT %s", (42,))
+
+    def test_parameters_with_sequence_rejected(self) -> None:
+        with pytest.raises(ValueError, match="single string"):
+            _db().execute_sql(["a", "b"], parameters=(1,))
+
+
+def _vs(**overrides) -> LakebaseVectorStoreModel:
+    """Minimal LakebaseVectorStoreModel with sensible defaults."""
+    base = dict(
+        database=_db(),
+        table="kb_articles",
+        content_column="passage",
+        embedding_column="embedding",
+        embedding_model="databricks-gte-large-en",
+    )
+    base.update(overrides)
+    return LakebaseVectorStoreModel(**base)
+
+
+@pytest.mark.unit
+class TestProvision:
+    def test_ann_only_minimal(self) -> None:
+        cur = MagicMock()
+        pool, _ = _mock_pool(cur)
+        with patch(
+            "dao_ai.memory.postgres.PostgresPoolManager.get_pool",
+            return_value=pool,
+        ):
+            _vs().provision(dimension=1024)
+        stmts = [c.args[0] for c in cur.execute.call_args_list]
+        # Only lakebase_vector — no lakebase_text without tsvector_column
+        assert any("CREATE EXTENSION IF NOT EXISTS lakebase_vector" in s for s in stmts)
+        assert not any("lakebase_text" in s for s in stmts)
+        assert any(
+            "CREATE TABLE IF NOT EXISTS public.kb_articles" in s for s in stmts
+        )
+        assert any("id text PRIMARY KEY" in s for s in stmts)
+        assert any("passage text NOT NULL" in s for s in stmts)
+        assert any("embedding vector(1024)" in s for s in stmts)
+        # ANN index only — no BM25 without tsvector
+        ann_stmts = [s for s in stmts if "USING lakebase_ann" in s]
+        bm25_stmts = [s for s in stmts if "USING lakebase_bm25" in s]
+        assert len(ann_stmts) == 1
+        assert len(bm25_stmts) == 0
+        assert "vector_cosine_ops" in ann_stmts[0]
+        assert "CREATE INDEX IF NOT EXISTS" in ann_stmts[0]
+
+    def test_hybrid_adds_tsvector_extension_column_and_index(self) -> None:
+        cur = MagicMock()
+        pool, _ = _mock_pool(cur)
+        with patch(
+            "dao_ai.memory.postgres.PostgresPoolManager.get_pool",
+            return_value=pool,
+        ):
+            _vs(tsvector_column="passage_tsv").provision(dimension=1024)
+        stmts = [c.args[0] for c in cur.execute.call_args_list]
+        assert any("lakebase_text" in s for s in stmts)
+        assert any(
+            "passage_tsv tsvector GENERATED ALWAYS AS "
+            "(to_tsvector('english', passage)) STORED" in s
+            for s in stmts
+        )
+        bm25 = [s for s in stmts if "USING lakebase_bm25" in s]
+        assert len(bm25) == 1
+        assert "passage_tsv" in bm25[0]
+
+    def test_metadata_column_types_respected(self) -> None:
+        cur = MagicMock()
+        pool, _ = _mock_pool(cur)
+        with patch(
+            "dao_ai.memory.postgres.PostgresPoolManager.get_pool",
+            return_value=pool,
+        ):
+            _vs(metadata_columns=["category", "priority"]).provision(
+                dimension=1024,
+                metadata_column_types={"priority": "int"},
+            )
+        stmts = [c.args[0] for c in cur.execute.call_args_list]
+        create = next(s for s in stmts if "CREATE TABLE" in s)
+        # category defaults to text; priority typed explicitly
+        assert "category text" in create
+        assert "priority int" in create
+
+    def test_distance_metric_l2(self) -> None:
+        cur = MagicMock()
+        pool, _ = _mock_pool(cur)
+        with patch(
+            "dao_ai.memory.postgres.PostgresPoolManager.get_pool",
+            return_value=pool,
+        ):
+            _vs(distance_metric="l2").provision(dimension=768)
+        stmts = [c.args[0] for c in cur.execute.call_args_list]
+        ann = next(s for s in stmts if "USING lakebase_ann" in s)
+        assert "vector_l2_ops" in ann
+        assert "vector(768)" in next(s for s in stmts if "CREATE TABLE" in s)
+
+    def test_id_column_type_override(self) -> None:
+        cur = MagicMock()
+        pool, _ = _mock_pool(cur)
+        with patch(
+            "dao_ai.memory.postgres.PostgresPoolManager.get_pool",
+            return_value=pool,
+        ):
+            _vs().provision(dimension=1024, id_column_type="bigint")
+        stmts = [c.args[0] for c in cur.execute.call_args_list]
+        create = next(s for s in stmts if "CREATE TABLE" in s)
+        assert "id bigint PRIMARY KEY" in create
+
+    def test_custom_schema_name_qualifies_object_names(self) -> None:
+        cur = MagicMock()
+        pool, _ = _mock_pool(cur)
+        with patch(
+            "dao_ai.memory.postgres.PostgresPoolManager.get_pool",
+            return_value=pool,
+        ):
+            _vs(schema_name="dao_ai_kb").provision(dimension=1024)
+        stmts = [c.args[0] for c in cur.execute.call_args_list]
+        assert any("CREATE TABLE IF NOT EXISTS dao_ai_kb.kb_articles" in s for s in stmts)
+
+    def test_bad_dimension_raises(self) -> None:
+        with pytest.raises(ValueError, match="positive int"):
+            _vs().provision(dimension=0)
+
+    def test_idempotent_uses_if_not_exists_everywhere(self) -> None:
+        """Every statement must include an IF NOT EXISTS guard so re-runs are safe."""
+        cur = MagicMock()
+        pool, _ = _mock_pool(cur)
+        with patch(
+            "dao_ai.memory.postgres.PostgresPoolManager.get_pool",
+            return_value=pool,
+        ):
+            _vs(tsvector_column="passage_tsv").provision(dimension=1024)
+        stmts = [c.args[0] for c in cur.execute.call_args_list]
+        for stmt in stmts:
+            assert "IF NOT EXISTS" in stmt, f"missing IF NOT EXISTS: {stmt!r}"


### PR DESCRIPTION
## Summary

Two idempotent utilities that let notebook/setup code provision a Lakebase retrieval table without hand-writing DDL.

### `DatabaseModel.execute_sql(statements, parameters=None)`

Runs one or more SQL statements through the synchronous connection pool (`PostgresPoolManager`). Single transaction, commits on success, rolls back on error. Accepts either a single string (with optional positional parameters) or a sequence of statements. Intended for ad-hoc DDL/DML from notebooks and setup scripts.

### `LakebaseVectorStoreModel.provision(dimension, ...)`

Idempotently creates the Postgres extensions + table + indexes for a Lakebase retriever. **Every statement uses `IF NOT EXISTS`** so re-running is safe — no data is dropped and no existing indexes are altered.

Table shape derives from the vector-store config:
- `{id_column} {id_column_type} PRIMARY KEY` (default: `text`)
- `{content_column} text NOT NULL`
- `{embedding_column} vector({dimension})`
- Each metadata column typed via `metadata_column_types` (default `text`)
- Optional: `{tsvector_column} tsvector GENERATED ALWAYS AS (to_tsvector('{tsv_language}', {content_column})) STORED`

Extensions + indexes:
- Always: `lakebase_vector` extension + `lakebase_ann` index (operator chosen from `distance_metric`: `vector_cosine_ops` / `vector_l2_ops` / `vector_ip_ops`)
- When `tsvector_column` set: `lakebase_text` extension + `lakebase_bm25` index

Callers pass `dimension` explicitly — no auto-detection from the embedding endpoint. Users know their model (e.g. `1024` for `databricks-gte-large-en`).

## Use case (workshop lab)

Turns the ~15-line SQL-file-execution loop from the lab-11 notebook (`data/kb_articles.sql` + manual `pool.connection().cursor().execute()` loop) into a one-liner:

```python
retriever.vector_store.provision(
    dimension=1024,
    metadata_column_types={"priority": "int"},
)
```

The lab notebook will migrate to this in a follow-up PR once this ships.

## Test plan

- [x] `uv run pytest tests/dao_ai/test_lakebase_provision.py` — 14/14 pass. Covers:
  - `execute_sql`: single statement / sequence / rollback on error / empty sequence no-op / parameters forwarded / parameters+sequence rejected
  - `provision`: ANN-only minimal / HYBRID / metadata_column_types respected / distance_metric l2 / id_column_type override / custom schema qualifier / bad-dimension raises / every statement has IF NOT EXISTS
- [x] Regression across `test_lakebase_search.py` + `test_retriever_model_hierarchy.py` — 90/90 pass.

## Deferred

- **Live E2E** — provision the workshop lab's `kb_articles` table on a real Lakebase project and verify all 3 configs (`ann_only` / `hybrid` / `reranked`) return non-empty results. In flight on a separate serverless-job run of the lab notebook; this PR ships the utilities standalone.
- **Auto-dimension** — reading dimension from `embedding_model` at provision time would need a serving-endpoint probe. Left for a follow-up if requested.

This pull request and its description were written by Isaac.