### PR TITLE
refactor: route background + a2a + memory pools through DatabaseModel.aget_pool

### DIFF
--- a/src/dao_ai/apps/a2a/task_store.py
+++ b/src/dao_ai/apps/a2a/task_store.py
@@ -24,11 +24,9 @@ import mlflow
 from a2a.server.tasks import InMemoryTaskStore, TaskStore
 from a2a.types import Task
 from loguru import logger
-from psycopg.rows import dict_row
 from psycopg.types.json import Json
 
 from dao_ai.background.store import _valid_identifier  # reuse the validator
-from dao_ai.memory.postgres import AsyncPostgresPoolManager
 
 if TYPE_CHECKING:
     from a2a.server.context import ServerCallContext
@@ -58,9 +56,6 @@ class LakebaseTaskStore(TaskStore):
         self.table_name = _valid_identifier(table_name)
         self._schema_ready = False
 
-    async def _pool(self):
-        return await AsyncPostgresPoolManager.get_pool(self.database)
-
     @mlflow.trace(name="a2a.task_store.ensure_schema", span_type="INTERNAL")
     async def ensure_schema(self) -> None:
         """Create the tasks table + indexes if they don't exist.
@@ -80,54 +75,39 @@ class LakebaseTaskStore(TaskStore):
             )
             return
 
-        pool = await self._pool()
-        async with pool.connection() as conn:
-            async with conn.cursor() as cur:
-                # Cheap existence probe; uses to_regclass which returns
-                # NULL when the table doesn't exist instead of raising.
-                await cur.execute(
-                    "SELECT to_regclass(%s) AS reg",
-                    (f"public.{self.table_name}",),
-                )
-                row = await cur.fetchone()
-                if row is None:
-                    # No rows shouldn't happen, but stay safe.
-                    table_present = False
-                elif isinstance(row, dict):
-                    table_present = row.get("reg") is not None
-                else:
-                    table_present = row[0] is not None
+        probe_rows = await self.database.aexecute_query(
+            "SELECT to_regclass(%s) AS reg",
+            (f"public.{self.table_name}",),
+        )
+        table_present = bool(probe_rows) and probe_rows[0].get("reg") is not None
 
-                if not table_present:
-                    ddl_tasks = f"""
-                    CREATE TABLE IF NOT EXISTS {self.table_name} (
-                        task_id    TEXT PRIMARY KEY,
-                        context_id TEXT NOT NULL,
-                        state      TEXT NOT NULL,
-                        task_json  JSONB NOT NULL,
-                        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-                    )
-                    """
-                    ddl_idx_ctx = (
-                        f"CREATE INDEX IF NOT EXISTS "
-                        f"idx_{self.table_name}_context_id "
-                        f"ON {self.table_name} (context_id)"
-                    )
-                    ddl_idx_upd = (
-                        f"CREATE INDEX IF NOT EXISTS "
-                        f"idx_{self.table_name}_updated_at "
-                        f"ON {self.table_name} (updated_at)"
-                    )
-                    await cur.execute(ddl_tasks)
-                    await cur.execute(ddl_idx_ctx)
-                    await cur.execute(ddl_idx_upd)
-                    logger.info(
-                        "A2A task store DDL applied",
-                        table=self.table_name,
-                        database=self.database.name,
-                    )
-            await conn.commit()
+        if not table_present:
+            ddl_tasks = f"""
+            CREATE TABLE IF NOT EXISTS {self.table_name} (
+                task_id    TEXT PRIMARY KEY,
+                context_id TEXT NOT NULL,
+                state      TEXT NOT NULL,
+                task_json  JSONB NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            """
+            ddl_idx_ctx = (
+                f"CREATE INDEX IF NOT EXISTS "
+                f"idx_{self.table_name}_context_id "
+                f"ON {self.table_name} (context_id)"
+            )
+            ddl_idx_upd = (
+                f"CREATE INDEX IF NOT EXISTS "
+                f"idx_{self.table_name}_updated_at "
+                f"ON {self.table_name} (updated_at)"
+            )
+            await self.database.aexecute_update([ddl_tasks, ddl_idx_ctx, ddl_idx_upd])
+            logger.info(
+                "A2A task store DDL applied",
+                table=self.table_name,
+                database=self.database.name,
+            )
 
         self._schema_ready = True
         logger.success(
@@ -154,19 +134,15 @@ class LakebaseTaskStore(TaskStore):
                 task_json  = EXCLUDED.task_json,
                 updated_at = NOW()
         """
-        pool = await self._pool()
-        async with pool.connection() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute(
-                    sql,
-                    (
-                        task.id,
-                        task.context_id,
-                        task.status.state.value,
-                        Json(task.model_dump(mode="json")),
-                    ),
-                )
-            await conn.commit()
+        await self.database.aexecute_update(
+            sql,
+            (
+                task.id,
+                task.context_id,
+                task.status.state.value,
+                Json(task.model_dump(mode="json")),
+            ),
+        )
         logger.debug(
             "A2A task persisted",
             table=self.table_name,
@@ -183,19 +159,15 @@ class LakebaseTaskStore(TaskStore):
     ) -> Task | None:
         await self.ensure_schema()
         sql = f"SELECT task_json FROM {self.table_name} WHERE task_id = %s"
-        pool = await self._pool()
-        async with pool.connection() as conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                await cur.execute(sql, (task_id,))
-                row = await cur.fetchone()
-        if row is None:
+        rows = await self.database.aexecute_query(sql, (task_id,))
+        if not rows:
             logger.trace(
                 "A2A task store miss",
                 table=self.table_name,
                 task_id=task_id,
             )
             return None
-        task = Task.model_validate(row["task_json"])
+        task = Task.model_validate(rows[0]["task_json"])
         logger.trace(
             "A2A task store hit",
             table=self.table_name,
@@ -212,17 +184,11 @@ class LakebaseTaskStore(TaskStore):
     ) -> None:
         await self.ensure_schema()
         sql = f"DELETE FROM {self.table_name} WHERE task_id = %s"
-        pool = await self._pool()
-        async with pool.connection() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute(sql, (task_id,))
-                rowcount = cur.rowcount
-            await conn.commit()
+        await self.database.aexecute_update(sql, (task_id,))
         logger.debug(
             "A2A task deleted",
             table=self.table_name,
             task_id=task_id,
-            rowcount=rowcount,
         )
 
 

--- a/src/dao_ai/background/store.py
+++ b/src/dao_ai/background/store.py
@@ -24,7 +24,6 @@ from psycopg.rows import dict_row
 from psycopg.types.json import Json
 
 from dao_ai.config import DatabaseModel
-from dao_ai.memory.postgres import AsyncPostgresPoolManager
 
 
 class ResponseStatus(str, Enum):
@@ -86,9 +85,6 @@ class BackgroundStore:
         self.messages_table = _valid_identifier(messages_table_name)
         self._schema_ready = False
 
-    async def _pool(self):
-        return await AsyncPostgresPoolManager.get_pool(self.database)
-
     @mlflow.trace(name="background.store.ensure_schema", span_type="INTERNAL")
     async def ensure_schema(self) -> None:
         """Create the two tables + index if they don't exist."""
@@ -127,13 +123,7 @@ class BackgroundStore:
         )
         """
 
-        pool = await self._pool()
-        async with pool.connection() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute(ddl_responses)
-                await cur.execute(ddl_index)
-                await cur.execute(ddl_messages)
-            await conn.commit()
+        await self.database.aexecute_update([ddl_responses, ddl_index, ddl_messages])
 
         self._schema_ready = True
         logger.info(
@@ -157,19 +147,15 @@ class BackgroundStore:
             (response_id, thread_id, status, request_json)
         VALUES (%s, %s, %s, %s)
         """
