### PR TITLE
feat(mcp): PR1 client-side advanced capabilities (progress, logging, elicitation, structured output)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "grandalf>=0.8",
     "langchain>=1.2.12",
     "langchain-community>=0.4.1",
-    "langchain-mcp-adapters>=0.2.2",
+    "langchain-mcp-adapters>=0.3.0",
     "langchain-tavily>=0.2.15",
     "langgraph-checkpoint-postgres==3.0.5",
     "langgraph>=1.1.10",

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -5364,6 +5364,88 @@ class TransportType(str, Enum):
     STDIO = "stdio"
 
 
+class McpSamplingCapabilityModel(BaseModel):
+    """Configuration for handling server-initiated sampling/createMessage requests.
+
+    When present on an McpFunctionModel, dao-ai routes sampling requests to the
+    referenced inference endpoint via AI Gateway. Requires the raw ClientSession
+    code path since langchain-mcp-adapters does not surface sampling callbacks.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    endpoint: "InferenceEndpointModel" = Field(
+        ...,
+        description="LLM endpoint used to satisfy sampling requests. AI Gateway required.",
+    )
+    max_iterations: int = Field(
+        default=3,
+        description="Cap on nested sampling calls per outer tool invocation. Prevents runaway server-driven recursion.",
+    )
+    allow_tool_use: bool = Field(
+        default=False,
+        description="Whether a sampling call may itself request tool use. Default false prevents cross-agent recursion.",
+    )
+
+
+class McpRootModel(BaseModel):
+    """A single URI root advertised to the MCP server via roots/list.
+
+    Roots let the server scope filesystem / storage operations to a bounded set
+    of URIs the client blesses.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    uri: str = Field(
+        ...,
+        description="Root URI, e.g. 'file:///workspace' or 'databricks:///Volumes/catalog/schema/vol'.",
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="Human-readable label for the root.",
+    )
+
+
+class McpCapabilitiesModel(BaseModel):
+    """Advanced MCP capabilities for an MCP client (McpFunctionModel).
+
+    When None (the default on McpFunctionModel), the classic
+    MultiServerMCPClient path runs with no callbacks or interceptors —
+    guaranteeing byte-for-byte behavior parity with the pre-capabilities
+    version.
+
+    When set, dao-ai wires langchain-mcp-adapters ``Callbacks`` and
+    ``ToolCallInterceptor`` middleware around the client. If ``sampling`` or
+    ``roots`` is populated, dao-ai drops to a raw ``mcp.client.session.ClientSession``
+    path since those callbacks are not surfaced by the adapter.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    progress: bool = Field(
+        default=False,
+        description="Consume progress notifications from the MCP server; forward as MLflow span events on the enclosing tool span.",
+    )
+    logging: Optional[Literal["debug", "info", "warning", "error"]] = Field(
+        default=None,
+        description="Subscribe to server logging/message notifications at this minimum level; forward as MLflow span events. None disables the capability.",
+    )
+    elicitation: Optional[Literal["hitl", "reject"]] = Field(
+        default=None,
+        description="Handle server-initiated elicitation/create. 'hitl' raises a LangGraph interrupt whose resume value becomes the ElicitResult; 'reject' returns action='cancel' without prompting.",
+    )
+    structured_output: bool = Field(
+        default=True,
+        description="Prefer CallToolResult.structuredContent and expand resource_link items into MLflow span attributes via a ToolCallInterceptor. Additive only; falls back to text extraction when structuredContent is absent.",
+    )
+    sampling: Optional[McpSamplingCapabilityModel] = Field(
+        default=None,
+        description="Handle server-initiated sampling/createMessage. Requires the raw ClientSession path (adapter does not surface sampling callback).",
+    )
+    roots: list[McpRootModel] = Field(
+        default_factory=list,
+        description="URI roots advertised to the server via roots/list. Requires the raw ClientSession path (adapter does not surface list_roots callback). Empty list disables the capability.",
+    )
+
+
 class McpFunctionModel(BaseFunctionModel, IsDatabricksResource):
     """
     MCP Function Model with authentication inherited from IsDatabricksResource.
@@ -5455,6 +5537,15 @@ class McpFunctionModel(BaseFunctionModel, IsDatabricksResource):
             "warehouse_id (DBSQL); num_results, filters, query_type, columns, "
             "score_threshold, include_score, columns_to_rerank (Vector Search). "
             "Values support AnyVariable (env vars, secrets, defaults)."
+        ),
+    )
+    capabilities: Optional[McpCapabilitiesModel] = Field(
+        default=None,
+        description=(
+            "Advanced MCP capabilities (progress, logging, elicitation, structured "
+            "output, sampling, roots). When None the classic MultiServerMCPClient "
+            "path is used with no callbacks or interceptors — zero regression from "
+            "the pre-capabilities behavior. See McpCapabilitiesModel."
         ),
     )
 

--- a/src/dao_ai/tools/mcp.py
+++ b/src/dao_ai/tools/mcp.py
@@ -302,6 +302,139 @@ def _extract_text_content(result: CallToolResult) -> str:
 _TRANSIENT_HTTP_STATUS_CODES = {429, 502, 503, 504}
 
 
+def _build_mcp_client(
+    function: McpFunctionModel,
+    context: "Context | None" = None,
+) -> MultiServerMCPClient:
+    """Construct a MultiServerMCPClient for a single ``mcp_function`` connection.
+
+    When ``function.capabilities`` is None (default), returns the classic
+    single-connection client with ``handle_tool_errors=False`` — preserving the
+    pre-0.3.0 ``ToolException`` semantics that dao-ai's agent loop relies on.
+
+    When ``function.capabilities`` is set, additionally attaches:
+    - ``Callbacks(on_progress=..., on_logging_message=..., on_elicitation=...)``
+      for the enabled server-→-client notifications.
+    - ``tool_interceptors=[DaoAiTraceInterceptor, ...]`` for MLflow correlation
+      and (optionally) structured-output observation.
+
+    Callback/interceptor construction is lazy: the classes are imported only
+    when at least one capability is enabled, keeping the classic import graph
+    unchanged.
+    """
+    connections = {"mcp_function": _build_connection_config(function, context)}
+
+    caps = function.capabilities
+    if caps is None:
+        return MultiServerMCPClient(connections, handle_tool_errors=False)
+
+    from langchain_mcp_adapters.callbacks import Callbacks
+    from langchain_mcp_adapters.interceptors import ToolCallInterceptor
+
+    from dao_ai.tools.mcp_callbacks import (
+        DaoAiElicitationCallback,
+        DaoAiLoggingCallback,
+        DaoAiProgressCallback,
+    )
+    from dao_ai.tools.mcp_interceptors import (
+        DaoAiStructuredOutputInterceptor,
+        DaoAiTraceInterceptor,
+    )
+
+    on_progress = DaoAiProgressCallback() if caps.progress else None
+    on_logging = DaoAiLoggingCallback(caps.logging) if caps.logging else None
+    on_elicit = DaoAiElicitationCallback(caps.elicitation) if caps.elicitation else None
+
+    callbacks: Callbacks | None = None
+    if any([on_progress, on_logging, on_elicit]):
+        callbacks = Callbacks(
+            on_logging_message=on_logging,
+            on_progress=on_progress,
+            on_elicitation=on_elicit,
+        )
+
+    interceptors: list[ToolCallInterceptor] = [DaoAiTraceInterceptor()]
+    if caps.structured_output:
+        interceptors.append(DaoAiStructuredOutputInterceptor())
+
+    return MultiServerMCPClient(
+        connections,
+        callbacks=callbacks,
+        tool_interceptors=interceptors,
+        handle_tool_errors=False,
+    )
+
+
+async def _call_tool_with_capabilities(
+    function: McpFunctionModel,
+    session: Any,
+    tool_name: str,
+    args: dict[str, Any],
+    meta: dict[str, Any] | None,
+) -> CallToolResult:
+    """Invoke ``session.call_tool`` honoring per-call capabilities.
+
+    langchain-mcp-adapters 0.3.0 wires ``progress_callback`` and
+    ``tool_interceptors`` inside its own ``load_mcp_tools()`` path. dao-ai's
+    custom tool wrapper uses the raw ``session.call_tool``, so we thread the
+    per-call progress callback and compose the interceptor onion manually
+    here. When ``function.capabilities`` is None, this is a straight
+    passthrough to ``session.call_tool`` — no behavior change.
+    """
+    caps = function.capabilities
+    if caps is None:
+        return await session.call_tool(tool_name, args, meta=meta)
+
+    from langchain_mcp_adapters.callbacks import CallbackContext
+    from langchain_mcp_adapters.interceptors import (
+        MCPToolCallRequest,
+        ToolCallInterceptor,
+    )
+
+    from dao_ai.tools.mcp_callbacks import DaoAiProgressCallback
+    from dao_ai.tools.mcp_interceptors import (
+        DaoAiStructuredOutputInterceptor,
+        DaoAiTraceInterceptor,
+    )
+
+    call_kwargs: dict[str, Any] = {"meta": meta}
+    if caps.progress:
+        progress_cb = DaoAiProgressCallback()
+        cb_ctx = CallbackContext(server_name="mcp_function", tool_name=tool_name)
+
+        async def _bound_progress(
+            progress: float, total: float | None, message: str | None
+        ) -> None:
+            await progress_cb(progress, total, message, cb_ctx)
+
+        call_kwargs["progress_callback"] = _bound_progress
+
+    interceptors: list[ToolCallInterceptor] = [DaoAiTraceInterceptor()]
+    if caps.structured_output:
+        interceptors.append(DaoAiStructuredOutputInterceptor())
+
+    async def _terminal_handler(request: MCPToolCallRequest) -> CallToolResult:
+        return await session.call_tool(request.name, request.args, **call_kwargs)
+
+    handler = _terminal_handler
+    for interceptor in reversed(interceptors):
+        prev = handler
+
+        async def _wrapped(
+            req: MCPToolCallRequest,
+            _interceptor: ToolCallInterceptor = interceptor,
+            _next: Any = prev,
+        ) -> Any:
+            return await _interceptor(req, _next)
+
+        handler = _wrapped
+
+    request = MCPToolCallRequest(
+        name=tool_name, args=args, server_name="mcp_function", headers=None
+    )
+    return await handler(request)  # type: ignore[return-value]
+
+
 def _is_transient_http_error(exc: BaseException) -> bool:
     """Return True for httpx.HTTPStatusError with a retryable status code."""
     if isinstance(exc, httpx.HTTPStatusError):
