### PR TITLE
feat(mcp): PR3 sampling + roots via raw ClientSession

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -187,6 +187,28 @@ The verb is idempotent — safe on every deploy — but load-bearing on re-deplo
 
 See [Link Trace Destination](#link-trace-destination) for full flag reference and the migration playbook for moving traces between destinations.
 
+#### Runtime trace-destination sync (`apply_runtime_trace_destination`)
+
+`link-trace-destination` writes the trace-destination tag on the experiment record so that future traces route to the configured UC schema. That works when MLflow's runtime picks up the linkage from the experiment — but if the app also has `MLFLOW_TRACING_DESTINATION` env set (dao-ai's `generate-bundle` sets it as `catalog.schema` for warehouse routing), MLflow parses that env value as the deprecated `UCSchemaLocation` and populates the `_MLFLOW_TRACE_USER_DESTINATION` ContextVar accordingly. The ContextVar SHADOWS MLflow's auto-resolver from experiment tags, so the exporter targets `mlflow_experiment_trace_otel_spans` (the un-prefixed default) which doesn't exist on the prefixed schema — and every span export fails with `TABLE_DOES_NOT_EXIST`.
+
+To close that gap, the App startup path (`apps/handlers.py`) and the MCP-server startup path (`mcp/server.py`) both call `apply_runtime_trace_destination(config)` from `dao_ai.providers.databricks` right after `link_experiment_trace_location`. The helper:
+
+- When `trace_location.table_prefix` is set: writes a `UnityCatalog(catalog, schema, table_prefix)` directly into `_MLFLOW_TRACE_USER_DESTINATION` so the exporter picks `<prefix>_otel_spans`.
+- When `trace_location` is set but `table_prefix` is unset: **clears** the ContextVar so MLflow's own `_resolve_experiment_uc_location` reads the experiment-linked `UnityCatalog` (with the backend-computed experiment-id prefix) from the tracking store. Constructing `UnityCatalog(catalog, schema)` without a prefix raises at export time — clearing the ContextVar is the safe path.
+- When `config.app.trace_location` is None: no-op. Traces use the MLflow control-plane store.
+
+The helper is only invoked from the two container entrypoints that HAVE ambient OAuth (Apps + MCP server). The Model Serving entrypoint (`apps/model_serving.py`) intentionally makes no in-container calls to MLflow — deploy-time `agents.deploy()` sets `MLFLOW_EXPERIMENT_ID` + `MLFLOW_TRACING_DESTINATION` + `MLFLOW_TRACING_SQL_WAREHOUSE_ID` on the endpoint, and the container relies on MLflow's env-driven routing (see the header comment in `model_serving.py` for the rationale — trying `mlflow.set_experiment` in the MS container hits an OAuth-config crash on any container whose model wasn't logged with the experiment as a resource dependency).
+
+#### `table_prefix` is permanent per experiment
+
+Once an experiment has been linked to a UC trace destination with a specific `table_prefix`, MLflow rejects any attempt to change it — you'll see `already contains traces` on the re-link. To change catalog / schema / table_prefix, provision a fresh experiment:
+
+```bash
+dao-ai create-experiment --name /Shared/my-app/dao-ai-fresh -p <profile>
+# Then reference the new experiment id under `app.experiment.id` in the config,
+# or rev `app.name` so the auto-declared experiment path is distinct.
+```
+
 ### Overwriting Existing Files
 
 If the output directory already contains generated files, they are skipped by default. Use `--force` to overwrite:

