### PR TITLE
feat(mcp): general notification handler replaces log-specific callback

### DIFF
--- a/docs/mcp-callbacks.md
+++ b/docs/mcp-callbacks.md
@@ -1,0 +1,112 @@
+# Surfacing MCP callbacks to the caller
+
+MCP servers can send `notifications/progress` and `notifications/message`
+while a tool call is running. dao-ai's client-side callbacks translate them
+into MLflow span events for post-hoc tracing **and** — when the tool is
+running under a streaming ResponsesAgent — forward normalized envelopes to
+the outer response stream so callers see in-flight status.
+
+## Configuration
+
+```yaml
+tools:
+  - name: genie_mcp
+    type: mcp
+    mcp_url: https://<workspace>/api/2.0/mcp/genie/<space>
+    capabilities:
+      progress: true      # opt into progress notifications
+      logging: info       # opt into log notifications ≥ info level
+```
+
+When either flag is set, dao-ai wires the corresponding MCP callback and
+begins dual-emitting envelopes to both MLflow spans and the outer stream.
+No separate stream-toggle: opting in via `progress`/`logging` opts in to
+both surfaces.
+
+## Wire format on the response stream
+
+Every progress or log notification the server emits becomes one
+`ResponsesAgentStreamEvent` on the SSE stream:
+
+```json
+{
+  "type": "response.output_item.added",
+  "item": {
+    "id": "mcp_<server>_<msg_id>_<seq>",
+    "type": "custom_tool_call",
+    "status": "in_progress",
+    "name": "mcp.progress",
+    "input": {
+      "channel": "mcp.progress",
+      "server_name": "genie",
+      "tool_name": "run_genie_query",
+      "progress": 0.3,
+      "total": 1.0,
+      "message": "Fetched 3/10 docs"
+    }
+  }
+}
+```
+
+Log envelopes use `"channel": "mcp.log"` plus `level`, `logger`, and
+`data` fields. The stable `id` shape (`mcp_<server>_<msg_id>_<seq>`) lets
+a UI overwrite same-line status updates idempotently.
+
+The event type (`response.output_item.added` with `status="in_progress"`)
+is the OpenAI Responses SSE convention. Any client that already renders
+Responses-API streams (Vercel AI SDK, OpenAI clients,
+e2e-chatbot-app-next) will surface these envelopes as generic status
+items without dao-ai-specific code.
+
+## Transport under the hood
+
+The MCP callback layer dispatches envelopes via **LangChain's callback
+manager**, not via LangGraph's `stream_mode="custom"` channel. `apredict_stream`
+attaches an `AsyncCallbackHandler` (`_McpEventCollector`) to
+`config["callbacks"]` before invoking `graph.astream(...)`. Tools inside
+the graph call `adispatch_custom_event(channel, envelope, config=...)`;
+the handler pushes envelopes onto a per-request `asyncio.Queue` that
+`apredict_stream` drains between astream chunks and yields as
+`response.output_item.added` events.
+
+This choice was empirically driven — the `get_stream_writer()` +
+`stream_mode="custom"` route silently drops writes when the tool lives
+inside a `create_agent`-built subgraph
+([LangGraph #6447](https://github.com/langchain-ai/langgraph/issues/6447)).
+The callback-manager route is proven end-to-end by langchain-core's own
+`test_custom_event_root_dispatch_with_in_tool` and doesn't share that
+propagation gap. See
+`/Users/nate.fleming/Documents/SSA-brain/40-reference/dao-ai/mcp-callback-streaming-2026-07-13.md`
+for the full analysis + citations.
+
+## Non-streaming (batch) fallback
+
+Non-streaming callers (batch `predict()`, `/invocations` with
+`stream: false`) do not receive individual events on the wire.
+`apredict_stream` additionally mirrors the full envelope timeline into
+`custom_outputs["mcp_events"]` on the final `response.output_item.done`
+event so a replay client can reconstruct what happened. Batch callers
+who want the timeline should hit the streaming endpoint once.
+
+## Elicitation
+
+`capabilities.elicitation: hitl` raises a LangGraph interrupt whose value
+carries `{"type": "mcp.elicitation", "server_name", "tool_name",
+"message", "requestedSchema"}`. That interrupt surfaces via the existing
+HITL path — `custom_outputs["interrupts"]` on the response — and resumes
+via `custom_inputs["decisions"]` on the next request. No additional
+stream plumbing.
+
+## MCP notifications currently wired
+
+| MCP notification              | Wired? | Channel        |
+|-------------------------------|--------|----------------|
+| `notifications/progress`      | Yes    | `mcp.progress` |
+| `notifications/message`       | Yes    | `mcp.log`      |
+| `elicitation/create`          | Yes    | HITL interrupt |
+| `sampling/createMessage`      | Yes    | AI Gateway     |
+| `roots/list`                  | Yes    | static config  |
+| `notifications/resources/*`   | Not wired — extensible via new callback class + channel |
+| `notifications/tools/*`       | Not wired |
+| `notifications/prompts/*`     | Not wired |
+| `notifications/cancelled`     | Not wired |

--- a/src/dao_ai/apps/handlers.py
+++ b/src/dao_ai/apps/handlers.py
@@ -90,6 +90,15 @@ if _experiment_id:
                 link_experiment_trace_location,
             )
 
+            # ``mlflow.set_experiment(experiment_id, trace_location=UC(...))``
+            # internally calls ``_sync_trace_destination_and_provider`` which
+            # populates the client-side ``_MLFLOW_TRACE_USER_DESTINATION``
+            # ContextVar. On re-deploys where the link is already in place,
+            # ``link_experiment_trace_location`` short-circuits — MLflow's
+            # own fallback resolver (``_resolve_experiment_uc_location``,
+            # provider.py:632) then reads the experiment's linked
+            # ``UnityCatalog`` from the tracking store on the first span
+            # export. No explicit ContextVar manipulation needed.
             link_experiment_trace_location(config, _experiment_id)
             # Also set the client-side ContextVar so the OTEL span exporter
             # picks the prefixed UC table. Without this, MLflow's env-var

--- a/src/dao_ai/apps/model_serving.py
+++ b/src/dao_ai/apps/model_serving.py
@@ -52,13 +52,16 @@ config.initialize()
 # are driven by env vars that ``agents.deploy()`` sets on the endpoint:
 #
 #   * ``MLFLOW_EXPERIMENT_ID`` — active experiment for autolog runs.
-#   * ``MLFLOW_TRACING_DESTINATION`` — UC schema for OTEL trace tables
-#     (set when ``config.app.trace_location`` is configured).
 #   * ``MLFLOW_TRACING_SQL_WAREHOUSE_ID`` — warehouse used for the
 #     UC-table export path.
 #
-# MLflow's ``_get_span_processors`` reads these directly and picks the
-# right processor + exporter (``DatabricksUCTableSpanExporter`` when a
+# ``MLFLOW_TRACING_DESTINATION`` is deliberately NOT set — it would parse
+# as a legacy ``UCSchemaLocation`` with hardcoded default table name
+# ``mlflow_experiment_trace_otel_spans`` and shadow the experiment-linked
+# UnityCatalog resolved via ``_resolve_experiment_uc_location``.
+#
+# MLflow's ``_get_span_processors`` reads the remaining env vars and picks
+# the right processor + exporter (``DatabricksUCTableSpanExporter`` when a
 # UC destination is present, ``MlflowV3SpanExporter`` otherwise).
 #
 # An earlier iteration of this file wrapped ``set_experiment`` in a

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -5532,9 +5532,9 @@ class McpCapabilitiesModel(BaseModel):
         default=False,
         description="Consume progress notifications from the MCP server; forward as MLflow span events on the enclosing tool span.",
     )