@@ -337,8 +470,7 @@ async def _afetch_tools_from_server(function: McpFunctionModel) -> list[Tool]:
     Raises:
         RuntimeError: If connection to MCP server fails after all retries.
     """
-    connection_config = _build_connection_config(function)
-    client = MultiServerMCPClient({"mcp_function": connection_config})
+    client = _build_mcp_client(function)
 
     try:
         async with client.session("mcp_function") as session:
@@ -594,14 +726,18 @@ async def acreate_mcp_tools(
             # Get context for OBO support
             context: Context | None = runtime.context if runtime else None
 
-            invocation_client: MultiServerMCPClient = MultiServerMCPClient(
-                {"mcp_function": _build_connection_config(function, context)}
+            invocation_client: MultiServerMCPClient = _build_mcp_client(
+                function, context
             )
 
             try:
                 async with invocation_client.session("mcp_function") as session:
-                    result: CallToolResult = await session.call_tool(
-                        mcp_tool.name, kwargs, meta=_resolve_meta(function.meta)
+                    result: CallToolResult = await _call_tool_with_capabilities(
+                        function,
+                        session,
+                        mcp_tool.name,
+                        kwargs,
+                        _resolve_meta(function.meta),
                     )
 
                     text_result: str = _extract_text_content(result)
@@ -724,14 +860,18 @@ def create_mcp_tools(
             context: Context | None = runtime.context if runtime else None
 
             # Create a fresh client/session for each invocation with OBO support
-            invocation_client: MultiServerMCPClient = MultiServerMCPClient(
-                {"mcp_function": _build_connection_config(function, context)}
+            invocation_client: MultiServerMCPClient = _build_mcp_client(
+                function, context
             )
 
             try:
                 async with invocation_client.session("mcp_function") as session:
-                    result: CallToolResult = await session.call_tool(
-                        mcp_tool.name, kwargs, meta=_resolve_meta(function.meta)
+                    result: CallToolResult = await _call_tool_with_capabilities(
+                        function,
+                        session,
+                        mcp_tool.name,
+                        kwargs,
+                        _resolve_meta(function.meta),
                     )
 
                     # Extract text content, avoiding extra fields

--- a/src/dao_ai/tools/mcp_callbacks.py
+++ b/src/dao_ai/tools/mcp_callbacks.py
@@ -1,0 +1,168 @@
+"""MCP client-side callbacks that bridge server-initiated notifications
+into dao-ai's observability + HITL surfaces.
+
+Wired into ``langchain_mcp_adapters.callbacks.Callbacks`` when an
+``McpFunctionModel`` declares an ``McpCapabilitiesModel``. When capabilities
+is absent the classic path skips this module entirely.
+
+The three callables here match the ``LoggingMessageCallback``,
+``ProgressCallback``, and ``ElicitationCallback`` Protocols defined by
+``langchain-mcp-adapters`` 0.3.0. Each is a class (not a closure) so its
+name surfaces in MLflow trace spans.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Optional
+
+import mlflow
+from langchain_mcp_adapters.callbacks import CallbackContext
+from langgraph.types import interrupt as langgraph_interrupt
+from loguru import logger
+from mcp.shared.context import RequestContext as MCPRequestContext
+from mcp.types import (
+    ElicitRequestParams,
+    ElicitResult,
+    LoggingMessageNotificationParams,
+)
+
+_LOG_LEVEL_ORDER: dict[str, int] = {
+    "debug": 10,
+    "info": 20,
+    "notice": 20,
+    "warning": 30,
+    "error": 40,
+    "critical": 50,
+    "alert": 50,
+    "emergency": 50,
+}
+
+
+def _add_span_event(name: str, attributes: dict[str, Any]) -> None:
+    """Add an event to the currently active MLflow span. Silent when no span."""
+    span = mlflow.get_current_active_span()
+    if span is None:
+        return
+    try:
+        span.add_event(name, attributes=attributes)
+    except Exception as exc:
+        logger.debug(f"mcp callback: failed to add span event {name!r}: {exc}")
+
+
+class DaoAiProgressCallback:
+    """Forwards MCP ``notifications/progress`` to the active MLflow span
+    as ``mcp.progress`` events."""
+
+    async def __call__(
+        self,
+        progress: float,
+        total: float | None,
+        message: str | None,
+        context: CallbackContext,
+    ) -> None:
+        _add_span_event(
+            "mcp.progress",
+            {
+                "mcp.server_name": context.server_name,
+                "mcp.tool_name": context.tool_name or "",
+                "mcp.progress": progress,
+                "mcp.total": total if total is not None else -1.0,
+                "mcp.message": message or "",
+            },
+        )
+
+
+class DaoAiLoggingCallback:
+    """Forwards MCP ``notifications/message`` to the active MLflow span
+    as ``mcp.log.<level>`` events. Records below ``min_level`` are dropped."""
+
+    def __init__(self, min_level: Literal["debug", "info", "warning", "error"]) -> None:
+        self.min_level = min_level
+        self._min_severity = _LOG_LEVEL_ORDER[min_level]
+
+    async def __call__(
+        self,
+        params: LoggingMessageNotificationParams,
+        context: CallbackContext,
+    ) -> None:
+        level = str(params.level).lower()
+        severity = _LOG_LEVEL_ORDER.get(level, 20)
+        if severity < self._min_severity:
+            return
+        _add_span_event(
+            f"mcp.log.{level}",
+            {
+                "mcp.server_name": context.server_name,
+                "mcp.tool_name": context.tool_name or "",
+                "mcp.logger": params.logger or "",
+                "mcp.data": str(params.data)[:2000],
+            },
+        )
+
+
+class DaoAiElicitationCallback:
+    """Handles server-initiated ``elicitation/create`` requests.
+
+    ``mode='reject'``: return ``action='cancel'`` without prompting.
+
+    ``mode='hitl'``: raise a LangGraph interrupt whose resume value is
+    interpreted as user-provided form content. The graph must be
+    running under a checkpointer; without one the interrupt bubbles up.
+    """
+
+    def __init__(self, mode: Literal["hitl", "reject"]) -> None:
+        self.mode = mode
+
+    async def __call__(
+        self,
+        mcp_context: MCPRequestContext,
+        params: ElicitRequestParams,
+        context: CallbackContext,
+    ) -> ElicitResult:
+        if self.mode == "reject":
+            _add_span_event(
+                "mcp.elicitation.reject",
+                {
+                    "mcp.server_name": context.server_name,
+                    "mcp.tool_name": context.tool_name or "",
+                    "mcp.message": params.message[:500],
+                },
+            )
+            return ElicitResult(action="cancel")
+
+        payload: dict[str, Any] = {
+            "type": "mcp.elicitation",
+            "server_name": context.server_name,
+            "tool_name": context.tool_name,
+            "message": params.message,
+            "requestedSchema": params.requestedSchema,
+        }
+        _add_span_event(
+            "mcp.elicitation.request",
+            {
+                "mcp.server_name": context.server_name,
+                "mcp.tool_name": context.tool_name or "",
+                "mcp.message": params.message[:500],
+            },
+        )
+        resume_value: Any = langgraph_interrupt(payload)
+        return _resume_value_to_elicit_result(resume_value)
+
+
+def _resume_value_to_elicit_result(resume_value: Any) -> ElicitResult:
+    """Interpret a LangGraph interrupt resume value as an ElicitResult.
+
+    Recognized shapes:
+      - ``{"action": "accept" | "decline" | "cancel", "content": {...}}``
+      - a bare dict → treated as ``action='accept'`` with ``content=<dict>``
+      - ``None`` → ``action='cancel'``
+    """
+    if resume_value is None:
+        return ElicitResult(action="cancel")
+    if isinstance(resume_value, dict) and "action" in resume_value:
+        action = resume_value["action"]
+        content: Optional[dict[str, Any]] = resume_value.get("content")
+        return ElicitResult(action=action, content=content)
+    if isinstance(resume_value, dict):
+        return ElicitResult(action="accept", content=resume_value)
+    return ElicitResult(action="cancel")

