### PR TITLE
feat(config): AnyVectorStore union — register Lakebase + AI Search under resources.vector_stores

### DIFF
--- a/config/examples/21_lakebase_search/ann_only.yaml
+++ b/config/examples/21_lakebase_search/ann_only.yaml
@@ -77,13 +77,13 @@ resources:
       client_secret: *client_secret
       workspace_host: *workspace_host
 
-# Top-level retrievers block — same shape ai_search uses. Tools reference
-# these by anchor rather than inlining the retriever config into
-# ``function.retriever``.
-retrievers:
-  kb_ann: &kb_ann
-    type: lakebase_search
-    vector_store:
+  # Register the vector store under `resources.vector_stores` so multiple
+  # retrievers can share one definition (dao-ai 0.1.108+). The `type:`
+  # discriminator selects the concrete class — either `ai_search` (default,
+  # AiSearchVectorStoreModel) or `lakebase_search` (LakebaseVectorStoreModel).
+  vector_stores:
+    kb_ann_vs: &kb_ann_vs
+      type: lakebase_search
       database: *kb_lakebase
       schema_name: ${var.schema_name}
       table: ${var.table_name}
@@ -94,6 +94,14 @@ retrievers:
         - category
         - source_url
       distance_metric: cosine                    # cosine | l2 | ip
+
+# Top-level retrievers block — same shape ai_search uses. Tools reference
+# these by anchor rather than inlining the retriever config into
+# ``function.retriever``.
+retrievers:
+  kb_ann: &kb_ann
+    type: lakebase_search
+    vector_store: *kb_ann_vs                     # reference the registered store
 
 tools:
   kb_search: &kb_search

--- a/config/examples/21_lakebase_search/bm25_only.yaml
+++ b/config/examples/21_lakebase_search/bm25_only.yaml
@@ -55,10 +55,9 @@ resources:
       client_secret: *client_secret
       workspace_host: *workspace_host
 
-retrievers:
-  kb_bm25: &kb_bm25
-    type: lakebase_search
-    vector_store:
+  vector_stores:
+    kb_bm25_vs: &kb_bm25_vs
+      type: lakebase_search
       database: *kb_lakebase
       schema_name: ${var.schema_name}
       table: ${var.table_name}
@@ -68,6 +67,11 @@ retrievers:
       embedding_model: databricks-gte-large-en
       metadata_columns:
         - category
+
+retrievers:
+  kb_bm25: &kb_bm25
+    type: lakebase_search
+    vector_store: *kb_bm25_vs
     search_parameters:
       query_type: BM25
       num_results: 5

--- a/config/examples/21_lakebase_search/dynamic_schema.yaml
+++ b/config/examples/21_lakebase_search/dynamic_schema.yaml
@@ -61,10 +61,9 @@ resources:
       client_secret: *client_secret
       workspace_host: *workspace_host
 
-retrievers:
-  scoped_kb_retriever: &scoped_kb_retriever
-    type: lakebase_search
-    vector_store:
+  vector_stores:
+    hardware_kb_vs: &hardware_kb_vs
+      type: lakebase_search
       database: *kb_lakebase
       schema_name: ${var.schema_name}
       table: ${var.table_name}
@@ -73,11 +72,16 @@ retrievers:
       tsvector_column: passage_tsv
       embedding_model: databricks-gte-large-en
       # metadata_columns still set for Document.metadata surfacing;
-      # columns below is what drives the LLM args_schema.
+      # `columns` on the retriever is what drives the LLM args_schema.
       metadata_columns:
         - category
         - priority
         - source_url
+
+retrievers:
+  scoped_kb_retriever: &scoped_kb_retriever
+    type: lakebase_search
+    vector_store: *hardware_kb_vs
     # Hand-declared columns (Mode A — no Postgres discovery call).
     columns:
       - name: category

--- a/config/examples/21_lakebase_search/filters_and_traces.yaml
+++ b/config/examples/21_lakebase_search/filters_and_traces.yaml
@@ -68,12 +68,9 @@ resources:
       client_secret: *client_secret
       workspace_host: *workspace_host
 
