### PR TITLE
feat(config): async query methods on DatabaseModel; audit uses them

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -201,6 +201,7 @@ referencing==0.37.0
 regex==2026.5.9
 requests==2.34.2
 requests-toolbelt==1.0.0
+rfc8785==0.1.4
 rich==15.0.0
 rpds-py==2026.5.1
 ruamel-yaml==0.18.17

--- a/src/dao_ai/audit/lakebase.py
+++ b/src/dao_ai/audit/lakebase.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING, Optional
 
 from loguru import logger
 from psycopg import sql
-from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool
 
 from dao_ai.audit.base import AuditReceipt
@@ -102,11 +101,6 @@ class LakebaseAuditSink:
 
     # ---- Schema lifecycle -----------------------------------------------
 
-    async def _pool(self) -> AsyncConnectionPool:
-        from dao_ai.memory.postgres import AsyncPostgresPoolManager
-
-        return await AsyncPostgresPoolManager.get_pool(self._config.database)
-
     async def ensure_schema(self) -> None:
         if self._schema_ready:
             return
@@ -144,7 +138,7 @@ class LakebaseAuditSink:
                     f"{self._nonces_table}_thread_call_idx"
                 ),
             )
-            pool: AsyncConnectionPool = await self._pool()
+            pool: AsyncConnectionPool = await self._config.database.aget_pool()
             async with pool.connection() as conn:
                 async with conn.cursor() as cur:
                     await cur.execute(ddl_composed)
@@ -166,7 +160,7 @@ class LakebaseAuditSink:
         """
         await self.ensure_schema()
         sealed: AuditReceipt = await self.chain.link_and_seal(receipt)
-        pool: AsyncConnectionPool = await self._pool()
+        pool: AsyncConnectionPool = await self._config.database.aget_pool()
         async with pool.connection() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(self._insert_sql(), self._insert_params(sealed))
@@ -227,19 +221,17 @@ class LakebaseAuditSink:
     async def head_hash(self, thread_id: str) -> Optional[str]:
         """Return the ``this_hash`` of the most recent receipt for ``thread_id``."""
         await self.ensure_schema()
-        pool: AsyncConnectionPool = await self._pool()
         query: sql.Composed = sql.SQL(
             "SELECT this_hash FROM {table} "
             "WHERE thread_id = %s "
             "ORDER BY recorded_at DESC LIMIT 1"
         ).format(table=sql.Identifier(self._receipts_table))
-        async with pool.connection() as conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                await cur.execute(query, (thread_id,))
-                row: Optional[dict[str, str]] = await cur.fetchone()
-        if row is None:
+        rows: list[dict[str, str]] = await self._config.database.aexecute_query(
+            query, (thread_id,)
+        )
+        if not rows:
             return None
-        return row["this_hash"]
+        return rows[0]["this_hash"]
 
     # ---- Nonces (called by NonceIssuer) --------------------------------
     #
@@ -265,16 +257,13 @@ class LakebaseAuditSink:
         Dormant in v1 — see module-level "v1.5 note" above.
         """
         await self.ensure_schema()
-        pool: AsyncConnectionPool = await self._pool()
         query: sql.Composed = sql.SQL(
             "INSERT INTO {table} (nonce, thread_id, tool_call_id, expires_at) "
             "VALUES (%s, %s, %s, %s)"
         ).format(table=sql.Identifier(self._nonces_table))
