### PR TITLE
fix(apps): guard remaining resources.py vector_stores iterations for the union

### DIFF
--- a/src/dao_ai/apps/resources.py
+++ b/src/dao_ai/apps/resources.py
@@ -1219,10 +1219,17 @@ def _extract_sdk_secrets_from_config(config: AppConfig) -> list[AppResource]:
 
 
 def _extract_raw_vector_search_resources(
-    vector_stores: dict[str, VectorStoreModel],
+    vector_stores: dict[str, Any],
 ) -> list[dict[str, Any]]:
     """
     Extract vector search index resources as raw dicts for the REST API.
+
+    ``vector_stores`` is the discriminated-union dict, so entries may be
+    either :class:`AiSearchVectorStoreModel` or
+    :class:`LakebaseVectorStoreModel`. Only the former produces a
+    ``VECTOR_SEARCH_INDEX``-shaped bundle resource — Lakebase entries
+    authenticate via their nested ``DatabaseModel`` at runtime and don't
+    have an equivalent App-platform resource type.
 
     Vector search indexes are stored as TABLE securables in Unity Catalog,
     so the App platform expects ``securable_type: "TABLE"`` with SELECT
@@ -1232,8 +1239,14 @@ def _extract_raw_vector_search_resources(
     retryable error and the fallback strips the index out entirely, so the
     App ends up unable to read the index at runtime.
     """
+    from dao_ai.config import AiSearchVectorStoreModel
+
     resources: list[dict[str, Any]] = []
     for key, vs in vector_stores.items():
+        if not isinstance(vs, AiSearchVectorStoreModel):
+            # LakebaseVectorStoreModel entries emit nothing here — their
+            # auth flows through ``vs.database`` at runtime.
+            continue
         if vs.index is None:
             continue
 
@@ -1824,8 +1837,13 @@ def get_resource_env_mappings(config: AppConfig) -> list[dict[str, Any]]:
             }
         )
 
-    # Map vector search indexes
+    # Map vector search indexes — AI Search only. Lakebase entries have
+    # no `index` field (their table + auth is reached via `database`).
+    from dao_ai.config import AiSearchVectorStoreModel
+
     for key, vs in config.resources.vector_stores.items():
+        if not isinstance(vs, AiSearchVectorStoreModel):
+            continue
         if vs.index:
             env_mappings.append(
                 {


### PR DESCRIPTION
## Summary

Follow-up bugfix to #168. Two additional call sites in \`apps/resources.py\` iterate \`resources.vector_stores.values()\` and access \`vs.index\` directly — they were missed in #168 and blow up with \`AttributeError: 'LakebaseVectorStoreModel' object has no attribute 'index'\` when a Lakebase entry is registered under \`resources.vector_stores\`.

## Sites fixed

1. **\`_extract_raw_vector_search_resources()\`** (line ~1221) — the SDK/REST deploy path's equivalent of \`_extract_vector_search_resources\`. Same \`isinstance(vs, AiSearchVectorStoreModel)\` guard added.
2. **\`_env_mappings_for_config()\`** env-var emission (line ~1841) — emits \`<KEY>_INDEX\` env vars for AI Search entries. Skip Lakebase entries (they have no \`index\` field).

## How I caught this

Workshop lab-11 job run \`396468529264180\` \`AttributeError\`'d on \`_extract_raw_vector_search_resources\` after migrating the yaml to \`resources.vector_stores.kb_vs: {type: lakebase_search, ...}\`.

## Behavior parity

Matches the fix in #168 for \`_extract_vector_search_resources\`: Lakebase entries authenticate via their nested \`DatabaseModel\` at runtime, so no App-platform vector-search resource is emitted for them.

## Test plan

- [x] \`uv run pytest tests/dao_ai/test_vector_store_union.py tests/dao_ai/test_deploy_mixed_vector_stores.py\` → 18/18 pass.
- [ ] Live E2E: rerun the workshop lab-11 job with a registered Lakebase vector_store — deferred to after this + a release.

This pull request and its description were written by Isaac.