-retrievers:
-  # Only surface published, high-priority auth-related docs to the agent.
-  # Filter columns must appear in vector_store.metadata_columns (allowlist).
-  active_auth_retriever: &active_auth_retriever
-    type: lakebase_search
-    vector_store:
+  vector_stores:
+    active_auth_vs: &active_auth_vs
+      type: lakebase_search
       database: *kb_lakebase
       schema_name: ${var.schema_name}
       table: ${var.table_name}
@@ -86,6 +83,13 @@ retrievers:
         - status
         - priority
         - source_url
+
+retrievers:
+  # Only surface published, high-priority auth-related docs to the agent.
+  # Filter columns must appear in vector_store.metadata_columns (allowlist).
+  active_auth_retriever: &active_auth_retriever
+    type: lakebase_search
+    vector_store: *active_auth_vs
     search_parameters:
       query_type: HYBRID
       num_results: 5

--- a/config/examples/21_lakebase_search/hybrid_rrf.yaml
+++ b/config/examples/21_lakebase_search/hybrid_rrf.yaml
@@ -61,10 +61,13 @@ resources:
       client_secret: *client_secret
       workspace_host: *workspace_host
 
-retrievers:
-  kb_hybrid_retriever: &kb_hybrid_retriever
-    type: lakebase_search
-    vector_store:
+  # Register the vector store under `resources.vector_stores` so multiple
+  # retrievers can share one definition (dao-ai 0.1.108+). The `type:`
+  # discriminator selects the concrete class — either `ai_search` (default,
+  # AiSearchVectorStoreModel) or `lakebase_search` (LakebaseVectorStoreModel).
+  vector_stores:
+    kb_hybrid_vs: &kb_hybrid_vs
+      type: lakebase_search
       database: *kb_lakebase
       schema_name: ${var.schema_name}
       table: ${var.table_name}
@@ -78,6 +81,11 @@ retrievers:
       metadata_columns:
         - category
         - source_url
+
+retrievers:
+  kb_hybrid_retriever: &kb_hybrid_retriever
+    type: lakebase_search
+    vector_store: *kb_hybrid_vs                 # reference the registered store
     search_parameters:
       query_type: HYBRID                      # ANN | BM25 | HYBRID
       num_results: 5

--- a/config/examples/21_lakebase_search/instructed.yaml
+++ b/config/examples/21_lakebase_search/instructed.yaml
@@ -66,10 +66,9 @@ resources:
       client_secret: *client_secret
       workspace_host: *workspace_host
 
-retrievers:
-  kb_instructed_retriever: &kb_instructed_retriever
-    type: lakebase_search
-    vector_store:
+  vector_stores:
+    kb_instructed_vs: &kb_instructed_vs
+      type: lakebase_search
       database: *kb_lakebase
       schema_name: ${var.schema_name}
       table: ${var.table_name}
@@ -80,6 +79,11 @@ retrievers:
       metadata_columns:
         - category
         - priority
+
+retrievers:
+  kb_instructed_retriever: &kb_instructed_retriever
+    type: lakebase_search
+    vector_store: *kb_instructed_vs
     search_parameters:
       query_type: HYBRID
       num_results: 20

--- a/config/examples/21_lakebase_search/reranked.yaml
+++ b/config/examples/21_lakebase_search/reranked.yaml
@@ -60,11 +60,9 @@ resources:
       client_secret: *client_secret
       workspace_host: *workspace_host
 
-retrievers:
-  # Cast a wide net, then rerank down to the top 5 most relevant.
-  kb_reranked_retriever: &kb_reranked_retriever
-    type: lakebase_search
-    vector_store:
+  vector_stores:
+    kb_reranked_vs: &kb_reranked_vs
+      type: lakebase_search
       database: *kb_lakebase
       schema_name: ${var.schema_name}
       table: ${var.table_name}
@@ -73,6 +71,24 @@ retrievers:
       tsvector_column: passage_tsv
       embedding_model: databricks-gte-large-en
       metadata_columns: [category, priority]