-        async with pool.connection() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute(
-                    query, (nonce, thread_id, tool_call_id, expires_at)
-                )
+        await self._config.database.aexecute_update(
+            query, (nonce, thread_id, tool_call_id, expires_at)
+        )
 
     async def consume_nonce(
         self,
@@ -293,7 +282,6 @@ class LakebaseAuditSink:
         Dormant in v1 — see module-level "v1.5 note" above.
         """
         await self.ensure_schema()
-        pool: AsyncConnectionPool = await self._pool()
         query: sql.Composed = sql.SQL(
             "UPDATE {table} "
             "SET used_at = NOW() "
@@ -304,8 +292,7 @@ class LakebaseAuditSink:
             "  AND expires_at > NOW() "
             "RETURNING nonce"
         ).format(table=sql.Identifier(self._nonces_table))
-        async with pool.connection() as conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                await cur.execute(query, (nonce, thread_id, tool_call_id))
-                row: Optional[dict[str, str]] = await cur.fetchone()
-        return row is not None
+        rows: list[dict[str, str]] = await self._config.database.aexecute_query(
+            query, (nonce, thread_id, tool_call_id)
+        )
+        return bool(rows)

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -4,14 +4,15 @@ import os
 import re
 import sys
 from abc import ABC, abstractmethod
+from contextlib import asynccontextmanager, contextmanager
 from enum import Enum
-from contextlib import contextmanager
 from os import PathLike
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
+    AsyncIterator,
     Callable,
     Final,
     Iterable,
@@ -3966,6 +3967,135 @@ class DatabaseModel(IsDatabricksResource):
             except Exception:
                 conn.rollback()
                 raise
+
+    async def aget_pool(self) -> Any:
+        """Return the shared async :class:`psycopg_pool.AsyncConnectionPool` for this database.
+
+        Thin async accessor over
+        :class:`dao_ai.memory.postgres.AsyncPostgresPoolManager` — every
+        async caller in dao-ai (audit receipts, checkpointer, memory
+        store, background queue, A2A task store) should route pool
+        acquisition through this method so ``DatabaseModel`` remains the
+        single entry point for database access.
+
+        Prefer :meth:`aexecute_query` / :meth:`aexecute_update` /
+        :meth:`aexecute_many` / :meth:`aconnect` for typical work;
+        reach for the raw pool only when you need psycopg-specific
+        control (e.g. streaming reads, ``COPY``, or composing
+        ``sql.Composed`` inside a shared cursor).
+        """
+        from dao_ai.memory.postgres import AsyncPostgresPoolManager
+
+        return await AsyncPostgresPoolManager.get_pool(self)
+
+    async def aexecute_update(
+        self,
+        statements: str | Sequence[str],
+        parameters: Sequence[Any] | None = None,
+    ) -> None:
+        """Async twin of :meth:`execute_update`.
+
+        Runs one or more write SQL statements against the shared async
+        pool (:class:`dao_ai.memory.postgres.AsyncPostgresPoolManager`).
+        Async Lakebase pools run with ``autocommit=True``, so each
+        statement commits individually; on error the exception
+        propagates.
+
+        Args:
+            statements: A single SQL string OR a sequence of SQL
+                strings. When passing a sequence, ``parameters`` must
+                be ``None``.
+            parameters: Optional positional parameters passed to
+                ``cursor.execute()``. Only valid when ``statements`` is
+                a single string.
+        """
+        if isinstance(statements, str):
+            stmts: list[str] = [statements]
+        else:
+            stmts = list(statements)
+            if parameters is not None:
+                raise ValueError(
+                    "`parameters` is only supported when `statements` is a "
+                    "single string; got a sequence."
+                )
+        if not stmts:
+            return
+
+        pool = await self.aget_pool()
+        async with pool.connection() as conn:
+            async with conn.cursor() as cur:
+                for stmt in stmts:
+                    if parameters is not None:
+                        await cur.execute(stmt, parameters)
+                    else:
+                        await cur.execute(stmt)
+
+    async def aexecute_query(
+        self,
+        query: Any,
+        parameters: Sequence[Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Async twin of :meth:`execute_query`.
+
+        Runs a single read query and returns rows as ``list[dict]``
+        keyed by column name (async pools use
+        ``row_factory=dict_row``). Returns an empty list when the
+        query yields no rows.
+
+        Args:
+            query: The SQL query — either a plain ``str`` or a
+                ``psycopg.sql.Composable`` (``sql.SQL`` / ``sql.Composed``)
+                for identifier-safe composition.
+            parameters: Optional positional parameters passed to
+                ``cursor.execute()``.
+        """
+        from psycopg.rows import dict_row
+
+        pool = await self.aget_pool()
+        async with pool.connection() as conn:
+            async with conn.cursor(row_factory=dict_row) as cur:
+                if parameters is not None:
+                    await cur.execute(query, parameters)
+                else:
+                    await cur.execute(query)
+                if cur.description is None:
+                    return []
+                return list(await cur.fetchall())
+
+    async def aexecute_many(
+        self,
+        query: str,
+        param_seq: Iterable[Sequence[Any]],
+    ) -> None:
+        """Async twin of :meth:`execute_many`.
+
+        Wraps psycopg's ``cursor.executemany()`` on the shared async
+        pool. Async Lakebase pools run with ``autocommit=True``.
+        """
+        pool = await self.aget_pool()
+        async with pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.executemany(query, param_seq)
+
+    @asynccontextmanager
+    async def aconnect(self) -> AsyncIterator[Any]:
+        """Async twin of :meth:`connect`.
+
+        Yields a psycopg async cursor scoped to a single connection
+        acquired from the shared async pool. Async Lakebase pools run
+        with ``autocommit=True``, so the caller gets each statement
+        auto-committed.
+
+        .. code-block:: python
+
+            async with database.aconnect() as cur:
+                await cur.execute("SELECT ... WHERE embedding IS NULL")
+                rows = await cur.fetchall()
+        """
+        pool = await self.aget_pool()
+        async with pool.connection() as conn:
+            async with conn.cursor() as cur:
+                yield cur
 
 
 class GenieLRUCacheParametersModel(BaseModel):

--- a/src/dao_ai/tools/audit_query.py
+++ b/src/dao_ai/tools/audit_query.py
@@ -306,11 +306,9 @@ def create_query_audit_receipts_tool(audit: AuditConfigInput) -> BaseTool:
 
         sink: LakebaseAuditSink = _sink_for(audit_model)
         await sink.ensure_schema()
-        pool: AsyncConnectionPool = await sink._pool()
-        async with pool.connection() as conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                await cur.execute(query, tuple(params))
-                rows: list[dict[str, Any]] = list(await cur.fetchall())
+        rows: list[dict[str, Any]] = await audit_model.database.aexecute_query(
+            query, tuple(params)
+        )
         logger.info(
             "query_audit_receipts",
             filters={
@@ -362,14 +360,12 @@ def create_get_audit_receipt_by_id_tool(audit: AuditConfigInput) -> BaseTool:
         )
         sink: LakebaseAuditSink = _sink_for(audit_model)
         await sink.ensure_schema()
-        pool: AsyncConnectionPool = await sink._pool()
-        async with pool.connection() as conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                await cur.execute(query, (receipt_id,))
-                row: Optional[dict[str, Any]] = await cur.fetchone()
-        if row is None:
+        rows: list[dict[str, Any]] = await audit_model.database.aexecute_query(
+            query, (receipt_id,)
+        )
+        if not rows:
             return None
-        return _row_to_receipt(row)
+        return _row_to_receipt(rows[0])
 
     return get_audit_receipt_by_id
 
@@ -414,11 +410,9 @@ def create_verify_audit_hash_chain_tool(audit: AuditConfigInput) -> BaseTool:
         ).format(table=sql.Identifier(receipts_table))
         sink: LakebaseAuditSink = _sink_for(audit_model)
         await sink.ensure_schema()
-        pool: AsyncConnectionPool = await sink._pool()
-        async with pool.connection() as conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                await cur.execute(query, (thread_id,))
-                rows: list[dict[str, Any]] = list(await cur.fetchall())
+        rows: list[dict[str, Any]] = await audit_model.database.aexecute_query(
+            query, (thread_id,)
+        )
 
         breaks: list[dict[str, Any]] = []
         expected_prev: Optional[str] = None
@@ -548,7 +542,7 @@ def create_summarize_audit_activity_tool(audit: AuditConfigInput) -> BaseTool:
 
         sink: LakebaseAuditSink = _sink_for(audit_model)
         await sink.ensure_schema()
-        pool: AsyncConnectionPool = await sink._pool()
+        pool: AsyncConnectionPool = await audit_model.database.aget_pool()
         async with pool.connection() as conn:
             async with conn.cursor(row_factory=dict_row) as cur:
                 await cur.execute(
@@ -728,11 +722,9 @@ def create_find_security_incidents_tool(audit: AuditConfigInput) -> BaseTool:
 
         sink: LakebaseAuditSink = _sink_for(audit_model)
         await sink.ensure_schema()
-        pool: AsyncConnectionPool = await sink._pool()
-        async with pool.connection() as conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                await cur.execute(query, tuple(params))
-                rows: list[dict[str, Any]] = list(await cur.fetchall())
+        rows: list[dict[str, Any]] = await audit_model.database.aexecute_query(
+            query, tuple(params)
+        )
 
         def _incident_type(row: dict[str, Any]) -> str:
             status: Any = row.get("execution_status")
@@ -813,11 +805,9 @@ def create_get_thread_timeline_tool(audit: AuditConfigInput) -> BaseTool:
 
         sink: LakebaseAuditSink = _sink_for(audit_model)
         await sink.ensure_schema()
-        pool: AsyncConnectionPool = await sink._pool()
-        async with pool.connection() as conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                await cur.execute(query, (thread_id,))
-                rows: list[dict[str, Any]] = list(await cur.fetchall())
+        rows: list[dict[str, Any]] = await audit_model.database.aexecute_query(
+            query, (thread_id,)
+        )
 
         timeline: list[dict[str, Any]] = []
         expected_prev: Optional[str] = None
@@ -913,7 +903,7 @@ def create_get_approver_activity_tool(audit: AuditConfigInput) -> BaseTool:
 
         sink: LakebaseAuditSink = _sink_for(audit_model)
         await sink.ensure_schema()
-        pool: AsyncConnectionPool = await sink._pool()
+        pool: AsyncConnectionPool = await audit_model.database.aget_pool()
         async with pool.connection() as conn:
             async with conn.cursor(row_factory=dict_row) as cur:
                 await cur.execute(


### PR DESCRIPTION
## Summary

- Add `aget_pool`, `aexecute_query`, `aexecute_update`, `aexecute_many`, and `aconnect` on `DatabaseModel` as async twins of the existing sync `execute_*`/`connect` helpers. Backed by `AsyncPostgresPoolManager.get_pool(self)` — same pool the audit sink, checkpointer, memory store, background queue, and A2A task store already share.
- Migrate the audit-receipts feature to route through `DatabaseModel`:
  - `LakebaseAuditSink._pool()` deleted. Write-path sites (`ensure_schema`, `record`) source the pool via `self._config.database.aget_pool()`; read-path sites (`head_hash`, `record_nonce`, `consume_nonce`) call the new `aexecute_query` / `aexecute_update`.
  - Five single-query auditor tools (`query_audit_receipts`, `get_audit_receipt_by_id`, `verify_audit_hash_chain`, `find_security_incidents`, `get_thread_timeline`) collapse to `database.aexecute_query`.
  - Two multi-query aggregation tools (`summarize_audit_activity`, `get_approver_activity`) keep an explicit `pool.connection()` block for round-trip efficiency, but now source the pool via `database.aget_pool()`.
- Zero behavioural change to pooling — same per-loop, per-database pool cache in `AsyncPostgresPoolManager`. This just gives async callers a `DatabaseModel`-level entry point matching what the sync side has had since the beginning.

Follow-up (not in this PR): the identical `_pool()` shim still lives on `background/store.py` and `apps/a2a/task_store.py`. Once this lands, those can also route through `database.aget_pool()` so the pattern converges across every subsystem.

## Test plan

- [x] `uv run pytest tests/dao_ai/audit/ tests/dao_ai/test_config.py tests/dao_ai/background/ tests/dao_ai/test_a2a_task_store.py` — 179 passed, 9 skipped (integration tests requiring live Lakebase)
- [x] `make schema` — no schema drift (config-object shape unchanged)
- [x] `uv run ruff check --ignore E501` on all changed files — clean
- [x] Live deploy to FEVM Databricks App using `config/examples/07_human_in_the_loop/human_in_the_loop_audited.yaml` + `retail_consumer_goods` Lakebase project
- [x] Invoked `current_time_audited` twice — both wrote execution receipts (write path via new `aget_pool`)
- [x] Called `query_audit_receipts` — returned expected receipts via new `aexecute_query`
- [x] Called `verify_audit_hash_chain` — chain valid across 2 receipts, `prev_hash → this_hash` links intact
- [x] Called `summarize_audit_activity` — 8 aggregation queries via `aget_pool` returned correct totals across 5 receipts
- [x] MLflow trace inspection — every span (`AuditedHumanInTheLoopMiddleware.after_model`, `current_time_tool`, LangGraph nodes, `ChatUnityAIGateway`) reports `STATUS_CODE_OK`; no exceptions

This pull request and its description were written by Isaac.