### PR TITLE
fix(model_serving): remove in-container experiment binding — MLflow env vars drive routing

### DIFF
--- a/src/dao_ai/apps/model_serving.py
+++ b/src/dao_ai/apps/model_serving.py
@@ -32,36 +32,49 @@ configure_logging(level=log_level)
 
 config.initialize()
 
-# Set the active MLflow experiment BEFORE enabling autolog. If autolog is
-# enabled first, its instrumentation captures the initial LangChain callbacks
-# under the workspace-default experiment and the resulting run lives there —
-# subsequent set_experiment() calls change the active experiment but the run
-# is already stuck under the default. That produces
-# ``Span for run_id ... not found`` at trace-write time. See handlers.py for
-# the symmetric Apps-side fix.
-_experiment_id_env: str | None = os.environ.get("MLFLOW_EXPERIMENT_ID")
-if _experiment_id_env:
-    # Set the active experiment id first — load-bearing for autolog run
-    # placement. Trace-destination linkage is a separate concern handled
-    # by the idempotent helper below (same shape as apps/handlers.py).
-    mlflow.set_experiment(experiment_id=_experiment_id_env)
-    if config.app and config.app.trace_location:
-        try:
-            from dao_ai.providers.databricks import (  # noqa: E402
-                link_experiment_trace_location,
-            )
-
-            link_experiment_trace_location(config, _experiment_id_env)
-        except Exception as _link_err:  # noqa: BLE001
-            from loguru import logger as _log  # noqa: E402
-
-            _log.warning(
-                "dao_ai.trace_location.link_failed "
-                "experiment_id={} err={}: {}",
-                _experiment_id_env,
-                type(_link_err).__name__,
-                _link_err,
-            )
+# In-container experiment / trace-destination binding for Model Serving.
+#
+# Historically this file called ``mlflow.set_experiment(experiment_id=…)``
+# followed by ``link_experiment_trace_location(...)``. Both hit
+# ``GET /api/2.0/mlflow/experiments/get`` under the hood, which the
+# serverless Model Serving container's ambient auth cannot satisfy without
+# the served model having been logged with the experiment declared as a
+# resource dependency (see mlflow ``databricks_utils.py`` /
+# ``DatabricksModelServingConfigProvider``). Result was model-load crash:
+#
+#   mlflow.exceptions.RestException: INTERNAL_ERROR ... < 400 Bad Request
+#   < Unable to load OAuth Config
+#
+# The correct pattern (per Databricks MLflow eng — Aravind Segu in
+# #mlflow-3, Serena Ruan on es-1538671-swiggy, Shaylan Dias / Sid
+# Murching in #agents) is to make no in-container experiment binding
+# call at all. Both experiment placement and UC trace_location routing
+# are driven by env vars that ``agents.deploy()`` sets on the endpoint:
+#
+#   * ``MLFLOW_EXPERIMENT_ID`` — active experiment for autolog runs.
+#   * ``MLFLOW_TRACING_DESTINATION`` — UC schema for OTEL trace tables
+#     (set when ``config.app.trace_location`` is configured).
+#   * ``MLFLOW_TRACING_SQL_WAREHOUSE_ID`` — warehouse used for the
+#     UC-table export path.
+#
+# MLflow's ``_get_span_processors`` reads these directly and picks the
+# right processor + exporter (``DatabricksUCTableSpanExporter`` when a
+# UC destination is present, ``MlflowV3SpanExporter`` otherwise).
+#
+# An earlier iteration of this file wrapped ``set_experiment`` in a
+# try/except, then later swapped to ``set_destination(MlflowExperiment
+# Location(...))``. Both moved the crash aside but the ``set_destination``
+# path forced ``MlflowV3SpanProcessor`` (control-plane) and silently
+# bypassed the UC exporter path — verified empirically: with
+# ``trace_location`` configured, the OTEL span table was 0 rows while
+# ``mlflow.get_trace(...)`` returned the trace from the experiment's
+# default store. Removing the call restores UC routing.
+#
+# The Apps entrypoint (``handlers.py``) keeps the original
+# ``set_experiment`` + ``link_experiment_trace_location`` pattern —
+# Apps containers have full ambient OAuth so those REST calls succeed,
+# and Apps's tracing writer path relies on the explicit linkage.
+# The two entrypoints legitimately diverge here.
 
 mlflow.langchain.autolog(run_tracer_inline=True)
 suppress_autolog_context_warnings()


### PR DESCRIPTION
## Summary

- Removes `mlflow.set_experiment(experiment_id=X)` and `link_experiment_trace_location(...)` from the Model Serving entrypoint (`src/dao_ai/apps/model_serving.py`). Both hit `GET /api/2.0/mlflow/experiments/get` at import time, which the serverless MS container's ambient auth cannot satisfy unless the model was logged with the experiment declared as a resource dependency. Customers who log without that dependency crash at model load with `Unable to load OAuth Config`.
- MLflow's `_get_span_processors` already reads the routing env vars that `agents.deploy()` sets on the endpoint (`MLFLOW_EXPERIMENT_ID`, `MLFLOW_TRACING_DESTINATION`, `MLFLOW_TRACING_SQL_WAREHOUSE_ID`) and picks the correct processor + exporter (`DatabricksUCTableSpanExporter` when a UC destination is present, `MlflowV3SpanExporter` otherwise). No in-container binding needed.
- Aligns with Databricks MLflow eng guidance — cited inline (Aravind Segu in #mlflow-3, Serena Ruan on es-1538671-swiggy, Sid Murching / Shaylan Dias in #agents).
- The Apps entrypoint (`handlers.py`) is unchanged — Apps containers have full ambient OAuth so the original pattern remains correct there.

An earlier iteration that wrapped the call in `try/except` and then swapped to `set_destination(MlflowExperimentLocation(...))` was insufficient: that path forced `MlflowV3SpanProcessor` and silently bypassed UC routing (empirically: OTEL span table was 0 rows while `mlflow.get_trace` still returned traces from the experiment default store). Rationale is documented at the removal site.

## Test plan (both scenarios validated on FEVM)

**Case A — no `trace_location` (control-plane experiment routing):**
- [x] Endpoint starts clean (`Model registered with MLflow via set_model - READY`, no OAuth error)
- [x] Inference returns a full analyst response
- [x] Trace lands in the configured experiment (9 spans: `predict → dao_ai_apredict → LangGraph → __start__ → router → analyst → model → ChatUnityAIGateway`), 0 ERROR spans

**Case B — `app.service_principal` + `app.trace_location` (UC OTEL routing):**
- [x] Endpoint starts clean, no OAuth error, no `set_destination`/`set_experiment` in logs
- [x] Trace-id URI encodes the UC schema: `trace:/retail_consumer_goods.dao_ai_ms_traces/<hash>`
- [x] `<catalog>.<schema>.<prefix>_otel_spans` UC table populates with the full agent flow, all `STATUS_CODE_OK`
- [x] SP grants applied at deploy time (`_grant_uc_trace_table_permissions_to_principal`)

## Known follow-up (not in this PR)

`mlflow.get_trace(<uc-uri>)` client-side path fails with `NOT_FOUND: mlflow_experiment_trace_otel_spans` when `table_prefix` is set — MLflow's reader doesn't consult the prefix. Direct SQL against the prefixed OTEL table works fine. Writer path is correct; this is an MLflow client-side gap independent of this fix.

This pull request and its description were written by Isaac.