+
+    # Same table, narrower metadata surface for the ANN-only variant.
+    kb_reranked_default_vs: &kb_reranked_default_vs
+      type: lakebase_search
+      database: *kb_lakebase
+      schema_name: ${var.schema_name}
+      table: ${var.table_name}
+      content_column: passage
+      embedding_column: embedding
+      tsvector_column: passage_tsv
+      embedding_model: databricks-gte-large-en
+      metadata_columns: [category]
+
+retrievers:
+  # Cast a wide net, then rerank down to the top 5 most relevant.
+  kb_reranked_retriever: &kb_reranked_retriever
+    type: lakebase_search
+    vector_store: *kb_reranked_vs
     search_parameters:
       query_type: HYBRID
       num_results: 20                # broad recall — cast the wide net
@@ -84,15 +100,7 @@ retrievers:
   # (returns all num_results docs, just reordered by rerank score).
   kb_reranked_default_retriever: &kb_reranked_default_retriever
     type: lakebase_search
-    vector_store:
-      database: *kb_lakebase
-      schema_name: ${var.schema_name}
-      table: ${var.table_name}
-      content_column: passage
-      embedding_column: embedding
-      tsvector_column: passage_tsv
-      embedding_model: databricks-gte-large-en
-      metadata_columns: [category]
+    vector_store: *kb_reranked_default_vs
     search_parameters:
       query_type: ANN
       num_results: 5