-        pool = await self._pool()
-        async with pool.connection() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute(
-                    sql,
-                    (
-                        response_id,
-                        thread_id,
-                        status.value,
-                        Json(request) if request is not None else None,
-                    ),
-                )
-            await conn.commit()
+        await self.database.aexecute_update(
+            sql,
+            (
+                response_id,
+                thread_id,
+                status.value,
+                Json(request) if request is not None else None,
+            ),
+        )
         logger.info(
             "Background response created",
             response_id=response_id,
@@ -182,11 +168,7 @@ class BackgroundStore:
             f"UPDATE {self.responses_table} SET agent_task_id = %s, updated_at = NOW() "
             f"WHERE response_id = %s"
         )
-        pool = await self._pool()
-        async with pool.connection() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute(sql, (task_id, response_id))
-            await conn.commit()
+        await self.database.aexecute_update(sql, (task_id, response_id))
 
     @mlflow.trace(name="background.store.set_status", span_type="INTERNAL")
     async def set_status(
@@ -202,18 +184,14 @@ class BackgroundStore:
             f"SET status = %s, error_json = %s, updated_at = NOW(){completed_clause} "
             f"WHERE response_id = %s"
         )
-        pool = await self._pool()
-        async with pool.connection() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute(
-                    sql,
-                    (
-                        status.value,
-                        Json(error) if error is not None else None,
-                        response_id,
-                    ),
-                )
-            await conn.commit()
+        await self.database.aexecute_update(
+            sql,
+            (
+                status.value,
+                Json(error) if error is not None else None,
+                response_id,
+            ),
+        )
         logger.info(
             "Background response status updated",
             response_id=response_id,
@@ -231,13 +209,10 @@ class BackgroundStore:
             f"request_json, error_json, created_at, updated_at, completed_at "
             f"FROM {self.responses_table} WHERE response_id = %s"
         )