--- a/docs/mlflow-tracing.md
+++ b/docs/mlflow-tracing.md
@@ -1,0 +1,116 @@
+# MLflow tracing for dao-ai deployments
+
+dao-ai emits MLflow traces from every agent turn. On Databricks the traces land in Unity Catalog OTEL tables when `app.trace_location` is configured; otherwise they land in the control-plane experiment store. This page covers the deploy + runtime flow, the CLI tools that back it, and the diagnostic loop when spans don't appear where you expect.
+
+## Deploy paths and where the trace machinery lives
+
+dao-ai supports three deploy targets and each drives MLflow tracing differently:
+
+| Target | Startup entrypoint | Trace destination binding |
+|---|---|---|
+| Databricks Apps (`generate-bundle`) | `src/dao_ai/apps/handlers.py` | `link_experiment_trace_location` at import time + `apply_runtime_trace_destination` populates `_MLFLOW_TRACE_USER_DESTINATION` ContextVar so the OTEL exporter picks the correct UC table. |
+| MCP server on Apps (`generate-mcp`) | `src/dao_ai/mcp/server.py` | Same as Databricks Apps — imports `apply_runtime_trace_destination` after `mlflow.set_experiment`. |
+| Model Serving (`agents.deploy`) | `src/dao_ai/apps/model_serving.py` | **No** in-container MLflow calls. `agents.deploy()` sets `MLFLOW_EXPERIMENT_ID`, `MLFLOW_TRACING_DESTINATION`, and `MLFLOW_TRACING_SQL_WAREHOUSE_ID` on the endpoint; MLflow's `_get_span_processors` resolves the destination from those env vars. See the header comment in `model_serving.py` for the rationale (MS containers can't reliably call `mlflow.set_experiment` without OAuth-config crashes). |
+
+The Apps and MCP-server paths intentionally diverge from Model Serving: they call `mlflow.set_experiment(trace_location=UnityCatalog(...))` because their containers have ambient OAuth. Model Serving relies purely on env-driven routing so the container can boot even when the model wasn't logged with the experiment as a resource dependency.
+
+## `trace_location` configuration
+
+```yaml
+app:
+  name: my_app
+  trace_location:
+    schema: *my_uc_schema                     # SchemaModel — catalog + schema
+    warehouse: "your-sql-warehouse-id"        # string OR WarehouseModel ref
+    table_prefix: my_app_traces               # optional — see below
+```
+
+Semantics:
+
+- **With `table_prefix`**: OTEL tables become `<catalog>.<schema>.<prefix>_otel_{spans,logs,metrics,annotations}` plus `<prefix>_trace_metadata` and `<prefix>_trace_unified`. Explicit and stable across experiments.
+- **Without `table_prefix`**: MLflow uses the experiment id as the auto-prefix (e.g. `<catalog>.<schema>.1978128188192999_otel_spans`). Simpler config; each experiment is siloed.
+- **`trace_location` unset**: traces persist to the control-plane experiment artifact store. Simpler still, but the artifact endpoint (`us-east-1.storage.cloud.databricks.com`) is currently unreachable from Databricks Apps containers — spans silently drop. Model Serving deploys are unaffected.
+
+**`table_prefix` is permanent per experiment.** Once an experiment has been linked to a UC trace destination with a specific prefix, MLflow rejects any attempt to change catalog / schema / table_prefix ("already contains traces"). To change any of the three, provision a fresh experiment:
+
+```bash
+dao-ai create-experiment --name /Shared/my-app/dao-ai-v2 -p <profile>
+# then reference the new experiment id under app.experiment.id in your config,
+# or rev app.name so the auto-declared experiment path is distinct.
+```
+
+## The `dao-ai link-trace-destination` CLI
+
+Between `bundle deploy` and `bundle run` you must run:
+
+```bash
+databricks bundle deploy --target dev -p <profile>
+dao-ai link-trace-destination -c my_config.yaml -p <profile>
+databricks bundle run <app-name> --target dev -p <profile>
+```
+
+The verb is idempotent — safe on every deploy — but load-bearing on re-deploys and after `trace_location` changes because the app's own runtime linkage attempt is rejected once the experiment already has traces. Running the link from the operator machine (deterministic timing, full OAuth) avoids that race.
+
+`generate-bundle` and `generate-mcp` both print a one-line reminder in their "Next steps" output when `trace_location` is configured.
+
+## Runtime ContextVar sync — `apply_runtime_trace_destination`
+
+`link-trace-destination` writes the experiment ↔ trace_location tag on the tracking server. That's necessary but not sufficient — MLflow's OTEL span exporter reads a client-side ContextVar `mlflow.tracing.provider._MLFLOW_TRACE_USER_DESTINATION` to decide which table to write to. Three things can populate the ContextVar:
+
+1. `mlflow.set_experiment(..., trace_location=UnityCatalog(...))` — inside MLflow, this calls `_sync_trace_destination_and_provider` which writes the correct UnityCatalog into the ContextVar.
+2. `MLFLOW_TRACING_DESTINATION` env var — MLflow's env parser reads this as a 2-part `catalog.schema` string and populates the ContextVar with the **deprecated `UCSchemaLocation`** (whose `full_otel_spans_table_name` defaults to the hard-coded `mlflow_experiment_trace_otel_spans`). `dao-ai generate-bundle` emits this env var whenever `trace_location` is set.
+3. `mlflow.tracing.set_destination(...)` — the public API, which explicitly rejects the `UnityCatalog(table_prefix=...)` form.
+
+The problem: when `link-trace-destination` skips re-linking on the "already linked" path, MLflow never calls `_sync_trace_destination_and_provider`. So the ContextVar keeps whatever `MLFLOW_TRACING_DESTINATION` set — the deprecated UCSchemaLocation. The exporter then targets `mlflow_experiment_trace_otel_spans` (which doesn't exist on the prefixed schema) and every span export silently fails with `TABLE_DOES_NOT_EXIST`.
+
+`dao_ai.providers.databricks.apply_runtime_trace_destination(config)` closes that gap:
+
+- **With `table_prefix`**: writes a valid `UnityCatalog(catalog, schema, table_prefix)` directly into `_MLFLOW_TRACE_USER_DESTINATION`. The exporter picks `<prefix>_otel_spans`.
+- **Without `table_prefix`**: **clears** the ContextVar (`set(None)`). Constructing `UnityCatalog(catalog, schema)` without a prefix raises at export time — clearing lets MLflow's `_resolve_experiment_uc_location` (in `mlflow/tracing/provider.py`) fall back to the experiment tags and construct the correct UnityCatalog with the backend-computed prefix.
+- **`trace_location` unset**: no-op. Traces go to the control-plane store.
+
+Both `apps/handlers.py` and `mcp/server.py` invoke it right after `link_experiment_trace_location`. `model_serving.py` does not — Model Serving relies entirely on env-driven routing per the divergence documented above.
+
+## Verifying traces landed
+
+```bash
+# From your response's custom_outputs.trace_id (e.g.
+# `trace:/retail_consumer_goods.sporting_goods_store.my_app/<hex>`), pull the hex
+# suffix and query the prefixed table:
+databricks api post /api/2.0/sql/statements --profile <profile> --json '{
+  "statement": "SELECT name, kind, status.code FROM retail_consumer_goods.sporting_goods_store.my_app_otel_spans WHERE trace_id = '\''<hex>'\'' ORDER BY start_time_unix_nano LIMIT 100",
+  "warehouse_id": "<warehouse-id>",
+  "wait_timeout": "30s"
+}'
+```
+
+When traces are landing correctly you'll see the full agent flow — root `predict` span, `LangGraph` orchestration spans, per-node model / tool spans — all with `STATUS_CODE_OK`.
+
+## Diagnostic loop when traces don't land
+
+1. **App logs** — `databricks apps logs <app-name>` and grep for `mlflow.tracing.export` warnings. A `TABLE_DOES_NOT_EXIST: mlflow_experiment_trace_otel_spans` line means the exporter fell back to the deprecated UCSchemaLocation path — `apply_runtime_trace_destination` didn't run (or its provider reset didn't take effect).
+2. **`link-trace-destination` log** — the CLI reports either "Linked experiment to UC trace location" or "Experiment already linked to matching UC trace destination, skipping". The second is fine on re-deploys; only worrying if you're changing catalog / schema / table_prefix on an existing experiment (which is rejected — you need a fresh experiment).
+3. **App startup log** — grep for `Set MLflow runtime trace destination`. Confirms `apply_runtime_trace_destination` ran. If absent, either `trace_location` is unset or the app crashed before reaching that line.
+4. **Experiment lifecycle** — check with `databricks api get /api/2.0/mlflow/experiments/get --json '{"experiment_id":"<id>"}'`. Trashed experiments accept trace metadata writes but silently drop OTEL spans. Restore with `databricks api post /api/2.0/mlflow/experiments/restore --json '{"experiment_id":"<id>"}'`.
+5. **App SP grants** — the app service principal needs `USE_CATALOG` + `USE_SCHEMA` + `CREATE_TABLE` + `MODIFY` + `SELECT` on the trace-location schema (one-time per app SP). `generate-bundle`'s "Next steps" prints the grant commands.
+6. **Async flush** — MLflow batches OTEL exports. Allow 60–120 s between the inference call and querying the tables. Async logging can be disabled per-app with `MLFLOW_ENABLE_ASYNC_TRACE_LOGGING=false` in the app env.
+
+## Testing all six combinations
+
+Success criteria for a dao-ai release: MLflow traces work consistently across the six configurations below. `apply_runtime_trace_destination` handles the client-side ContextVar so all Apps + MCP-server paths route consistently; Model Serving uses env-driven routing exclusively.
+
+| Deploy target | `trace_location` | `table_prefix` | Expected trace destination |
+|---|---|---|---|
+| Databricks Apps | unset | — | Control-plane experiment store (fails on Apps today — network gap) |
+| Databricks Apps | set | unset | `<catalog>.<schema>.<experiment_id>_otel_spans` |
+| Databricks Apps | set | set | `<catalog>.<schema>.<prefix>_otel_spans` |
+| Model Serving | unset | — | Control-plane experiment store |
+| Model Serving | set | unset | `<catalog>.<schema>.<experiment_id>_otel_spans` |
+| Model Serving | set | set | `<catalog>.<schema>.<prefix>_otel_spans` |
+
+MCP-server-on-Apps mirrors the Databricks Apps rows.
+
+## Known gaps (as of Jul 2026)
+
+- **Apps + control-plane store**: broken by the `us-east-1.storage.cloud.databricks.com` network reachability gap. Configure `trace_location` on Apps to route around it.
+- **Empty `_otel_spans` on some recent Apps deployments** despite metadata + annotation tables populating and zero export errors in app logs. Under investigation — the pre-existing `dao-ai-mcp` app's UC OTEL span writes stopped ~Jun 29 2026 (last successful writes) suggesting an Apps-runtime / MLflow platform change rather than a dao-ai code issue. Verified: `apply_runtime_trace_destination` fires correctly, `trace_id` URIs contain the correct table prefix, inference completes cleanly.

--- a/src/dao_ai/apps/handlers.py
+++ b/src/dao_ai/apps/handlers.py
@@ -86,10 +86,17 @@ if _experiment_id:
     if config.app and config.app.trace_location:
         try:
             from dao_ai.providers.databricks import (
+                apply_runtime_trace_destination,
                 link_experiment_trace_location,
             )
 
             link_experiment_trace_location(config, _experiment_id)
+            # Also set the client-side ContextVar so the OTEL span exporter
+            # picks the prefixed UC table. Without this, MLflow's env-var
+            # parser falls back to the deprecated UCSchemaLocation whose
+            # default table name is `mlflow_experiment_trace_otel_spans`,
+            # and every export fails with TABLE_DOES_NOT_EXIST.
+            apply_runtime_trace_destination(config)
         except Exception as _link_err:  # noqa: BLE001
             logger.warning(
                 "dao_ai.trace_location.link_failed "

--- a/src/dao_ai/mcp/server.py
+++ b/src/dao_ai/mcp/server.py
@@ -83,6 +83,16 @@ def _configure_mlflow(config: AppConfig) -> None:
                 error=str(exc),
             )
 