--- a/src/dao_ai/apps/resources.py
+++ b/src/dao_ai/apps/resources.py
@@ -217,15 +217,28 @@ def _extract_llm_resources(
 
 
 def _extract_vector_search_resources(
-    vector_stores: dict[str, VectorStoreModel],
+    vector_stores: dict[str, Any],
 ) -> list[dict[str, Any]]:
-    """Extract vector search index resources from VectorStoreModels.
+    """Extract AI Search vector-search-index resources from vector stores.
+
+    ``vector_stores`` is the discriminated-union dict, so entries may be
+    either :class:`AiSearchVectorStoreModel` or
+    :class:`LakebaseVectorStoreModel`. Only the former produces a
+    ``vector-search-index`` bundle resource — Lakebase entries authenticate
+    via their nested ``DatabaseModel`` at runtime and don't have an
+    equivalent Databricks-App resource type.
 
     Skips resources where ``on_behalf_of_user=True`` (served via
     ``user_api_scopes``).
     """
+    from dao_ai.config import AiSearchVectorStoreModel
+
     resources: list[dict[str, Any]] = []
     for key, vs in vector_stores.items():
+        if not isinstance(vs, AiSearchVectorStoreModel):
+            # LakebaseVectorStoreModel entries emit nothing here — their
+            # auth flows through ``vs.database`` at runtime.
+            continue
         if vs.index is None:
             continue
         if vs.on_behalf_of_user:

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -2964,13 +2964,16 @@ class SkillModel(BaseModel):
         )
 
 
-class AiSearchIndexModel(IsDatabricksResource, ManagedResource):
+class AiSearchVectorStoreModel(IsDatabricksResource, ManagedResource):
     """
-    Configuration model for a Databricks AI Search index.
+    Configuration model for a Databricks AI Search vector store.
 
-    (Formerly ``VectorStoreModel``. Databricks rebranded Vector Search to
-    AI Search; the old class name remains as an alias defined at the end
-    of the class body for backwards compatibility.)
+    (Formerly ``VectorStoreModel`` / ``AiSearchIndexModel``. Databricks
+    rebranded Vector Search to AI Search; ``AiSearchVectorStoreModel`` is
+    the current name — chosen to parallel ``LakebaseVectorStoreModel`` so
+    both retriever backends can co-exist under ``resources.vector_stores``.
+    Both legacy names remain as aliases defined at the end of the class
+    body for backwards compatibility.)
 
     Supports two modes:
     1. **Use Existing Index**: Provide only `index` (fully qualified name).
@@ -3043,6 +3046,13 @@ class AiSearchIndexModel(IsDatabricksResource, ManagedResource):
     doc_uri: Optional[str] = Field(
         default=None,
         description="Column name containing document URIs for provenance tracking.",
+    )
+    # Discriminator field for the ``AnyVectorStore`` union. Plain-string
+    # Literal (not the enum instance) to keep yaml.safe_dump round-tripping
+    # clean — same pattern as ``AnyRetriever``.
+    type: Literal["ai_search"] = Field(
+        default="ai_search",
+        description="Discriminator. Must be 'ai_search' (or omitted — defaults).",
     )
 
     _index_details: Optional[dict[str, Any]] = PrivateAttr(default=None)
@@ -3317,9 +3327,11 @@ class AiSearchIndexModel(IsDatabricksResource, ManagedResource):
         provider.create_vector_store(self)
 
 
-# Backwards-compatible alias — Vector Search naming will eventually be
-# deprecated. Both names refer to the same class.
-VectorStoreModel = AiSearchIndexModel
+# Backwards-compatible aliases — both legacy names point at the same class.
+# Python code importing either continues to work. Prefer
+# ``AiSearchVectorStoreModel`` in new code.
+AiSearchIndexModel = AiSearchVectorStoreModel
+VectorStoreModel = AiSearchVectorStoreModel
 
 
 class ConnectionModel(IsDatabricksResource, HasFullName):
@@ -4687,6 +4699,13 @@ class LakebaseVectorStoreModel(BaseModel):
 
     model_config = ConfigDict(use_enum_values=True, extra="forbid")
 
+    # Discriminator field for the ``AnyVectorStore`` union. Plain-string
+    # Literal to keep yaml.safe_dump round-tripping clean — same pattern
+    # as ``AnyRetriever``.
+    type: Literal["lakebase_search"] = Field(
+        default="lakebase_search",
+        description="Discriminator. Must be 'lakebase_search'.",
+    )
     database: DatabaseModel = Field(
         description=(
             "Lakebase (or PostgreSQL) database connection. Reuses the "
@@ -4766,6 +4785,27 @@ class LakebaseVectorStoreModel(BaseModel):
                 f"{self.schema_name}.{self.table}_{self.tsvector_column}_bm25"
             )
         return self
+
+    # -- IsDatabricksResource-shaped delegation --------------------------
+    # LakebaseVectorStoreModel is not itself a Databricks resource — its
+    # auth genuinely lives on the nested ``database``. Delegating the
+    # three IsDatabricksResource members that deploy paths iterate
+    # (``as_resources()``, ``api_scopes``, ``on_behalf_of_user``) keeps
+    # ``resources.vector_stores`` polymorphic without lying about class
+    # identity or forcing multiple inheritance. Callers that need to
+    # dispatch further (e.g. only emit ``vector-search-index`` bundle
+    # resources for AI Search) still do so via ``isinstance``.
+
+    @property
+    def on_behalf_of_user(self) -> bool:
+        return self.database.on_behalf_of_user
+
+    @property
+    def api_scopes(self) -> Sequence[str]:
+        return self.database.api_scopes
+
+    def as_resources(self) -> Sequence["DatabricksResource"]:
+        return self.database.as_resources()
 
     def provision(
         self,
@@ -4936,6 +4976,40 @@ AnyRetriever: TypeAlias = Annotated[
         Annotated[LakebaseRetrieverModel, Tag(RetrieverType.LAKEBASE_SEARCH.value)],
     ],
     Discriminator(_retriever_discriminator),
+]
+
+
+def _vector_store_discriminator(v: Any) -> str:
+    """Callable discriminator for :data:`AnyVectorStore`.
+
+    Mirrors :func:`_retriever_discriminator`. Defaults to ``"ai_search"``
+    when the ``type`` field is absent — load-bearing back-compat hook
+    that lets existing YAML ``resources.vector_stores:`` entries (which
+    never specified ``type:``) keep parsing as
+    :class:`AiSearchVectorStoreModel`.
+    """
+    if isinstance(v, (AiSearchVectorStoreModel, LakebaseVectorStoreModel)):
+        return v.type if isinstance(v.type, str) else v.type.value
+    if isinstance(v, dict):
+        raw = v.get("type")
+        if raw is None:
+            return "ai_search"
+        return raw.value if hasattr(raw, "value") else str(raw)
+    raise ValueError(
+        f"cannot infer vector_store discriminator from {type(v).__name__}"
+    )
+
+
+# Discriminated union — Pydantic dispatches to the concrete class using
+# the callable above. Existing YAML entries under
+# ``resources.vector_stores`` that omit ``type`` default to
+# :class:`AiSearchVectorStoreModel` for back-compat.
+AnyVectorStore: TypeAlias = Annotated[
+    Union[
+        Annotated[AiSearchVectorStoreModel, Tag("ai_search")],
+        Annotated[LakebaseVectorStoreModel, Tag("lakebase_search")],
+    ],
+    Discriminator(_vector_store_discriminator),
 ]
 
 
@@ -5667,9 +5741,9 @@ class AiSearchToolModel(BaseFunctionModel):
         default=None,
         description="Full retriever configuration with search parameters and reranking. Mutually exclusive with vector_store.",
     )
-    vector_store: Optional[AiSearchIndexModel] = Field(
+    vector_store: Optional[AiSearchVectorStoreModel] = Field(
         default=None,
-        description="Direct AI Search index reference (uses default search parameters). Mutually exclusive with retriever.",
+        description="Direct AI Search vector-store reference (uses default search parameters). Mutually exclusive with retriever.",
     )
     name: Optional[str] = Field(
         default=None,
@@ -9431,9 +9505,16 @@ class ResourcesModel(BaseModel):
             "the legacy key is still accepted via validation alias and will be removed in a future major release."
         ),
     )
-    vector_stores: dict[str, VectorStoreModel] = Field(
+    vector_stores: dict[str, AnyVectorStore] = Field(
         default_factory=dict,
-        description="Vector search index configurations for semantic retrieval.",
+        description=(
+            "Named vector-store configurations, keyed by name. Each entry "
+            "is a discriminated union — the ``type`` field selects between "
+            "``AiSearchVectorStoreModel`` (default, `type: ai_search`) and "
+            "``LakebaseVectorStoreModel`` (`type: lakebase_search`). "
+            "Existing YAMLs that omit ``type`` continue to parse as AI Search "
+            "vector stores."
+        ),
     )
     genie_rooms: dict[str, GenieRoomModel] = Field(
         default_factory=dict,

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -175,9 +175,11 @@ def _collect_resources_with_obo_flag(
         return ()
 
     llms: Sequence[InferenceEndpointModel] = list(config.resources.models.values())
-    vector_indexes: Sequence[VectorStoreModel] = list(
-        config.resources.vector_stores.values()
-    )
+    # Each entry is either AiSearchVectorStoreModel (IsDatabricksResource
+    # directly) or LakebaseVectorStoreModel (delegates auth + as_resources
+    # to its nested DatabaseModel). Both quack as IsDatabricksResource
+    # via delegation for the deploy iteration below.
+    vector_indexes: Sequence[Any] = list(config.resources.vector_stores.values())
     warehouses: Sequence[WarehouseModel] = list(config.resources.warehouses.values())
     genie_rooms: Sequence[GenieRoomModel] = list(config.resources.genie_rooms.values())
     functions: Sequence[FunctionModel] = list(config.resources.functions.values())

--- a/tests/dao_ai/test_vector_store_union.py
+++ b/tests/dao_ai/test_vector_store_union.py
@@ -1,0 +1,154 @@
+"""Unit tests for the ``AnyVectorStore`` discriminated union.
+
+Covers:
+  - Both concrete types register under ``resources.vector_stores``.
+  - Legacy YAML entries (no ``type`` field) default to
+    :class:`AiSearchVectorStoreModel`.
+  - :class:`LakebaseVectorStoreModel` delegates the IsDatabricksResource
+    trio (``as_resources``, ``api_scopes``, ``on_behalf_of_user``) to its
+    nested :class:`DatabaseModel`, so deploy-path iteration works
+    polymorphically.
+  - The app-bundle vector-search-index extractor filters to
+    :class:`AiSearchVectorStoreModel` entries only.
+  - Backwards-compat aliases still resolve.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dao_ai.config import (
+    AiSearchIndexModel,
+    AiSearchVectorStoreModel,
+    AppConfig,
+    DatabaseModel,
+    IndexModel,
+    LakebaseVectorStoreModel,
+    ResourcesModel,
+    SchemaModel,
+    VectorSearchEndpoint,
+    VectorStoreModel,
+)
+
+
+def _ai_search() -> AiSearchVectorStoreModel:
+    return AiSearchVectorStoreModel(
+        index=IndexModel(
+            name="c.s.i", schema=SchemaModel(catalog_name="c", schema_name="s")
+        ),
+        endpoint=VectorSearchEndpoint(name="e"),
+    )
+
+
+def _lakebase() -> LakebaseVectorStoreModel:
+    return LakebaseVectorStoreModel(
+        database=DatabaseModel(project="p"),
+        table="kb_articles",
+        content_column="passage",
+        embedding_column="embedding",
+        embedding_model="databricks-gte-large-en",
+    )
+
+
+@pytest.mark.unit
+class TestBackwardsCompatibleAliases:
+    def test_legacy_names_resolve_to_new_class(self) -> None:
+        # Python code importing either legacy name keeps working
+        assert AiSearchIndexModel is AiSearchVectorStoreModel
+        assert VectorStoreModel is AiSearchVectorStoreModel
+
+
+@pytest.mark.unit
+class TestTypeDiscriminator:
+    def test_ai_search_default_type(self) -> None:
+        assert _ai_search().type == "ai_search"
+
+    def test_lakebase_default_type(self) -> None:
+        assert _lakebase().type == "lakebase_search"
+
+
+@pytest.mark.unit
+class TestUnionDispatchFromDict:
+    """YAML/dict input goes through the ``_vector_store_discriminator``
+    callable — legacy entries without ``type`` default to ai_search."""
+
+    def test_registers_both_types_side_by_side(self) -> None:
+        resources = ResourcesModel(
+            vector_stores={"ai": _ai_search(), "lb": _lakebase()},
+        )
+        assert isinstance(resources.vector_stores["ai"], AiSearchVectorStoreModel)
+        assert isinstance(resources.vector_stores["lb"], LakebaseVectorStoreModel)
+
+    def test_dict_with_lakebase_type_dispatches_correctly(self) -> None:
+        resources = ResourcesModel(
+            vector_stores={
+                "lb": {
+                    "type": "lakebase_search",
+                    "database": {"project": "p"},
+                    "table": "t",
+                    "content_column": "c",
+                    "embedding_column": "e",
+                    "embedding_model": "m",
+                }
+            }
+        )
+        assert isinstance(resources.vector_stores["lb"], LakebaseVectorStoreModel)
+
+    def test_dict_without_type_defaults_to_ai_search(self) -> None:
+        """Legacy YAML back-compat — the discriminator returns 'ai_search'
+        when ``type`` is absent, so pre-refactor configs continue to load."""
+        resources = ResourcesModel(
+            vector_stores={
+                "legacy_ai": {
+                    # NO ``type`` field
+                    "index": {
+                        "name": "c.s.i",
+                        "schema": {"catalog_name": "c", "schema_name": "s"},
+                    },
+                    "endpoint": {"name": "e"},
+                }
+            }
+        )
+        assert isinstance(
+            resources.vector_stores["legacy_ai"], AiSearchVectorStoreModel
+        )
+
+
+@pytest.mark.unit
+class TestLakebaseDelegation:
+    """LakebaseVectorStoreModel is NOT IsDatabricksResource, but it
+    delegates the three members deploy paths iterate to its database."""
+
+    def test_on_behalf_of_user_delegates_to_database(self) -> None:
+        lb = _lakebase()
+        assert lb.on_behalf_of_user == lb.database.on_behalf_of_user
+
+    def test_api_scopes_delegates_to_database(self) -> None:
+        lb = _lakebase()
+        assert lb.api_scopes == lb.database.api_scopes
+
+    def test_as_resources_delegates_to_database(self) -> None:
+        lb = _lakebase()
+        assert lb.as_resources() == lb.database.as_resources()
+
+
+@pytest.mark.unit
+class TestAppBundleVectorSearchExtractor:
+    """``_extract_vector_search_resources`` emits vector-search-index bundle
+    entries only for AI Search vector stores; Lakebase entries produce
+    nothing (they authenticate via their DatabaseModel at runtime)."""
+
+    def test_skips_lakebase_entries(self) -> None:
+        from dao_ai.apps.resources import _extract_vector_search_resources
+
+        vector_stores = {"ai": _ai_search(), "lb": _lakebase()}
+        resources = _extract_vector_search_resources(vector_stores)
+        assert len(resources) == 1
+        assert resources[0]["name"] == "ai"
+        assert resources[0]["type"] == "vector-search-index"
+
+    def test_only_lakebase_produces_empty(self) -> None:
+        from dao_ai.apps.resources import _extract_vector_search_resources
+
+        vector_stores = {"lb": _lakebase()}
+        assert _extract_vector_search_resources(vector_stores) == []


### PR DESCRIPTION
## Summary

Rename `AiSearchIndexModel` → `AiSearchVectorStoreModel` (matching `LakebaseVectorStoreModel`) and turn `resources.vector_stores` into a **discriminated union** so both retriever backends can register and share a single vector-store definition.

## Design

**Discriminated union at the container level. No forced inheritance.**

- `AiSearchVectorStoreModel` keeps its `IsDatabricksResource + ManagedResource` inheritance — nothing changes about how it emits App-bundle / MLflow resources.
- `LakebaseVectorStoreModel` stays a bare `BaseModel` — its auth genuinely lives on the nested `database: DatabaseModel`. It now **delegates** the three `IsDatabricksResource`-shaped members to `self.database` so polymorphic deploy iteration works without lying about class identity:
  - `on_behalf_of_user` property → `self.database.on_behalf_of_user`
  - `api_scopes` property → `self.database.api_scopes`
  - `as_resources()` → `self.database.as_resources()`
- New `AnyVectorStore = Annotated[Union[..., ...], Discriminator(_vector_store_discriminator)]` — mirrors the existing `AnyRetriever` pattern.

## API changes

- Rename class + add legacy aliases: `AiSearchIndexModel = VectorStoreModel = AiSearchVectorStoreModel`.
- Add `type: Literal["ai_search"]` (defaults) / `type: Literal["lakebase_search"]` discriminator fields to each concrete class.
- `ResourcesModel.vector_stores: dict[str, AnyVectorStore]` (was `dict[str, VectorStoreModel]`).

**Back-compat:** Legacy YAML entries under `resources.vector_stores` that omit `type:` continue to load as `AiSearchVectorStoreModel` — the callable discriminator defaults to `"ai_search"`.

## Deploy paths

- **App-bundle** (`apps/resources.py:_extract_vector_search_resources`) now filters to `AiSearchVectorStoreModel` via `isinstance`. Lakebase entries emit no `vector-search-index` bundle resource — their auth flows through runtime OAuth on `database.client_id`/`_secret`.
- **Model Serving `log_model`** (`providers/databricks.py:_collect_resources_with_obo_flag` → `build_auth_policy`) now types the vector-stores sequence as `Sequence[Any]` and relies on the delegating members so both concrete types quack correctly.

## Example migrations

All 6 examples in `config/examples/21_lakebase_search/` migrated to the register-then-reference pattern:

```yaml
resources:
  vector_stores:
    kb_hybrid_vs: &kb_hybrid_vs
      type: lakebase_search
      database: *kb_lakebase
      table: kb_articles
      # ...
retrievers:
  kb_hybrid_retriever:
    type: lakebase_search
    vector_store: *kb_hybrid_vs
```

All 6 continue to pass `dao-ai validate`.

## Test plan

- [x] `tests/dao_ai/test_vector_store_union.py` (11 new tests) — register both types side by side, dict/YAML dispatch (with and without explicit `type`), Lakebase delegates all 3 IsDatabricksResource members, `_extract_vector_search_resources` filters correctly, backwards-compat aliases resolve.
- [x] 185/185 pass across `test_vector_store_union` + `test_retriever_model_hierarchy` + `test_vector_search_dynamic_schema` + `test_lakebase_search` + `test_lakebase_provision`.
- [x] All 7 `config/examples/21_lakebase_search/*.yaml` pass `dao-ai validate`.
- [ ] **Live E2E** — workshop `lab-11-lakebase-search` deploy from the local wheel + real inference + app-log + trace inspection. **Deferred to a follow-up commit on the same branch** once the wheel is built + uploaded + notebook flipped to the register-then-reference config.
- [ ] Model Serving `deploy_agent(target=DeploymentTarget.MODEL_SERVING)` on a Lakebase-only config — deferred to same live pass.

_Note: 14 pre-existing failures in `test_databricks.py` (Mock-fixture issue with `manage_permissions`) are unrelated to this refactor — they fail on main too._

This pull request and its description were written by Isaac.