-        pool = await self._pool()
-        async with pool.connection() as conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                await cur.execute(sql, (response_id,))
-                row = await cur.fetchone()
-        if row is None:
+        rows = await self.database.aexecute_query(sql, (response_id,))
+        if not rows:
             return None
+        row = rows[0]
         return ResponseRecord(
             response_id=row["response_id"],
             thread_id=row["thread_id"],
@@ -270,22 +245,19 @@ class BackgroundStore:
         )
         RETURNING sequence_number
         """
-        pool = await self._pool()
-        async with pool.connection() as conn:
-            # The pool is configured with dict_row, so fetchone() returns a
-            # dict; access by column name rather than positional index.
-            async with conn.cursor() as cur:
-                await cur.execute(sql, (response_id, response_id, Json(event)))
-                row = await cur.fetchone()
-                assert row is not None
-                seq = int(row["sequence_number"])
-            # bump updated_at so pollers notice activity
-            await conn.execute(
+        # INSERT-RETURNING + follow-up UPDATE. Held on one connection so the
+        # pair round-trips together; autocommit means no explicit txn needed.
+        # Pool defaults to dict_row so fetchone() returns a dict.
+        async with self.database.aconnect() as cur:
+            await cur.execute(sql, (response_id, response_id, Json(event)))
+            row = await cur.fetchone()
+            assert row is not None
+            seq = int(row["sequence_number"])
+            await cur.execute(
                 f"UPDATE {self.responses_table} SET updated_at = NOW() "
                 f"WHERE response_id = %s",
                 (response_id,),
             )
-            await conn.commit()
         return seq
 
     async def append_output(
@@ -294,6 +266,8 @@ class BackgroundStore:
         items: list[dict[str, Any]],
     ) -> None:
         """Append the final list of output items (non-streaming result)."""
+        if not items:
+            return
         sql = f"""
         INSERT INTO {self.messages_table}
             (response_id, sequence_number, item)