--- a/src/dao_ai/tools/mcp_interceptors.py
+++ b/src/dao_ai/tools/mcp_interceptors.py
@@ -1,0 +1,114 @@
+"""MCP tool-call interceptors that shape requests + responses in the
+langchain-mcp-adapters onion pipeline.
+
+Wired into ``MultiServerMCPClient(tool_interceptors=[...])`` when an
+``McpFunctionModel`` declares an ``McpCapabilitiesModel``. Named classes
+(not closures) so their execution shows up in MLflow trace spans.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable
+
+import mlflow
+from langchain_mcp_adapters.interceptors import (
+    MCPToolCallRequest,
+    MCPToolCallResult,
+)
+from loguru import logger
+from mcp.types import CallToolResult
+
+_HandlerT = Callable[[MCPToolCallRequest], Awaitable[MCPToolCallResult]]
+
+
+def _active_span_add_attribute(key: str, value: Any) -> None:
+    span = mlflow.get_current_active_span()
+    if span is None:
+        return
+    try:
+        span.set_attribute(key, value)
+    except Exception as exc:
+        logger.debug(f"mcp interceptor: failed to set attr {key!r}: {exc}")
+
+
+def _active_span_add_event(name: str, attributes: dict[str, Any]) -> None:
+    span = mlflow.get_current_active_span()
+    if span is None:
+        return
+    try:
+        span.add_event(name, attributes=attributes)
+    except Exception as exc:
+        logger.debug(f"mcp interceptor: failed to add event {name!r}: {exc}")
+
+
+class DaoAiTraceInterceptor:
+    """Injects the current MLflow trace id into request headers as
+    ``x-dao-ai-trace-id`` so downstream MCP servers can correlate their
+    own traces with the caller."""
+
+    async def __call__(
+        self,
+        request: MCPToolCallRequest,
+        handler: _HandlerT,
+    ) -> MCPToolCallResult:
+        trace_id: str | None = None
+        span = mlflow.get_current_active_span()
+        if span is not None:
+            try:
+                trace_id = span.request_id or span.trace_id
+            except Exception:
+                trace_id = None
+        if trace_id:
+            headers = dict(request.headers or {})
+            headers.setdefault("x-dao-ai-trace-id", str(trace_id))
+            request = request.override(headers=headers)
+        return await handler(request)
+
+
+class DaoAiStructuredOutputInterceptor:
+    """Expands ``resource_link`` items from a ``CallToolResult`` into MLflow
+    span attributes, and records the presence of ``structuredContent`` so
+    downstream consumers can rely on schema-typed output when present.
+
+    The interceptor does NOT swallow errors or transform the result payload —
+    it is observation-only. The adapter still returns the same CallToolResult
+    to the LangChain tool.
+    """
+
+    async def __call__(
+        self,
+        request: MCPToolCallRequest,
+        handler: _HandlerT,
+    ) -> MCPToolCallResult:
+        result = await handler(request)
+
+        if not isinstance(result, CallToolResult):
+            return result
+
+        if getattr(result, "structuredContent", None) is not None:
+            _active_span_add_attribute("mcp.structured_output", True)
+
+        resource_links: list[dict[str, Any]] = []
+        for item in result.content or []:
+            if getattr(item, "type", None) == "resource_link":
+                resource_links.append(
+                    {
+                        "uri": getattr(item, "uri", None),
+                        "name": getattr(item, "name", None),
+                        "mimeType": getattr(item, "mimeType", None),
+                    }
+                )
+
+        if resource_links:
+            _active_span_add_event(
+                "mcp.resource_link",
+                {
+                    "mcp.server_name": request.server_name,
+                    "mcp.tool_name": request.name,
+                    "mcp.resource_link.count": len(resource_links),
+                    "mcp.resource_link.uris": [
+                        str(link.get("uri", "")) for link in resource_links
+                    ],
+                },
+            )
+        return result

--- a/tests/dao_ai/capabilities_mcp_server.py
+++ b/tests/dao_ai/capabilities_mcp_server.py
@@ -1,0 +1,74 @@
+"""In-process FastMCP fixture that exercises every advanced capability
+we wire from ``McpCapabilitiesModel``.
+
+Run standalone for manual smoke:
+    uv run python tests/dao_ai/capabilities_mcp_server.py
+
+Integration tests import ``build_server()`` and mount it on an ephemeral
+port via uvicorn in a background thread.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.types import ResourceLink
+
+
+def build_server(name: str = "capabilities_probe") -> FastMCP:
+    mcp = FastMCP(name)
+
+    @mcp.tool()
+    async def long_task(steps: int, ctx: Context) -> str:
+        """Emit `steps` progress notifications, return final message."""
+        for i in range(1, steps + 1):
+            await ctx.report_progress(
+                progress=float(i),
+                total=float(steps),
+                message=f"step {i}/{steps}",
+            )
+        return f"completed {steps} steps"
+
+    @mcp.tool()
+    async def noisy_task(ctx: Context) -> str:
+        """Emit one message at each of the four standard log levels."""
+        for level in ("debug", "info", "warning", "error"):
+            await ctx.log(level=level, message=f"probe {level}")
+        return "logged 4 levels"
+
+    @mcp.tool()
+    async def list_documents(ctx: Context) -> list[dict[str, Any]]:
+        """Return content array containing a resource_link.
+
+        FastMCP will wrap the returned Python object into TextContent by
+        default; to emit a real ResourceLink we return the raw content list
+        via the low-level API.
+        """
+        # FastMCP JSON-serializes structured returns; the client sees the
+        # structuredContent path. For a bona-fide resource_link, use the
+        # `raw_content` return path below.
+        return [
+            {
+                "type": "resource_link",
+                "uri": "https://example.com/probe/doc-1.txt",
+                "name": "doc-1.txt",
+                "mimeType": "text/plain",
+            }
+        ]
+
+    @mcp.tool()
+    async def structured_result(query: str, ctx: Context) -> dict[str, Any]:
+        """Return a dict — FastMCP surfaces this as `structuredContent`."""
+        return {"answer": f"echo:{query}", "confidence": 0.87}
+
+    @mcp.tool()
+    async def raise_tool_error(ctx: Context) -> str:
+        """Signal an error via raise — surfaces as CallToolResult(isError=True)."""
+        raise ValueError("intentional error from raise_tool_error")
+
+    return mcp
+
+
+if __name__ == "__main__":
+    build_server().run(transport="streamable-http")