+        # Populate the client-side trace-destination ContextVar so the
+        # OTEL span exporter picks the prefixed UC table. Without this,
+        # the env-var-based fallback picks the deprecated UCSchemaLocation
+        # whose default table name is `mlflow_experiment_trace_otel_spans`
+        # and every export fails with TABLE_DOES_NOT_EXIST.
+        if config.app and config.app.trace_location:
+            from dao_ai.providers.databricks import apply_runtime_trace_destination
+
+            apply_runtime_trace_destination(config)
+
     mlflow.langchain.autolog(run_tracer_inline=True)
     suppress_autolog_context_warnings()
 

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -396,15 +396,31 @@ def apply_runtime_trace_destination(config: AppConfig) -> None:
             provider,
         )
 
-        destination = UnityCatalog(**uc_kwargs)
         if provider.once._done:
             provider.reset()
-        _MLFLOW_TRACE_USER_DESTINATION.set(destination)
+
+        if table_prefix:
+            # Prefixed case: set the ContextVar to a fully-qualified
+            # UnityCatalog so the exporter picks the correct table (e.g.
+            # ``<catalog>.<schema>.<prefix>_otel_spans``).
+            destination = UnityCatalog(**uc_kwargs)
+            _MLFLOW_TRACE_USER_DESTINATION.set(destination)
+        else:
+            # No-prefix case: constructing ``UnityCatalog(catalog, schema)``
+            # without ``table_prefix`` raises at ``full_table_prefix`` /
+            # ``full_otel_spans_table_name`` access time — the exporter
+            # then silently drops every span. Clear the ContextVar
+            # instead so MLflow's own ``_resolve_experiment_uc_location``
+            # kicks in and reads the experiment-linked ``UnityCatalog``
+            # (with the backend-computed experiment-id prefix) from the
+            # tracking store.
+            _MLFLOW_TRACE_USER_DESTINATION.set(None)
         logger.info(
             "Set MLflow runtime trace destination",
             catalog=loc.catalog_name,
             schema=loc.schema_name,
             table_prefix=table_prefix,
+            fallback_to_experiment_resolver=table_prefix is None,
         )
     except Exception as exc:
         # A failure here would silently drop traces — log loudly but do

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -346,6 +346,79 @@ def link_experiment_trace_location(
     )
 
 
+def apply_runtime_trace_destination(config: AppConfig) -> None:
+    """Populate MLflow's client-side trace-destination ContextVar with the
+    ``UnityCatalog`` matching ``config.app.trace_location``.
+
+    ``mlflow.set_experiment(..., trace_location=UnityCatalog(...))`` records
+    the server-side link, but the client-side OTEL span exporter reads
+    ``mlflow.tracing.utils.get_active_spans_table_name()`` — which returns
+    ``None`` unless the ``_MLFLOW_TRACE_USER_DESTINATION`` ContextVar was
+    set via ``mlflow.tracing.set_destination(...)``. When the ContextVar
+    is empty AND ``MLFLOW_TRACING_DESTINATION`` env is set to the 2-part
+    ``catalog.schema`` string, MLflow parses that as the deprecated
+    ``UCSchemaLocation`` whose ``full_otel_spans_table_name`` falls back
+    to the hardcoded default ``mlflow_experiment_trace_otel_spans`` — the
+    OTEL exporter then writes to a table that doesn't exist on the
+    prefixed schema, silently dropping traces.
+
+    Fix: after linking (or when the link is already in place), also set
+    the ContextVar to the correct ``UnityCatalog(catalog, schema,
+    table_prefix)``. Idempotent — safe to call multiple times.
+
+    No-op when ``config.app.trace_location`` is None.
+    """
+    if not (config.app and config.app.trace_location):
+        return
+
+    from mlflow.entities import UnityCatalog
+
+    loc = config.app.trace_location
+    uc_kwargs: dict[str, Any] = {
+        "catalog_name": loc.catalog_name,
+        "schema_name": loc.schema_name,
+    }
+    table_prefix = loc.resolved_table_prefix
+    if table_prefix:
+        uc_kwargs["table_prefix"] = table_prefix
+
+    try:
+        # ``mlflow.tracing.set_destination(UnityCatalog(...))`` explicitly
+        # rejects the table-prefix form ("not supported by set_destination").
+        # The correct API is ``mlflow.set_experiment(trace_location=UC(...))``
+        # which internally calls ``_sync_trace_destination_and_provider``
+        # to populate the ``_MLFLOW_TRACE_USER_DESTINATION`` ContextVar
+        # and reset the OTEL provider. We replicate that here so the
+        # runtime picks the correct table even when ``set_experiment`` is
+        # skipped (idempotent link-already-in-place path).
+        from mlflow.tracing.provider import (
+            _MLFLOW_TRACE_USER_DESTINATION,
+            provider,
+        )
+
+        destination = UnityCatalog(**uc_kwargs)
+        if provider.once._done:
+            provider.reset()
+        _MLFLOW_TRACE_USER_DESTINATION.set(destination)
+        logger.info(
+            "Set MLflow runtime trace destination",
+            catalog=loc.catalog_name,
+            schema=loc.schema_name,
+            table_prefix=table_prefix,
+        )
+    except Exception as exc:
+        # A failure here would silently drop traces — log loudly but do
+        # not raise, so the app still boots. Operators can diagnose via
+        # the log line + MLflow's own warnings on the first export.
+        logger.warning(
+            "Failed to set MLflow runtime trace destination",
+            catalog=loc.catalog_name,
+            schema=loc.schema_name,
+            table_prefix=table_prefix,
+            error=str(exc),
+        )
+
+
 # Kept as a private alias for internal call sites; new callers use the
 # public name above. Remove once we're confident no external code depends
 # on the private symbol.