@@ -307,12 +281,11 @@ class BackgroundStore:
             %s
         )
         """
-        pool = await self._pool()
-        async with pool.connection() as conn:
-            async with conn.cursor() as cur:
-                for item in items:
-                    await cur.execute(sql, (response_id, response_id, Json(item)))
-            await conn.commit()
+        # Kept in one connection so the correlated MAX(sequence_number)+1
+        # subquery observes prior INSERTs within this batch.
+        async with self.database.aconnect() as cur:
+            for item in items:
+                await cur.execute(sql, (response_id, response_id, Json(item)))
 
     async def iter_events(
         self,
@@ -320,14 +293,18 @@ class BackgroundStore:
         *,
         cursor: int = 0,
     ) -> AsyncIterator[tuple[int, dict[str, Any]]]:
-        """Yield ``(sequence_number, stream_event)`` tuples after ``cursor``."""
+        """Yield ``(sequence_number, stream_event)`` tuples after ``cursor``.
+
+        Uses the raw pool because the cursor must stay open across the
+        `async for row in cur` yields — `aexecute_query` materializes rows.
+        """
         sql = (
             f"SELECT sequence_number, stream_event FROM {self.messages_table} "
             f"WHERE response_id = %s AND sequence_number > %s "
             f"AND stream_event IS NOT NULL "
             f"ORDER BY sequence_number ASC"
         )
-        pool = await self._pool()
+        pool = await self.database.aget_pool()
         async with pool.connection() as conn:
             async with conn.cursor(row_factory=dict_row) as cur:
                 await cur.execute(sql, (response_id, cursor))
@@ -341,11 +318,7 @@ class BackgroundStore:
             f"WHERE response_id = %s AND item IS NOT NULL "
             f"ORDER BY sequence_number ASC"
         )
-        pool = await self._pool()
-        async with pool.connection() as conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                await cur.execute(sql, (response_id,))
-                rows = await cur.fetchall()
+        rows = await self.database.aexecute_query(sql, (response_id,))
         return [_coerce_json(r["item"]) for r in rows]
 
 

--- a/src/dao_ai/memory/postgres.py
+++ b/src/dao_ai/memory/postgres.py
@@ -391,7 +391,7 @@ class AsyncPostgresStoreManager(StoreManagerBase):
 
         from langgraph.store.postgres.aio import AsyncPostgresStore
 
-        self.pool = await AsyncPostgresPoolManager.get_pool(self.store_model.database)
+        self.pool = await self.store_model.database.aget_pool()
         self._store = AsyncPostgresStore(conn=self.pool)
         await self._store.setup()
 
@@ -442,9 +442,7 @@ class AsyncPostgresCheckpointerManager(CheckpointManagerBase):
 
         from langgraph.checkpoint.postgres.aio import AsyncShallowPostgresSaver
 
-        self.pool = await AsyncPostgresPoolManager.get_pool(
-            self.checkpointer_model.database
-        )
+        self.pool = await self.checkpointer_model.database.aget_pool()
         self._checkpointer = AsyncShallowPostgresSaver(conn=self.pool)
         await self._checkpointer.setup()
 


### PR DESCRIPTION
## Summary

Follow-up to #180. Migrates the remaining async subsystems off private `_pool()` helpers and direct `AsyncPostgresPoolManager.get_pool` calls, onto the `DatabaseModel` async API added in the prior PR.

- **`LakebaseTaskStore`** (`src/dao_ai/apps/a2a/task_store.py`): `save`, `get`, `delete` → `database.aexecute_*`; `ensure_schema` → `aexecute_query` (probe) + `aexecute_update([...])` (DDL); `_pool()` deleted.
- **`BackgroundStore`** (`src/dao_ai/background/store.py`): 8 sites migrate to `aexecute_query` / `aexecute_update`; `append_event` and `append_output` use `aconnect()` where the correlated `MAX(seq)+1` subquery needs to see prior inserts in the same connection; **`iter_events` intentionally keeps `pool.connection()`** — its cursor must stay open across `async for row in cur` yields, and `aexecute_query` materializes rows. `_pool()` deleted.
- **`AsyncPostgresStoreManager` / `AsyncPostgresCheckpointerManager`** (`src/dao_ai/memory/postgres.py`): switch the pool source in `_async_setup` from `AsyncPostgresPoolManager.get_pool(db)` → `db.aget_pool()`. LangGraph still owns the connection lifecycle (`AsyncPostgresStore(conn=self.pool)`, `AsyncShallowPostgresSaver(conn=self.pool)`); only the acquisition point changed.

After this PR, `AsyncPostgresPoolManager.get_pool(` appears only in `DatabaseModel.aget_pool` (`config.py`) and inside the pool-manager module itself. The last remaining external caller is `retrievers/lakebase.py` — deliberately out of scope, part of the Bucket C sync-caller convergence tracked separately.

No behavioural change: pool sharing semantics, per-loop keying, autocommit — all identical.

## Test plan

- [x] `uv run pytest tests/dao_ai/background/ tests/dao_ai/test_a2a_task_store.py tests/dao_ai/audit/ tests/dao_ai/test_config.py` — 179 passed, 9 skipped (integration tests requiring live Lakebase, unchanged baseline).
- [x] `uv run ruff check --ignore E501` on all changed files — clean.
- [x] Static sweep: `rg 'AsyncPostgresPoolManager\.get_pool\('` returns only `DatabaseModel.aget_pool` and the manager module. `rg 'async def _pool\('` returns zero hits.
- [x] **Live deploy on FEVM** (`retail-consumer-goods-audit` Lakebase, `retail_consumer_goods` secret scope, `fevm` profile) using an off-tree copy of `config/examples/20_a2a_protocol/a2a_background.yaml` — the config that exercises `background + a2a + memory checkpointer` against the same DatabaseModel anchor.
- [x] **Background lifecycle**: `POST /v1/responses background:true` → status `completed` with correct output text `"It's currently 11:52 AM on July 15th, 2026."` (exercises `BackgroundStore.ensure_schema`, `create`, `set_status`, `get`, `get_output` via the new methods).
- [x] **A2A lifecycle**: `POST /a2a message/send` → task persisted; `POST /a2a tasks/get` returns the same task (exercises `LakebaseTaskStore.ensure_schema`, `save`, `get`).
- [x] **MLflow trace verification**: every `background.store.*` and `a2a.task_store.*` span reports `STATUS_CODE_OK` — no errors in migrated code paths.

### Notes on validation coverage

- `AsyncPostgresStoreManager` / `AsyncPostgresCheckpointerManager` are only routed to for **non-Lakebase Postgres** configs (Lakebase configs go through `LakebaseCheckpointerManager` / `LakebaseStoreManager` in `memory/databricks.py`). The 1-line-per-file change in `memory/postgres.py` is therefore not exercised by the Lakebase-only FEVM test environment; it relies on unit-test coverage + the static equivalence of `AsyncPostgresPoolManager.get_pool(db)` and `db.aget_pool()`.
- During validation, the FEVM app also surfaced a **pre-existing** cross-loop `asyncio.locks.Lock` binding error in `dao_ai.models:apredict` / `apredict_stream` when a sync request is followed by a background one (or vice versa). Confirmed on `main` prior to this branch — reproduces with identical stack traces. Not caused by this PR, and orthogonal to pool acquisition.

This pull request and its description were written by Isaac.