--- a/tests/dao_ai/mcp/test_capabilities_integration.py
+++ b/tests/dao_ai/mcp/test_capabilities_integration.py
@@ -1,0 +1,356 @@
+"""Tier 2 integration tests for MCP advanced capabilities.
+
+Spins up a real ``FastMCP`` server in a background thread on an ephemeral
+port and drives ``create_mcp_tools()`` at it. Verifies that our
+callback + interceptor wiring receives progress / logging / structured-content
+notifications from a real MCP transport, and that the default
+(``capabilities=None``) path stays silent.
+
+No Databricks credentials required — everything is localhost.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import threading
+import time
+from contextlib import closing
+from typing import Iterator
+
+import pytest
+import uvicorn
+from mcp.server.fastmcp import Context, FastMCP
+from pydantic import BaseModel
+
+from dao_ai.config import McpCapabilitiesModel, McpFunctionModel
+from dao_ai.tools.mcp import acreate_mcp_tools
+
+
+class _StructuredAnswer(BaseModel):
+    answer: str
+    confidence: float
+
+
+def _free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _build_probe_server(name: str) -> FastMCP:
+    # Stateful HTTP: notifications channel is preserved across the call.
+    # With stateless_http=True the session terminates before progress /
+    # logging notifications reach the client.
+    mcp = FastMCP(name)
+
+    @mcp.tool()
+    async def long_task(steps: int, ctx: Context) -> str:
+        for i in range(1, steps + 1):
+            await ctx.report_progress(
+                progress=float(i),
+                total=float(steps),
+                message=f"step {i}/{steps}",
+            )
+        return f"completed {steps} steps"
+
+    @mcp.tool()
+    async def noisy_task(ctx: Context) -> str:
+        for level in ("debug", "info", "warning", "error"):
+            await ctx.log(level=level, message=f"probe {level}")
+        return "logged 4 levels"
+
+    @mcp.tool()
+    async def structured_result(query: str, ctx: Context) -> _StructuredAnswer:
+        # Typed return: FastMCP populates CallToolResult.structuredContent.
+        return _StructuredAnswer(answer=f"echo:{query}", confidence=0.87)
+
+    @mcp.tool()
+    async def raise_tool_error(ctx: Context) -> str:
+        raise ValueError("intentional error")
+
+    return mcp
+
+
+class _ServerThread:
+    def __init__(self, port: int, app) -> None:
+        config = uvicorn.Config(
+            app,
+            host="127.0.0.1",
+            port=port,
+            log_level="warning",
+            lifespan="on",
+        )
+        self.server = uvicorn.Server(config)
+        self.thread = threading.Thread(target=self.server.run, daemon=True)
+
+    def start(self) -> None:
+        self.thread.start()
+        deadline = time.time() + 10.0
+        while time.time() < deadline:
+            if self.server.started:
+                return
+            time.sleep(0.05)
+        raise RuntimeError("uvicorn did not start in 10s")
+
+    def stop(self) -> None:
+        self.server.should_exit = True
+        self.thread.join(timeout=5.0)
+
+
+@pytest.fixture(scope="module")
+def probe_url() -> Iterator[str]:
+    port = _free_port()
+    mcp = _build_probe_server("caps_probe")
+    server = _ServerThread(port, mcp.streamable_http_app())
+    server.start()
+    try:
+        yield f"http://127.0.0.1:{port}/mcp"
+    finally:
+        server.stop()
+
+
+def _fn(url: str, capabilities: McpCapabilitiesModel | None) -> McpFunctionModel:
+    return McpFunctionModel(url=url, capabilities=capabilities)
+
+
+class _RecordingProgress:
+    """Drop-in for DaoAiProgressCallback that also records calls."""
+
+    events: list[tuple] = []
+
+    def __init__(self) -> None:
+        pass
+
+    async def __call__(self, progress, total, message, context) -> None:
+        _RecordingProgress.events.append(
+            (progress, total, message, context.tool_name)
+        )
+
+
+class _RecordingLogging:
+    """Drop-in for DaoAiLoggingCallback that also records level-filtered events."""
+
+    events: list[tuple] = []
+
+    def __init__(self, min_level: str) -> None:
+        self.min_level = min_level
+        self._min_severity = {
+            "debug": 10, "info": 20, "warning": 30, "error": 40,
+        }[min_level]
+
+    async def __call__(self, params, context) -> None:
+        level = str(params.level).lower()
+        severity = {
+            "debug": 10, "info": 20, "notice": 20, "warning": 30, "error": 40,
+        }.get(level, 20)
+        if severity < self._min_severity:
+            return
+        _RecordingLogging.events.append((level, str(params.data), context.tool_name))
+
+
+class _RecordingStructured:
+    """Interceptor spy that records the CallToolResult it sees."""
+
+    seen: list[dict] = []
+
+    def __init__(self) -> None:
+        pass
+
+    async def __call__(self, request, handler):
+        result = await handler(request)
+        from mcp.types import CallToolResult
+
+        if isinstance(result, CallToolResult):
+            _RecordingStructured.seen.append(
+                {
+                    "has_structured": getattr(result, "structuredContent", None)
+                    is not None,
+                    "structured": result.structuredContent,
+                    "server_name": request.server_name,
+                    "tool_name": request.name,
+                }
+            )
+        return result
+
+
+class _RecordingTrace:
+    """Interceptor spy that records the request headers it sees + emits after."""
+
+    seen: list[dict] = []
+
+    def __init__(self) -> None:
+        pass
+
+    async def __call__(self, request, handler):
+        # Only record header state; do not mutate.
+        _RecordingTrace.seen.append(
+            {
+                "before_headers": dict(request.headers or {}),
+                "server_name": request.server_name,
+                "tool_name": request.name,
+            }
+        )
+        return await handler(request)
+
+
+class TestClassicPathParity:
+    def test_tools_discovered(self, probe_url: str) -> None:
+        async def run() -> None:
+            tools = await acreate_mcp_tools(_fn(probe_url, None))
+            names = {t.name for t in tools}
+            assert "long_task" in names
+            assert "noisy_task" in names
+            assert "structured_result" in names
+
+        asyncio.run(run())
+
+    def test_long_task_invokable(self, probe_url: str) -> None:
+        async def run() -> None:
+            tools = await acreate_mcp_tools(_fn(probe_url, None))
+            long_task = next(t for t in tools if t.name == "long_task")
+            result = await long_task.ainvoke({"steps": 3})
+            assert "completed" in str(result)
+
+        asyncio.run(run())
+
+
+class TestProgressCapability:
+    def test_progress_callback_receives_notifications(
+        self, probe_url: str, monkeypatch
+    ) -> None:
+        """Server emits 5 progress events; our progress callback should be
+        invoked exactly 5 times with monotonically increasing progress."""
+        _RecordingProgress.events = []
+        # Swap the class used by _call_tool_with_capabilities.
+        monkeypatch.setattr(
+            "dao_ai.tools.mcp.DaoAiProgressCallback",
+            _RecordingProgress,
+            raising=False,
+        )
+        # It's imported lazily inside _call_tool_with_capabilities from
+        # dao_ai.tools.mcp_callbacks — patch there too.
+        monkeypatch.setattr(
+            "dao_ai.tools.mcp_callbacks.DaoAiProgressCallback",
+            _RecordingProgress,
+        )
+
+        caps = McpCapabilitiesModel(progress=True, structured_output=False)
+
+        async def run() -> None:
+            tools = await acreate_mcp_tools(_fn(probe_url, caps))
+            long_task = next(t for t in tools if t.name == "long_task")
+            result = await long_task.ainvoke({"steps": 5})
+            assert "completed 5" in str(result)
+
+        asyncio.run(run())
+        assert (
+            len(_RecordingProgress.events) == 5
+        ), f"expected 5 progress events, got {len(_RecordingProgress.events)}: {_RecordingProgress.events}"
+        progresses = [e[0] for e in _RecordingProgress.events]
+        assert progresses == [1.0, 2.0, 3.0, 4.0, 5.0]
+        assert all(e[1] == 5.0 for e in _RecordingProgress.events)
+        assert all(e[3] == "long_task" for e in _RecordingProgress.events)
+
+
+class TestLoggingCapability:
+    def test_logging_at_warning_filters_debug_and_info(
+        self, probe_url: str, monkeypatch
+    ) -> None:
+        _RecordingLogging.events = []
+        monkeypatch.setattr(
+            "dao_ai.tools.mcp_callbacks.DaoAiLoggingCallback",
+            _RecordingLogging,
+        )
+        # _build_mcp_client imports DaoAiLoggingCallback lazily from the
+        # mcp_callbacks module — patching there covers the fresh binding.
+
+        caps = McpCapabilitiesModel(logging="warning", structured_output=False)
+
+        async def run() -> None:
+            tools = await acreate_mcp_tools(_fn(probe_url, caps))
+            noisy = next(t for t in tools if t.name == "noisy_task")
+            await noisy.ainvoke({})
+
+        asyncio.run(run())
+        levels = [e[0] for e in _RecordingLogging.events]
+        assert "warning" in levels
+        assert "error" in levels
+        assert "debug" not in levels
+        assert "info" not in levels
+
+
+class TestStructuredOutputCapability:
+    def test_structured_content_returned(self, probe_url: str, monkeypatch) -> None:
+        _RecordingStructured.seen = []
+        monkeypatch.setattr(
+            "dao_ai.tools.mcp_interceptors.DaoAiStructuredOutputInterceptor",
+            _RecordingStructured,
+        )
+
+        caps = McpCapabilitiesModel(structured_output=True)
+
+        async def run() -> None:
+            tools = await acreate_mcp_tools(_fn(probe_url, caps))
+            sr = next(t for t in tools if t.name == "structured_result")
+            await sr.ainvoke({"query": "ping"})
+
+        asyncio.run(run())
+        assert _RecordingStructured.seen, "interceptor never ran"
+        record = _RecordingStructured.seen[-1]
+        assert record["tool_name"] == "structured_result"
+        assert record["has_structured"] is True
+        assert record["structured"] is not None
+
+
+class TestTraceInterceptor:
+    def test_trace_interceptor_runs_on_each_call(
+        self, probe_url: str, monkeypatch
+    ) -> None:
+        """When capabilities is set, the trace interceptor must run for every
+        tool call — proves the onion chain composes."""
+        _RecordingTrace.seen = []
+        monkeypatch.setattr(
+            "dao_ai.tools.mcp_interceptors.DaoAiTraceInterceptor",
+            _RecordingTrace,
+        )
+
+        caps = McpCapabilitiesModel(structured_output=True)
+
+        async def run() -> None:
+            tools = await acreate_mcp_tools(_fn(probe_url, caps))
+            sr = next(t for t in tools if t.name == "structured_result")
+            await sr.ainvoke({"query": "hi"})
+
+        asyncio.run(run())
+        assert _RecordingTrace.seen, "trace interceptor never ran"
+        record = _RecordingTrace.seen[-1]
+        assert record["tool_name"] == "structured_result"
+        assert record["server_name"] == "mcp_function"
+
+
+class TestErrorHandling:
+    def test_isError_surfaces_as_text_on_classic_path(self, probe_url: str) -> None:
+        """dao-ai's custom wrapper has always returned server-side error text
+        rather than raising. Verify that contract persists on the 0.3.0 bump."""
+
+        async def run() -> str:
+            tools = await acreate_mcp_tools(_fn(probe_url, None))
+            err = next(t for t in tools if t.name == "raise_tool_error")
+            return await err.ainvoke({})
+
+        result = str(asyncio.run(run()))
+        assert "intentional error" in result.lower()
+
+    def test_isError_surfaces_as_text_on_capabilities_path(
+        self, probe_url: str
+    ) -> None:
+        caps = McpCapabilitiesModel(progress=True, structured_output=True)
+
+        async def run() -> str:
+            tools = await acreate_mcp_tools(_fn(probe_url, caps))
+            err = next(t for t in tools if t.name == "raise_tool_error")
+            return await err.ainvoke({})
+
+        result = str(asyncio.run(run()))
+        assert "intentional error" in result.lower()

--- a/tests/dao_ai/test_mcp_capabilities_client.py
+++ b/tests/dao_ai/test_mcp_capabilities_client.py
@@ -1,0 +1,506 @@
+"""Unit tests for the MCP capabilities client-side wiring (PR 1).
+
+Covers three concerns:
+
+1. Pydantic capability models load and validate correctly.
+2. ``_build_mcp_client`` constructs a plain ``MultiServerMCPClient`` when
+   ``capabilities`` is None (regression guard) and attaches callbacks +
+   interceptors when it's set.
+3. Callback + interceptor classes conform to their Protocols and fire the
+   expected MLflow span events (via patched ``mlflow.get_current_active_span``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_mcp_adapters.callbacks import (
+    CallbackContext,
+    ElicitationCallback,
+    LoggingMessageCallback,
+    ProgressCallback,
+)
+from langchain_mcp_adapters.interceptors import (
+    MCPToolCallRequest,
+    ToolCallInterceptor,
+)
+from mcp.types import (
+    CallToolResult,
+    ElicitRequestFormParams,
+    ElicitResult,
+    LoggingMessageNotificationParams,
+    ResourceLink,
+    TextContent,
+)
+
+from dao_ai.config import (
+    McpCapabilitiesModel,
+    McpFunctionModel,
+    McpRootModel,
+)
+from dao_ai.tools.mcp_callbacks import (
+    DaoAiElicitationCallback,
+    DaoAiLoggingCallback,
+    DaoAiProgressCallback,
+    _resume_value_to_elicit_result,
+)
+from dao_ai.tools.mcp_interceptors import (
+    DaoAiStructuredOutputInterceptor,
+    DaoAiTraceInterceptor,
+)
+
+
+class TestCapabilityModels:
+    def test_defaults(self) -> None:
+        caps = McpCapabilitiesModel()
+        assert caps.progress is False
+        assert caps.logging is None
+        assert caps.elicitation is None
+        assert caps.structured_output is True
+        assert caps.sampling is None
+        assert caps.roots == []
+
+    def test_full_shape(self) -> None:
+        caps = McpCapabilitiesModel(
+            progress=True,
+            logging="info",
+            elicitation="hitl",
+            structured_output=True,
+            roots=[McpRootModel(uri="file:///workspace", name="workspace")],
+        )
+        assert caps.progress is True
+        assert caps.logging == "info"
+        assert caps.elicitation == "hitl"
+        assert caps.roots[0].uri == "file:///workspace"
+
+    def test_invalid_logging_level_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            McpCapabilitiesModel(logging="trace")  # type: ignore[arg-type]
+
+    def test_invalid_elicitation_mode_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            McpCapabilitiesModel(elicitation="prompt")  # type: ignore[arg-type]
+
+    def test_mcpfunctionmodel_accepts_capabilities(self) -> None:
+        model = McpFunctionModel(
+            url="http://example.com/mcp",
+            capabilities=McpCapabilitiesModel(progress=True, logging="warning"),
+        )
+        assert model.capabilities is not None
+        assert model.capabilities.progress is True
+        assert model.capabilities.logging == "warning"
+
+
+class TestBuildMcpClient:
+    """``_build_mcp_client`` is the single construction site for the client."""
+
+    def _make_fn(self, capabilities=None) -> McpFunctionModel:
+        return McpFunctionModel(url="http://example.com/mcp", capabilities=capabilities)
+
+    def test_classic_path_when_capabilities_none(self) -> None:
+        from dao_ai.tools import mcp as mcp_mod
+
+        with patch.object(mcp_mod, "MultiServerMCPClient") as mock_cls, patch.object(
+            mcp_mod, "_build_connection_config", return_value={"url": "x"}
+        ):
+            mcp_mod._build_mcp_client(self._make_fn(capabilities=None))
+            _, kwargs = mock_cls.call_args
+            assert "callbacks" not in kwargs or kwargs.get("callbacks") is None
+            assert "tool_interceptors" not in kwargs or kwargs.get("tool_interceptors") is None
+            assert kwargs["handle_tool_errors"] is False
+
+    def test_capabilities_path_attaches_callbacks_and_interceptors(self) -> None:
+        from dao_ai.tools import mcp as mcp_mod
+
+        caps = McpCapabilitiesModel(
+            progress=True,
+            logging="info",
+            elicitation="reject",
+            structured_output=True,
+        )
+
+        with patch.object(mcp_mod, "MultiServerMCPClient") as mock_cls, patch.object(
+            mcp_mod, "_build_connection_config", return_value={"url": "x"}
+        ):
+            mcp_mod._build_mcp_client(self._make_fn(capabilities=caps))
+            _, kwargs = mock_cls.call_args
+            assert kwargs["callbacks"] is not None
+            assert kwargs["handle_tool_errors"] is False
+            interceptors = kwargs["tool_interceptors"]
+            assert len(interceptors) == 2
+            assert isinstance(interceptors[0], DaoAiTraceInterceptor)
+            assert isinstance(interceptors[1], DaoAiStructuredOutputInterceptor)
+
+    def test_capabilities_path_skips_structured_interceptor_when_disabled(self) -> None:
+        from dao_ai.tools import mcp as mcp_mod
+
+        caps = McpCapabilitiesModel(progress=True, structured_output=False)
+        with patch.object(mcp_mod, "MultiServerMCPClient") as mock_cls, patch.object(
+            mcp_mod, "_build_connection_config", return_value={"url": "x"}
+        ):
+            mcp_mod._build_mcp_client(self._make_fn(capabilities=caps))
+            _, kwargs = mock_cls.call_args
+            interceptors = kwargs["tool_interceptors"]
+            assert len(interceptors) == 1
+            assert isinstance(interceptors[0], DaoAiTraceInterceptor)
+
+    def test_capabilities_path_omits_callbacks_when_all_disabled(self) -> None:
+        from dao_ai.tools import mcp as mcp_mod
+
+        caps = McpCapabilitiesModel(structured_output=True)
+        with patch.object(mcp_mod, "MultiServerMCPClient") as mock_cls, patch.object(
+            mcp_mod, "_build_connection_config", return_value={"url": "x"}
+        ):
+            mcp_mod._build_mcp_client(self._make_fn(capabilities=caps))
+            _, kwargs = mock_cls.call_args
+            assert kwargs["callbacks"] is None
+
+
+class TestClientRoutingCallsites:
+    """Every ``MultiServerMCPClient`` construction site in tools/mcp.py MUST
+    flow through ``_build_mcp_client`` so capabilities propagate uniformly.
+    """
+
+    def _make_fn(self, capabilities=None) -> McpFunctionModel:
+        return McpFunctionModel(url="http://example.com/mcp", capabilities=capabilities)
+
+    def test_afetch_tools_from_server_uses_build_mcp_client(self) -> None:
+        from dao_ai.tools import mcp as mcp_mod
+
+        fake_client = MagicMock()
+
+        class _FakeSession:
+            async def list_tools(self):
+                return SimpleNamespace(tools=[])
+
+        class _FakeCtx:
+            async def __aenter__(self_inner):
+                return _FakeSession()
+
+            async def __aexit__(self_inner, exc_type, exc, tb):
+                return False
+
+        fake_client.session.return_value = _FakeCtx()
+
+        caps = McpCapabilitiesModel(progress=True)
+        with patch.object(
+            mcp_mod, "_build_mcp_client", return_value=fake_client
+        ) as mock_build:
+            asyncio.run(mcp_mod._afetch_tools_from_server(self._make_fn(caps)))
+
+        mock_build.assert_called_once()
+        # Pass-through — the same function object we handed in.
+        passed_fn, *_ = mock_build.call_args.args
+        assert passed_fn.capabilities is caps
+
+    def test_acreate_tool_wrapper_uses_build_mcp_client(self) -> None:
+        """The wrapper produced by acreate_mcp_tools() must route through
+        _build_mcp_client on invocation, threading context + capabilities."""
+        from dao_ai.tools import mcp as mcp_mod
+        from mcp.types import Tool
+
+        # Skip discovery — return one fake Tool so a wrapper is built.
+        fake_tool = Tool(
+            name="probe",
+            description="probe",
+            inputSchema={"type": "object", "properties": {}},
+        )
+
+        # Fake session that returns a benign text result. Accepts arbitrary
+        # kwargs so we don't need to track SDK signature changes.
+        class _FakeSession:
+            async def call_tool(self, name, args, **_kwargs):
+                return CallToolResult(
+                    content=[TextContent(type="text", text="ok")]
+                )
+
+        class _FakeCtx:
+            async def __aenter__(self_inner):
+                return _FakeSession()
+
+            async def __aexit__(self_inner, exc_type, exc, tb):
+                return False
+
+        fake_client = MagicMock()
+        fake_client.session.return_value = _FakeCtx()
+
+        caps = McpCapabilitiesModel(progress=True, structured_output=True)
+        fn = self._make_fn(capabilities=caps)
+
+        async def _run() -> str:
+            with patch.object(
+                mcp_mod, "_afetch_tools_from_server", return_value=[fake_tool]
+            ), patch.object(
+                mcp_mod, "_build_mcp_client", return_value=fake_client
+            ) as mock_build, patch.object(
+                mcp_mod, "set_resource_attributes"
+            ):
+                tools = await mcp_mod.acreate_mcp_tools(fn)
+                assert len(tools) == 1
+                result = await tools[0].ainvoke({})
+                # Assert build was called at least once inside the wrapper.
+                mock_build.assert_called()
+                # Confirm capabilities on the invoked function are ours.
+                call_fn, *_ = mock_build.call_args.args
+                assert call_fn.capabilities is caps
+                return result
+
+        assert asyncio.run(_run()) == "ok"
+
+
+class TestProtocolConformance:
+    def test_progress_callback_is_protocol(self) -> None:
+        assert isinstance(DaoAiProgressCallback(), ProgressCallback)
+
+    def test_logging_callback_is_protocol(self) -> None:
+        assert isinstance(DaoAiLoggingCallback("info"), LoggingMessageCallback)
+
+    def test_elicitation_callback_is_protocol(self) -> None:
+        assert isinstance(DaoAiElicitationCallback("reject"), ElicitationCallback)
+
+    def test_trace_interceptor_is_protocol(self) -> None:
+        assert isinstance(DaoAiTraceInterceptor(), ToolCallInterceptor)
+
+    def test_structured_output_interceptor_is_protocol(self) -> None:
+        assert isinstance(DaoAiStructuredOutputInterceptor(), ToolCallInterceptor)
+
+
+class TestProgressCallback:
+    def test_forwards_to_span_event(self) -> None:
+        span = MagicMock()
+        with patch(
+            "dao_ai.tools.mcp_callbacks.mlflow.get_current_active_span",
+            return_value=span,
+        ):
+            cb = DaoAiProgressCallback()
+            asyncio.run(
+                cb(
+                    progress=0.5,
+                    total=1.0,
+                    message="halfway",
+                    context=CallbackContext(server_name="genie", tool_name="query"),
+                )
+            )
+        span.add_event.assert_called_once()
+        args, kwargs = span.add_event.call_args
+        assert args[0] == "mcp.progress"
+        attrs = kwargs["attributes"]
+        assert attrs["mcp.progress"] == 0.5
+        assert attrs["mcp.tool_name"] == "query"
+
+    def test_silent_when_no_active_span(self) -> None:
+        with patch(
+            "dao_ai.tools.mcp_callbacks.mlflow.get_current_active_span",
+            return_value=None,
+        ):
+            cb = DaoAiProgressCallback()
+            # Must not raise.
+            asyncio.run(
+                cb(
+                    progress=0.5,
+                    total=None,
+                    message=None,
+                    context=CallbackContext(server_name="x"),
+                )
+            )
+
+
+class TestLoggingCallback:
+    def test_forwards_at_or_above_min_level(self) -> None:
+        span = MagicMock()
+        with patch(
+            "dao_ai.tools.mcp_callbacks.mlflow.get_current_active_span",
+            return_value=span,
+        ):
+            cb = DaoAiLoggingCallback("warning")
+            asyncio.run(
+                cb(
+                    LoggingMessageNotificationParams(
+                        level="error", data="boom", logger="genie"
+                    ),
+                    CallbackContext(server_name="genie", tool_name="query"),
+                )
+            )
+        span.add_event.assert_called_once()
+        assert span.add_event.call_args[0][0] == "mcp.log.error"
+
+    def test_drops_below_min_level(self) -> None:
+        span = MagicMock()
+        with patch(
+            "dao_ai.tools.mcp_callbacks.mlflow.get_current_active_span",
+            return_value=span,
+        ):
+            cb = DaoAiLoggingCallback("warning")
+            asyncio.run(
+                cb(
+                    LoggingMessageNotificationParams(
+                        level="info", data="fyi", logger="genie"
+                    ),
+                    CallbackContext(server_name="genie"),
+                )
+            )
+        span.add_event.assert_not_called()
+
+
+class TestElicitationCallback:
+    def test_reject_mode_returns_cancel(self) -> None:
+        span = MagicMock()
+        with patch(
+            "dao_ai.tools.mcp_callbacks.mlflow.get_current_active_span",
+            return_value=span,
+        ):
+            cb = DaoAiElicitationCallback("reject")
+            result = asyncio.run(
+                cb(
+                    mcp_context=SimpleNamespace(),  # type: ignore[arg-type]
+                    params=ElicitRequestFormParams(
+                        message="please provide", requestedSchema={}
+                    ),
+                    context=CallbackContext(server_name="s"),
+                )
+            )
+        assert isinstance(result, ElicitResult)
+        assert result.action == "cancel"
+
+    def test_hitl_mode_delegates_to_langgraph_interrupt(self) -> None:
+        # In hitl mode the callback surfaces the elicitation as a LangGraph
+        # interrupt whose resume value becomes the ElicitResult. Verify by
+        # patching the interrupt shim to return an accept payload directly.
+        cb = DaoAiElicitationCallback("hitl")
+        with patch(
+            "dao_ai.tools.mcp_callbacks.langgraph_interrupt",
+            return_value={"action": "accept", "content": {"answer": "42"}},
+        ) as mock_interrupt:
+            result = asyncio.run(
+                cb(
+                    mcp_context=SimpleNamespace(),  # type: ignore[arg-type]
+                    params=ElicitRequestFormParams(
+                        message="need info", requestedSchema={"type": "object"}
+                    ),
+                    context=CallbackContext(server_name="s", tool_name="t"),
+                )
+            )
+        mock_interrupt.assert_called_once()
+        payload = mock_interrupt.call_args.args[0]
+        assert payload["type"] == "mcp.elicitation"
+        assert payload["server_name"] == "s"
+        assert payload["tool_name"] == "t"
+        assert payload["message"] == "need info"
+        assert result.action == "accept"
+        assert result.content == {"answer": "42"}
+
+
+class TestResumeValueMapping:
+    def test_none_maps_to_cancel(self) -> None:
+        r = _resume_value_to_elicit_result(None)
+        assert r.action == "cancel"
+
+    def test_action_dict_pass_through(self) -> None:
+        r = _resume_value_to_elicit_result({"action": "decline"})
+        assert r.action == "decline"
+
+    def test_bare_dict_maps_to_accept(self) -> None:
+        r = _resume_value_to_elicit_result({"name": "Nate"})
+        assert r.action == "accept"
+        assert r.content == {"name": "Nate"}
+
+
+class TestStructuredOutputInterceptor:
+    def test_resource_link_expanded_to_span_event(self) -> None:
+        span = MagicMock()
+        request = MCPToolCallRequest(
+            name="tool_a", args={}, server_name="server_a"
+        )
+        result = CallToolResult(
+            content=[
+                TextContent(type="text", text="hello"),
+                ResourceLink(
+                    type="resource_link",
+                    uri="https://example.com/foo.txt",
+                    name="foo.txt",
+                    mimeType="text/plain",
+                ),
+            ],
+            structuredContent={"final_message": "done"},
+        )
+
+        async def handler(req: MCPToolCallRequest) -> CallToolResult:
+            return result
+
+        with patch(
+            "dao_ai.tools.mcp_interceptors.mlflow.get_current_active_span",
+            return_value=span,
+        ):
+            interceptor = DaoAiStructuredOutputInterceptor()
+            out = asyncio.run(interceptor(request, handler))
+        assert out is result
+        span.set_attribute.assert_any_call("mcp.structured_output", True)
+        event_calls = [
+            c for c in span.add_event.call_args_list if c[0][0] == "mcp.resource_link"
+        ]
+        assert len(event_calls) == 1
+        attrs = event_calls[0][1]["attributes"]
+        assert attrs["mcp.resource_link.count"] == 1
+        assert any(
+            "example.com/foo.txt" in uri for uri in attrs["mcp.resource_link.uris"]
+        )
+
+    def test_no_resource_link_no_event(self) -> None:
+        span = MagicMock()
+        request = MCPToolCallRequest(name="t", args={}, server_name="s")
+        result = CallToolResult(content=[TextContent(type="text", text="hi")])
+
+        async def handler(req: MCPToolCallRequest) -> CallToolResult:
+            return result
+
+        with patch(
+            "dao_ai.tools.mcp_interceptors.mlflow.get_current_active_span",
+            return_value=span,
+        ):
+            interceptor = DaoAiStructuredOutputInterceptor()
+            asyncio.run(interceptor(request, handler))
+        assert not any(
+            c[0][0] == "mcp.resource_link" for c in span.add_event.call_args_list
+        )
+
+
+class TestTraceInterceptor:
+    def test_injects_trace_id_header(self) -> None:
+        span = MagicMock()
+        span.request_id = "req-abc"
+        span.trace_id = None
+        request = MCPToolCallRequest(name="t", args={}, server_name="s")
+        captured: dict = {}
+
+        async def handler(req: MCPToolCallRequest) -> CallToolResult:
+            captured["headers"] = req.headers
+            return CallToolResult(content=[TextContent(type="text", text="x")])
+
+        with patch(
+            "dao_ai.tools.mcp_interceptors.mlflow.get_current_active_span",
+            return_value=span,
+        ):
+            interceptor = DaoAiTraceInterceptor()
+            asyncio.run(interceptor(request, handler))
+        assert captured["headers"] == {"x-dao-ai-trace-id": "req-abc"}
+
+    def test_no_span_no_header(self) -> None:
+        request = MCPToolCallRequest(
+            name="t", args={}, server_name="s", headers={"a": "b"}
+        )
+        captured: dict = {}
+
+        async def handler(req: MCPToolCallRequest) -> CallToolResult:
+            captured["headers"] = req.headers
+            return CallToolResult(content=[TextContent(type="text", text="x")])
+
+        with patch(
+            "dao_ai.tools.mcp_interceptors.mlflow.get_current_active_span",
+            return_value=None,
+        ):
+            interceptor = DaoAiTraceInterceptor()
+            asyncio.run(interceptor(request, handler))
+        assert captured["headers"] == {"a": "b"}

--- a/uv.lock
+++ b/uv.lock
@@ -1111,7 +1111,7 @@ requires-dist = [
     { name = "grandalf", specifier = ">=0.8" },
     { name = "langchain", specifier = ">=1.2.12" },
     { name = "langchain-community", specifier = ">=0.4.1" },
-    { name = "langchain-mcp-adapters", specifier = ">=0.2.2" },
+    { name = "langchain-mcp-adapters", specifier = ">=0.3.0" },
     { name = "langchain-tavily", specifier = ">=0.2.15" },
     { name = "langgraph", specifier = ">=1.1.10" },
     { name = "langgraph-checkpoint-postgres", specifier = "==3.0.5" },


### PR DESCRIPTION
## Summary

Adds an opt-in `McpCapabilitiesModel` to `McpFunctionModel` so a client-side MCP tool can consume the 4 advanced capabilities the langchain-mcp-adapters `Callbacks` object surfaces in v0.3.0:

- **progress** — consume `notifications/progress` → forward as `mcp.progress` MLflow span events with `progress/total/message/tool_name`.
- **logging** — consume `notifications/message`, filter by declared min level, forward as `mcp.log.<level>` span events.
- **elicitation** — handle server-initiated `elicitation/create` in either `"reject"` (return `action='cancel'`) or `"hitl"` (raise a LangGraph interrupt whose resume value maps to `ElicitResult`) mode.
- **structured output** — a `ToolCallInterceptor` that observes `CallToolResult.structuredContent` and expands `resource_link` items into MLflow span events + attributes.

Bumps `langchain-mcp-adapters` from `>=0.2.2` → `>=0.3.0`. The classic path (no `capabilities:` block on the MCP tool) is byte-for-byte unchanged, with `handle_tool_errors=False` passed explicitly to preserve the pre-0.3.0 `ToolException` semantics that dao-ai's agent loop relies on.

Sampling + roots config fields are declared but not wired at runtime — deferred to PR 3 because langchain-mcp-adapters 0.3.0 does not surface those callbacks and we need to drop below the adapter to raw `mcp.client.session.ClientSession` for them.

## Design

- Route selection lives in one place: `_build_mcp_client` at `src/dao_ai/tools/mcp.py:305`. All three inline `MultiServerMCPClient(...)` sites (async wrapper, sync wrapper, `_afetch_tools_from_server`) route through it. Zero-regression by construction — `capabilities is None` yields the classic client.
- langchain-mcp-adapters wires `logging_callback` + `elicitation_callback` at `ClientSession` construction via `session_kwargs`, but only wires `progress_callback` + `tool_interceptors` inside its own `load_mcp_tools()` code path. dao-ai's custom `@create_tool` wrapper uses the raw `session.call_tool` directly, so PR 1 adds `_call_tool_with_capabilities` (`src/dao_ai/tools/mcp.py:368`) that (a) threads a bound `progress_callback` into `session.call_tool(...)` and (b) composes the interceptor onion manually around the raw call.
- Named subclasses (`DaoAiProgressCallback`, `DaoAiLoggingCallback`, `DaoAiElicitationCallback`, `DaoAiTraceInterceptor`, `DaoAiStructuredOutputInterceptor`) so their execution surfaces in MLflow trace spans — per `feedback_subclass_for_trace_observability`.
- Every new `Field` has a `description=` per `feedback_pydantic_field_descriptions`.

## Files

- `pyproject.toml` — bump `langchain-mcp-adapters>=0.3.0`.
- `src/dao_ai/config.py` — `McpCapabilitiesModel`, `McpSamplingCapabilityModel`, `McpRootModel`; attach `capabilities` to `McpFunctionModel`.
- `src/dao_ai/tools/mcp.py` — `_build_mcp_client` helper + `_call_tool_with_capabilities` helper; route all three inline client-construction sites through them.
- `src/dao_ai/tools/mcp_callbacks.py` (new) — Protocol-conformant callback classes.
- `src/dao_ai/tools/mcp_interceptors.py` (new) — Protocol-conformant interceptor classes.
- `tests/dao_ai/test_mcp_capabilities_client.py` (new) — 29 unit tests covering Pydantic validation, `_build_mcp_client` routing branches, Protocol conformance, callback + interceptor behavior, resume-value mapping.
- `tests/dao_ai/mcp/test_capabilities_integration.py` (new) — 8 integration tests against a real background `FastMCP` server. Fires real progress + log notifications through the SDK and asserts our callbacks receive them.
- `tests/dao_ai/capabilities_mcp_server.py` (new) — reusable FastMCP fixture (kept for PR 3).

## Test plan

- [ ] `uv run pytest tests/dao_ai/test_mcp_capabilities_client.py tests/dao_ai/mcp/test_capabilities_integration.py -q --timeout=60` — 37/37 pass.
- [ ] `uv run pytest tests/dao_ai/test_mcp_function_model.py tests/dao_ai/test_mcp_filtering.py tests/dao_ai/mcp/ tests/test_mcp_app_auth.py -q --timeout=60` — full pre-existing MCP suite green.
- [ ] `make schema` — new fields present under `$defs.McpCapabilitiesModel` with descriptions; `McpFunctionModel.capabilities` present.
- [ ] Live-verified on FEVM (`fevm-nfleming-stable-aws`):
  - Scenario A (baseline, `capabilities=None`) — 2 substantive product-grounded live inferences via `dao-ai-mcp-capstest` app; zero errors in app logs; 2 agent turns completed cleanly with vector_search MCP tool call.
  - Scenario B (`capabilities: {progress: true, logging: info, structured_output: true}`) — deploy loads `McpCapabilitiesModel(progress=True, logging='info', structured_output=True, ...)`; live golf-product inference returns substantive response; tool wrapper reaches `MCP tool completed result_length=3554` — only reachable if `_call_tool_with_capabilities` composed the interceptor onion + returned cleanly.

## Notes

- Two upstream Databricks bugs discovered while live-testing: `mlflow.tracing.export.uc_table` fails with `object of type '_io.BytesIO' has no len()`; `mlflow.tracing.export.mlflow_v3` looks for the un-prefixed OTEL table name even when `trace_location.table_prefix` is set. These block trace-level assertions on FEVM Apps but are unrelated to PR 1 — filed separately.
- PR 2 (server-side resources + prompts + progress emission from LangGraph) and PR 3 (sampling + roots via raw `ClientSession`) will stack on this branch.

This pull request and its description were written by Isaac.