### PR TITLE
fix(tracing): remove MLFLOW_TRACING_DESTINATION env-var shadowing

### DIFF
--- a/src/dao_ai/apps/handlers.py
+++ b/src/dao_ai/apps/handlers.py
@@ -89,6 +89,15 @@ if _experiment_id:
                 link_experiment_trace_location,
             )
 
+            # ``mlflow.set_experiment(experiment_id, trace_location=UC(...))``
+            # internally calls ``_sync_trace_destination_and_provider`` which
+            # populates the client-side ``_MLFLOW_TRACE_USER_DESTINATION``
+            # ContextVar. On re-deploys where the link is already in place,
+            # ``link_experiment_trace_location`` short-circuits — MLflow's
+            # own fallback resolver (``_resolve_experiment_uc_location``,
+            # provider.py:632) then reads the experiment's linked
+            # ``UnityCatalog`` from the tracking store on the first span
+            # export. No explicit ContextVar manipulation needed.
             link_experiment_trace_location(config, _experiment_id)
         except Exception as _link_err:  # noqa: BLE001
             logger.warning(

--- a/src/dao_ai/apps/model_serving.py
+++ b/src/dao_ai/apps/model_serving.py
@@ -52,13 +52,16 @@ config.initialize()
 # are driven by env vars that ``agents.deploy()`` sets on the endpoint:
 #
 #   * ``MLFLOW_EXPERIMENT_ID`` — active experiment for autolog runs.
-#   * ``MLFLOW_TRACING_DESTINATION`` — UC schema for OTEL trace tables
-#     (set when ``config.app.trace_location`` is configured).
 #   * ``MLFLOW_TRACING_SQL_WAREHOUSE_ID`` — warehouse used for the
 #     UC-table export path.
 #
-# MLflow's ``_get_span_processors`` reads these directly and picks the
-# right processor + exporter (``DatabricksUCTableSpanExporter`` when a
+# ``MLFLOW_TRACING_DESTINATION`` is deliberately NOT set — it would parse
+# as a legacy ``UCSchemaLocation`` with hardcoded default table name
+# ``mlflow_experiment_trace_otel_spans`` and shadow the experiment-linked
+# UnityCatalog resolved via ``_resolve_experiment_uc_location``.
+#
+# MLflow's ``_get_span_processors`` reads the remaining env vars and picks
+# the right processor + exporter (``DatabricksUCTableSpanExporter`` when a
 # UC destination is present, ``MlflowV3SpanExporter`` otherwise).
 #
 # An earlier iteration of this file wrapped ``set_experiment`` in a

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -8706,8 +8706,17 @@ class AppModel(BaseModel):
         * ``experiment.id`` → ``MLFLOW_EXPERIMENT_ID`` (only when id is
           explicit at config-load; the ``name`` and auto-derive cases are
           resolved at deploy time in ``deploy_*_agent``).
-        * ``trace_location`` → ``MLFLOW_TRACING_DESTINATION`` /
-          ``MLFLOW_TRACING_SQL_WAREHOUSE_ID``.
+        * ``trace_location`` → ``MLFLOW_TRACING_SQL_WAREHOUSE_ID`` (documented).
+          ``MLFLOW_TRACING_DESTINATION`` is intentionally NOT set — Databricks
+          docs do not use it, and MLflow's ``_get_trace_location_from_env``
+          parses the ``<catalog>.<schema>`` string as legacy
+          ``UCSchemaLocation`` with the hardcoded default table name
+          ``mlflow_experiment_trace_otel_spans``, shadowing the correct
+          experiment-linked ``UnityCatalog`` (see docs.databricks.com/aws/en/
+          mlflow3/genai/tracing/trace-unity-catalog for the recommended
+          pattern). Trace-location routing at runtime relies on MLflow's
+          own fallback resolver reading the experiment's linked
+          ``UnityCatalog`` from the tracking store.
         """
         from dao_ai.utils import get_default_databricks_host
 
@@ -8730,10 +8739,6 @@ class AppModel(BaseModel):
             )
 
         if self.trace_location is not None:
-            self.environment_vars.setdefault(
-                "MLFLOW_TRACING_DESTINATION",
-                f"{self.trace_location.catalog_name}.{self.trace_location.schema_name}",
-            )
             self.environment_vars.setdefault(
                 "MLFLOW_TRACING_SQL_WAREHOUSE_ID",
                 self.trace_location.warehouse_id,

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -2231,9 +2231,15 @@ def test_vector_store_create_mode_detection():
 
 
 @pytest.mark.unit
-def test_set_databricks_env_vars_injects_trace_location_env_vars():
-    """Test that set_databricks_env_vars auto-injects MLFLOW_TRACING_DESTINATION
-    and MLFLOW_TRACING_SQL_WAREHOUSE_ID when trace_location is configured."""
+def test_set_databricks_env_vars_injects_warehouse_but_not_destination():
+    """`set_databricks_env_vars` auto-injects `MLFLOW_TRACING_SQL_WAREHOUSE_ID`
+    when `trace_location` is set, but NOT `MLFLOW_TRACING_DESTINATION` —
+    Databricks docs (docs.databricks.com/aws/en/mlflow3/genai/tracing/
+    trace-unity-catalog) do not use that env var, and MLflow's env-var
+    parser converts the 2-part string to legacy UCSchemaLocation with a
+    hardcoded default table name, shadowing the correct experiment-linked
+    UnityCatalog.
+    """
     from dao_ai.config import AppModel, SchemaModel, TraceLocationModel
 
     schema = SchemaModel(catalog_name="my_catalog", schema_name="my_schema")
@@ -2243,6 +2249,7 @@ def test_set_databricks_env_vars_injects_trace_location_env_vars():
     mock_app.environment_vars = {}
     mock_app.service_principal = None
     mock_app.trace_location = trace_loc
+    mock_app.experiment = None
 
     with patch(
         "dao_ai.utils.get_default_databricks_host",
@@ -2250,51 +2257,21 @@ def test_set_databricks_env_vars_injects_trace_location_env_vars():
     ):
         AppModel.set_databricks_env_vars(mock_app)
 
-    assert (
-        mock_app.environment_vars["MLFLOW_TRACING_DESTINATION"]
-        == "my_catalog.my_schema"
-    )
+    assert "MLFLOW_TRACING_DESTINATION" not in mock_app.environment_vars
     assert mock_app.environment_vars["MLFLOW_TRACING_SQL_WAREHOUSE_ID"] == "abc123"
 
 
 @pytest.mark.unit
-def test_set_databricks_env_vars_does_not_override_explicit_trace_vars():
-    """Test that explicit environment_vars for tracing take precedence."""
-    from dao_ai.config import AppModel, SchemaModel, TraceLocationModel
-
-    schema = SchemaModel(catalog_name="my_catalog", schema_name="my_schema")
-    trace_loc = TraceLocationModel(schema=schema, warehouse="abc123")
-
-    mock_app = MagicMock(spec=AppModel)
-    mock_app.environment_vars = {
-        "MLFLOW_TRACING_DESTINATION": "override_catalog.override_schema",
-        "MLFLOW_TRACING_SQL_WAREHOUSE_ID": "override_wh",
-    }
-    mock_app.service_principal = None
-    mock_app.trace_location = trace_loc
-
-    with patch(
-        "dao_ai.utils.get_default_databricks_host",
-        return_value="https://test.databricks.com",
-    ):
-        AppModel.set_databricks_env_vars(mock_app)
-
-    assert (
-        mock_app.environment_vars["MLFLOW_TRACING_DESTINATION"]
-        == "override_catalog.override_schema"
-    )
-    assert mock_app.environment_vars["MLFLOW_TRACING_SQL_WAREHOUSE_ID"] == "override_wh"
-
-
-@pytest.mark.unit
 def test_set_databricks_env_vars_no_trace_vars_without_trace_location():
-    """Test that MLFLOW_TRACING_DESTINATION is not set when trace_location is None."""
+    """When trace_location is unset, neither MLFLOW_TRACING_DESTINATION nor
+    MLFLOW_TRACING_SQL_WAREHOUSE_ID is injected."""
     from dao_ai.config import AppModel
 
     mock_app = MagicMock(spec=AppModel)
     mock_app.environment_vars = {}
     mock_app.service_principal = None
     mock_app.trace_location = None
+    mock_app.experiment = None
 
     with patch(
         "dao_ai.utils.get_default_databricks_host",


### PR DESCRIPTION
## Summary

- **Bug**: `AppModel.set_databricks_env_vars` injected `MLFLOW_TRACING_DESTINATION=<catalog>.<schema>` whenever `app.trace_location` was set. MLflow's `_get_trace_location_from_env` parsed this 2-part string as a legacy `UCSchemaLocation` with hardcoded default table name `mlflow_experiment_trace_otel_spans`, which shadowed the experiment-linked `UnityCatalog` that `_resolve_experiment_uc_location` would otherwise return. Net effect: OTEL spans routed to a non-existent legacy table on Apps + Model Serving.
- **Fix**: Stop injecting `MLFLOW_TRACING_DESTINATION`. Keep `MLFLOW_TRACING_SQL_WAREHOUSE_ID` (documented). MLflow's fallback resolver reads the experiment's linked `UnityCatalog` from the tracking store on first export.
- **Docs alignment**: Databricks docs at [trace-unity-catalog](https://docs.databricks.com/aws/en/mlflow3/genai/tracing/trace-unity-catalog) use only `MLFLOW_TRACING_SQL_WAREHOUSE_ID` + `mlflow.set_experiment(name, trace_location=UnityCatalog(...))`. No `MLFLOW_TRACING_DESTINATION` and no ContextVar manipulation.

## Files changed

- `src/dao_ai/config.py` — remove `MLFLOW_TRACING_DESTINATION` setdefault + docstring update
- `src/dao_ai/apps/handlers.py` — comment above existing `link_experiment_trace_location` call
- `src/dao_ai/apps/model_serving.py` — docstring update
- `tests/dao_ai/test_databricks.py` — assert `MLFLOW_TRACING_DESTINATION` NOT set; remove obsolete override test

## Test plan

- [x] Unit tests pass locally (trace-env-var tests updated; 3 tests fixed, no new failures)
- [x] Live matrix validated on FEVM — 6 fresh deployments:

| # | Surface | trace_location | table_prefix | Result |
|---|---|---|---|---|
| 1 | Apps | ✓ | (default `<exp_id>`) | 13 spans in `<exp>_otel_spans`, target trace matched |
| 2 | Apps | ✓ | `v2_apps_prefix` | 13 spans in `v2_apps_prefix_otel_spans`, target trace matched |
| 3 | Apps | ✗ | — | HTTP 200; control-plane persistence blocked by documented `us-east-1.storage.cloud.databricks.com` reachability gap (unrelated) |
| 4 | MS | ✓ | (default `<exp_id>`) | 25 spans, target trace = 12 spans |
| 5 | MS | ✓ | `v2_ms_prefix` | 30 spans in `v2_ms_prefix_otel_spans`, target trace = 12 spans |
| 6 | MS | ✗ | — | 2 traces landed in control-plane via `mlflow.search_traces` |

Zero `TABLE_DOES_NOT_EXIST` errors in any app logs post-fix.

This pull request and its description were written by Isaac.