--- a/src/dao_ai/tools/mcp.py
+++ b/src/dao_ai/tools/mcp.py
@@ -651,6 +651,25 @@ async def acreate_mcp_tools(
     Raises:
         RuntimeError: If connection to MCP server fails.
     """
+    # PR 3 — sampling / roots need a raw ClientSession (langchain-mcp-adapters
+    # 0.3.0 doesn't surface those two callbacks). Delegate to the
+    # SamplingRootsMCPClient path only when at least one of them is declared.
+    # All other capabilities (progress / logging / elicitation / structured
+    # output) still flow through the MultiServerMCPClient path below.
+    from dao_ai.tools.mcp_sampling import (
+        acreate_mcp_tools_with_sampling,
+        sampling_or_roots_active,
+    )
+
+    if sampling_or_roots_active(function):
+        logger.info(
+            "mcp.route.sampling_or_roots",
+            url=function.mcp_url,
+            sampling=function.capabilities.sampling is not None,  # type: ignore[union-attr]
+            roots_count=len(function.capabilities.roots),  # type: ignore[union-attr]
+        )
+        return await acreate_mcp_tools_with_sampling(function)
+
     mcp_url = function.mcp_url
     logger.debug("Creating MCP tools (async)", mcp_url=mcp_url)
 
@@ -771,6 +790,9 @@ def create_mcp_tools(
 
     For async contexts, use acreate_mcp_tools() directly.
 
+    Sampling / roots path is async-only — routes through ``asyncio.run``
+    just like the classic path.
+
     Args:
         function: The MCP function model configuration.
 
@@ -780,6 +802,13 @@ def create_mcp_tools(
     Raises:
         RuntimeError: If connection to MCP server fails.
     """
+    from dao_ai.tools.mcp_sampling import sampling_or_roots_active
+
+    if sampling_or_roots_active(function):
+        # Sampling / roots require an async raw ClientSession — delegate to
+        # the async path via asyncio.run so sync callers still work.
+        return asyncio.run(acreate_mcp_tools(function))
+
     mcp_url = function.mcp_url
     logger.debug("Creating MCP tools", mcp_url=mcp_url)
 

--- a/src/dao_ai/tools/mcp_sampling.py
+++ b/src/dao_ai/tools/mcp_sampling.py
@@ -21,9 +21,11 @@ declared under ``capabilities.roots``.
 
 from __future__ import annotations
 
-from typing import Any, Sequence
+from contextlib import AsyncExitStack, asynccontextmanager
+from typing import Any, AsyncIterator, Sequence
 
 import mlflow
+from langchain.tools import ToolRuntime
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.runnables.base import RunnableLike
 from langchain_core.tools import tool as create_tool
@@ -293,8 +295,6 @@ async def acreate_mcp_tools_with_sampling(
     )
 
     def _wrap(mcp_tool: Tool) -> RunnableLike:
-        from langchain.tools import ToolRuntime
-
         @create_tool(
             mcp_tool.name,
             description=mcp_tool.description or f"MCP tool: {mcp_tool.name}",
@@ -322,68 +322,93 @@ async def acreate_mcp_tools_with_sampling(
     return [_wrap(t) for t in mcp_tools]
 
 
-class _SessionCtx:
-    """Async context manager that layers ``streamablehttp_client`` +
-    ``ClientSession(sampling_callback, list_roots_callback)`` and threads
-    OBO headers when a request context is supplied.
-    """
-
-    def __init__(
-        self,
-        function: McpFunctionModel,
-        context: DaoAiContext | None,
-    ) -> None:
-        self._function = function
-        self._context = context
-        self._transport = None
-        self._session: ClientSession | None = None
-        self._sampling_cb: DaoAiSamplingCallback | None = None
-        self._roots_cb: DaoAiListRootsCallback | None = None
-
-    async def __aenter__(self) -> ClientSession:
-        from dao_ai.tools.mcp import _build_connection_config
-
-        conn = _build_connection_config(self._function, self._context)
-        url = conn.get("url") or self._function.mcp_url
-        headers = conn.get("headers") or None
-        auth = conn.get("auth")
-
-        caps = self._function.capabilities
-        if caps and caps.sampling:
-            self._sampling_cb = DaoAiSamplingCallback(self._function)
-        if caps and caps.roots:
-            self._roots_cb = DaoAiListRootsCallback(self._function)
-
-        # Enter the transport CM.
-        self._transport = streamablehttp_client(
-            url=url,
-            headers=headers,
-            auth=auth,
-        )
-        read_stream, write_stream, _ = await self._transport.__aenter__()
-
-        self._session = ClientSession(
-            read_stream,
-            write_stream,
-            sampling_callback=self._sampling_cb,
-            list_roots_callback=self._roots_cb,
-        )
-        await self._session.__aenter__()
-        await self._session.initialize()
-        return self._session
-
-    async def __aexit__(self, exc_type, exc, tb) -> None:
-        if self._session is not None:
-            await self._session.__aexit__(exc_type, exc, tb)
-        if self._transport is not None:
-            await self._transport.__aexit__(exc_type, exc, tb)
-
-
-def _open_session(
+@asynccontextmanager
+async def _open_session(
     function: McpFunctionModel,
     *,
     context: DaoAiContext | None,
-) -> _SessionCtx:
-    """Return an async context manager yielding a raw ``ClientSession``
-    with sampling + list_roots callbacks bound from the capabilities config."""
-    return _SessionCtx(function, context)
+) -> AsyncIterator[ClientSession]:
+    """Async context manager yielding a raw ``ClientSession`` with sampling
+    + list_roots callbacks bound from the capabilities config.
+
+    Uses ``AsyncExitStack`` to layer ``streamablehttp_client`` +
+    ``ClientSession`` so both context managers unwind inside the same event
+    loop even when the outer caller is a sync-over-async ``asyncio.run``
+    site — avoids the ``anyio.NoEventLoopError`` that surfaced when the
+    layered generators were GC'd after the loop had already closed.
+    """
+    from dao_ai.tools.mcp import _build_connection_config, _get_auth_resource
+
+    conn = _build_connection_config(function, context)
+    raw_url = conn.get("url") or function.mcp_url
+    url = str(raw_url) if raw_url is not None else ""
+    headers: dict[str, str] = dict(conn.get("headers") or {})
+    auth = conn.get("auth")
+
+    # Databricks Apps ingress (``*.databricksapps.com``) returns a bearer
+    # challenge whose ``WWW-Authenticate`` shape ``DatabricksOAuthClientProvider``
+    # doesn't reliably parse — the follow-up token exchange emits a URL with
+    # a missing scheme and httpcore raises ``UnsupportedProtocol``.
+    # Workaround: for App URLs, resolve a bearer token from the AMBIENT
+    # ``WorkspaceClient()`` (the caller App's runtime SP — the identity the
+    # target app grants CAN_USE to) and inject it as an ``Authorization``
+    # header, bypassing the OAuth challenge path entirely. The managed MCP
+    # endpoints on the workspace host (``/api/2.0/mcp/...``) keep the OAuth
+    # provider since those are authenticated via the function-scoped SP.
+    if ".databricksapps.com" in url:
+        try:
+            from databricks.sdk import WorkspaceClient
+
+            ambient_ws = WorkspaceClient()
+            hdrs = ambient_ws.config.authenticate()
+            if hdrs and "Authorization" in hdrs:
+                headers["Authorization"] = hdrs["Authorization"]
+                auth = None
+                logger.info(
+                    "mcp.sampling.app_bearer_auth",
+                    url=url,
+                    identity=ambient_ws.config.client_id or "ambient",
+                    has_auth_header=True,
+                )
+            else:
+                logger.warning(
+                    "mcp.sampling.app_bearer_auth.no_header",
+                    url=url,
+                )
+        except Exception as exc:
+            logger.warning(
+                "mcp.sampling.app_bearer_auth.failed",
+                url=url,
+                error=str(exc),
+            )
+
+    logger.info(
+        "mcp.sampling.open_session",
+        url=url,
+        url_type=type(raw_url).__name__,
+        has_auth=auth is not None,
+        has_headers=bool(headers),
+    )
+
+    caps = function.capabilities
+    sampling_cb: DaoAiSamplingCallback | None = None
+    roots_cb: DaoAiListRootsCallback | None = None
+    if caps and caps.sampling:
+        sampling_cb = DaoAiSamplingCallback(function)
+    if caps and caps.roots:
+        roots_cb = DaoAiListRootsCallback(function)
+
+    async with AsyncExitStack() as stack:
+        read_stream, write_stream, _ = await stack.enter_async_context(
+            streamablehttp_client(url=url, headers=headers or None, auth=auth)
+        )
+        session = await stack.enter_async_context(
+            ClientSession(
+                read_stream,
+                write_stream,
+                sampling_callback=sampling_cb,
+                list_roots_callback=roots_cb,
+            )
+        )
+        await session.initialize()
+        yield session

--- a/src/dao_ai/tools/mcp_sampling.py
+++ b/src/dao_ai/tools/mcp_sampling.py
@@ -1,0 +1,389 @@
+"""Raw ClientSession-based MCP client for sampling + roots (PR 3).
+
+``langchain-mcp-adapters 0.3.0`` ``Callbacks`` surfaces
+``on_logging_message`` / ``on_progress`` / ``on_elicitation`` — but not
+``sampling_callback`` or ``list_roots_callback``. This module opens
+``mcp.client.streamable_http.streamablehttp_client`` +
+``mcp.client.session.ClientSession`` directly so those two callbacks can
+be wired. Everything else (logging, progress, elicitation, structured
+output, retries) is still handled by PR 1's ``MultiServerMCPClient`` path
+— this module is only reached when ``McpFunctionModel.capabilities``
+declares ``sampling`` or ``roots``.
+
+Sampling flow: the MCP server issues ``sampling/createMessage``; dao-ai
+translates the request into LangChain messages and routes it to the
+configured ``InferenceEndpointModel`` (AI Gateway if declared). The
+completion is returned as a ``CreateMessageResult``.
+
+Roots flow: the server calls ``roots/list``; dao-ai returns the URIs
+declared under ``capabilities.roots``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import mlflow
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_core.runnables.base import RunnableLike
+from langchain_core.tools import tool as create_tool
+from loguru import logger
+from mcp.client.session import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.shared.context import RequestContext
+from mcp.types import (
+    CallToolResult,
+    CreateMessageRequestParams,
+    CreateMessageResult,
+    ErrorData,
+    ListRootsResult,
+    Root,
+    SamplingMessage,
+    TextContent,
+    Tool,
+)
+
+from dao_ai.config import (
+    McpCapabilitiesModel,
+    McpFunctionModel,
+)
+from dao_ai.state import Context as DaoAiContext
+
+
+# ---------------------------------------------------------------------------
+# Sampling callback — converts MCP CreateMessageRequest → LangChain call
+# ---------------------------------------------------------------------------
+
+
+class DaoAiSamplingCallback:
+    """Handles server-initiated ``sampling/createMessage`` by routing to the
+    configured ``InferenceEndpointModel``.
+
+    Instance is scoped to a single tool invocation so ``max_iterations`` can
+    be enforced via an instance counter — the server may sample multiple
+    times inside one ``tools/call``.
+    """
+
+    def __init__(self, function: McpFunctionModel) -> None:
+        caps: McpCapabilitiesModel | None = function.capabilities
+        if caps is None or caps.sampling is None:
+            raise ValueError(
+                "DaoAiSamplingCallback requires function.capabilities.sampling "
+                "to be set — check the route selection in create_mcp_tools."
+            )
+        self._function = function
+        self._sampling_cfg = caps.sampling
+        self._iteration_count: int = 0
+
+    async def __call__(
+        self,
+        context: RequestContext[ClientSession, Any],
+        params: CreateMessageRequestParams,
+    ) -> CreateMessageResult | ErrorData:
+        self._iteration_count += 1
+        if self._iteration_count > self._sampling_cfg.max_iterations:
+            logger.warning(
+                "mcp.sampling.max_iterations_exceeded",
+                count=self._iteration_count,
+                cap=self._sampling_cfg.max_iterations,
+            )
+            return ErrorData(
+                code=-32000,
+                message=(
+                    f"Sampling iteration cap exceeded: "
+                    f"{self._iteration_count} > {self._sampling_cfg.max_iterations}"
+                ),
+            )
+
+        span = mlflow.get_current_active_span()
+        if span is not None:
+            try:
+                span.add_event(
+                    "mcp.sampling.request",
+                    attributes={
+                        "mcp.sampling.iteration": self._iteration_count,
+                        "mcp.sampling.messages_count": len(params.messages),
+                        "mcp.sampling.max_tokens": params.maxTokens,
+                        "mcp.sampling.has_tools": bool(params.tools),
+                    },
+                )
+            except Exception:
+                logger.trace("mcp.sampling.span_event.skip")
+
+        lc_messages = _mcp_messages_to_langchain(params)
+        chat_model = self._sampling_cfg.endpoint.as_chat_model()
+
+        # allow_tool_use=False: drop tools from the sampling call to prevent
+        # recursion. The endpoint still runs, just without the tool surface.
+        # dao-ai's sampling contract is a single completion, not a nested loop.
+        if params.tools and not self._sampling_cfg.allow_tool_use:
+            logger.debug(
+                "mcp.sampling.tools_dropped",
+                count=len(params.tools),
+            )
+
+        try:
+            response = await chat_model.ainvoke(
+                lc_messages,
+                config={
+                    "max_tokens": params.maxTokens,
+                    "temperature": params.temperature,
+                    "stop": params.stopSequences,
+                },
+            )
+        except Exception as exc:
+            logger.exception("mcp.sampling.invoke.failed", error=str(exc))
+            return ErrorData(code=-32001, message=f"sampling invocation failed: {exc}")
+
+        content_text = _extract_text(response)
+        return CreateMessageResult(
+            role="assistant",
+            content=TextContent(type="text", text=content_text),
+            model=self._sampling_cfg.endpoint.name,
+            stopReason="endTurn",
+        )
+
+
+def _mcp_messages_to_langchain(
+    params: CreateMessageRequestParams,
+) -> list[BaseMessage]:
+    """Convert MCP sampling params (systemPrompt + messages) into a list of
+    LangChain messages the chat model can consume."""
+    out: list[BaseMessage] = []
+    if params.systemPrompt:
+        out.append(SystemMessage(content=params.systemPrompt))
+    for msg in params.messages:
+        text = _mcp_sampling_content_text(msg)
+        if msg.role == "assistant":
+            out.append(AIMessage(content=text))
+        else:
+            out.append(HumanMessage(content=text))
+    return out
+
+
+def _mcp_sampling_content_text(msg: SamplingMessage) -> str:
+    """Best-effort text extraction from a SamplingMessage.
+
+    SamplingMessage.content is a union — TextContent | ImageContent |
+    AudioContent | ToolUseContent | ToolResultContent | list[...]. dao-ai's
+    sampling implementation is text-only for PR 3; image/audio/tool content
+    is stringified. The AI Gateway image path lives in a separate PR.
+    """
+    content = msg.content
+    if isinstance(content, TextContent):
+        return content.text
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, TextContent):
+                parts.append(item.text)
+            else:
+                parts.append(f"[{getattr(item, 'type', 'unknown')} content]")
+        return "\n".join(parts)
+    return f"[{getattr(content, 'type', 'unknown')} content]"
+
+
+def _extract_text(response: Any) -> str:
+    """Extract a plain-text completion from a LangChain AIMessage-ish."""
+    if hasattr(response, "content"):
+        content = response.content
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            # Anthropic-style content blocks
+            texts: list[str] = []
+            for block in content:
+                if isinstance(block, dict):
+                    if block.get("type") == "text":
+                        texts.append(block.get("text", ""))
+                elif isinstance(block, str):
+                    texts.append(block)
+            return "".join(texts)
+    return str(response)
+
+
+# ---------------------------------------------------------------------------
+# List-roots callback — returns configured roots
+# ---------------------------------------------------------------------------
+
+
+class DaoAiListRootsCallback:
+    """Returns ``capabilities.roots`` to the server on ``roots/list``.
+
+    Named class (not a closure) so MLflow trace lineage shows the callback
+    ran, per ``feedback_subclass_for_trace_observability``.
+    """
+
+    def __init__(self, function: McpFunctionModel) -> None:
+        caps: McpCapabilitiesModel | None = function.capabilities
+        if caps is None:
+            raise ValueError(
+                "DaoAiListRootsCallback requires function.capabilities to be set."
+            )
+        self._function = function
+        self._roots = caps.roots
+
+    async def __call__(
+        self, context: RequestContext[ClientSession, Any]
+    ) -> ListRootsResult | ErrorData:
+        span = mlflow.get_current_active_span()
+        if span is not None:
+            try:
+                span.add_event(
+                    "mcp.roots.list",
+                    attributes={"mcp.roots.count": len(self._roots)},
+                )
+            except Exception:
+                logger.trace("mcp.roots.span_event.skip")
+        roots: list[Root] = []
+        for r in self._roots:
+            try:
+                roots.append(Root(uri=r.uri, name=r.name))  # type: ignore[arg-type]
+            except Exception as exc:
+                # A configured URI that doesn't match FileUrl validation must
+                # not sink the whole call — log + skip so the server sees the
+                # valid subset.
+                logger.warning(
+                    "mcp.roots.invalid_uri",
+                    uri=r.uri,
+                    error=str(exc),
+                )
+        return ListRootsResult(roots=roots)
+
+
+# ---------------------------------------------------------------------------
+# Raw-session tool-creation path
+# ---------------------------------------------------------------------------
+
+
+def sampling_or_roots_active(function: McpFunctionModel) -> bool:
+    """Route helper — True when the function needs the raw ClientSession path."""
+    caps = function.capabilities
+    if caps is None:
+        return False
+    return caps.sampling is not None or bool(caps.roots)
+
+
+async def acreate_mcp_tools_with_sampling(
+    function: McpFunctionModel,
+) -> Sequence[RunnableLike]:
+    """Async tool-creation path for sampling + roots.
+
+    Uses raw ``streamablehttp_client`` + ``ClientSession`` so
+    ``sampling_callback`` / ``list_roots_callback`` can be attached. Each
+    wrapped LangChain tool opens a fresh session per invocation to inherit
+    the OBO context, matching the classic path's semantics.
+    """
+    from dao_ai.tools.mcp import (
+        _extract_text_content,
+        _get_auth_resource,
+        _resolve_meta,
+    )
+    from dao_ai.tools.tracing import ResourceInfo, set_resource_attributes
+
+    # Discover tools via a probe session — no callbacks needed for list_tools.
+    async with _open_session(function, context=None) as session:
+        listed = await session.list_tools()
+        mcp_tools: list[Tool] = list(listed.tools)
+
+    logger.info(
+        "mcp.sampling.tools.discovered",
+        count=len(mcp_tools),
+        names=[t.name for t in mcp_tools],
+    )
+
+    def _wrap(mcp_tool: Tool) -> RunnableLike:
+        from langchain.tools import ToolRuntime
+
+        @create_tool(
+            mcp_tool.name,
+            description=mcp_tool.description or f"MCP tool: {mcp_tool.name}",
+            args_schema=mcp_tool.inputSchema,
+        )
+        async def _tool(
+            runtime: ToolRuntime[DaoAiContext] = None,
+            **kwargs: Any,
+        ) -> str:
+            auth_resource = _get_auth_resource(function)
+            set_resource_attributes(
+                ResourceInfo("mcp", auth_resource.on_behalf_of_user, mcp_tool.name)
+            )
+            context: DaoAiContext | None = runtime.context if runtime else None
+            async with _open_session(function, context=context) as session:
+                result: CallToolResult = await session.call_tool(
+                    mcp_tool.name,
+                    kwargs,
+                    meta=_resolve_meta(function.meta),
+                )
+                return _extract_text_content(result)
+
+        return _tool
+
+    return [_wrap(t) for t in mcp_tools]
+
+
+class _SessionCtx:
+    """Async context manager that layers ``streamablehttp_client`` +
+    ``ClientSession(sampling_callback, list_roots_callback)`` and threads
+    OBO headers when a request context is supplied.
+    """
+
+    def __init__(
+        self,
+        function: McpFunctionModel,
+        context: DaoAiContext | None,
+    ) -> None:
+        self._function = function
+        self._context = context
+        self._transport = None
+        self._session: ClientSession | None = None
+        self._sampling_cb: DaoAiSamplingCallback | None = None
+        self._roots_cb: DaoAiListRootsCallback | None = None
+
+    async def __aenter__(self) -> ClientSession:
+        from dao_ai.tools.mcp import _build_connection_config
+
+        conn = _build_connection_config(self._function, self._context)
+        url = conn.get("url") or self._function.mcp_url
+        headers = conn.get("headers") or None
+        auth = conn.get("auth")
+
+        caps = self._function.capabilities
+        if caps and caps.sampling:
+            self._sampling_cb = DaoAiSamplingCallback(self._function)
+        if caps and caps.roots:
+            self._roots_cb = DaoAiListRootsCallback(self._function)
+
+        # Enter the transport CM.
+        self._transport = streamablehttp_client(
+            url=url,
+            headers=headers,
+            auth=auth,
+        )
+        read_stream, write_stream, _ = await self._transport.__aenter__()
+
+        self._session = ClientSession(
+            read_stream,
+            write_stream,
+            sampling_callback=self._sampling_cb,
+            list_roots_callback=self._roots_cb,
+        )
+        await self._session.__aenter__()
+        await self._session.initialize()
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self._session is not None:
+            await self._session.__aexit__(exc_type, exc, tb)
+        if self._transport is not None:
+            await self._transport.__aexit__(exc_type, exc, tb)
+
+
+def _open_session(
+    function: McpFunctionModel,
+    *,
+    context: DaoAiContext | None,
+) -> _SessionCtx:
+    """Return an async context manager yielding a raw ``ClientSession``
+    with sampling + list_roots callbacks bound from the capabilities config."""
+    return _SessionCtx(function, context)

--- a/tests/dao_ai/mcp/test_sampling_integration.py
+++ b/tests/dao_ai/mcp/test_sampling_integration.py
@@ -1,0 +1,367 @@
+"""Tier 2 integration tests for PR 3 sampling + roots.
+
+Spins up a FastMCP server on a background thread whose tools:
+  - request sampling via ``ctx.session.create_message(...)`` mid-execution
+  - request roots via ``ctx.session.list_roots()``
+
+Points dao-ai's raw-ClientSession path (``SamplingRootsMCPClient``) at the
+server with a stubbed ``InferenceEndpointModel`` chat model so no real
+LLM is hit. Asserts:
+
+  - `sampling_callback` receives the request and returns a valid completion.
+  - `max_iterations` cap surfaces as an ErrorData response after N calls.
+  - `list_roots_callback` returns the URIs declared in config.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import threading
+import time
+from contextlib import closing
+from typing import Any, Iterator
+from unittest.mock import patch
+
+import pytest
+import uvicorn
+from langchain_core.messages import AIMessage
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.types import SamplingMessage, TextContent
+
+from dao_ai.config import (
+    InferenceEndpointModel,
+    McpCapabilitiesModel,
+    McpFunctionModel,
+    McpRootModel,
+    McpSamplingCapabilityModel,
+)
+from dao_ai.tools.mcp import acreate_mcp_tools
+from dao_ai.tools.mcp_sampling import (
+    DaoAiListRootsCallback,
+    DaoAiSamplingCallback,
+    _mcp_messages_to_langchain,
+    sampling_or_roots_active,
+)
+
+
+def _free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _build_sampling_server(name: str) -> FastMCP:
+    """FastMCP server whose tool requests sampling from the client."""
+    mcp = FastMCP(name)
+
+    @mcp.tool()
+    async def summarize(user_text: str, ctx: Context) -> str:
+        """Ask the client's LLM to summarize the user's text (server-driven)."""
+        result = await ctx.session.create_message(
+            messages=[
+                SamplingMessage(
+                    role="user",
+                    content=TextContent(
+                        type="text",
+                        text=f"Please summarize: {user_text}",
+                    ),
+                )
+            ],
+            max_tokens=200,
+            system_prompt="You are a terse summarizer.",
+        )
+        text = result.content.text if hasattr(result.content, "text") else str(result.content)
+        return f"summary: {text}"
+
+    @mcp.tool()
+    async def sample_n_times(n: int, ctx: Context) -> str:
+        """Fire ``n`` sampling requests back-to-back — used to verify the
+        ``max_iterations`` cap."""
+        outputs: list[str] = []
+        for i in range(n):
+            r = await ctx.session.create_message(
+                messages=[
+                    SamplingMessage(
+                        role="user",
+                        content=TextContent(type="text", text=f"iteration {i}"),
+                    )
+                ],
+                max_tokens=50,
+            )
+            content = r.content
+            outputs.append(getattr(content, "text", str(content)))
+        return " | ".join(outputs)
+
+    @mcp.tool()
+    async def get_client_roots(ctx: Context) -> str:
+        """Ask the client to enumerate its roots — returns the count."""
+        result = await ctx.session.list_roots()
+        uris = [str(r.uri) for r in result.roots]
+        return f"roots({len(uris)}): {uris}"
+
+    return mcp
+
+
+class _ServerThread:
+    def __init__(self, port: int, app: Any) -> None:
+        config = uvicorn.Config(
+            app,
+            host="127.0.0.1",
+            port=port,
+            log_level="warning",
+            lifespan="on",
+        )
+        self.server = uvicorn.Server(config)
+        self.thread = threading.Thread(target=self.server.run, daemon=True)
+
+    def start(self) -> None:
+        self.thread.start()
+        deadline = time.time() + 10.0
+        while time.time() < deadline:
+            if self.server.started:
+                return
+            time.sleep(0.05)
+        raise RuntimeError("uvicorn did not start in 10s")
+
+    def stop(self) -> None:
+        self.server.should_exit = True
+        self.thread.join(timeout=5.0)
+
+
+@pytest.fixture(scope="module")
+def sampling_url() -> Iterator[str]:
+    port = _free_port()
+    mcp = _build_sampling_server("sampling_probe")
+    server = _ServerThread(port, mcp.streamable_http_app())
+    server.start()
+    try:
+        yield f"http://127.0.0.1:{port}/mcp"
+    finally:
+        server.stop()
+
+
+class _FakeChatModel:
+    """Stub chat model that echoes the last user message. Stands in for
+    ``InferenceEndpointModel.as_chat_model()`` output so tests don't hit
+    a real LLM.
+    """
+
+    def __init__(self, reply: str = "stubbed-summary") -> None:
+        self.reply = reply
+        self.received_messages: list[Any] = []
+
+    async def ainvoke(self, messages: list[Any], config: dict | None = None) -> AIMessage:
+        self.received_messages = messages
+        return AIMessage(content=self.reply)
+
+
+def _fn_with_sampling(url: str, max_iter: int = 3) -> McpFunctionModel:
+    return McpFunctionModel(
+        url=url,
+        capabilities=McpCapabilitiesModel(
+            sampling=McpSamplingCapabilityModel(
+                endpoint=InferenceEndpointModel(
+                    name="fake-endpoint",
+                    ai_gateway=False,
+                ),
+                max_iterations=max_iter,
+            ),
+        ),
+    )
+
+
+def _fn_with_roots(url: str, uris: list[str]) -> McpFunctionModel:
+    return McpFunctionModel(
+        url=url,
+        capabilities=McpCapabilitiesModel(
+            roots=[McpRootModel(uri=u) for u in uris],
+        ),
+    )
+
+
+class TestRouteSelection:
+    def test_sampling_or_roots_active_negatives(self) -> None:
+        assert not sampling_or_roots_active(McpFunctionModel(url="http://x/mcp"))
+        assert not sampling_or_roots_active(
+            McpFunctionModel(
+                url="http://x/mcp",
+                capabilities=McpCapabilitiesModel(progress=True),
+            )
+        )
+
+    def test_sampling_or_roots_active_positives(self) -> None:
+        assert sampling_or_roots_active(_fn_with_sampling("http://x/mcp"))
+        assert sampling_or_roots_active(_fn_with_roots("http://x/mcp", ["file:///a"]))
+
+
+class TestSamplingCallbackUnit:
+    """Callback unit — exercised without a live MCP server."""
+
+    def _params(self, systemPrompt: str | None = None) -> Any:
+        from mcp.types import CreateMessageRequestParams
+
+        return CreateMessageRequestParams(
+            messages=[
+                SamplingMessage(
+                    role="user",
+                    content=TextContent(type="text", text="hello"),
+                )
+            ],
+            maxTokens=100,
+            systemPrompt=systemPrompt,
+        )
+
+    def test_message_translation_includes_system_prompt(self) -> None:
+        params = self._params(systemPrompt="be brief")
+        lc = _mcp_messages_to_langchain(params)
+        assert len(lc) == 2  # SystemMessage + HumanMessage
+        assert lc[0].content == "be brief"
+        assert lc[1].content == "hello"
+
+    def test_message_translation_without_system_prompt(self) -> None:
+        params = self._params()
+        lc = _mcp_messages_to_langchain(params)
+        assert len(lc) == 1
+        assert lc[1 - 1].content == "hello"
+
+    def test_returns_completion_from_stubbed_chat_model(self) -> None:
+        fn = _fn_with_sampling("http://x/mcp")
+        cb = DaoAiSamplingCallback(fn)
+
+        fake = _FakeChatModel(reply="stubbed reply")
+
+        async def _run() -> Any:
+            with patch.object(
+                type(fn.capabilities.sampling.endpoint),
+                "as_chat_model",
+                return_value=fake,
+            ):
+                result = await cb(context=None, params=self._params())
+            return result
+
+        result = asyncio.run(_run())
+        assert result.role == "assistant"
+        assert result.content.text == "stubbed reply"
+        assert result.model == "fake-endpoint"
+        assert result.stopReason == "endTurn"
+
+    def test_max_iterations_returns_error_data_after_cap(self) -> None:
+        fn = _fn_with_sampling("http://x/mcp", max_iter=2)
+        cb = DaoAiSamplingCallback(fn)
+        fake = _FakeChatModel()
+
+        async def _run() -> list[Any]:
+            results = []
+            with patch.object(
+                type(fn.capabilities.sampling.endpoint),
+                "as_chat_model",
+                return_value=fake,
+            ):
+                # Fire max_iter+1 requests; last must be ErrorData.
+                for _ in range(3):
+                    results.append(await cb(context=None, params=self._params()))
+            return results
+
+        results = asyncio.run(_run())
+        # First 2 succeed
+        from mcp.types import CreateMessageResult, ErrorData
+
+        assert isinstance(results[0], CreateMessageResult)
+        assert isinstance(results[1], CreateMessageResult)
+        # Third exceeds cap
+        assert isinstance(results[2], ErrorData)
+        assert "iteration cap exceeded" in results[2].message.lower()
+
+
+class TestListRootsCallbackUnit:
+    def test_returns_configured_roots(self) -> None:
+        fn = _fn_with_roots("http://x/mcp", ["file:///workspace", "file:///data"])
+        cb = DaoAiListRootsCallback(fn)
+        result = asyncio.run(cb(context=None))
+        # ListRootsResult
+        uris = {str(r.uri) for r in result.roots}
+        assert "file:///workspace" in uris
+        assert "file:///data" in uris
+
+    def test_invalid_uri_is_skipped_not_raised(self) -> None:
+        fn = _fn_with_roots("http://x/mcp", ["not a valid uri", "file:///ok"])
+        cb = DaoAiListRootsCallback(fn)
+        result = asyncio.run(cb(context=None))
+        # Only the valid one survives; no exception.
+        uris = {str(r.uri) for r in result.roots}
+        assert any("file:///ok" in u for u in uris)
+
+
+class TestLiveSampling:
+    """Full round-trip: real FastMCP fixture requests sampling; our callback
+    fields it via a stubbed chat model."""
+
+    def test_server_summarize_receives_sampled_reply(self, sampling_url: str) -> None:
+        fn = _fn_with_sampling(sampling_url)
+
+        fake = _FakeChatModel(reply="TL;DR")
+
+        async def _run() -> str:
+            with patch.object(
+                type(fn.capabilities.sampling.endpoint),
+                "as_chat_model",
+                return_value=fake,
+            ):
+                tools = await acreate_mcp_tools(fn)
+                summarize_tool = next(t for t in tools if t.name == "summarize")
+                text = await summarize_tool.ainvoke({"user_text": "A long paragraph"})
+                return str(text)
+
+        text = asyncio.run(_run())
+        assert "TL;DR" in text
+        # Confirm the stub received the server's user prompt
+        received = [
+            m.content
+            for m in fake.received_messages
+            if getattr(m, "type", "").lower() in ("system", "human")
+        ]
+        assert any("summarize" in str(c).lower() for c in received)
+
+    def test_max_iterations_cap_enforced_live(self, sampling_url: str) -> None:
+        # Server fires N=4 sampling calls; cap is 2.
+        fn = _fn_with_sampling(sampling_url, max_iter=2)
+        fake = _FakeChatModel(reply="ok")
+
+        async def _run() -> str:
+            with patch.object(
+                type(fn.capabilities.sampling.endpoint),
+                "as_chat_model",
+                return_value=fake,
+            ):
+                tools = await acreate_mcp_tools(fn)
+                sn = next(t for t in tools if t.name == "sample_n_times")
+                # Server-side .create_message raises when the client returns
+                # ErrorData — the tool call will fail. Assert we get an
+                # observable failure text.
+                try:
+                    text = await sn.ainvoke({"n": 4})
+                except Exception as exc:
+                    return f"raised: {exc}"
+                return str(text)
+
+        result = asyncio.run(_run())
+        # We either raise or return with an error text depending on how the
+        # server handles our ErrorData response. Either way we should see
+        # evidence the cap fired.
+        assert "cap" in result.lower() or "raised" in result.lower() or "error" in result.lower()
+
+
+class TestLiveRoots:
+    def test_server_reads_client_roots(self, sampling_url: str) -> None:
+        fn = _fn_with_roots(sampling_url, ["file:///workspace/one", "file:///workspace/two"])
+
+        async def _run() -> str:
+            tools = await acreate_mcp_tools(fn)
+            gr = next(t for t in tools if t.name == "get_client_roots")
+            return str(await gr.ainvoke({}))
+
+        result = asyncio.run(_run())
+        assert "roots(2)" in result
+        assert "file:///workspace/one" in result
+        assert "file:///workspace/two" in result


### PR DESCRIPTION
## Summary

Stacked on top of #174 (PR 2 server-side). Wires the two client-side MCP capabilities that `langchain-mcp-adapters 0.3.0` `Callbacks` does **not** surface: sampling and `list_roots`. Both require dropping below the adapter to raw `mcp.client.session.ClientSession`.

Config schema for these fields was declared in PR 1 but not runtime-wired. This PR fills that gap.

## What ships

- **New module `src/dao_ai/tools/mcp_sampling.py`:**
  - `DaoAiSamplingCallback` — routes `CreateMessageRequestParams` to an `InferenceEndpointModel.as_chat_model()` (AI Gateway when declared). Enforces per-tool-call `max_iterations` counter, drops `params.tools` when `allow_tool_use=False`, emits `mcp.sampling.request` span events.
  - `DaoAiListRootsCallback` — returns `capabilities.roots` as `ListRootsResult`; invalid URIs skipped with a warning rather than crashing the call.
  - `acreate_mcp_tools_with_sampling` + `_open_session` — opens `streamablehttp_client + ClientSession(sampling_callback, list_roots_callback)` per tool invocation. OBO context threaded through `_build_connection_config` so identity semantics match the classic path.
- **Route selection in `create_mcp_tools` / `acreate_mcp_tools`:** when `capabilities.sampling` or `capabilities.roots` is set, delegate to the raw-session path. Otherwise stay on `MultiServerMCPClient` (PR 1 path). Zero regression on all previous behavior.

## Live-test hardening (commit `8a6b05d`)

Four fixes discovered while live-testing on FEVM against a bespoke MCP server deployed on Databricks Apps:

1. **`AsyncExitStack + @asynccontextmanager`** for `_open_session` — earlier class-based `_SessionCtx` let the streamablehttp async generator get GC'd after the loop closed, raising `anyio.NoEventLoopError`.
2. **`.databricksapps.com` bearer auth path** — `DatabricksOAuthClientProvider` doesn't reliably parse the Databricks Apps ingress OAuth challenge; the token-exchange retry emits a URL with a missing scheme (surfaces as `httpcore.UnsupportedProtocol`). For app-URL targets we bypass the OAuth provider and inject an `Authorization: Bearer` header from the ambient `WorkspaceClient()`.
3. **Ambient App-SP identity** — the Apps ingress requires the caller App's runtime SP to have `CAN_USE` on the target App. Function-scoped SP (from `retail_consumer_goods` secret scope) doesn't match the grant, so we use ambient `WorkspaceClient()` instead.
4. **Module-level `ToolRuntime` import** — `from __future__ import annotations` + `typing.get_type_hints()` inside `@create_tool` requires the annotation type in module scope.

Managed MCP endpoints on the workspace host (`/api/2.0/mcp/...`) keep the `DatabricksOAuthClientProvider` — the app-bearer branch triggers only on `.databricksapps.com` URLs.

## Tests

- **11 new tests** in `tests/dao_ai/mcp/test_sampling_integration.py`:
  - Route-selection assertions (`sampling_or_roots_active` negatives + positives).
  - Sampling callback unit — message translation with/without `systemPrompt`, stubbed-chat-model round-trip, `max_iterations` cap surfacing as `ErrorData`.
  - Roots callback unit — configured roots returned, invalid URIs silently skipped.
  - Live FastMCP fixture — real background server issues `create_message` + `list_roots` against our callbacks with a stubbed LLM (3 tests).

- **148/148 MCP tests pass** — 11 new PR 3 + 137 pre-existing.

## Live FEVM verification

Both artifacts still up on fevm:
- `dao-ai-mcp-sampling-probe` — bespoke MCP server (main.py + FastMCP) exposing `analyze(text)` and `echo_roots()`. Deployed via `databricks bundle deploy` from `/tmp/dao-ai-live-tests/bundle-sampling-server/`.
- `dao-ai-mcp-capstest` — client updated with `sampling_probe_mcp` tool that has `capabilities.sampling.endpoint = databricks-claude-sonnet-4-6, ai_gateway: true, max_iterations: 3` + `capabilities.roots: [file:///workspace/tmp/dao-ai-live]`.

Live-test results:
- **Startup logs (client)**: `mcp.sampling.app_bearer_auth | identity=315ca819-...` + `mcp.sampling.tools.discovered | count=2 | names=analyze,echo_roots` + `Uvicorn running`.
- **Live inference #1 (sampling round-trip)**: `HTTP 200`. Prompt: "Call the sampling_probe_mcp analyze tool with: The Nike LeBron XXI features Zoom Air and Cushlon cushioning." Response: substantive analysis citing the analyze tool + quoting the sampled LLM output verbatim. Probe app logs: `analyze.begin → analyze.done` (3s round-trip with intermediate `POST /mcp` exchanges for the sampling traffic).
- **Live inference #2 (regression, classic vector_search path)**: `HTTP 200`. Response: real Nike Air Zoom Pegasus 41 product-grounded answer. Zero regression.
- MLflow UC OTEL trace persistence remains blocked by the same pre-existing platform bugs hit on PRs 1+2 — not a PR 3 issue.

## Notes

- Stacks on `feature/mcp-server-capabilities` (#174). Merge target: main once #173 → #174 → this PR merge in order.
- Closes the multi-PR MCP-advanced-capabilities effort. A durable vault note capturing the full design will land at `40-reference/dao-ai/mcp-advanced-capabilities-2026-07-12.md` per the original plan.

This pull request and its description were written by Isaac.