-    logging: Optional[Literal["debug", "info", "warning", "error"]] = Field(
-        default=None,
-        description="Subscribe to server logging/message notifications at this minimum level; forward as MLflow span events. None disables the capability.",
+    logging: bool = Field(
+        default=False,
+        description="Consume server-→-client notifications via a session-scoped message_handler and advertise MCP's 'logging' capability so the server emits notifications/message frames. Forwards every notification (notifications/message and any custom notifications/<method>) as a channel-tagged envelope; notifications/progress is routed through the progress callback and skipped here to avoid duplicate emission.",
     )
     elicitation: Optional[Literal["hitl", "reject"]] = Field(
         default=None,

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -8916,8 +8916,17 @@ class AppModel(BaseModel):
         * ``experiment.id`` → ``MLFLOW_EXPERIMENT_ID`` (only when id is
           explicit at config-load; the ``name`` and auto-derive cases are
           resolved at deploy time in ``deploy_*_agent``).
-        * ``trace_location`` → ``MLFLOW_TRACING_DESTINATION`` /
-          ``MLFLOW_TRACING_SQL_WAREHOUSE_ID``.
+        * ``trace_location`` → ``MLFLOW_TRACING_SQL_WAREHOUSE_ID`` (documented).
+          ``MLFLOW_TRACING_DESTINATION`` is intentionally NOT set — Databricks
+          docs do not use it, and MLflow's ``_get_trace_location_from_env``
+          parses the ``<catalog>.<schema>`` string as legacy
+          ``UCSchemaLocation`` with the hardcoded default table name
+          ``mlflow_experiment_trace_otel_spans``, shadowing the correct
+          experiment-linked ``UnityCatalog`` (see docs.databricks.com/aws/en/
+          mlflow3/genai/tracing/trace-unity-catalog for the recommended
+          pattern). Trace-location routing at runtime relies on MLflow's
+          own fallback resolver reading the experiment's linked
+          ``UnityCatalog`` from the tracking store.
         """
         from dao_ai.utils import get_default_databricks_host
 
@@ -8940,10 +8949,6 @@ class AppModel(BaseModel):
             )
 
         if self.trace_location is not None:
-            self.environment_vars.setdefault(
-                "MLFLOW_TRACING_DESTINATION",
-                f"{self.trace_location.catalog_name}.{self.trace_location.schema_name}",
-            )
             self.environment_vars.setdefault(
                 "MLFLOW_TRACING_SQL_WAREHOUSE_ID",
                 self.trace_location.warehouse_id,

--- a/src/dao_ai/models.py
+++ b/src/dao_ai/models.py
@@ -1,7 +1,9 @@
+import asyncio
 import json
 import uuid
 from os import PathLike
 from pathlib import Path
+from uuid import UUID
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -31,6 +33,7 @@ from langchain.agents.middleware.human_in_the_loop import (
     RespondDecision,
     ReviewConfig,
 )
+from langchain_core.callbacks import AsyncCallbackHandler
 from langchain_core.language_models import LanguageModelLike
 from langchain_core.messages import (
     AIMessage,
@@ -1353,6 +1356,68 @@ class LanggraphResponsesAgent(ResponsesAgent):
         seen_interrupt_keys: set[str] = set()
         structured_response: Any = None
 
+        # MCP notification envelopes captured from tools via LangChain's
+        # callback manager. A per-request AsyncCallbackHandler is attached
+        # to ``custom_inputs["callbacks"]`` below; tools call
+        # ``adispatch_custom_event(channel, envelope)`` and our handler
+        # pushes them onto ``mcp_event_queue``. The outer astream loop
+        # drains the queue between chunks and yields
+        # ``response.output_item.added(status="in_progress")`` events;
+        # the same envelopes accumulate into ``custom_outputs["mcp_events"]``
+        # for non-streaming replay.
+        mcp_event_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        mcp_event_buffer: list[dict[str, Any]] = []
+        mcp_event_seq: int = 0
+
+        class _McpEventCollector(AsyncCallbackHandler):
+            def __init__(self, queue: asyncio.Queue[dict[str, Any]]) -> None:
+                self._queue = queue
+
+            async def on_custom_event(
+                self,
+                name: str,
+                data: Any,
+                *,
+                run_id: UUID,
+                tags: list[str] | None = None,
+                metadata: dict[str, Any] | None = None,
+                **kwargs: Any,
+            ) -> None:
+                if not isinstance(data, dict):
+                    return
+                channel = data.get("channel")
+                if not isinstance(channel, str) or not channel.startswith("mcp."):
+                    return
+                await self._queue.put(data)
+
+        _mcp_collector = _McpEventCollector(mcp_event_queue)
+        # Merge our handler into any callbacks the caller already provided.
+        existing_callbacks = custom_inputs.get("callbacks") or []
+        if not isinstance(existing_callbacks, list):
+            existing_callbacks = [existing_callbacks]
+        custom_inputs["callbacks"] = [*existing_callbacks, _mcp_collector]
+
+        async def _drain_mcp_queue() -> (
+            AsyncGenerator[ResponsesAgentStreamEvent, None]
+        ):
+            nonlocal mcp_event_seq
+            while not mcp_event_queue.empty():
+                envelope = mcp_event_queue.get_nowait()
+                mcp_event_buffer.append(envelope)
+                mcp_event_seq += 1
+                channel = str(envelope.get("channel", "mcp.event"))
+                server_name = str(envelope.get("server_name", "unknown"))
+                yield ResponsesAgentStreamEvent(
+                    type="response.output_item.added",
+                    item={
+                        "id": f"mcp_{server_name}_{item_id}_{mcp_event_seq}",
+                        "type": "custom_tool_call",
+                        "status": "in_progress",
+                        "name": channel,
+                        "input": envelope,
+                    },
+                )
+
         try:
             turn = await decide_graph_turn(
                 graph=self.graph,
@@ -1393,6 +1458,11 @@ class LanggraphResponsesAgent(ResponsesAgent):
                 ):
                     nodes: tuple[str, ...]
                     stream_mode: str
+
+                    # Surface any MCP envelopes the collector received while
+                    # the astream generator was awaiting this chunk.
+                    async for evt in _drain_mcp_queue():
+                        yield evt
 
                     if stream_mode == "messages":
                         messages_batch: Sequence[BaseMessage] = data
@@ -1492,6 +1562,17 @@ class LanggraphResponsesAgent(ResponsesAgent):
             trace_id = mlflow.get_active_trace_id()
             if trace_id:
                 custom_outputs["trace_id"] = trace_id
+
+            # Drain any envelopes that arrived after the last astream chunk
+            # (MCP notifications from tool completion often race the astream
+            # generator's exit).
+            async for evt in _drain_mcp_queue():
+                yield evt
+
+            # Mirror MCP notification envelopes into custom_outputs so
+            # non-streaming replays and batch callers see the same timeline.
+            if mcp_event_buffer:
+                custom_outputs["mcp_events"] = mcp_event_buffer
 
             # Extract visualization specs from tool messages collected during streaming
             visualizations: list[dict[str, Any]] = (

--- a/src/dao_ai/tools/mcp.py
+++ b/src/dao_ai/tools/mcp.py
@@ -313,8 +313,11 @@ def _build_mcp_client(
     pre-0.3.0 ``ToolException`` semantics that dao-ai's agent loop relies on.
 
     When ``function.capabilities`` is set, additionally attaches:
-    - ``Callbacks(on_progress=..., on_logging_message=..., on_elicitation=...)``
-      for the enabled server-→-client notifications.
+    - ``Callbacks(on_progress=..., on_elicitation=...)`` for per-call
+      progress notifications and server-initiated elicitation.
+    - A session-scoped ``message_handler`` (via ``session_kwargs`` on the
+      connection config) that forwards every server notification. Enabled
+      by ``caps.logging``.
     - ``tool_interceptors=[DaoAiTraceInterceptor, ...]`` for MLflow correlation
       and (optionally) structured-output observation.
 
@@ -322,18 +325,20 @@ def _build_mcp_client(
     when at least one capability is enabled, keeping the classic import graph
     unchanged.
     """
-    connections = {"mcp_function": _build_connection_config(function, context)}
+    connection = _build_connection_config(function, context)
 
     caps = function.capabilities
     if caps is None:
-        return MultiServerMCPClient(connections, handle_tool_errors=False)
+        return MultiServerMCPClient(
+            {"mcp_function": connection}, handle_tool_errors=False
+        )
 
     from langchain_mcp_adapters.callbacks import Callbacks
     from langchain_mcp_adapters.interceptors import ToolCallInterceptor
 
     from dao_ai.tools.mcp_callbacks import (
         DaoAiElicitationCallback,
-        DaoAiLoggingCallback,
+        DaoAiNotificationCallback,
         DaoAiProgressCallback,
     )
     from dao_ai.tools.mcp_interceptors import (
@@ -342,23 +347,31 @@ def _build_mcp_client(
     )
 
     on_progress = DaoAiProgressCallback() if caps.progress else None
-    on_logging = DaoAiLoggingCallback(caps.logging) if caps.logging else None
     on_elicit = DaoAiElicitationCallback(caps.elicitation) if caps.elicitation else None
 
     callbacks: Callbacks | None = None
-    if any([on_progress, on_logging, on_elicit]):
+    if any([on_progress, on_elicit]):
         callbacks = Callbacks(
-            on_logging_message=on_logging,
             on_progress=on_progress,
             on_elicitation=on_elicit,
         )
+
+    if caps.logging:
+        # langchain-mcp-adapters' ``Callbacks`` has no slot for a general
+        # message_handler; inject it via session_kwargs, which sessions.py
+        # forwards to ``ClientSession(read, write, **session_kwargs)``.
+        session_kwargs = dict(connection.get("session_kwargs") or {})
+        session_kwargs["message_handler"] = DaoAiNotificationCallback(
+            server_name="mcp_function"
+        )
+        connection["session_kwargs"] = session_kwargs
 
     interceptors: list[ToolCallInterceptor] = [DaoAiTraceInterceptor()]
     if caps.structured_output:
         interceptors.append(DaoAiStructuredOutputInterceptor())
 
     return MultiServerMCPClient(
-        connections,
+        {"mcp_function": connection},
         callbacks=callbacks,
         tool_interceptors=interceptors,
         handle_tool_errors=False,

--- a/src/dao_ai/tools/mcp_callbacks.py
+++ b/src/dao_ai/tools/mcp_callbacks.py
@@ -1,5 +1,5 @@
 """MCP client-side callbacks that bridge server-initiated notifications
-into dao-ai's observability + HITL surfaces.
+into dao-ai's observability + client-stream surfaces.
 
 Wired into ``langchain_mcp_adapters.callbacks.Callbacks`` when an
 ``McpFunctionModel`` declares an ``McpCapabilitiesModel``. When capabilities
@@ -9,6 +9,28 @@ The three callables here match the ``LoggingMessageCallback``,
 ``ProgressCallback``, and ``ElicitationCallback`` Protocols defined by
 ``langchain-mcp-adapters`` 0.3.0. Each is a class (not a closure) so its
 name surfaces in MLflow trace spans.
+
+Notification transport
+----------------------
+Each MCP notification is dual-emitted:
+
+1. **MLflow span** — via :func:`_add_span_event`, for post-hoc tracing.
+2. **LangChain callback manager** — via :func:`_dispatch_custom_event`
+   which wraps ``langchain_core.callbacks.adispatch_custom_event``.
+
+The callback-manager path is the LangChain-native mechanism to surface
+events from inside a tool up through ``create_agent``'s ToolNode to a
+callback handler attached on the outer ``RunnableConfig``. Any
+``AsyncCallbackHandler`` registered at ``graph.astream(config={"callbacks":
+[handler]})`` time receives ``on_custom_event(name, data, ...)`` calls for
+each envelope.
+
+We use this in place of ``langgraph.config.get_stream_writer()`` because
+the LangGraph streaming system (``stream_mode="custom"``) has open issue
+#6447 — writes made from inside a create_agent subgraph don't bubble up to
+the outer ``astream``'s custom channel. The callback-manager path is
+proven end-to-end by langchain-core's own test
+``test_custom_event_root_dispatch_with_in_tool``.
 """
 
 from __future__ import annotations
@@ -16,6 +38,8 @@ from __future__ import annotations
 from typing import Any, Literal, Optional
 
 import mlflow
+from langchain_core.callbacks import adispatch_custom_event
+from langchain_core.runnables.config import RunnableConfig, ensure_config
 from langchain_mcp_adapters.callbacks import CallbackContext
 from langgraph.types import interrupt as langgraph_interrupt
 from loguru import logger
@@ -39,19 +63,97 @@ _LOG_LEVEL_ORDER: dict[str, int] = {
 
 
 def _add_span_event(name: str, attributes: dict[str, Any]) -> None:
-    """Add an event to the currently active MLflow span. Silent when no span."""
+    """Add an event to the currently active MLflow span. Silent when no span.
+
+    MLflow's ``LiveSpan.add_event`` takes a single ``SpanEvent`` object
+    (``mlflow/entities/span.py`` — ``def add_event(self, event: SpanEvent)``).
+    Constructing the SpanEvent here keeps the caller-side ergonomics
+    ``(name, attributes)`` intact.
+    """
     span = mlflow.get_current_active_span()
     if span is None:
         return
     try:
-        span.add_event(name, attributes=attributes)
+        from mlflow.entities import SpanEvent
+
+        span.add_event(SpanEvent(name=name, attributes=attributes))
     except Exception as exc:
         logger.debug(f"mcp callback: failed to add span event {name!r}: {exc}")
 
 
+def capture_runnable_config() -> RunnableConfig | None:
+    """Capture the current LangChain ``RunnableConfig`` for later use.
+
+    Called at callback-construction time (in the tool wrapper's task, which
+    inherited the outer graph's ``var_child_runnable_config`` ContextVar).
+    The returned config is passed explicitly to ``adispatch_custom_event``
+    when the MCP client's background listener task fires our callback —
+    that background task may not have the ContextVar, so we can't rely on
+    ``ensure_config(None)`` inside the callback.
+
+    Returns None outside a runnable context (e.g. batch predict without a
+    graph.astream, or import-time construction) — callers should treat that
+    as "no client forwarding; MLflow span events only".
+    """
+    try:
+        cfg = ensure_config(None)
+    except Exception:
+        return None
+    # ensure_config always returns a valid dict; treat empty ``callbacks`` as
+    # "no handlers registered" — dispatching would still be safe but a no-op.
+    return cfg
+
+
+async def _dispatch_custom_event(
+    channel: str,
+    envelope: dict[str, Any],
+    config: RunnableConfig | None,
+) -> None:
+    """Dispatch an MCP envelope via LangChain's callback manager.
+
+    Any ``AsyncCallbackHandler`` registered on the outer runnable's config
+    receives ``on_custom_event(channel, envelope, ...)``.
+    """
+    if config is None:
+        return
+    try:
+        await adispatch_custom_event(channel, envelope, config=config)
+    except Exception as exc:
+        logger.debug(
+            f"mcp callback: failed to dispatch {channel!r} custom event: {exc}"
+        )
+
+
+async def _emit(
+    span_event_name: str,
+    envelope: dict[str, Any],
+    config: RunnableConfig | None,
+) -> None:
+    """Dual-emit an MCP notification envelope to MLflow span + callback manager.
+
+    The span event uses the canonical ``mcp.progress`` / ``mcp.log.<level>``
+    name; the callback-manager event uses the ``channel`` field of the
+    envelope (``mcp.progress`` / ``mcp.log``). Both receive the same
+    envelope so downstream consumers see identical shape.
+    """
+    _add_span_event(span_event_name, envelope)
+    await _dispatch_custom_event(envelope["channel"], envelope, config)
+
+
 class DaoAiProgressCallback:
     """Forwards MCP ``notifications/progress`` to the active MLflow span
-    as ``mcp.progress`` events."""
+    and — when a callback handler is registered on the outer runnable —
+    to that handler as an ``on_custom_event("mcp.progress", envelope)``.
+
+    The RunnableConfig is captured at construction time (in the tool
+    wrapper's task, which has the outer ContextVar). MCP client notifications
+    fire in a background listener task where that ContextVar may not be
+    inherited, so we pass the captured config explicitly to
+    ``adispatch_custom_event``.
+    """
+
+    def __init__(self) -> None:
+        self._config = capture_runnable_config()
 
     async def __call__(
         self,
@@ -60,25 +162,33 @@ class DaoAiProgressCallback:
         message: str | None,
         context: CallbackContext,
     ) -> None:
-        _add_span_event(
-            "mcp.progress",
-            {
-                "mcp.server_name": context.server_name,
-                "mcp.tool_name": context.tool_name or "",
-                "mcp.progress": progress,
-                "mcp.total": total if total is not None else -1.0,
-                "mcp.message": message or "",
-            },
-        )
+        envelope: dict[str, Any] = {
+            "channel": "mcp.progress",
+            "server_name": context.server_name,
+            "tool_name": context.tool_name or "",
+            "progress": progress,
+            "total": total if total is not None else -1.0,
+            "message": message or "",
+        }
+        await _emit("mcp.progress", envelope, self._config)
 
 
 class DaoAiLoggingCallback:
     """Forwards MCP ``notifications/message`` to the active MLflow span
-    as ``mcp.log.<level>`` events. Records below ``min_level`` are dropped."""
+    and — when a callback handler is registered on the outer runnable —
+    to that handler as an ``on_custom_event("mcp.log", envelope)``. Records
+    below ``min_level`` are dropped.
 
-    def __init__(self, min_level: Literal["debug", "info", "warning", "error"]) -> None:
+    Config capture semantics match ``DaoAiProgressCallback``.
+    """
+
+    def __init__(
+        self,
+        min_level: Literal["debug", "info", "warning", "error"],
+    ) -> None:
         self.min_level = min_level
         self._min_severity = _LOG_LEVEL_ORDER[min_level]
+        self._config = capture_runnable_config()
 
     async def __call__(
         self,
@@ -89,15 +199,15 @@ class DaoAiLoggingCallback:
         severity = _LOG_LEVEL_ORDER.get(level, 20)
         if severity < self._min_severity:
             return
-        _add_span_event(
-            f"mcp.log.{level}",
-            {
-                "mcp.server_name": context.server_name,
-                "mcp.tool_name": context.tool_name or "",
-                "mcp.logger": params.logger or "",
-                "mcp.data": str(params.data)[:2000],
-            },
-        )
+        envelope: dict[str, Any] = {
+            "channel": "mcp.log",
+            "server_name": context.server_name,
+            "tool_name": context.tool_name or "",
+            "level": level,
+            "logger": params.logger or "",
+            "data": str(params.data)[:2000],
+        }
+        await _emit(f"mcp.log.{level}", envelope, self._config)
 
 
 class DaoAiElicitationCallback:

--- a/src/dao_ai/tools/mcp_callbacks.py
+++ b/src/dao_ai/tools/mcp_callbacks.py
@@ -1,18 +1,28 @@
 """MCP client-side callbacks that bridge server-initiated notifications
 into dao-ai's observability + client-stream surfaces.
 
-Wired into ``langchain_mcp_adapters.callbacks.Callbacks`` when an
-``McpFunctionModel`` declares an ``McpCapabilitiesModel``. When capabilities
-is absent the classic path skips this module entirely.
+Three callables live here:
 
-The three callables here match the ``LoggingMessageCallback``,
-``ProgressCallback``, and ``ElicitationCallback`` Protocols defined by
-``langchain-mcp-adapters`` 0.3.0. Each is a class (not a closure) so its
-name surfaces in MLflow trace spans.
+* :class:`DaoAiProgressCallback` — call-scoped MCP ``progress_callback``
+  matching ``ProgressCallback`` from ``langchain-mcp-adapters`` 0.3.0.
+  Progress notifications are correlated to a specific tool call via
+  ``progressToken``, so the SDK's per-call callback is the right hook.
+* :class:`DaoAiNotificationCallback` — session-scoped MCP
+  ``MessageHandlerFnT`` (``mcp.client.session.MessageHandlerFnT``).
+  Receives *every* incoming server message and forwards notifications
+  (except progress, which is handled by the callback above to avoid
+  duplicate emission). Replaces the earlier ``DaoAiLoggingCallback`` —
+  ``notifications/message`` is a strict subset of the notification stream,
+  and a generic handler captures any custom notification a server chooses
+  to emit.
+* :class:`DaoAiElicitationCallback` — server→client
+  ``elicitation/create`` handler.
+
+Each is a class (not a closure) so its name surfaces in MLflow trace spans.
 
 Notification transport
 ----------------------
-Each MCP notification is dual-emitted:
+Each notification we forward is dual-emitted:
 
 1. **MLflow span** — via :func:`_add_span_event`, for post-hoc tracing.
 2. **LangChain callback manager** — via :func:`_dispatch_custom_event`
@@ -35,7 +45,7 @@ proven end-to-end by langchain-core's own test
 
 from __future__ import annotations
 
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 import mlflow
 from langchain_core.callbacks import adispatch_custom_event
@@ -44,22 +54,14 @@ from langchain_mcp_adapters.callbacks import CallbackContext
 from langgraph.types import interrupt as langgraph_interrupt
 from loguru import logger
 from mcp.shared.context import RequestContext as MCPRequestContext
+from mcp.shared.session import RequestResponder
 from mcp.types import (
     ElicitRequestParams,
     ElicitResult,
-    LoggingMessageNotificationParams,
+    LoggingMessageNotification,
+    ProgressNotification,
+    ServerNotification,
 )
-
-_LOG_LEVEL_ORDER: dict[str, int] = {
-    "debug": 10,
-    "info": 20,
-    "notice": 20,
-    "warning": 30,
-    "error": 40,
-    "critical": 50,
-    "alert": 50,
-    "emergency": 50,
-}
 
 
 def _add_span_event(name: str, attributes: dict[str, Any]) -> None:
@@ -173,41 +175,102 @@ class DaoAiProgressCallback:
         await _emit("mcp.progress", envelope, self._config)
 
 
-class DaoAiLoggingCallback:
-    """Forwards MCP ``notifications/message`` to the active MLflow span
-    and — when a callback handler is registered on the outer runnable —
-    to that handler as an ``on_custom_event("mcp.log", envelope)``. Records
-    below ``min_level`` are dropped.
+class DaoAiNotificationCallback:
+    """Session-scoped MCP ``MessageHandlerFnT`` — forwards every server
+    notification to the active MLflow span and (when a callback handler is
+    registered on the outer runnable) to that handler as an
+    ``on_custom_event(channel, envelope, ...)``.
 
-    Config capture semantics match ``DaoAiProgressCallback``.
+    Fully generic. The channel is the MCP method name mapped from
+    ``notifications/<x>/<y>`` to ``mcp.<x>.<y>``, and the envelope carries the
+    raw params dict — no notification-type-specific extraction. Custom
+    server-defined notifications are forwarded on the same path as spec
+    notifications.
+
+    ``notifications/progress`` is intentionally skipped here — progress is
+    correlated to a specific tool call via ``progressToken`` and handled by
+    :class:`DaoAiProgressCallback` (per-call, from the langchain-mcp-adapters
+    ``on_progress`` slot) to preserve tool-call correlation and avoid
+    duplicate emission.
+
+    The handler ignores request-responder frames (elicitation/sampling are
+    routed by the SDK to their own callbacks) and logs exceptions at debug.
+
+    Config capture semantics match :class:`DaoAiProgressCallback`.
     """
 
-    def __init__(
-        self,
-        min_level: Literal["debug", "info", "warning", "error"],
-    ) -> None:
-        self.min_level = min_level
-        self._min_severity = _LOG_LEVEL_ORDER[min_level]
+    def __init__(self, server_name: str = "mcp_function") -> None:
+        self._server_name = server_name
         self._config = capture_runnable_config()
 
     async def __call__(
         self,
-        params: LoggingMessageNotificationParams,
-        context: CallbackContext,
+        message: RequestResponder[Any, Any] | ServerNotification | Exception,
     ) -> None:
-        level = str(params.level).lower()
-        severity = _LOG_LEVEL_ORDER.get(level, 20)
-        if severity < self._min_severity:
+        if isinstance(message, Exception):
+            logger.debug(f"mcp notification handler: transport error {message!r}")
             return
+        if not isinstance(message, ServerNotification):
+            # Request-responder frames (e.g. elicitation/create,
+            # sampling/createMessage) are handled by the SDK's dedicated
+            # request handlers — nothing to forward here.
+            return
+
+        root = message.root
+        method: str = getattr(root, "method", "") or ""
+
+        # Progress goes through DaoAiProgressCallback (per-call,
+        # progressToken-scoped) to preserve tool-call correlation.
+        if isinstance(root, ProgressNotification):
+            return
+
+        params_obj = getattr(root, "params", None)
+        if params_obj is None:
+            params_dict: dict[str, Any] = {}
+        elif hasattr(params_obj, "model_dump"):
+            params_dict = params_obj.model_dump(exclude_none=True)
+        else:
+            params_dict = dict(params_obj) if isinstance(params_obj, dict) else {}
+
+        channel = _method_to_channel(method)
         envelope: dict[str, Any] = {
-            "channel": "mcp.log",
-            "server_name": context.server_name,
-            "tool_name": context.tool_name or "",
-            "level": level,
-            "logger": params.logger or "",
-            "data": str(params.data)[:2000],
+            "channel": channel,
+            "method": method,
+            "server_name": self._server_name,
+            "params": params_dict,
         }
-        await _emit(f"mcp.log.{level}", envelope, self._config)
+        # For notifications/message, MCP guarantees `level` and `data` on
+        # params (spec) with optional `logger`. Lift them to top-level so
+        # consumers can route on level without inspecting params. No
+        # server-side filter is applied — every level flows through.
+        if isinstance(root, LoggingMessageNotification):
+            envelope["level"] = str(root.params.level).lower()
+            envelope["logger"] = root.params.logger or ""
+            envelope["data"] = str(root.params.data)[:2000]
+
+        await _emit(channel, envelope, self._config)
+
+
+def _method_to_channel(method: str) -> str:
+    """Map an MCP notification method to a channel name.
+
+    * ``notifications/message`` → ``mcp.log`` (the MCP ``logging`` capability
+      — the method is called ``message`` but the semantic is a log record).
+    * ``notifications/<x>/<y>`` → ``mcp.<x>.<y>`` for every other spec or
+      custom notification.
+
+    Distinct channels let downstream consumers route logs to a log stream
+    and other notifications to a general notification stream without
+    inspecting envelope contents.
+    """
+    if not method:
+        return "mcp.unknown"
+    if method == "notifications/message":
+        return "mcp.log"
+    if method.startswith("notifications/"):
+        suffix = method[len("notifications/") :].replace("/", ".")
+        return f"mcp.{suffix}"
+    return f"mcp.{method}"
 
 
 class DaoAiElicitationCallback:

--- a/src/dao_ai/tools/mcp_sampling.py
+++ b/src/dao_ai/tools/mcp_sampling.py
@@ -39,7 +39,6 @@ from mcp.types import (
     CreateMessageResult,
     ErrorData,
     ListRootsResult,
-    LoggingMessageNotificationParams,
     Root,
     SamplingMessage,
     TextContent,
@@ -53,7 +52,7 @@ from dao_ai.config import (
 )
 from dao_ai.state import Context as DaoAiContext
 from dao_ai.tools.mcp_callbacks import (
-    _LOG_LEVEL_ORDER,
+    DaoAiNotificationCallback,
     _emit,
     capture_runnable_config,
 )
@@ -107,35 +106,13 @@ class _RawProgressAdapter:
         await _emit("mcp.progress", envelope, self._config)
 
 
-class _RawLoggingAdapter:
-    """MCP ``LoggingFnT`` adapter that mirrors ``DaoAiLoggingCallback``.
-
-    Config capture semantics match ``_RawProgressAdapter``.
-    """
-
-    def __init__(
-        self,
-        server_name: str,
-        min_level: str,
-    ) -> None:
-        self._server_name = server_name
-        self._min_severity = _LOG_LEVEL_ORDER[min_level]
-        self._config = capture_runnable_config()
-
-    async def __call__(self, params: LoggingMessageNotificationParams) -> None:
-        level = str(params.level).lower()
-        severity = _LOG_LEVEL_ORDER.get(level, 20)
-        if severity < self._min_severity:
-            return
-        envelope: dict[str, Any] = {
-            "channel": "mcp.log",
-            "server_name": self._server_name,
-            "tool_name": "",
-            "level": level,
-            "logger": params.logger or "",
-            "data": str(params.data)[:2000],
-        }
-        await _emit(f"mcp.log.{level}", envelope, self._config)
+# ---------------------------------------------------------------------------
+# Notification handling on the raw ClientSession path
+#
+# The raw path uses ``mcp.ClientSession(message_handler=...)`` directly, and
+# ``DaoAiNotificationCallback`` (from ``mcp_callbacks``) is a MessageHandlerFnT
+# out of the box — no local adapter needed.
+# ---------------------------------------------------------------------------
 
 
 # ---------------------------------------------------------------------------
@@ -502,16 +479,13 @@ async def _open_session(
     caps = function.capabilities
     sampling_cb: DaoAiSamplingCallback | None = None
     roots_cb: DaoAiListRootsCallback | None = None
-    logging_cb: _RawLoggingAdapter | None = None
+    message_handler: DaoAiNotificationCallback | None = None
     if caps and caps.sampling:
         sampling_cb = DaoAiSamplingCallback(function)
     if caps and caps.roots:
         roots_cb = DaoAiListRootsCallback(function)
     if caps and caps.logging:
-        logging_cb = _RawLoggingAdapter(
-            server_name="mcp_function",
-            min_level=caps.logging,
-        )
+        message_handler = DaoAiNotificationCallback(server_name="mcp_function")
 
     async with AsyncExitStack() as stack:
         read_stream, write_stream, _ = await stack.enter_async_context(
@@ -523,7 +497,7 @@ async def _open_session(
                 write_stream,
                 sampling_callback=sampling_cb,
                 list_roots_callback=roots_cb,
-                logging_callback=logging_cb,
+                message_handler=message_handler,
             )
         )
         await session.initialize()

--- a/src/dao_ai/tools/mcp_sampling.py
+++ b/src/dao_ai/tools/mcp_sampling.py
@@ -39,6 +39,7 @@ from mcp.types import (
     CreateMessageResult,
     ErrorData,
     ListRootsResult,
+    LoggingMessageNotificationParams,
     Root,
     SamplingMessage,
     TextContent,
@@ -48,8 +49,93 @@ from mcp.types import (
 from dao_ai.config import (
     McpCapabilitiesModel,
     McpFunctionModel,
+    value_of,
 )
 from dao_ai.state import Context as DaoAiContext
+from dao_ai.tools.mcp_callbacks import (
+    _LOG_LEVEL_ORDER,
+    _emit,
+    capture_runnable_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# Raw-MCP progress + logging adapters
+#
+# ``langchain-mcp-adapters`` supplies a ``CallbackContext`` (with server_name /
+# tool_name) to its ``Callbacks`` protocol. The raw ``mcp.client.session``
+# hooks have no such context object — ``LoggingFnT`` takes ``(params,)`` and
+# ``ProgressFnT`` takes ``(progress, total, message)``. These thin wrappers
+# build the same normalized envelope used by ``dao_ai.tools.mcp_callbacks``
+# and dispatch through the shared ``_emit`` helper so span events + outer
+# stream events look identical across the MultiServer path and the raw
+# ClientSession path.
+# ---------------------------------------------------------------------------
+
+
+class _RawProgressAdapter:
+    """MCP ``ProgressFnT`` adapter that mirrors ``DaoAiProgressCallback``.
+
+    Captures the outer RunnableConfig at construction time so background
+    MCP listener tasks can dispatch through LangChain's callback manager
+    even when their own ContextVar has drifted.
+    """
+
+    def __init__(
+        self,
+        server_name: str,
+        tool_name: str,
+    ) -> None:
+        self._server_name = server_name
+        self._tool_name = tool_name
+        self._config = capture_runnable_config()
+
+    async def __call__(
+        self,
+        progress: float,
+        total: float | None,
+        message: str | None,
+    ) -> None:
+        envelope: dict[str, Any] = {
+            "channel": "mcp.progress",
+            "server_name": self._server_name,
+            "tool_name": self._tool_name,
+            "progress": progress,
+            "total": total if total is not None else -1.0,
+            "message": message or "",
+        }
+        await _emit("mcp.progress", envelope, self._config)
+
+
+class _RawLoggingAdapter:
+    """MCP ``LoggingFnT`` adapter that mirrors ``DaoAiLoggingCallback``.
+
+    Config capture semantics match ``_RawProgressAdapter``.
+    """
+
+    def __init__(
+        self,
+        server_name: str,
+        min_level: str,
+    ) -> None:
+        self._server_name = server_name
+        self._min_severity = _LOG_LEVEL_ORDER[min_level]
+        self._config = capture_runnable_config()
+
+    async def __call__(self, params: LoggingMessageNotificationParams) -> None:
+        level = str(params.level).lower()
+        severity = _LOG_LEVEL_ORDER.get(level, 20)
+        if severity < self._min_severity:
+            return
+        envelope: dict[str, Any] = {
+            "channel": "mcp.log",
+            "server_name": self._server_name,
+            "tool_name": "",
+            "level": level,
+            "logger": params.logger or "",
+            "data": str(params.data)[:2000],
+        }
+        await _emit(f"mcp.log.{level}", envelope, self._config)
 
 
 # ---------------------------------------------------------------------------
@@ -309,11 +395,18 @@ async def acreate_mcp_tools_with_sampling(
                 ResourceInfo("mcp", auth_resource.on_behalf_of_user, mcp_tool.name)
             )
             context: DaoAiContext | None = runtime.context if runtime else None
+            caps = function.capabilities
+            call_kwargs: dict[str, Any] = {"meta": _resolve_meta(function.meta)}
+            if caps and caps.progress:
+                call_kwargs["progress_callback"] = _RawProgressAdapter(
+                    server_name="mcp_function",
+                    tool_name=mcp_tool.name,
+                )
             async with _open_session(function, context=context) as session:
                 result: CallToolResult = await session.call_tool(
                     mcp_tool.name,
                     kwargs,
-                    meta=_resolve_meta(function.meta),
+                    **call_kwargs,
                 )
                 return _extract_text_content(result)
 
@@ -349,31 +442,47 @@ async def _open_session(
     # challenge whose ``WWW-Authenticate`` shape ``DatabricksOAuthClientProvider``
     # doesn't reliably parse — the follow-up token exchange emits a URL with
     # a missing scheme and httpcore raises ``UnsupportedProtocol``.
-    # Workaround: for App URLs, resolve a bearer token from the AMBIENT
-    # ``WorkspaceClient()`` (the caller App's runtime SP — the identity the
-    # target app grants CAN_USE to) and inject it as an ``Authorization``
-    # header, bypassing the OAuth challenge path entirely. The managed MCP
-    # endpoints on the workspace host (``/api/2.0/mcp/...``) keep the OAuth
-    # provider since those are authenticated via the function-scoped SP.
+    # Workaround: for App URLs, resolve a bearer token from the
+    # **resource-scoped** ``WorkspaceClient`` (i.e. the SP declared on the
+    # McpFunctionModel via ``client_id`` / ``client_secret`` / ``workspace_host``,
+    # or on a nested ``app`` / ``connection`` resource) and inject it as an
+    # ``Authorization`` header, bypassing the OAuth challenge path entirely.
+    #
+    # Using the resource-scoped SP (not ambient) matters on Model Serving:
+    # the MS-created ambient SP is a "System Service Principal" that
+    # cannot be granted CAN_USE on a Databricks App via the standard
+    # permissions API (Databricks IAM constraint, verified with the
+    # Model Serving team — SSPs are not exposed as regular grantable
+    # principals). The resource-scoped SP (config's client_id/client_secret,
+    # a regular user-managed SP) can be granted CAN_USE like any other
+    # principal, so this path works on both Apps and MS.
+    #
+    # The managed MCP endpoints on the workspace host (``/api/2.0/mcp/...``)
+    # keep the OAuth provider since those authenticate via the same
+    # resource-scoped SP through ``_build_connection_config``.
     if ".databricksapps.com" in url:
         try:
-            from databricks.sdk import WorkspaceClient
-
-            ambient_ws = WorkspaceClient()
-            hdrs = ambient_ws.config.authenticate()
+            auth_resource = _get_auth_resource(function)
+            auth_ws = auth_resource.workspace_client_from(context)
+            hdrs = auth_ws.config.authenticate()
+            identity = (
+                value_of(auth_resource.client_id) if auth_resource.client_id else None
+            ) or auth_ws.config.client_id or "resource-scoped"
             if hdrs and "Authorization" in hdrs:
                 headers["Authorization"] = hdrs["Authorization"]
                 auth = None
                 logger.info(
                     "mcp.sampling.app_bearer_auth",
                     url=url,
-                    identity=ambient_ws.config.client_id or "ambient",
+                    identity=identity,
+                    resource_type=auth_resource.__class__.__name__,
                     has_auth_header=True,
                 )
             else:
                 logger.warning(
                     "mcp.sampling.app_bearer_auth.no_header",
                     url=url,
+                    resource_type=auth_resource.__class__.__name__,
                 )
         except Exception as exc:
             logger.warning(
@@ -393,10 +502,16 @@ async def _open_session(
     caps = function.capabilities
     sampling_cb: DaoAiSamplingCallback | None = None
     roots_cb: DaoAiListRootsCallback | None = None
+    logging_cb: _RawLoggingAdapter | None = None
     if caps and caps.sampling:
         sampling_cb = DaoAiSamplingCallback(function)
     if caps and caps.roots:
         roots_cb = DaoAiListRootsCallback(function)
+    if caps and caps.logging:
+        logging_cb = _RawLoggingAdapter(
+            server_name="mcp_function",
+            min_level=caps.logging,
+        )
 
     async with AsyncExitStack() as stack:
         read_stream, write_stream, _ = await stack.enter_async_context(
@@ -408,6 +523,7 @@ async def _open_session(
                 write_stream,
                 sampling_callback=sampling_cb,
                 list_roots_callback=roots_cb,
+                logging_callback=logging_cb,
             )
         )
         await session.initialize()

--- a/tests/dao_ai/mcp/test_capabilities_integration.py
+++ b/tests/dao_ai/mcp/test_capabilities_integration.py
@@ -128,25 +128,53 @@ class _RecordingProgress:
         )
 
 
-class _RecordingLogging:
-    """Drop-in for DaoAiLoggingCallback that also records level-filtered events."""
+class _RecordingNotification:
+    """Drop-in for DaoAiNotificationCallback that records level-filtered log events.
+
+    The signature matches ``MessageHandlerFnT`` — session-scoped, no per-call
+    context. Non-log notifications are recorded with ``level=None``.
+    """
 
     events: list[tuple] = []
 
-    def __init__(self, min_level: str) -> None:
+    def __init__(self, min_level: str | None = None, server_name: str = "mcp_function") -> None:
         self.min_level = min_level
-        self._min_severity = {
-            "debug": 10, "info": 20, "warning": 30, "error": 40,
-        }[min_level]
+        self._min_severity = (
+            {
+                "debug": 10, "info": 20, "warning": 30, "error": 40,
+            }[min_level]
+            if min_level is not None
+            else 0
+        )
 
-    async def __call__(self, params, context) -> None:
-        level = str(params.level).lower()
-        severity = {
-            "debug": 10, "info": 20, "notice": 20, "warning": 30, "error": 40,
-        }.get(level, 20)
-        if severity < self._min_severity:
+    async def __call__(self, message) -> None:
+        # Ignore exceptions and request-responders — same shape as the real handler.
+        from mcp.types import (
+            LoggingMessageNotification,
+            ProgressNotification,
+            ServerNotification,
+        )
+
+        if isinstance(message, Exception):
             return
-        _RecordingLogging.events.append((level, str(params.data), context.tool_name))
+        if not isinstance(message, ServerNotification):
+            return
+        root = message.root
+        if isinstance(root, ProgressNotification):
+            return
+        if isinstance(root, LoggingMessageNotification):
+            level = str(root.params.level).lower()
+            severity = {
+                "debug": 10, "info": 20, "notice": 20, "warning": 30, "error": 40,
+            }.get(level, 20)
+            if severity < self._min_severity:
+                return
+            _RecordingNotification.events.append(
+                (level, str(root.params.data), None)
+            )
+            return
+        # Non-log notification.
+        _RecordingNotification.events.append((None, str(root), None))
 
 
 class _RecordingStructured:
@@ -253,19 +281,19 @@ class TestProgressCapability:
         assert all(e[3] == "long_task" for e in _RecordingProgress.events)
 
 
-class TestLoggingCapability:
+class TestNotificationCapability:
     def test_logging_at_warning_filters_debug_and_info(
         self, probe_url: str, monkeypatch
     ) -> None:
-        _RecordingLogging.events = []
+        _RecordingNotification.events = []
         monkeypatch.setattr(
-            "dao_ai.tools.mcp_callbacks.DaoAiLoggingCallback",
-            _RecordingLogging,
+            "dao_ai.tools.mcp_callbacks.DaoAiNotificationCallback",
+            _RecordingNotification,
         )
-        # _build_mcp_client imports DaoAiLoggingCallback lazily from the
+        # _build_mcp_client imports DaoAiNotificationCallback lazily from the
         # mcp_callbacks module — patching there covers the fresh binding.
 
-        caps = McpCapabilitiesModel(logging="warning", structured_output=False)
+        caps = McpCapabilitiesModel(logging=True, structured_output=False)
 
         async def run() -> None:
             tools = await acreate_mcp_tools(_fn(probe_url, caps))
@@ -273,11 +301,14 @@ class TestLoggingCapability:
             await noisy.ainvoke({})
 
         asyncio.run(run())
-        levels = [e[0] for e in _RecordingLogging.events]
+        log_events = [e for e in _RecordingNotification.events if e[0] is not None]
+        levels = [e[0] for e in log_events]
+        # Generic handler no longer filters by level — every log emitted by
+        # the probe should be forwarded.
+        assert "debug" in levels
+        assert "info" in levels
         assert "warning" in levels
         assert "error" in levels
-        assert "debug" not in levels
-        assert "info" not in levels
 
 
 class TestStructuredOutputCapability:

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -2231,9 +2231,15 @@ def test_vector_store_create_mode_detection():
 
 
 @pytest.mark.unit
-def test_set_databricks_env_vars_injects_trace_location_env_vars():
-    """Test that set_databricks_env_vars auto-injects MLFLOW_TRACING_DESTINATION
-    and MLFLOW_TRACING_SQL_WAREHOUSE_ID when trace_location is configured."""
+def test_set_databricks_env_vars_injects_warehouse_but_not_destination():
+    """`set_databricks_env_vars` auto-injects `MLFLOW_TRACING_SQL_WAREHOUSE_ID`
+    when `trace_location` is set, but NOT `MLFLOW_TRACING_DESTINATION` —
+    Databricks docs (docs.databricks.com/aws/en/mlflow3/genai/tracing/
+    trace-unity-catalog) do not use that env var, and MLflow's env-var
+    parser converts the 2-part string to legacy UCSchemaLocation with a
+    hardcoded default table name, shadowing the correct experiment-linked
+    UnityCatalog.
+    """
     from dao_ai.config import AppModel, SchemaModel, TraceLocationModel
 
     schema = SchemaModel(catalog_name="my_catalog", schema_name="my_schema")
@@ -2243,6 +2249,7 @@ def test_set_databricks_env_vars_injects_trace_location_env_vars():
     mock_app.environment_vars = {}
     mock_app.service_principal = None
     mock_app.trace_location = trace_loc
+    mock_app.experiment = None
 
     with patch(
         "dao_ai.utils.get_default_databricks_host",
@@ -2250,51 +2257,21 @@ def test_set_databricks_env_vars_injects_trace_location_env_vars():
     ):
         AppModel.set_databricks_env_vars(mock_app)
 
-    assert (
-        mock_app.environment_vars["MLFLOW_TRACING_DESTINATION"]
-        == "my_catalog.my_schema"
-    )
+    assert "MLFLOW_TRACING_DESTINATION" not in mock_app.environment_vars
     assert mock_app.environment_vars["MLFLOW_TRACING_SQL_WAREHOUSE_ID"] == "abc123"
 
 
 @pytest.mark.unit
-def test_set_databricks_env_vars_does_not_override_explicit_trace_vars():
-    """Test that explicit environment_vars for tracing take precedence."""
-    from dao_ai.config import AppModel, SchemaModel, TraceLocationModel
-
-    schema = SchemaModel(catalog_name="my_catalog", schema_name="my_schema")
-    trace_loc = TraceLocationModel(schema=schema, warehouse="abc123")
-
-    mock_app = MagicMock(spec=AppModel)
-    mock_app.environment_vars = {
-        "MLFLOW_TRACING_DESTINATION": "override_catalog.override_schema",
-        "MLFLOW_TRACING_SQL_WAREHOUSE_ID": "override_wh",
-    }
-    mock_app.service_principal = None
-    mock_app.trace_location = trace_loc
-
-    with patch(
-        "dao_ai.utils.get_default_databricks_host",
-        return_value="https://test.databricks.com",
-    ):
-        AppModel.set_databricks_env_vars(mock_app)
-
-    assert (
-        mock_app.environment_vars["MLFLOW_TRACING_DESTINATION"]
-        == "override_catalog.override_schema"
-    )
-    assert mock_app.environment_vars["MLFLOW_TRACING_SQL_WAREHOUSE_ID"] == "override_wh"
-
-
-@pytest.mark.unit
 def test_set_databricks_env_vars_no_trace_vars_without_trace_location():
-    """Test that MLFLOW_TRACING_DESTINATION is not set when trace_location is None."""
+    """When trace_location is unset, neither MLFLOW_TRACING_DESTINATION nor
+    MLFLOW_TRACING_SQL_WAREHOUSE_ID is injected."""
     from dao_ai.config import AppModel
 
     mock_app = MagicMock(spec=AppModel)
     mock_app.environment_vars = {}
     mock_app.service_principal = None
     mock_app.trace_location = None
+    mock_app.experiment = None
 
     with patch(
         "dao_ai.utils.get_default_databricks_host",

--- a/tests/dao_ai/test_mcp_capabilities_client.py
+++ b/tests/dao_ai/test_mcp_capabilities_client.py
@@ -20,7 +20,6 @@ import pytest
 from langchain_mcp_adapters.callbacks import (
     CallbackContext,
     ElicitationCallback,
-    LoggingMessageCallback,
     ProgressCallback,
 )
 from langchain_mcp_adapters.interceptors import (
@@ -31,8 +30,10 @@ from mcp.types import (
     CallToolResult,
     ElicitRequestFormParams,
     ElicitResult,
+    LoggingMessageNotification,
     LoggingMessageNotificationParams,
     ResourceLink,
+    ServerNotification,
     TextContent,
 )
 
@@ -43,7 +44,7 @@ from dao_ai.config import (
 )
 from dao_ai.tools.mcp_callbacks import (
     DaoAiElicitationCallback,
-    DaoAiLoggingCallback,
+    DaoAiNotificationCallback,
     DaoAiProgressCallback,
     _resume_value_to_elicit_result,
 )
@@ -57,7 +58,7 @@ class TestCapabilityModels:
     def test_defaults(self) -> None:
         caps = McpCapabilitiesModel()
         assert caps.progress is False
-        assert caps.logging is None
+        assert caps.logging is False
         assert caps.elicitation is None
         assert caps.structured_output is True
         assert caps.sampling is None
@@ -66,19 +67,15 @@ class TestCapabilityModels:
     def test_full_shape(self) -> None:
         caps = McpCapabilitiesModel(
             progress=True,
-            logging="info",
+            logging=True,
             elicitation="hitl",
             structured_output=True,
             roots=[McpRootModel(uri="file:///workspace", name="workspace")],
         )
         assert caps.progress is True
-        assert caps.logging == "info"
+        assert caps.logging is True
         assert caps.elicitation == "hitl"
         assert caps.roots[0].uri == "file:///workspace"
-
-    def test_invalid_logging_level_rejected(self) -> None:
-        with pytest.raises(ValueError):
-            McpCapabilitiesModel(logging="trace")  # type: ignore[arg-type]
 
     def test_invalid_elicitation_mode_rejected(self) -> None:
         with pytest.raises(ValueError):
@@ -87,11 +84,11 @@ class TestCapabilityModels:
     def test_mcpfunctionmodel_accepts_capabilities(self) -> None:
         model = McpFunctionModel(
             url="http://example.com/mcp",
-            capabilities=McpCapabilitiesModel(progress=True, logging="warning"),
+            capabilities=McpCapabilitiesModel(progress=True, logging=True),
         )
         assert model.capabilities is not None
         assert model.capabilities.progress is True
-        assert model.capabilities.logging == "warning"
+        assert model.capabilities.logging is True
 
 
 class TestBuildMcpClient:
@@ -117,7 +114,7 @@ class TestBuildMcpClient:
 
         caps = McpCapabilitiesModel(
             progress=True,
-            logging="info",
+            logging=True,
             elicitation="reject",
             structured_output=True,
         )
@@ -126,13 +123,21 @@ class TestBuildMcpClient:
             mcp_mod, "_build_connection_config", return_value={"url": "x"}
         ):
             mcp_mod._build_mcp_client(self._make_fn(capabilities=caps))
-            _, kwargs = mock_cls.call_args
+            args, kwargs = mock_cls.call_args
             assert kwargs["callbacks"] is not None
             assert kwargs["handle_tool_errors"] is False
             interceptors = kwargs["tool_interceptors"]
             assert len(interceptors) == 2
             assert isinstance(interceptors[0], DaoAiTraceInterceptor)
             assert isinstance(interceptors[1], DaoAiStructuredOutputInterceptor)
+            # logging=True → message_handler injected via session_kwargs
+            from dao_ai.tools.mcp_callbacks import DaoAiNotificationCallback
+
+            connections = args[0]
+            session_kwargs = connections["mcp_function"].get("session_kwargs") or {}
+            assert isinstance(
+                session_kwargs.get("message_handler"), DaoAiNotificationCallback
+            )
 
     def test_capabilities_path_skips_structured_interceptor_when_disabled(self) -> None:
         from dao_ai.tools import mcp as mcp_mod
@@ -255,9 +260,6 @@ class TestProtocolConformance:
     def test_progress_callback_is_protocol(self) -> None:
         assert isinstance(DaoAiProgressCallback(), ProgressCallback)
 
-    def test_logging_callback_is_protocol(self) -> None:
-        assert isinstance(DaoAiLoggingCallback("info"), LoggingMessageCallback)
-
     def test_elicitation_callback_is_protocol(self) -> None:
         assert isinstance(DaoAiElicitationCallback("reject"), ElicitationCallback)
 
@@ -312,40 +314,72 @@ class TestProgressCallback:
             )
 
 
-class TestLoggingCallback:
-    def test_forwards_at_or_above_min_level(self) -> None:
-        span = MagicMock()
-        with patch(
-            "dao_ai.tools.mcp_callbacks.mlflow.get_current_active_span",
-            return_value=span,
-        ):
-            cb = DaoAiLoggingCallback("warning")
-            asyncio.run(
-                cb(
-                    LoggingMessageNotificationParams(
-                        level="error", data="boom", logger="genie"
-                    ),
-                    CallbackContext(server_name="genie", tool_name="query"),
-                )
+class TestNotificationCallback:
+    @staticmethod
+    def _log_notification(level: str) -> ServerNotification:
+        return ServerNotification(
+            LoggingMessageNotification(
+                method="notifications/message",
+                params=LoggingMessageNotificationParams(
+                    level=level, data="boom", logger="genie"
+                ),
             )
-        span.add_event.assert_called_once()
-        assert span.add_event.call_args[0][0].name == "mcp.log.error"
+        )
 
-    def test_drops_below_min_level(self) -> None:
+    def test_forwards_log_notification_generically(self) -> None:
         span = MagicMock()
         with patch(
             "dao_ai.tools.mcp_callbacks.mlflow.get_current_active_span",
             return_value=span,
         ):
-            cb = DaoAiLoggingCallback("warning")
-            asyncio.run(
-                cb(
-                    LoggingMessageNotificationParams(
-                        level="info", data="fyi", logger="genie"
+            cb = DaoAiNotificationCallback(server_name="genie")
+            asyncio.run(cb(self._log_notification("error")))
+        span.add_event.assert_called_once()
+        span_event = span.add_event.call_args[0][0]
+        # Span-event name equals the channel. For notifications/message
+        # frames MCP guarantees level+data on params; those are also lifted
+        # to top-level of the envelope for consumer convenience.
+        assert span_event.name == "mcp.log"
+        attrs = span_event.attributes
+        assert attrs["channel"] == "mcp.log"
+        assert attrs["method"] == "notifications/message"
+        assert attrs["server_name"] == "genie"
+        assert attrs["level"] == "error"
+        assert attrs["logger"] == "genie"
+        assert attrs["data"] == "boom"
+        # Raw params also carried through for consumers that want the
+        # original shape.
+        assert attrs["params"]["level"] == "error"
+
+    def test_ignores_exceptions_and_requests(self) -> None:
+        span = MagicMock()
+        with patch(
+            "dao_ai.tools.mcp_callbacks.mlflow.get_current_active_span",
+            return_value=span,
+        ):
+            cb = DaoAiNotificationCallback()
+            asyncio.run(cb(RuntimeError("transport blew up")))
+            asyncio.run(cb(SimpleNamespace(this_is_a="request-responder")))
+        span.add_event.assert_not_called()
+
+    def test_skips_progress_notification(self) -> None:
+        from mcp.types import ProgressNotification, ProgressNotificationParams
+
+        span = MagicMock()
+        with patch(
+            "dao_ai.tools.mcp_callbacks.mlflow.get_current_active_span",
+            return_value=span,
+        ):
+            cb = DaoAiNotificationCallback()
+            note = ServerNotification(
+                ProgressNotification(
+                    method="notifications/progress",
+                    params=ProgressNotificationParams(
+                        progressToken="t1", progress=0.5, total=1.0
                     ),
-                    CallbackContext(server_name="genie"),
                 )
             )
+            asyncio.run(cb(note))
         span.add_event.assert_not_called()
 
 

--- a/tests/dao_ai/test_mcp_capabilities_client.py
+++ b/tests/dao_ai/test_mcp_capabilities_client.py
@@ -286,10 +286,14 @@ class TestProgressCallback:
             )
         span.add_event.assert_called_once()
         args, kwargs = span.add_event.call_args
-        assert args[0] == "mcp.progress"
-        attrs = kwargs["attributes"]
-        assert attrs["mcp.progress"] == 0.5
-        assert attrs["mcp.tool_name"] == "query"
+        # MLflow LiveSpan.add_event(event: SpanEvent) — single positional arg.
+        span_event = args[0]
+        assert span_event.name == "mcp.progress"
+        attrs = span_event.attributes
+        assert attrs["channel"] == "mcp.progress"
+        assert attrs["progress"] == 0.5
+        assert attrs["tool_name"] == "query"
+        assert attrs["server_name"] == "genie"
 
     def test_silent_when_no_active_span(self) -> None:
         with patch(
@@ -325,7 +329,7 @@ class TestLoggingCallback:
                 )
             )
         span.add_event.assert_called_once()
-        assert span.add_event.call_args[0][0] == "mcp.log.error"
+        assert span.add_event.call_args[0][0].name == "mcp.log.error"
 
     def test_drops_below_min_level(self) -> None:
         span = MagicMock()

--- a/tests/dao_ai/test_mcp_stream_forwarding.py
+++ b/tests/dao_ai/test_mcp_stream_forwarding.py
@@ -24,7 +24,7 @@ from mlflow.types.responses_helpers import Message
 
 from dao_ai.models import LanggraphResponsesAgent
 from dao_ai.tools.mcp_callbacks import (
-    DaoAiLoggingCallback,
+    DaoAiNotificationCallback,
     DaoAiProgressCallback,
 )
 
@@ -220,11 +220,16 @@ def test_progress_callback_dispatches_via_callback_manager():
     span.assert_called_once_with("mcp.progress", envelope)
 
 
-def test_logging_callback_respects_min_level():
-    """Below-threshold records are dropped entirely — no dispatch, no span."""
+def test_notification_callback_dispatches_via_callback_manager():
+    """Every incoming ServerNotification (except progress) is forwarded on
+    both channels: the MLflow span event and the outer runnable's callback
+    manager. Envelope contains the raw params under ``params``."""
 
-    from langchain_mcp_adapters.callbacks import CallbackContext
-    from mcp.types import LoggingMessageNotificationParams
+    from mcp.types import (
+        LoggingMessageNotification,
+        LoggingMessageNotificationParams,
+        ServerNotification,
+    )
 
     fake_config = {"callbacks": [MagicMock()]}
     with (
@@ -237,23 +242,28 @@ def test_logging_callback_respects_min_level():
         ) as dispatch,
         patch("dao_ai.tools.mcp_callbacks._add_span_event") as span,
     ):
-        cb = DaoAiLoggingCallback("warning")
-        ctx = CallbackContext(server_name="s", tool_name="t")
-        below = LoggingMessageNotificationParams(
-            level="info", logger="l", data="drop me"
+        cb = DaoAiNotificationCallback(server_name="s")
+        info = ServerNotification(
+            LoggingMessageNotification(
+                method="notifications/message",
+                params=LoggingMessageNotificationParams(
+                    level="info", logger="l", data="show me"
+                ),
+            )
         )
-        at = LoggingMessageNotificationParams(
-            level="warning", logger="l", data="show me"
-        )
-        _run_async(cb(below, ctx))
-        _run_async(cb(at, ctx))
+        _run_async(cb(info))
 
     assert dispatch.call_count == 1
     assert span.call_count == 1
     envelope = dispatch.call_args.args[1]
     assert envelope["channel"] == "mcp.log"
-    assert envelope["level"] == "warning"
+    assert envelope["method"] == "notifications/message"
+    assert envelope["server_name"] == "s"
+    # Log-specific top-level fields.
+    assert envelope["level"] == "info"
     assert envelope["data"] == "show me"
+    # Raw params carried through too.
+    assert envelope["params"]["level"] == "info"
 
 
 def test_callback_dispatch_safe_outside_runnable_context():

--- a/tests/dao_ai/test_mcp_stream_forwarding.py
+++ b/tests/dao_ai/test_mcp_stream_forwarding.py
@@ -1,0 +1,284 @@
+"""Tests for MCP callback → outer LangGraph stream forwarding via LangChain's
+callback manager.
+
+Covers the wire contract:
+- MCP progress + log notifications from a tool call reach an
+  ``AsyncCallbackHandler`` registered on the outer ``RunnableConfig``.
+- ``apredict_stream`` attaches its own collector handler and translates
+  captured envelopes into ``response.output_item.added(status="in_progress")``
+  events between astream chunks.
+- Envelopes accumulate into ``custom_outputs["mcp_events"]`` on the terminal
+  ``response.output_item.done`` event for non-streaming replay.
+- When no runnable context is present (e.g. batch predict without a graph
+  stream), the callbacks still emit MLflow span events but skip dispatch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from mlflow.types.responses import ResponsesAgentRequest
+from mlflow.types.responses_helpers import Message
+
+from dao_ai.models import LanggraphResponsesAgent
+from dao_ai.tools.mcp_callbacks import (
+    DaoAiLoggingCallback,
+    DaoAiProgressCallback,
+)
+
+
+def _run_async(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _mock_graph() -> MagicMock:
+    graph = MagicMock()
+    graph.ainvoke = AsyncMock()
+    graph.astream = AsyncMock()
+    graph.aget_state = AsyncMock()
+    graph.checkpointer = None
+    snapshot = MagicMock()
+    snapshot.interrupts = ()
+    snapshot.values = {}
+    graph.aget_state.return_value = snapshot
+    return graph
+
+
+def _make_request() -> ResponsesAgentRequest:
+    return ResponsesAgentRequest(
+        input=[Message(role="user", content="Run the MCP tool")],
+        custom_inputs={
+            "configurable": {
+                "thread_id": "mcp-stream-test",
+                "user_id": "test_user",
+            }
+        },
+    )
+
+
+def test_apredict_stream_forwards_mcp_envelopes_via_collector():
+    """MCP envelopes pushed onto the collector's queue during astream are
+    drained between chunks and yielded as
+    ``response.output_item.added(status="in_progress")`` events."""
+
+    progress_envelope: dict[str, Any] = {
+        "channel": "mcp.progress",
+        "server_name": "genie",
+        "tool_name": "run_genie_query",
+        "progress": 0.3,
+        "total": 1.0,
+        "message": "Fetched 3/10 docs",
+    }
+    log_envelope: dict[str, Any] = {
+        "channel": "mcp.log",
+        "server_name": "genie",
+        "tool_name": "run_genie_query",
+        "level": "info",
+        "logger": "genie.executor",
+        "data": "generating SQL",
+    }
+
+    captured_collector: dict[str, Any] = {}
+
+    async def mock_astream(*args, **kwargs):
+        # Capture the collector attached to the config so we can
+        # simulate a tool dispatching custom events during the run.
+        cfg = kwargs.get("config") or (args[2] if len(args) > 2 else {})
+        for cb in cfg.get("callbacks", []) or []:
+            if type(cb).__name__ == "_McpEventCollector":
+                captured_collector["cb"] = cb
+                break
+
+        collector = captured_collector.get("cb")
+        assert collector is not None, "apredict_stream must attach the collector"
+        # Simulate two envelopes arriving mid-stream.
+        from uuid import uuid4
+
+        await collector.on_custom_event(
+            "mcp.progress", progress_envelope, run_id=uuid4()
+        )
+        await collector.on_custom_event("mcp.log", log_envelope, run_id=uuid4())
+        yield (
+            ("agent",),
+            "messages",
+            [MagicMock(content="done", type="ai")],
+        )
+
+    graph = _mock_graph()
+    graph.astream = MagicMock(side_effect=lambda *a, **kw: mock_astream(*a, **kw))
+    agent = LanggraphResponsesAgent(graph)
+
+    async def _test():
+        events = []
+        async for event in agent.apredict_stream(_make_request()):
+            events.append(event)
+        return events
+
+    with patch(
+        "dao_ai.models.get_state_snapshot_async", new_callable=AsyncMock
+    ) as mock_state:
+        mock_state.return_value = None
+        events = _run_async(_test())
+
+    added = [e for e in events if e.type == "response.output_item.added"]
+    assert len(added) == 2, f"expected 2 added events, got {len(added)}: {events}"
+    assert all(e.item["status"] == "in_progress" for e in added)
+    assert added[0].item["name"] == "mcp.progress"
+    assert added[0].item["input"] == progress_envelope
+    assert added[1].item["name"] == "mcp.log"
+    assert added[1].item["input"] == log_envelope
+    assert added[0].item["id"].startswith("mcp_genie_")
+    assert added[0].item["id"] != added[1].item["id"]
+
+    done = [e for e in events if e.type == "response.output_item.done"]
+    assert len(done) == 1
+    assert done[0].custom_outputs["mcp_events"] == [progress_envelope, log_envelope]
+
+
+def test_apredict_stream_collector_ignores_non_mcp_events():
+    """Custom events not matching the ``mcp.*`` channel prefix must be
+    dropped — other tools may also dispatch via the same callback manager."""
+
+    async def mock_astream(*args, **kwargs):
+        cfg = kwargs.get("config") or {}
+        collector = None
+        for cb in cfg.get("callbacks", []) or []:
+            if type(cb).__name__ == "_McpEventCollector":
+                collector = cb
+                break
+        assert collector is not None
+        from uuid import uuid4
+
+        # Non-dict, dict without channel, and non-mcp channel — all ignored.
+        await collector.on_custom_event("other", "string payload", run_id=uuid4())
+        await collector.on_custom_event(
+            "other", {"unrelated": "payload"}, run_id=uuid4()
+        )
+        await collector.on_custom_event(
+            "other", {"channel": "not.mcp", "x": 1}, run_id=uuid4()
+        )
+        yield (
+            ("agent",),
+            "messages",
+            [MagicMock(content="hi", type="ai")],
+        )
+
+    graph = _mock_graph()
+    graph.astream = MagicMock(side_effect=lambda *a, **kw: mock_astream(*a, **kw))
+    agent = LanggraphResponsesAgent(graph)
+
+    async def _test():
+        events = []
+        async for event in agent.apredict_stream(_make_request()):
+            events.append(event)
+        return events
+
+    with patch(
+        "dao_ai.models.get_state_snapshot_async", new_callable=AsyncMock
+    ) as mock_state:
+        mock_state.return_value = None
+        events = _run_async(_test())
+
+    added = [e for e in events if e.type == "response.output_item.added"]
+    assert added == [], f"non-mcp events should be dropped, got {added}"
+    done = [e for e in events if e.type == "response.output_item.done"][0]
+    assert "mcp_events" not in done.custom_outputs
+
+
+def test_progress_callback_dispatches_via_callback_manager():
+    """``DaoAiProgressCallback`` captures the RunnableConfig at construction
+    and dispatches envelopes through ``adispatch_custom_event`` on notify."""
+
+    from langchain_mcp_adapters.callbacks import CallbackContext
+
+    fake_config = {"callbacks": [MagicMock()]}
+    with (
+        patch(
+            "dao_ai.tools.mcp_callbacks.ensure_config", return_value=fake_config
+        ),
+        patch(
+            "dao_ai.tools.mcp_callbacks.adispatch_custom_event",
+            new_callable=AsyncMock,
+        ) as dispatch,
+        patch("dao_ai.tools.mcp_callbacks._add_span_event") as span,
+    ):
+        cb = DaoAiProgressCallback()
+        ctx = CallbackContext(server_name="genie", tool_name="q")
+        _run_async(cb(0.5, 1.0, "half done", ctx))
+
+    dispatch.assert_called_once()
+    args, kwargs = dispatch.call_args
+    assert args[0] == "mcp.progress"
+    envelope = args[1]
+    assert envelope["channel"] == "mcp.progress"
+    assert envelope["server_name"] == "genie"
+    assert envelope["progress"] == 0.5
+    assert envelope["message"] == "half done"
+    assert kwargs["config"] is fake_config
+    span.assert_called_once_with("mcp.progress", envelope)
+
+
+def test_logging_callback_respects_min_level():
+    """Below-threshold records are dropped entirely — no dispatch, no span."""
+
+    from langchain_mcp_adapters.callbacks import CallbackContext
+    from mcp.types import LoggingMessageNotificationParams
+
+    fake_config = {"callbacks": [MagicMock()]}
+    with (
+        patch(
+            "dao_ai.tools.mcp_callbacks.ensure_config", return_value=fake_config
+        ),
+        patch(
+            "dao_ai.tools.mcp_callbacks.adispatch_custom_event",
+            new_callable=AsyncMock,
+        ) as dispatch,
+        patch("dao_ai.tools.mcp_callbacks._add_span_event") as span,
+    ):
+        cb = DaoAiLoggingCallback("warning")
+        ctx = CallbackContext(server_name="s", tool_name="t")
+        below = LoggingMessageNotificationParams(
+            level="info", logger="l", data="drop me"
+        )
+        at = LoggingMessageNotificationParams(
+            level="warning", logger="l", data="show me"
+        )
+        _run_async(cb(below, ctx))
+        _run_async(cb(at, ctx))
+
+    assert dispatch.call_count == 1
+    assert span.call_count == 1
+    envelope = dispatch.call_args.args[1]
+    assert envelope["channel"] == "mcp.log"
+    assert envelope["level"] == "warning"
+    assert envelope["data"] == "show me"
+
+
+def test_callback_dispatch_safe_outside_runnable_context():
+    """When ``ensure_config`` returns no callbacks (no runnable context /
+    batch predict) the callback still emits its span event but does not
+    dispatch (dispatch would raise inside adispatch_custom_event)."""
+
+    from langchain_mcp_adapters.callbacks import CallbackContext
+
+    def _boom(_config):
+        raise RuntimeError("not inside a runnable context")
+
+    with (
+        patch("dao_ai.tools.mcp_callbacks.ensure_config", side_effect=_boom),
+        patch(
+            "dao_ai.tools.mcp_callbacks.adispatch_custom_event",
+            new_callable=AsyncMock,
+        ) as dispatch,
+        patch("dao_ai.tools.mcp_callbacks._add_span_event") as span,
+    ):
+        cb = DaoAiProgressCallback()
+        ctx = CallbackContext(server_name="s", tool_name="t")
+        _run_async(cb(0.1, 1.0, "tick", ctx))
+
+    # Span still fires (observability preserved).
+    span.assert_called_once()
+    # Dispatch skipped because config capture failed at __init__.
+    dispatch.assert_not_called()


### PR DESCRIPTION
## Summary

- Replaces `DaoAiLoggingCallback` with `DaoAiNotificationCallback` — a session-scoped MCP `MessageHandlerFnT` that forwards every server-→-client notification through the same dual-emit path (MLflow span event + LangChain callback manager).
- **Rationale**: `notifications/message` is one of many MCP notification types. A generic message_handler subsumes it with less code and also captures `notifications/resources/*`, `notifications/tools/list_changed`, and any server-defined custom `notifications/<method>` — none of which the log-specific callback could see.
- Config change: `McpCapabilitiesModel.logging` type changes from `Optional[LogLevel]` → `bool`. No client-side min-level filter; the server decides what to emit via its own logging capability.

## Channel mapping

| MCP method | Channel | Notes |
|---|---|---|
| `notifications/message` | `mcp.log` | `level`, `logger`, `data` lifted to envelope top-level for convenience; also in `params` |
| `notifications/progress` | (skipped) | Routed through `DaoAiProgressCallback` per-call to preserve `progressToken` correlation |
| `notifications/<x>/<y>` | `mcp.<x>.<y>` | Any spec notification |
| Custom `notifications/foo` | `mcp.foo` | Server-defined |

## Wiring

- **MultiServerMCPClient path** (`tools/mcp.py`) — inject `message_handler` via `session_kwargs` on the Connection config (`langchain-mcp-adapters` `Callbacks` has no slot for it).
- **Raw ClientSession path** (`tools/mcp_sampling.py`) — pass `message_handler` directly to `ClientSession(...)`; drops the local `_RawLoggingAdapter` class.

## Test plan

- [x] Unit tests pass — 41/41 in `test_mcp_capabilities_client.py`, `test_mcp_stream_forwarding.py`, and `test_capabilities_integration.py`
- [x] Live inference on FEVM (`dao-ai-notif-handler-04`, experiment `2128996850809278`)
  - Streamed 3 log envelopes (info/warning/info) + 4 progress envelopes
  - Envelope `channel` values correctly separated: `mcp.log` vs `mcp.progress`
  - Log envelopes include top-level `level`, `logger`, `data` + full `params`
- [x] MLflow trace persistence — 13 spans in `2128996850809278_otel_spans`, 7 `mcp.*` events on the `slow_analyze` tool span
- [x] `mlflow.search_traces(locations=[<exp_id>])` returns the trace with all 7 events visible via the MLflow API

## Notes

Includes a cherry-pick of #176 (`87ce0ab fix(tracing): remove MLFLOW_TRACING_DESTINATION env-var shadowing`) so this branch can deploy standalone. That cherry-pick will drop cleanly once #176 merges to main.

This pull request and its description were written by Isaac.