### PR TITLE
feat(genie): Genie Agent Mode API as a streaming model resource

### DIFF
--- a/config/examples/10_agent_integrations/README.md
+++ b/config/examples/10_agent_integrations/README.md
@@ -65,6 +65,26 @@ Three first-class shapes cover the vast majority of agent-composition cases. **P
 | [`kasal.yaml`](./kasal.yaml) | Delegate to Kasal specialist agents using `type: serving_endpoint` |
 | [`vertex_agent_engine.yaml`](./vertex_agent_engine.yaml) | Call a Google Cloud ADK agent on Vertex AI Agent Engine |
 | [`a2a_agent.yaml`](./a2a_agent.yaml) | Comprehensive `type: a2a` walkthrough — bearer / GCP / none auth, AppResource mode, card-path overrides |
+| [`genie_agent_model.yaml`](./genie_agent_model.yaml) | **Genie Agent as a model** — a `GenieAgentModel` (Genie Agent Mode API) as an agent's streaming reasoning model, not a tool; `tools: []` Genie specialist |
+| [`genie_agent_model_obo.yaml`](./genie_agent_model_obo.yaml) | Same, with `on_behalf_of_user` + `app:` block — deployable App exercising forwarded-token OBO |
+
+## Genie Agent as a model (not a tool)
+
+The `genie_agent_model*.yaml` examples use the Databricks **Genie Agent Mode
+API** as an agent's **reasoning model** rather than wrapping it as a tool. A
+`GenieAgentModel` streams Genie's output (SQL + table + narrative) as
+`AIMessageChunk`s, so an agent with `tools: []` is a streaming "Genie
+specialist" a supervisor can route to. Contrast `type: genie` (the tool), which
+is atomic and returns one `ToolMessage`. Key points:
+
+- **Assignment** — `model: *genie_room_anchor` (bare room auto-wraps) or the
+  explicit `model: {genie_room: *anchor, timeout_seconds: N}` wrapper.
+- **Registration** — the room MUST be under `resources.genie_rooms` (deploy
+  grant + OBO scope); config-load fails otherwise.
+- **Multi-turn / OBO** — `GenieAgentMiddleware` caches the Genie
+  `conversation_id` in `session.genie.spaces[agent_id]` and builds the
+  per-request client (forwarded token on Apps, `ModelServingUserCredentials`
+  on Model Serving). See [configuration-reference → Genie Agent as a model](../../../docs/configuration-reference.md#genie-agent-as-a-model).
 
 ## Vertex AI Agent Engine (Google ADK)
 

--- a/config/examples/10_agent_integrations/genie_agent_model.yaml
+++ b/config/examples/10_agent_integrations/genie_agent_model.yaml
@@ -15,10 +15,16 @@
 # to the end user through the agent's response. A model node streams
 # AIMessageChunks (`stream_mode="messages"`).
 #
-# Multi-turn: the Genie server owns conversation history keyed by
-# conversation_id. GenieAgentChatModel stamps the id on the returned
-# AIMessage's response_metadata and recovers it from the message history on
-# the next turn — no graph state or session cache required.
+# Multi-turn: the Genie server owns conversation history keyed by a
+# Genie-issued conversation_id (independent of the LangGraph thread_id).
+# GenieAgentMiddleware caches it in session.genie.spaces[agent_id] — the same
+# channel the `type: genie` tool uses — reading the prior id before each turn
+# and persisting the newly-issued one after, via the merge_session reducer.
+#
+# Registration: a GenieAgentModel is a plain wrapper, not a deploy resource.
+# Its `genie_room` MUST be registered under `resources.genie_rooms` (shared by
+# anchor below) so the bundle emits the genie-space grant; config-load fails
+# otherwise.
 #
 # Preview status: the Genie Agent Mode API is in Beta. A workspace admin must
 # enable "Genie Agents Agent Mode API" from the Previews menu.

--- a/config/examples/10_agent_integrations/genie_agent_model.yaml
+++ b/config/examples/10_agent_integrations/genie_agent_model.yaml
@@ -1,0 +1,65 @@
+# yaml-language-server: $schema=../../../schemas/model_config_schema.json
+
+# ==============================================================================
+# Genie Agent as a streaming model resource
+# ==============================================================================
+# Models the Databricks Genie **Agent Mode** API
+# (POST /api/2.0/genie/agents/{agent_id}/responses) as an agent's *reasoning
+# model* rather than a tool. Assigning a `GenieAgentModel` to an agent with
+# `tools: []` produces a "Genie specialist" sub-agent that streams Genie's
+# output (SQL + result table + narrative) natively to the outer response
+# stream and is routable by a supervisor like any other agent.
+#
+# Why a model, not a tool: a LangGraph tool node is atomic (returns one
+# ToolMessage after the whole stream completes), so Genie output can't stream
+# to the end user through the agent's response. A model node streams
+# AIMessageChunks (`stream_mode="messages"`).
+#
+# Multi-turn: the Genie server owns conversation history keyed by
+# conversation_id. GenieAgentChatModel stamps the id on the returned
+# AIMessage's response_metadata and recovers it from the message history on
+# the next turn — no graph state or session cache required.
+#
+# Preview status: the Genie Agent Mode API is in Beta. A workspace admin must
+# enable "Genie Agents Agent Mode API" from the Previews menu.
+# ==============================================================================
+
+parameters:
+  catalog:
+    description: Unity Catalog name
+    default: retail_consumer_goods
+  schema:
+    description: Schema within the catalog
+    default: store_ops
+
+resources:
+  genie_rooms:
+    # `agent_id` is an alias of `space_id` (Genie Spaces were renamed to Genie
+    # Agents; same 32-char hex). OBO lives HERE — the single source of truth.
+    retail_genie_room: &retail_genie_room
+      name: "Retail AI Genie Room"
+      description: "Retail store-ops Genie space"
+      agent_id: 01f05dd06c421ad6b522bf7a517cf6d2
+      # on_behalf_of_user: true   # forward the calling user's token to Genie
+
+agents:
+  genie_specialist: &genie_specialist
+    name: genie_specialist
+    description: >-
+      Answers factual questions about retail stores, products, inventory, and
+      employee activity by querying the data warehouse with Databricks Genie.
+    # The Genie Agent IS this agent's brain (a GenieAgentModel, defined inline).
+    # No `tools:` — Genie decides and runs SQL itself, and its streamed output
+    # is the agent's response. A GenieAgentModel is not a serving endpoint, so
+    # it is not placed under `resources.models` (that map is
+    # `dict[str, InferenceEndpointModel]`); define it inline or as a top-level
+    # YAML anchor referenced here.
+    model:
+      genie_room: *retail_genie_room
+      # httpx client timeout (server-side response cap is 90 minutes).
+      timeout_seconds: 300
+    tools: []
+    prompt: |
+      You are a retail data specialist backed by Databricks Genie. Relay
+      Genie's answer clearly and concisely, preserving any SQL, result
+      tables, and citations Genie includes.

--- a/config/examples/10_agent_integrations/genie_agent_model_obo.yaml
+++ b/config/examples/10_agent_integrations/genie_agent_model_obo.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=../../../schemas/model_config_schema.json
+
+# ==============================================================================
+# Genie Agent model with OBO — deployable App (forwarded-token OBO test)
+# ==============================================================================
+# A single Genie-specialist agent whose reasoning model is a GenieAgentModel
+# with on_behalf_of_user=true. Deployed as a Databricks App: the App proxy
+# forwards the caller's x-forwarded-access-token, GenieAgentMiddleware builds
+# the per-request WorkspaceClient from it, and Genie runs queries as the
+# calling user (not the App service principal).
+#
+# The room is registered under resources.genie_rooms so the bundle emits both
+# the genie-space grant AND the dashboards.genie user_api_scope for OBO.
+#
+# Target space: "Bakehouse Supplier Insights" (samples.bakehouse.*), readable
+# by any workspace user — so forwarded-user identity works without extra grants.
+# ==============================================================================
+
+resources:
+  genie_rooms:
+    bakehouse_genie: &bakehouse_genie
+      name: "Bakehouse Supplier Insights"
+      agent_id: 01f1764266cd1f9aaedf0b35cd177835
+      on_behalf_of_user: true   # Genie runs as the forwarded user
+
+agents:
+  genie_specialist: &genie_specialist
+    name: genie_specialist
+    description: >-
+      Answers questions about bakehouse suppliers, sales, and franchises by
+      querying the data warehouse with Databricks Genie.
+    # Terse form: a bare registered room anchor auto-wraps to a GenieAgentModel.
+    model: *bakehouse_genie
+    tools: []
+    prompt: |
+      You are a bakehouse data specialist backed by Databricks Genie. Relay
+      Genie's answer clearly, preserving any SQL, result tables, and citations.
+
+app:
+  name: genie-agent-obo-dao
+  description: >
+    Genie Agent model with forwarded-token OBO, deployed as a Databricks App.
+  log_level: INFO
+  deployment_target: apps
+  agents:
+  - *genie_specialist
+
+  input_example:
+    messages:
+    - role: user
+      content: "How many suppliers are there?"

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -122,7 +122,12 @@ resources:
   genie_rooms:
     genie: &genie
       space_id: string             # or omit and provide name instead
+      agent_id: string             # alias of space_id (Genie Spaces → Genie Agents)
       name: string                 # resolves space_id by title if space_id is omitted
+      on_behalf_of_user: bool      # forward the caller's token to Genie (OBO)
+      # A room referenced by a GenieAgentModel (see "Genie Agent as a model")
+      # MUST be registered here so the deploy emits the genie-space grant and,
+      # when on_behalf_of_user is set, the dashboards.genie user_api_scope.
 
   # Unity Catalog references (used to wire deployment resources and grants)
   tables:
@@ -223,7 +228,10 @@ agents:
   agent_name: &agent_name
     name: string
     description: string
-    model: *model_name
+    model: *model_name          # InferenceEndpointModel (serving endpoint) OR a
+                                # GenieAgentModel (Genie Agent as a streaming brain —
+                                # see "Genie Agent as a model" below). A bare Genie
+                                # room anchor is auto-wrapped into a GenieAgentModel.
     tools: [*tool_name]
     guardrails: [*guardrail_ref]
     prompt: string | *prompt_ref
@@ -1007,6 +1015,75 @@ See [`config/examples/15_complete_applications/procurement_supplier_a2a/README.m
 - [`config/examples/10_agent_integrations/serving_endpoint_first_class.yaml`](../config/examples/10_agent_integrations/serving_endpoint_first_class.yaml)
 - [`config/examples/10_agent_integrations/README.md`](../config/examples/10_agent_integrations/README.md) — routing matrix and migration notes
 - [`config/examples/15_complete_applications/procurement_supplier_a2a/`](../config/examples/15_complete_applications/procurement_supplier_a2a/) — end-to-end A2A example
+
+---
+
+## Genie Agent as a model
+
+The Databricks **Genie Agent Mode API** (`POST /api/2.0/genie/agents/{agent_id}/responses`,
+Beta) can back an agent's **reasoning model** instead of being wrapped as a tool.
+A `GenieAgentModel` streams Genie's output (SQL + result table + narrative) as
+`AIMessageChunk`s to the outer response stream, so an agent with `tools: []`
+becomes a "Genie specialist" a supervisor can route to like any other sub-agent.
+
+**Tool vs. model.** `type: genie` (the tool) is atomic — a LangGraph tool node
+returns one `ToolMessage` after the whole stream completes, so Genie output can't
+stream to the end user through the agent's response. A `GenieAgentModel` streams
+natively (`stream_mode="messages"`). Both point at the same Genie space (the
+32-char `agent_id` is the renamed `space_id`); keep both while the Agent Mode API
+is Beta.
+
+```yaml
+resources:
+  genie_rooms:
+    retail_genie: &retail_genie          # register the room HERE (required)
+      agent_id: 01f0...                  # alias of space_id
+      on_behalf_of_user: true            # optional: run Genie as the caller (OBO)
+
+agents:
+  genie_specialist:
+    name: genie_specialist
+    description: Answers factual questions from the warehouse via Genie.
+    model: *retail_genie                 # terse: bare room → GenieAgentModel (timeout 300s)
+    # model:                             # explicit wrapper form (custom knobs):
+    #   genie_room: *retail_genie
+    #   timeout_seconds: 600
+    tools: []                            # Genie IS the brain; no tools
+    prompt: |
+      Relay Genie's answer, preserving SQL, tables, and citations.
+```
+
+**Assignment forms.** `model:` accepts either a bare Genie room (a
+`genie_rooms` anchor or a dict with `agent_id`/`space_id` — auto-wrapped into a
+`GenieAgentModel` with default `timeout_seconds`) or the explicit
+`{genie_room: <room>, timeout_seconds: <int>}` wrapper. A `{name: <endpoint>}`
+config has no `agent_id`/`space_id` and stays an `InferenceEndpointModel`, so
+there is no ambiguity. A `GenieAgentModel` is **not** a serving endpoint — do
+not place it under `resources.models`.
+
+**Room registration (required).** A `GenieAgentModel` is a wrapper, not a
+deploy resource. Its `genie_room` **must** be registered under
+`resources.genie_rooms` so the bundle emits the `genie-space` grant and, when
+`on_behalf_of_user: true`, the `dashboards.genie` `user_api_scope`. Config-load
+fails with a clear error if an agent's Genie room isn't registered.
+
+**Multi-turn.** The Genie server owns conversation history keyed by a
+Genie-issued `conversation_id` (independent of the LangGraph `thread_id`).
+`GenieAgentMiddleware` caches it in `session.genie.spaces[agent_id]` — the same
+channel `type: genie` uses — reading the prior id before each turn and
+persisting the newly-issued one after (via the `merge_session` reducer).
+
+**OBO.** Set `on_behalf_of_user: true` on the **room** (single source of truth).
+`GenieAgentMiddleware` builds the per-request client via
+`workspace_client_from(context)` — the forwarded `x-forwarded-access-token` on
+Databricks Apps, or `ModelServingUserCredentials` on Model Serving. When OBO is
+set, also set the room's `workspace_host` unless `DATABRICKS_HOST` is in the
+environment (it is on Apps/MS deploys).
+
+### See Also
+
+- [`config/examples/10_agent_integrations/genie_agent_model.yaml`](../config/examples/10_agent_integrations/genie_agent_model.yaml)
+- [`config/examples/10_agent_integrations/genie_agent_model_obo.yaml`](../config/examples/10_agent_integrations/genie_agent_model_obo.yaml) — OBO + deployable App
 
 ---
 

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -643,8 +643,16 @@
           "title": "Description"
         },
         "model": {
-          "$ref": "#/$defs/InferenceEndpointModel",
-          "description": "LLM model configuration (serving endpoint name, temperature, etc.)."
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InferenceEndpointModel"
+            },
+            {
+              "$ref": "#/$defs/GenieAgentModel"
+            }
+          ],
+          "description": "Reasoning model for this agent. Either an ``InferenceEndpointModel`` (a Model Serving chat endpoint) or a ``GenieAgentModel`` (a Genie Agent used as a streaming brain \u2014 typically with ``tools: []`` to make this a Genie specialist sub-agent).",
+          "title": "Model"
         },
         "tools": {
           "description": "Tools available to this agent during reasoning.",
@@ -1672,7 +1680,7 @@
             }
           ],
           "default": null,
-          "description": "Server-side MCP capabilities exposed when dao-ai is deployed as an MCP server (``dao-ai generate-mcp``). Declares static resources, prompt templates, and whether progress + logging notifications are emitted from the agent tool. When None the server publishes only the classic single-tool agent surface \u2014 zero regression from the pre-PR-2 default."
+          "description": "Server-side MCP capabilities exposed when dao-ai is deployed as an MCP server (``dao-ai generate-mcp``). Declares static resources, prompt templates, and whether progress + logging notifications are emitted from the agent tool. When None the server publishes only the single agent-as-tool surface with no notifications."
         },
         "experiment": {
           "anyOf": [
@@ -4373,6 +4381,27 @@
       "title": "FunctionModel",
       "type": "object"
     },
+    "GenieAgentModel": {
+      "additionalProperties": false,
+      "description": "A Genie Agent used as an agent's reasoning model (streaming brain).\n\nWraps a :class:`GenieRoomModel` and exposes the same duck-typed surface\n``AgentModel``/``OBOModelMiddleware`` expect from a model resource, so a\nplain agent with no tools becomes a natively-streaming \"Genie specialist\"\nthat a supervisor can route to like any other sub-agent.\n\nUnlike :class:`InferenceEndpointModel`, a Genie Agent is not a serving\nendpoint: :meth:`as_chat_model` returns a\n:class:`dao_ai.genie.agent_chat_model.GenieAgentChatModel` that streams the\nGenie Agent Mode API (``POST /api/2.0/genie/agents/{agent_id}/responses``)\nrather than a ``ChatDatabricks`` pointed at ``/serving-endpoints``. This is\na wrapper (composition), not a subclass of ``InferenceEndpointModel`` \u2014 a\nGenie Agent has no ``temperature``/``max_tokens``/``ai_gateway`` semantics\nand must never be substitutable into embedding/judge/rerank slots.\n\nAuthentication and OBO are delegated wholesale to the wrapped\n``genie_room`` (an :class:`IsDatabricksResource`), so there is exactly one\nOBO flag (``genie_room.on_behalf_of_user``) and no chance of a second flag\ndrifting out of sync.",
+      "properties": {
+        "genie_room": {
+          "$ref": "#/$defs/GenieRoomModel",
+          "description": "Genie space/agent to invoke. Accepts either ``space_id`` or ``agent_id`` (aliases) for the 32-char hex identifier, and carries the warehouse and OBO (``on_behalf_of_user``) configuration."
+        },
+        "timeout_seconds": {
+          "default": 300,
+          "description": "httpx client timeout in seconds for the streaming call. The Databricks server-side response timeout is 90 minutes.",
+          "title": "Timeout Seconds",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "genie_room"
+      ],
+      "title": "GenieAgentModel",
+      "type": "object"
+    },
     "GenieBenchmarkQuestion": {
       "additionalProperties": true,
       "description": "A benchmark question + expected SQL pair stored on the Genie space.\n\nMirrors ``benchmarks.questions[]`` in the serialized space and lets\nteams ship offline evaluation data alongside the space configuration.",
@@ -5236,7 +5265,7 @@
             }
           ],
           "default": null,
-          "description": "Databricks-assigned Genie space identifier. The only field guaranteed unique by the platform; titles are not enforced unique. Lifecycle: (a) Reference mode \u2014 set by the user in YAML; readable immediately. (b) Spec mode \u2014 left None, populated by .create() once the space is provisioned. Downstream consumers reading *room_anchor.space_id must wait until .create() has run. Required when on_behalf_of_user is true (name-based lookup cannot authenticate at Model Serving startup).",
+          "description": "Databricks-assigned Genie space identifier. The only field guaranteed unique by the platform; titles are not enforced unique. Also accepted under the alias ``agent_id`` \u2014 Databricks renamed Genie Spaces to Genie Agents, and the Agent Mode API refers to the same 32-char hex value as ``agent_id``. Both YAML keys resolve to this attribute. Lifecycle: (a) Reference mode \u2014 set by the user in YAML; readable immediately. (b) Spec mode \u2014 left None, populated by .create() once the space is provisioned. Downstream consumers reading *room_anchor.space_id must wait until .create() has run. Required when on_behalf_of_user is true (name-based lookup cannot authenticate at Model Serving startup).",
           "title": "Space Id"
         },
         "parent_path": {
@@ -7747,7 +7776,7 @@
     },
     "McpServerCapabilitiesModel": {
       "additionalProperties": false,
-      "description": "Advanced capabilities emitted BY dao-ai when deployed as an MCP server.\n\nClient-side capabilities are on ``McpFunctionModel.capabilities``. This\nmodel is the server-side complement \u2014 declaring what the dao-ai MCP\nserver itself publishes and how it reports progress/logging to callers.\n\nWhen None on ``AppModel`` (the default), dao-ai's MCP server publishes\nonly the single agent-as-tool it always has \u2014 byte-for-byte compatible\nwith pre-PR-2 behavior.",
+      "description": "Advanced capabilities emitted BY dao-ai when deployed as an MCP server.\n\nClient-side capabilities are on ``McpFunctionModel.capabilities``. This\nmodel is the server-side complement \u2014 declaring what the dao-ai MCP\nserver itself publishes and how it reports progress/logging to callers.\n\nWhen None on ``AppModel`` (the default), dao-ai's MCP server publishes\nonly the single agent-as-tool surface \u2014 no static resources or prompts,\nno progress/logging notifications.",
       "properties": {
         "progress": {
           "default": true,

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -7514,6 +7514,37 @@ class AgentModel(BaseModel):
         ),
     )
 
+    @field_validator("model", mode="before")
+    @classmethod
+    def _wrap_bare_genie_room(cls, value: Any) -> Any:
+        """Auto-wrap a bare Genie room assigned to ``model`` into a ``GenieAgentModel``.
+
+        Ergonomic sugar so a registered room anchor can be assigned directly::
+
+            model: *retail_genie_room          # bare room  → GenieAgentModel
+            model: {genie_room: *room, timeout_seconds: 600}  # explicit wrapper
+            model: {name: databricks-claude-sonnet-4}         # LLM (untouched)
+
+        Coercion is by shape, not by smart-union guessing:
+
+        * a :class:`GenieRoomModel` instance, or
+        * a dict carrying ``agent_id`` / ``space_id`` but not already the
+          wrapper key ``genie_room`` (and not a serving-endpoint ``name``-only
+          shape),
+
+        is rewritten to ``{"genie_room": value}``. Everything else (notably a
+        ``{"name": ...}`` serving-endpoint config, which has no
+        ``agent_id``/``space_id``) is left untouched for the normal union to
+        resolve. The bare form uses the default ``timeout_seconds``; use the
+        explicit ``{genie_room: ...}`` wrapper to set invocation knobs.
+        """
+        if isinstance(value, GenieRoomModel):
+            return {"genie_room": value}
+        if isinstance(value, dict) and "genie_room" not in value:
+            if "agent_id" in value or "space_id" in value:
+                return {"genie_room": value}
+        return value
+
     @model_validator(mode="after")
     def validate_requires_no_self_reference(self) -> Self:
         """Reject ``requires`` entries that reference the agent itself."""

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -1707,9 +1707,14 @@ class GenieRoomModel(IsDatabricksResource, ManagedResource):
     )
     space_id: Optional[AnyVariable] = Field(
         default=None,
+        validation_alias=AliasChoices("space_id", "agent_id"),
         description=(
             "Databricks-assigned Genie space identifier. The only field "
             "guaranteed unique by the platform; titles are not enforced unique. "
+            "Also accepted under the alias ``agent_id`` — Databricks renamed "
+            "Genie Spaces to Genie Agents, and the Agent Mode API refers to "
+            "the same 32-char hex value as ``agent_id``. Both YAML keys "
+            "resolve to this attribute. "
             "Lifecycle: "
             "(a) Reference mode — set by the user in YAML; readable immediately. "
             "(b) Spec mode — left None, populated by .create() once the space "
@@ -2730,6 +2735,104 @@ class GenieRoomModel(IsDatabricksResource, ManagedResource):
 
         provider: ServiceProvider = DatabricksProvider(w=w)
         provider.create_genie_space(self)
+
+
+class GenieAgentModel(BaseModel):
+    """A Genie Agent used as an agent's reasoning model (streaming brain).
+
+    Wraps a :class:`GenieRoomModel` and exposes the same duck-typed surface
+    ``AgentModel``/``OBOModelMiddleware`` expect from a model resource, so a
+    plain agent with no tools becomes a natively-streaming "Genie specialist"
+    that a supervisor can route to like any other sub-agent.
+
+    Unlike :class:`InferenceEndpointModel`, a Genie Agent is not a serving
+    endpoint: :meth:`as_chat_model` returns a
+    :class:`dao_ai.genie.agent_chat_model.GenieAgentChatModel` that streams the
+    Genie Agent Mode API (``POST /api/2.0/genie/agents/{agent_id}/responses``)
+    rather than a ``ChatDatabricks`` pointed at ``/serving-endpoints``. This is
+    a wrapper (composition), not a subclass of ``InferenceEndpointModel`` — a
+    Genie Agent has no ``temperature``/``max_tokens``/``ai_gateway`` semantics
+    and must never be substitutable into embedding/judge/rerank slots.
+
+    Authentication and OBO are delegated wholesale to the wrapped
+    ``genie_room`` (an :class:`IsDatabricksResource`), so there is exactly one
+    OBO flag (``genie_room.on_behalf_of_user``) and no chance of a second flag
+    drifting out of sync.
+    """
+
+    model_config = ConfigDict(use_enum_values=True, extra="forbid")
+    genie_room: GenieRoomModel = Field(
+        description=(
+            "Genie space/agent to invoke. Accepts either ``space_id`` or "
+            "``agent_id`` (aliases) for the 32-char hex identifier, and carries "
+            "the warehouse and OBO (``on_behalf_of_user``) configuration."
+        ),
+    )
+    timeout_seconds: int = Field(
+        default=300,
+        description=(
+            "httpx client timeout in seconds for the streaming call. The "
+            "Databricks server-side response timeout is 90 minutes."
+        ),
+    )
+
+    @property
+    def _agent_id(self) -> str:
+        """Resolve the wrapped room's agent/space id, or raise if unset."""
+        space_id: AnyVariable = self.genie_room.space_id or os.environ.get(
+            "DATABRICKS_GENIE_SPACE_ID"
+        )
+        if isinstance(space_id, dict):
+            space_id = CompositeVariableModel(**space_id)
+        resolved: Any = value_of(space_id)
+        if not resolved:
+            raise ValueError(
+                "GenieAgentModel: unable to resolve agent_id. Set "
+                "genie_room.space_id (or its alias agent_id), or the "
+                "DATABRICKS_GENIE_SPACE_ID env var."
+            )
+        return str(resolved)
+
+    @property
+    def name(self) -> str:
+        """Model name for logging / trace ``ResourceInfo`` (the agent_id)."""
+        return self._agent_id
+
+    @property
+    def on_behalf_of_user(self) -> bool:
+        """Delegate OBO to the wrapped room (the single source of truth)."""
+        return bool(self.genie_room.on_behalf_of_user)
+
+    def workspace_client_from(
+        self, context: "Context | None", *, strict: bool = False
+    ) -> WorkspaceClient:
+        """Delegate to the wrapped room so OBO resolves identically to tools."""
+        return self.genie_room.workspace_client_from(context, strict=strict)
+
+    def chat_model_for_workspace_client(
+        self,
+        workspace_client: WorkspaceClient,
+        *,
+        conversation_id: "str | None" = None,
+    ) -> LanguageModelLike:
+        """Build a chat model bound to a specific (e.g. OBO) workspace client.
+
+        Consumed by :class:`dao_ai.middleware.genie_agent.GenieAgentMiddleware`
+        to swap in a user-scoped client (OBO) and the prior Genie
+        ``conversation_id`` per request, in one step.
+        """
+        from dao_ai.genie.agent_chat_model import GenieAgentChatModel
+
+        return GenieAgentChatModel(
+            agent_id=self._agent_id,
+            workspace_client=workspace_client,
+            conversation_id=conversation_id,
+            timeout_seconds=self.timeout_seconds,
+        )
+
+    def as_chat_model(self) -> LanguageModelLike:
+        """Build the streaming Genie chat model using the ambient/room client."""
+        return self.chat_model_for_workspace_client(self.genie_room.workspace_client)
 
 
 def _unwrap_text(value: Any) -> str | None:
@@ -7325,8 +7428,13 @@ class AgentModel(BaseModel):
         default=None,
         description="Human-readable description shown when the LLM selects handoff targets.",
     )
-    model: InferenceEndpointModel = Field(
-        description="LLM model configuration (serving endpoint name, temperature, etc.).",
+    model: InferenceEndpointModel | GenieAgentModel = Field(
+        description=(
+            "Reasoning model for this agent. Either an ``InferenceEndpointModel`` "
+            "(a Model Serving chat endpoint) or a ``GenieAgentModel`` (a Genie "
+            "Agent used as a streaming brain — typically with ``tools: []`` to "
+            "make this a Genie specialist sub-agent)."
+        ),
     )
     tools: list[ToolModel] = Field(
         default_factory=list,
@@ -10484,7 +10592,12 @@ class AppConfig(BaseModel):
             )
             for room_key, room in config.resources.genie_rooms.items():
                 raw_room: dict[str, Any] = raw_rooms.get(room_key) or {}
-                room._raw_space_id = raw_room.get("space_id")
+                # ``agent_id`` is an alias of ``space_id`` on GenieRoomModel
+                # (the Genie Agent Mode API renamed the concept); accept
+                # either key when snapshotting the pre-substitution value.
+                room._raw_space_id = raw_room.get("space_id") or raw_room.get(
+                    "agent_id"
+                )
 
         if initialize:
             config.initialize()

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -10485,6 +10485,65 @@ class AppConfig(BaseModel):
 
         return self
 
+    @model_validator(mode="after")
+    def _validate_genie_agent_rooms_registered(self) -> Self:
+        """Require every ``GenieAgentModel`` agent's room to be registered
+        under ``resources.genie_rooms``.
+
+        A ``GenieAgentModel`` is a plain wrapper — it is not an
+        ``IsDatabricksResource`` and is never collected for deploy grants.
+        The Genie deploy resource (``genie-space`` + ``dashboards.genie``
+        scope) is emitted only from ``resources.genie_rooms``. If an agent's
+        Genie room is inlined solely under ``agent.model.genie_room`` and not
+        registered, the bundle deploys with NO Genie grant and the agent 403s
+        at runtime — a silent failure. Catch it at config-load instead.
+
+        Matching is by resolved ``agent_id``/``space_id`` (not object
+        identity), so it holds whether the room is shared via a YAML anchor or
+        written inline with the same id. Rooms whose id cannot be resolved
+        statically (name-only, resolved by a live lookup) are skipped — they
+        cannot be checked without an API call.
+        """
+        registered_ids: set[str] = set()
+        if self.resources and self.resources.genie_rooms:
+            for room in self.resources.genie_rooms.values():
+                raw_id: Any = room.space_id
+                resolved: Any = value_of(raw_id) if raw_id is not None else None
+                if resolved:
+                    registered_ids.add(str(resolved))
+
+        seen: set[int] = set()
+
+        def _check_one(agent: AgentModel) -> None:
+            if id(agent) in seen:
+                return
+            seen.add(id(agent))
+            model = agent.model
+            if not isinstance(model, GenieAgentModel):
+                return
+            raw_id = model.genie_room.space_id
+            resolved = value_of(raw_id) if raw_id is not None else None
+            if not resolved:
+                # Name-only room; can't verify without a live lookup.
+                return
+            if str(resolved) not in registered_ids:
+                raise ValueError(
+                    f"Agent '{agent.name}' uses a GenieAgentModel whose Genie "
+                    f"room (agent_id/space_id '{resolved}') is not registered "
+                    f"under resources.genie_rooms. Register it there (e.g. via "
+                    f"a YAML anchor shared with agent.model.genie_room) so the "
+                    f"deploy emits the genie-space grant; otherwise the agent "
+                    f"will fail with PERMISSION_DENIED at runtime."
+                )
+
+        for agent in (self.agents or {}).values():
+            _check_one(agent)
+        if self.app and self.app.agents:
+            for agent in self.app.agents:
+                _check_one(agent)
+
+        return self
+
     @classmethod
     def from_file(
         cls,

--- a/src/dao_ai/genie/agent_chat_model.py
+++ b/src/dao_ai/genie/agent_chat_model.py
@@ -1,0 +1,461 @@
+"""A ``BaseChatModel`` backed by the Databricks Genie Agent Mode API.
+
+This is the streaming, model-resource counterpart to the legacy
+``type: genie`` tool. It calls
+``POST /api/2.0/genie/agents/{agent_id}/responses`` — an SSE-streaming,
+OpenAI-Responses-*style* endpoint (Beta) — and surfaces Genie's output as
+``AIMessageChunk``s so a plain :class:`~dao_ai.config.AgentModel` with no
+tools becomes a natively-streaming "Genie specialist" node.
+
+Why a chat model instead of a tool
+-----------------------------------
+A LangGraph tool node is atomic: it returns one ``ToolMessage`` after the
+whole stream completes, so Genie output never reaches the end user through
+the agent's own response stream. A model node, by contrast, streams
+``AIMessageChunk``s to the outer stream (``stream_mode="messages"``) and is
+routable by a supervisor like any other sub-agent.
+
+Statelessness and multi-turn
+-----------------------------
+``BaseChatModel`` has no access to graph state or ``ToolRuntime``. The Genie
+server owns conversation history keyed by its own ``conversation_id`` (issued
+on the first turn), which is **independent** of the LangGraph ``thread_id``
+used for graph-state persistence. This model is pure with respect to that id:
+:attr:`conversation_id` is passed in as a field (or ``None`` to start fresh),
+and the Genie-issued id for the turn is stamped on the returned message's
+``response_metadata['genie_conversation_id']``.
+
+Ownership of the cross-turn value lives in
+:class:`dao_ai.middleware.genie_agent.GenieAgentMiddleware`, which reads the
+prior id from ``session.genie.spaces[agent_id]`` before the call and writes the
+newly-issued id back to the same channel afterward — exactly the mechanism the
+legacy ``type: genie`` tool uses. The model itself keeps no state and never
+scans the message history.
+
+Authentication / OBO
+--------------------
+The SSE call authenticates via :class:`dao_ai.auth.WorkspaceBearerAuth`
+wrapping a :class:`~databricks.sdk.WorkspaceClient` injected at construction.
+:class:`dao_ai.middleware.genie_agent.GenieAgentMiddleware` rebuilds this chat
+model per request with a user-scoped ``WorkspaceClient`` (OBO) *and* the prior
+``conversation_id`` in one step — the two per-request concerns are handled
+together (see ``GenieAgentModel.chat_model_for_workspace_client``).
+"""
+
+from __future__ import annotations
+
+import json
+from textwrap import dedent
+from typing import Any, AsyncIterator, Iterator, Optional
+
+import httpx
+import mlflow
+from langchain_core.callbacks import (
+    AsyncCallbackManagerForLLMRun,
+    CallbackManagerForLLMRun,
+)
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    BaseMessage,
+    HumanMessage,
+)
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+from loguru import logger
+
+from dao_ai.auth import WorkspaceBearerAuth
+
+# Key under which the Genie conversation_id is stamped on the AIMessage's
+# response_metadata so the next turn can continue the same server-side
+# conversation.
+CONVERSATION_ID_METADATA_KEY: str = "genie_conversation_id"
+
+# MLflow span attribute keys.
+ATTR_AGENT_ID = "dao_ai.genie_agent.agent_id"
+ATTR_CONVERSATION_ID = "dao_ai.genie_agent.conversation_id"
+ATTR_RESPONSE_ID = "dao_ai.genie_agent.response_id"
+ATTR_TERMINAL_STATE = "dao_ai.genie_agent.stream.terminal_state"
+ATTR_TOTAL_EVENTS = "dao_ai.genie_agent.stream.total_events"
+
+
+class GenieAgentError(RuntimeError):
+    """Raised when the Genie Agent Mode API returns a terminal error event
+    or a non-2xx HTTP status."""
+
+
+def _parse_sse_lines(lines: list[str]) -> Iterator[tuple[Optional[str], dict[str, Any]]]:
+    """Yield ``(event, data)`` pairs from buffered SSE lines.
+
+    Parses the standard ``event:`` / ``data:`` line format; a blank line
+    terminates a record. ``data:`` is expected to be JSON; malformed data is
+    skipped with a debug log.
+    """
+    event_type: Optional[str] = None
+    data_lines: list[str] = []
+    for raw_line in lines:
+        line: str = raw_line.rstrip("\r")
+        if line == "":
+            if data_lines:
+                data_str: str = "\n".join(data_lines)
+                try:
+                    payload: dict[str, Any] = json.loads(data_str)
+                except json.JSONDecodeError as exc:
+                    logger.debug(f"genie_agent: skipping non-JSON SSE data: {exc}")
+                else:
+                    yield event_type, payload
+            event_type = None
+            data_lines = []
+            continue
+        if line.startswith(":"):
+            continue  # SSE comment / keepalive
+        if line.startswith("event:"):
+            event_type = line[len("event:") :].strip()
+        elif line.startswith("data:"):
+            data_lines.append(line[len("data:") :].lstrip())
+        # Unknown SSE field — ignore per spec.
+
+
+def _format_function_call_block(item: dict[str, Any]) -> str:
+    """Render a ``function_call`` item (execute_sql) as a fenced markdown block."""
+    name: str = item.get("name") or "function_call"
+    arguments_raw: Any = item.get("arguments")
+    arguments: dict[str, Any] = {}
+    if isinstance(arguments_raw, str):
+        try:
+            arguments = json.loads(arguments_raw)
+        except json.JSONDecodeError:
+            arguments = {"raw": arguments_raw}
+    elif isinstance(arguments_raw, dict):
+        arguments = arguments_raw
+
+    title: Optional[str] = arguments.get("title") if isinstance(arguments, dict) else None
+    sql: Optional[str] = arguments.get("sql") if isinstance(arguments, dict) else None
+
+    if name == "execute_sql" and sql:
+        heading: str = f"**{title}**\n" if title else ""
+        return f"{heading}```sql\n{sql}\n```"
+    return f"**{name}**\n```json\n{json.dumps(arguments, indent=2)}\n```"
+
+
+def _format_function_call_output(item: dict[str, Any]) -> str:
+    """Render a ``function_call_output`` item's markdown table string."""
+    output: Any = item.get("output")
+    if isinstance(output, str):
+        return output
+    if isinstance(output, dict):
+        return json.dumps(output, indent=2)
+    return str(output) if output is not None else ""
+
+
+def _format_message_item(item: dict[str, Any]) -> str:
+    """Concatenate ``output_text`` chunks from a ``message`` item."""
+    parts: list[str] = []
+    for content in item.get("content") or []:
+        if not isinstance(content, dict):
+            continue
+        if content.get("type") == "output_text":
+            text: Optional[str] = content.get("text")
+            if text:
+                parts.append(text)
+    return "\n".join(parts)
+
+
+class _StreamState:
+    """Accumulates SSE events into ordered content segments + terminal status.
+
+    Feeds both the sync (``_generate``) and async (``_astream``) code paths so
+    the event → text mapping lives in one place. Each accepted event that
+    produces visible text returns that text (with a trailing separator) from
+    :meth:`handle` so a streaming caller can emit it as a chunk; the same text
+    is also appended to :attr:`segments` for the aggregated final message.
+    """
+
+    def __init__(self) -> None:
+        self.conversation_id: Optional[str] = None
+        self.response_id: Optional[str] = None
+        self.segments: list[str] = []
+        self.event_count: int = 0
+        self.terminal_status: Optional[str] = None
+        self.terminal_error: Optional[str] = None
+
+    def handle(self, event_type: Optional[str], payload: dict[str, Any]) -> Optional[str]:
+        """Process one event. Returns text to stream, or ``None``."""
+        self.event_count += 1
+        kind: str = event_type or payload.get("type") or ""
+
+        if kind == "response.created":
+            response_obj: dict[str, Any] = payload.get("response") or {}
+            self.conversation_id = response_obj.get("conversation_id") or self.conversation_id
+            self.response_id = response_obj.get("id") or self.response_id
+            return None
+
+        if kind == "response.output_item.done":
+            item: dict[str, Any] = payload.get("item") or {}
+            item_type: str = item.get("type") or ""
+            text: Optional[str] = None
+            if item_type == "function_call":
+                text = _format_function_call_block(item)
+            elif item_type == "function_call_output":
+                text = _format_function_call_output(item) or None
+            elif item_type == "message":
+                text = _format_message_item(item) or None
+            # reasoning items are intentionally not surfaced.
+            if text:
+                self.segments.append(text)
+                return text + "\n\n"
+            return None
+
+        if kind in {"response.completed", "response.failed"}:
+            response_obj = payload.get("response") or {}
+            self.conversation_id = response_obj.get("conversation_id") or self.conversation_id
+            self.response_id = response_obj.get("id") or self.response_id
+            self.terminal_status = response_obj.get("status") or kind
+            error: Optional[dict[str, Any]] = response_obj.get("error")
+            if error:
+                code: str = error.get("code") or "error"
+                message: str = error.get("message") or ""
+                self.terminal_error = f"[{code}] {message}"
+            return None
+
+        return None
+
+    def aggregated_content(self) -> str:
+        content: str = "\n\n".join(seg for seg in self.segments if seg)
+        return content or "(Genie Agent returned no output.)"
+
+    def raise_on_error(self) -> None:
+        if self.terminal_error:
+            raise GenieAgentError(
+                f"Genie Agent Mode API failed (status={self.terminal_status}): "
+                f"{self.terminal_error}"
+            )
+
+
+def _latest_human_text(messages: list[BaseMessage]) -> str:
+    """Return the text of the most recent ``HumanMessage``.
+
+    Genie takes exactly one user turn; prior turns and system prompts are not
+    replayed (the server owns history via ``conversation_id``).
+    """
+    for message in reversed(messages):
+        if isinstance(message, HumanMessage):
+            content: Any = message.content
+            if isinstance(content, str):
+                return content
+            # Content-block form: concatenate text blocks.
+            if isinstance(content, list):
+                parts: list[str] = [
+                    block.get("text", "")
+                    for block in content
+                    if isinstance(block, dict) and block.get("type") in {"text", "input_text"}
+                ]
+                return "\n".join(p for p in parts if p)
+    raise GenieAgentError("GenieAgentChatModel: no HumanMessage found in the input.")
+
+
+class GenieAgentChatModel(BaseChatModel):
+    """LangChain chat model that streams the Databricks Genie Agent Mode API.
+
+    Not registered as a serving endpoint — it targets
+    ``/api/2.0/genie/agents/{agent_id}/responses`` directly. Bind a specific
+    :class:`~databricks.sdk.WorkspaceClient` (SP or forwarded-user) at
+    construction so OBO is honored per request.
+    """
+
+    agent_id: str
+    """32-char hex Genie agent/space id (the renamed ``space_id``)."""
+
+    workspace_client: Any
+    """The :class:`~databricks.sdk.WorkspaceClient` whose auth identity Genie
+    sees. Swapped per request for OBO. Typed ``Any`` to avoid a strict pydantic
+    ``isinstance`` gate — only ``.config.host`` and ``.config.authenticate()``
+    (via :class:`~dao_ai.auth.WorkspaceBearerAuth`) are used."""
+
+    conversation_id: Optional[str] = None
+    """Genie-issued conversation id to continue on this call, or ``None`` to
+    start a new Genie conversation. The Genie service owns this value; the model
+    only replays it. Set per request by
+    :class:`dao_ai.middleware.genie_agent.GenieAgentMiddleware`, which reads it
+    from ``session.genie.spaces[agent_id]`` and writes the newly-issued id back
+    to the same channel. Kept independent of the LangGraph ``thread_id`` used
+    for graph-state persistence."""
+
+    timeout_seconds: int = 300
+    """httpx client timeout. The Genie server-side response cap is 90 minutes."""
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    @property
+    def _llm_type(self) -> str:
+        return "databricks-genie-agent"
+
+    @property
+    def _identifying_params(self) -> dict[str, Any]:
+        return {"agent_id": self.agent_id, "timeout_seconds": self.timeout_seconds}
+
+    # -- request helpers ------------------------------------------------
+
+    def _url(self) -> str:
+        host: str = self.workspace_client.config.host.rstrip("/")
+        return f"{host}/api/2.0/genie/agents/{self.agent_id}/responses"
+
+    def _body(self, messages: list[BaseMessage]) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": _latest_human_text(messages)}
+                    ],
+                }
+            ]
+        }
+        if self.conversation_id:
+            body["conversation_id"] = self.conversation_id
+        return body
+
+    def _set_span_attributes(self, state: _StreamState) -> None:
+        span = mlflow.get_current_active_span()
+        if span is None:
+            return
+        span.set_attribute(ATTR_AGENT_ID, self.agent_id)
+        span.set_attribute(ATTR_TOTAL_EVENTS, state.event_count)
+        if state.conversation_id:
+            span.set_attribute(ATTR_CONVERSATION_ID, state.conversation_id)
+        if state.response_id:
+            span.set_attribute(ATTR_RESPONSE_ID, state.response_id)
+        if state.terminal_status:
+            span.set_attribute(ATTR_TERMINAL_STATE, state.terminal_status)
+
+    def _final_message(self, state: _StreamState) -> AIMessage:
+        response_metadata: dict[str, Any] = {}
+        if state.conversation_id:
+            response_metadata[CONVERSATION_ID_METADATA_KEY] = state.conversation_id
+        if state.response_id:
+            response_metadata["genie_response_id"] = state.response_id
+        return AIMessage(
+            content=state.aggregated_content(),
+            response_metadata=response_metadata,
+        )
+
+    @staticmethod
+    def _raise_for_http(status_code: int, body: bytes) -> None:
+        message: str = body.decode("utf-8", errors="replace") if body else ""
+        raise GenieAgentError(
+            f"Genie Agent Mode API returned HTTP {status_code}: {message}"
+        )
+
+    # -- async streaming (primary path) --------------------------------
+
+    async def _astream(
+        self,
+        messages: list[BaseMessage],
+        stop: Optional[list[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[ChatGenerationChunk]:
+        state = _StreamState()
+        url: str = self._url()
+        body: dict[str, Any] = self._body(messages)
+
+        async with httpx.AsyncClient(
+            auth=WorkspaceBearerAuth(self.workspace_client),
+            timeout=self.timeout_seconds,
+        ) as client:
+            async with client.stream(
+                "POST", url, json=body, headers={"Accept": "text/event-stream"}
+            ) as response:
+                if response.status_code >= 400:
+                    self._raise_for_http(response.status_code, await response.aread())
+
+                buffer: list[str] = []
+                async for raw_line in response.aiter_lines():
+                    buffer.append(raw_line)
+                    if raw_line.rstrip("\r") != "":
+                        continue
+                    # Complete record boundary — parse and drain.
+                    for event_type, payload in _parse_sse_lines(buffer):
+                        text: Optional[str] = state.handle(event_type, payload)
+                        if text:
+                            chunk = ChatGenerationChunk(
+                                message=AIMessageChunk(content=text)
+                            )
+                            if run_manager:
+                                await run_manager.on_llm_new_token(text, chunk=chunk)
+                            yield chunk
+                    buffer = []
+
+        self._set_span_attributes(state)
+        state.raise_on_error()
+
+        # Emit a terminal chunk carrying the conversation_id metadata so the
+        # accumulated AIMessage the caller assembles can be continued next turn.
+        final_meta: dict[str, Any] = {}
+        if state.conversation_id:
+            final_meta[CONVERSATION_ID_METADATA_KEY] = state.conversation_id
+        if state.response_id:
+            final_meta["genie_response_id"] = state.response_id
+        if final_meta:
+            yield ChatGenerationChunk(
+                message=AIMessageChunk(content="", response_metadata=final_meta)
+            )
+
+    async def _agenerate(
+        self,
+        messages: list[BaseMessage],
+        stop: Optional[list[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        state = _StreamState()
+        url: str = self._url()
+        body: dict[str, Any] = self._body(messages)
+
+        async with httpx.AsyncClient(
+            auth=WorkspaceBearerAuth(self.workspace_client),
+            timeout=self.timeout_seconds,
+        ) as client:
+            async with client.stream(
+                "POST", url, json=body, headers={"Accept": "text/event-stream"}
+            ) as response:
+                if response.status_code >= 400:
+                    self._raise_for_http(response.status_code, await response.aread())
+                lines: list[str] = [line async for line in response.aiter_lines()]
+
+        for event_type, payload in _parse_sse_lines(lines):
+            state.handle(event_type, payload)
+        self._set_span_attributes(state)
+        state.raise_on_error()
+        return ChatResult(generations=[ChatGeneration(message=self._final_message(state))])
+
+    # -- sync path (aggregating) ---------------------------------------
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: Optional[list[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        state = _StreamState()
+        url: str = self._url()
+        body: dict[str, Any] = self._body(messages)
+
+        with httpx.Client(
+            auth=WorkspaceBearerAuth(self.workspace_client),
+            timeout=self.timeout_seconds,
+        ) as client:
+            with client.stream(
+                "POST", url, json=body, headers={"Accept": "text/event-stream"}
+            ) as response:
+                if response.status_code >= 400:
+                    self._raise_for_http(response.status_code, response.read())
+                lines: list[str] = list(response.iter_lines())
+
+        for event_type, payload in _parse_sse_lines(lines):
+            state.handle(event_type, payload)
+        self._set_span_attributes(state)
+        state.raise_on_error()
+        return ChatResult(generations=[ChatGeneration(message=self._final_message(state))])

--- a/src/dao_ai/middleware/genie_agent.py
+++ b/src/dao_ai/middleware/genie_agent.py
@@ -1,0 +1,156 @@
+"""Per-request middleware for :class:`~dao_ai.config.GenieAgentModel` agents.
+
+A Genie-Agent-backed agent has two per-request concerns that a plain
+``BaseChatModel`` cannot handle on its own:
+
+1. **OBO** — the SSE call must run under the calling user's identity when
+   ``genie_room.on_behalf_of_user`` is set, so the model is rebuilt per request
+   with a user-scoped ``WorkspaceClient`` (same idea as
+   :class:`dao_ai.middleware.obo.OBOModelMiddleware`).
+2. **Genie conversation continuity** — the Genie service issues a
+   ``conversation_id`` on the first turn that must be replayed on later turns to
+   continue the same server-side conversation. This id is **independent** of the
+   LangGraph ``thread_id`` used for graph-state persistence; it is cached in
+   ``session.genie.spaces[agent_id]`` — exactly where the legacy ``type: genie``
+   tool keeps it — and merged through the ``merge_session`` reducer.
+
+Both are inseparable per-request rebuilds of the model, so one middleware owns
+both. This replaces the generic ``OBOModelMiddleware`` for Genie models (a
+second, generic model-swap middleware would clobber the conversation-bound
+model this one installs).
+
+Flow per call:
+
+* read the prior ``conversation_id`` from ``request.state['session']``;
+* build a :class:`GenieAgentChatModel` bound to the (OBO-aware) workspace client
+  and that prior id;
+* run the model via ``handler(request.override(model=...))``;
+* read the Genie-issued id off the returned ``AIMessage.response_metadata``
+  (reliable here — read within the same run, before the ResponsesAgent
+  serialization strips metadata);
+* persist it back to ``session`` via
+  ``ExtendedModelResponse(command=Command(update={"session": ...}))``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Optional
+
+from langchain.agents.middleware.types import (
+    ExtendedModelResponse,
+    ModelRequest,
+    ModelResponse,
+)
+from langchain_core.language_models import LanguageModelLike
+from langchain_core.messages import AIMessage
+from langgraph.types import Command
+from loguru import logger
+
+from dao_ai.config import GenieAgentModel
+from dao_ai.genie.agent_chat_model import CONVERSATION_ID_METADATA_KEY
+from dao_ai.middleware.base import AgentMiddleware
+from dao_ai.state import AgentState, Context, SessionState
+from dao_ai.tools.tracing import ResourceInfo, set_resource_attributes
+
+
+class GenieAgentMiddleware(AgentMiddleware[AgentState, Context]):
+    """Rebuild a Genie chat model per request with OBO + prior conversation_id,
+    and persist the newly-issued conversation_id back to ``session``."""
+
+    def __init__(self, genie_model: GenieAgentModel) -> None:
+        self.genie_model = genie_model
+
+    # -- helpers -------------------------------------------------------
+
+    def _prior_conversation_id(self, state: AgentState) -> Optional[str]:
+        """Read the last Genie conversation_id for this agent from session."""
+        session: Optional[SessionState] = (state or {}).get("session")
+        if session is None:
+            return None
+        return session.genie.get_conversation_id(self.genie_model.name)
+
+    def _build_model(
+        self, context: Context | None, prior_conversation_id: Optional[str]
+    ) -> LanguageModelLike:
+        workspace_client = self.genie_model.workspace_client_from(context)
+        set_resource_attributes(
+            ResourceInfo(
+                "genie_agent",
+                self.genie_model.on_behalf_of_user,
+                self.genie_model.name,
+            )
+        )
+        return self.genie_model.chat_model_for_workspace_client(
+            workspace_client, conversation_id=prior_conversation_id
+        )
+
+    @staticmethod
+    def _issued_conversation_id(response: ModelResponse) -> Optional[str]:
+        """Pull the Genie-issued conversation_id off the response messages."""
+        for message in reversed(response.result or []):
+            if isinstance(message, AIMessage):
+                conv_id: Any = (message.response_metadata or {}).get(
+                    CONVERSATION_ID_METADATA_KEY
+                )
+                if conv_id:
+                    return str(conv_id)
+        return None
+
+    def _session_command(
+        self,
+        state: AgentState,
+        issued_conversation_id: Optional[str],
+        prior_conversation_id: Optional[str],
+    ) -> Command | None:
+        """Build a session-update Command when the conversation_id changed."""
+        if not issued_conversation_id:
+            return None
+        if issued_conversation_id == prior_conversation_id:
+            return None  # nothing new to persist
+        session: SessionState = (state or {}).get("session") or SessionState()
+        session.genie.update_space(
+            space_id=self.genie_model.name,
+            conversation_id=issued_conversation_id,
+        )
+        logger.debug(
+            "GenieAgentMiddleware persisted conversation_id",
+            agent_id=self.genie_model.name,
+            conversation_id=issued_conversation_id,
+        )
+        return Command(update={"session": session})
+
+    # -- sync ----------------------------------------------------------
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelResponse | ExtendedModelResponse:
+        context: Context | None = request.runtime.context if request.runtime else None
+        prior: Optional[str] = self._prior_conversation_id(request.state)
+        model: LanguageModelLike = self._build_model(context, prior)
+        response: ModelResponse = handler(request.override(model=model))
+        command: Command | None = self._session_command(
+            request.state, self._issued_conversation_id(response), prior
+        )
+        if command is None:
+            return response
+        return ExtendedModelResponse(model_response=response, command=command)
+
+    # -- async ---------------------------------------------------------
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse | ExtendedModelResponse:
+        context: Context | None = request.runtime.context if request.runtime else None
+        prior: Optional[str] = self._prior_conversation_id(request.state)
+        model: LanguageModelLike = self._build_model(context, prior)
+        response: ModelResponse = await handler(request.override(model=model))
+        command: Command | None = self._session_command(
+            request.state, self._issued_conversation_id(response), prior
+        )
+        if command is None:
+            return response
+        return ExtendedModelResponse(model_response=response, command=command)

--- a/src/dao_ai/middleware/obo.py
+++ b/src/dao_ai/middleware/obo.py
@@ -26,7 +26,7 @@ from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.language_models import LanguageModelLike
 from loguru import logger
 
-from dao_ai.config import InferenceEndpointModel
+from dao_ai.config import GenieAgentModel, InferenceEndpointModel
 from dao_ai.middleware.base import AgentMiddleware
 from dao_ai.state import AgentState, Context
 from dao_ai.tools.tracing import ResourceInfo, set_resource_attributes
@@ -43,7 +43,9 @@ class OBOModelMiddleware(AgentMiddleware[AgentState, Context]):
     4. Swaps the model via ``request.override(model=...)``
     """
 
-    def __init__(self, llm_model: InferenceEndpointModel) -> None:
+    def __init__(
+        self, llm_model: InferenceEndpointModel | GenieAgentModel
+    ) -> None:
         self.llm_model = llm_model
 
     def _create_obo_model(self, context: Context | None) -> LanguageModelLike:

--- a/src/dao_ai/nodes.py
+++ b/src/dao_ai/nodes.py
@@ -381,8 +381,24 @@ def create_agent_node(
                     auto_inject_limit=extraction.auto_inject_limit,
                 )
 
-    # Add OBO model middleware when LLM uses on-behalf-of-user authentication
-    if agent.model.on_behalf_of_user:
+    # Model middleware. A GenieAgentModel needs a per-request model rebuild for
+    # BOTH OBO and Genie conversation continuity, so it always gets the
+    # dedicated GenieAgentMiddleware (which also does OBO) instead of the
+    # generic OBOModelMiddleware. A regular serving-endpoint model only needs
+    # OBO, and only when on_behalf_of_user is set.
+    from dao_ai.config import GenieAgentModel
+
+    if isinstance(agent.model, GenieAgentModel):
+        from dao_ai.middleware.genie_agent import GenieAgentMiddleware
+
+        middleware_list.append(GenieAgentMiddleware(genie_model=agent.model))
+        logger.info(
+            "Genie agent middleware enabled",
+            agent=agent.name,
+            model=agent.model.name,
+            on_behalf_of_user=agent.model.on_behalf_of_user,
+        )
+    elif agent.model.on_behalf_of_user:
         from dao_ai.middleware.obo import OBOModelMiddleware
 
         middleware_list.append(OBOModelMiddleware(llm_model=agent.model))

--- a/tests/dao_ai/test_genie_agent_middleware.py
+++ b/tests/dao_ai/test_genie_agent_middleware.py
@@ -1,0 +1,136 @@
+"""Unit tests for :class:`dao_ai.middleware.genie_agent.GenieAgentMiddleware`.
+
+The middleware owns Genie conversation continuity (independent of the LangGraph
+thread_id). It must:
+
+1. Read the prior conversation_id from ``session.genie.spaces[agent_id]`` and
+   build the per-request model with it (and an OBO-aware workspace client).
+2. Read the Genie-issued conversation_id off the response and persist it back
+   to ``session`` via an ``ExtendedModelResponse`` Command — keyed by agent_id.
+3. Not emit a session update when the id is unchanged.
+
+The model build + handler are stubbed; this tests the middleware's read/write
+wiring, not the SSE call (covered by test_genie_agent_model.py).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+from langchain.agents.middleware.types import ExtendedModelResponse, ModelResponse
+from langchain_core.messages import AIMessage
+
+from dao_ai.config import GenieAgentModel, GenieRoomModel
+from dao_ai.genie.agent_chat_model import CONVERSATION_ID_METADATA_KEY
+from dao_ai.middleware.genie_agent import GenieAgentMiddleware
+from dao_ai.state import Context, SessionState
+
+AGENT_ID = "01f05dd06c421ad6b522bf7a517cf6d2"
+
+
+def _middleware(monkeypatch: Any) -> tuple[GenieAgentMiddleware, dict[str, Any]]:
+    """Build a middleware whose model-build is stubbed to record its args."""
+    model = GenieAgentModel(genie_room=GenieRoomModel(space_id=AGENT_ID))
+    built: dict[str, Any] = {}
+
+    # Stub OBO client resolution + the per-request model build so we don't hit
+    # the network or need a real WorkspaceClient.
+    monkeypatch.setattr(
+        GenieRoomModel, "workspace_client_from", lambda self, ctx, *, strict=False: MagicMock()
+    )
+
+    def _fake_build(self: GenieAgentModel, ws: Any, *, conversation_id: str | None = None) -> Any:
+        built["conversation_id"] = conversation_id
+        return MagicMock(name="GenieAgentChatModel")
+
+    monkeypatch.setattr(GenieAgentModel, "chat_model_for_workspace_client", _fake_build)
+    return GenieAgentMiddleware(genie_model=model), built
+
+
+def _request(session: SessionState | None) -> MagicMock:
+    request = MagicMock(name="ModelRequest")
+    request.state = {"session": session} if session is not None else {}
+    request.runtime.context = Context(user_id="u", thread_id="thr-1")
+    request.override.return_value = request
+    return request
+
+
+def _handler_returning(conversation_id: str | None):
+    def _handler(_req: Any) -> ModelResponse:
+        meta = {CONVERSATION_ID_METADATA_KEY: conversation_id} if conversation_id else {}
+        return ModelResponse(result=[AIMessage("answer", response_metadata=meta)])
+
+    return _handler
+
+
+class TestReadPriorId:
+    def test_prior_id_passed_to_model_build(self, monkeypatch: Any) -> None:
+        mw, built = _middleware(monkeypatch)
+        session = SessionState()
+        session.genie.update_space(space_id=AGENT_ID, conversation_id="conv-prior")
+        request = _request(session)
+
+        mw.wrap_model_call(request, _handler_returning("conv-prior"))
+        assert built["conversation_id"] == "conv-prior"
+
+    def test_no_session_means_no_prior_id(self, monkeypatch: Any) -> None:
+        mw, built = _middleware(monkeypatch)
+        request = _request(None)
+        mw.wrap_model_call(request, _handler_returning("conv-new"))
+        assert built["conversation_id"] is None
+
+
+class TestPersistIssuedId:
+    def test_new_id_persisted_to_session(self, monkeypatch: Any) -> None:
+        mw, _ = _middleware(monkeypatch)
+        request = _request(None)
+        result = mw.wrap_model_call(request, _handler_returning("conv-new"))
+        assert isinstance(result, ExtendedModelResponse)
+        session: SessionState = result.command.update["session"]
+        assert session.genie.get_conversation_id(AGENT_ID) == "conv-new"
+
+    def test_unchanged_id_no_command(self, monkeypatch: Any) -> None:
+        mw, _ = _middleware(monkeypatch)
+        session = SessionState()
+        session.genie.update_space(space_id=AGENT_ID, conversation_id="conv-same")
+        request = _request(session)
+        result = mw.wrap_model_call(request, _handler_returning("conv-same"))
+        # Unchanged id -> plain ModelResponse, no session write.
+        assert not isinstance(result, ExtendedModelResponse)
+
+    def test_no_issued_id_no_command(self, monkeypatch: Any) -> None:
+        mw, _ = _middleware(monkeypatch)
+        request = _request(None)
+        result = mw.wrap_model_call(request, _handler_returning(None))
+        assert not isinstance(result, ExtendedModelResponse)
+
+    def test_id_keyed_by_agent_id(self, monkeypatch: Any) -> None:
+        mw, _ = _middleware(monkeypatch)
+        # A different agent's conversation must not be clobbered.
+        session = SessionState()
+        session.genie.update_space(space_id="other-agent", conversation_id="other-conv")
+        request = _request(session)
+        result = mw.wrap_model_call(request, _handler_returning("conv-new"))
+        merged: SessionState = result.command.update["session"]
+        assert merged.genie.get_conversation_id(AGENT_ID) == "conv-new"
+        assert merged.genie.get_conversation_id("other-agent") == "other-conv"
+
+
+class TestAsync:
+    def test_awrap_persists(self, monkeypatch: Any) -> None:
+        mw, built = _middleware(monkeypatch)
+        session = SessionState()
+        session.genie.update_space(space_id=AGENT_ID, conversation_id="conv-prior")
+        request = _request(session)
+
+        async def _ahandler(_req: Any) -> ModelResponse:
+            return ModelResponse(
+                result=[AIMessage("a", response_metadata={CONVERSATION_ID_METADATA_KEY: "conv-next"})]
+            )
+
+        result = asyncio.run(mw.awrap_model_call(request, _ahandler))
+        assert built["conversation_id"] == "conv-prior"
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command.update["session"].genie.get_conversation_id(AGENT_ID) == "conv-next"

--- a/tests/dao_ai/test_genie_agent_model.py
+++ b/tests/dao_ai/test_genie_agent_model.py
@@ -323,6 +323,37 @@ class TestConfigModel:
         )
         assert isinstance(agent.model, InferenceEndpointModel)
 
+    def test_bare_room_dict_autowrapped(self) -> None:
+        # A bare room dict (agent_id) assigned to model is wrapped.
+        agent = AgentModel.model_validate(
+            {"name": "g", "model": {"agent_id": AGENT_ID}, "tools": []}
+        )
+        assert isinstance(agent.model, GenieAgentModel)
+        assert agent.model.name == AGENT_ID
+
+    def test_bare_room_instance_autowrapped(self) -> None:
+        agent = AgentModel.model_validate(
+            {"name": "g", "model": GenieRoomModel(space_id=AGENT_ID), "tools": []}
+        )
+        assert isinstance(agent.model, GenieAgentModel)
+
+    def test_bare_room_uses_default_timeout(self) -> None:
+        agent = AgentModel.model_validate(
+            {"name": "g", "model": {"space_id": AGENT_ID}, "tools": []}
+        )
+        assert agent.model.timeout_seconds == 300
+
+    def test_explicit_wrapper_keeps_custom_timeout(self) -> None:
+        agent = AgentModel.model_validate(
+            {
+                "name": "g",
+                "model": {"genie_room": {"agent_id": AGENT_ID}, "timeout_seconds": 600},
+                "tools": [],
+            }
+        )
+        assert isinstance(agent.model, GenieAgentModel)
+        assert agent.model.timeout_seconds == 600
+
     def test_unresolvable_agent_id_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # A name-only room (no space_id) with no env fallback cannot resolve
         # an agent_id without a live lookup.

--- a/tests/dao_ai/test_genie_agent_model.py
+++ b/tests/dao_ai/test_genie_agent_model.py
@@ -330,3 +330,44 @@ class TestConfigModel:
         m = GenieAgentModel(genie_room=GenieRoomModel(name="Some Room"))
         with pytest.raises(ValueError, match="unable to resolve agent_id"):
             _ = m.name
+
+
+# ---------------------------------------------------------------------------
+# AppConfig-level: GenieAgentModel room must be registered under genie_rooms
+# ---------------------------------------------------------------------------
+
+
+class TestGenieRoomRegistrationValidator:
+    def test_unregistered_room_rejected(self) -> None:
+        from dao_ai.config import AppConfig
+
+        cfg = {
+            "agents": {
+                "g": {"name": "g", "model": {"genie_room": {"agent_id": AGENT_ID}}, "tools": []}
+            }
+        }
+        with pytest.raises(ValueError, match="not registered under resources.genie_rooms"):
+            AppConfig(**cfg)
+
+    def test_registered_room_passes(self) -> None:
+        from dao_ai.config import AppConfig
+
+        cfg = {
+            "resources": {"genie_rooms": {"retail": {"agent_id": AGENT_ID}}},
+            "agents": {
+                "g": {"name": "g", "model": {"genie_room": {"agent_id": AGENT_ID}}, "tools": []}
+            },
+        }
+        # Should not raise.
+        AppConfig(**cfg)
+
+    def test_serving_endpoint_agent_unaffected(self) -> None:
+        from dao_ai.config import AppConfig
+
+        cfg = {
+            "agents": {
+                "x": {"name": "x", "model": {"name": "databricks-claude-sonnet-4"}, "tools": []}
+            }
+        }
+        # A non-Genie model is never subject to the genie_rooms check.
+        AppConfig(**cfg)

--- a/tests/dao_ai/test_genie_agent_model.py
+++ b/tests/dao_ai/test_genie_agent_model.py
@@ -1,0 +1,332 @@
+"""Unit tests for the Genie Agent *model* resource.
+
+Covers :class:`dao_ai.genie.agent_chat_model.GenieAgentChatModel` and
+:class:`dao_ai.config.GenieAgentModel`:
+
+1. SSE stream aggregation (sync ``_generate`` + async ``_astream``).
+2. Multi-turn: the prior ``conversation_id`` is recovered from the most
+   recent ``AIMessage.response_metadata`` and sent back in the body; a new
+   id is stamped on the returned message.
+3. ``_astream`` yields ``AIMessageChunk``s in stream order.
+4. HTTP >=400 and ``response.failed`` both raise :class:`GenieAgentError`.
+5. Config: ``GenieAgentModel`` exposes the ``InferenceEndpointModel``-duck-
+   typed surface (``name``, ``on_behalf_of_user``, ``workspace_client_from``,
+   ``chat_model_for_workspace_client``, ``as_chat_model``) and parses through
+   the ``AgentModel.model`` union.
+
+httpx is driven with a real ``MockTransport`` so the SSE parsing exercises the
+genuine ``iter_lines``/``aiter_lines`` code paths. The WorkspaceClient is a
+stub exposing only ``config.host`` and ``config.authenticate``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Iterable
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from dao_ai.config import AgentModel, GenieAgentModel, GenieRoomModel, InferenceEndpointModel
+from dao_ai.genie.agent_chat_model import (
+    CONVERSATION_ID_METADATA_KEY,
+    GenieAgentChatModel,
+    GenieAgentError,
+)
+from langchain_core.messages import AIMessage, HumanMessage
+
+AGENT_ID: str = "01f05dd06c421ad6b522bf7a517cf6d2"
+HOST: str = "https://example.cloud.databricks.com"
+
+
+# ---------------------------------------------------------------------------
+# SSE fixtures
+# ---------------------------------------------------------------------------
+
+
+def _sse(events: Iterable[tuple[str, dict[str, Any]]]) -> bytes:
+    lines: list[str] = []
+    for event_type, payload in events:
+        lines.append(f"event: {event_type}")
+        lines.append(f"data: {json.dumps(payload)}")
+        lines.append("")
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def _happy_events(conversation_id: str = "conv-1") -> list[tuple[str, dict[str, Any]]]:
+    return [
+        (
+            "response.created",
+            {"response": {"id": "resp-1", "conversation_id": conversation_id, "status": "in_progress"}},
+        ),
+        (
+            "response.output_item.done",
+            {
+                "item": {
+                    "id": "call-a",
+                    "type": "function_call",
+                    "name": "execute_sql",
+                    "arguments": json.dumps(
+                        {"title": "Store count", "sql": "SELECT state, COUNT(*) FROM stores GROUP BY state"}
+                    ),
+                }
+            },
+        ),
+        (
+            "response.output_item.done",
+            {"item": {"id": "out-a", "type": "function_call_output", "output": "| state | count |\n|---|---|\n| CA | 42 |\n"}},
+        ),
+        (
+            "response.output_item.done",
+            {"item": {"id": "msg-a", "type": "message", "content": [{"type": "output_text", "text": "California leads with 42 stores."}]}},
+        ),
+        (
+            "response.completed",
+            {"response": {"id": "resp-1", "conversation_id": conversation_id, "status": "completed"}},
+        ),
+    ]
+
+
+def _fake_workspace_client() -> Any:
+    """A duck-typed WorkspaceClient: ``config.host`` + ``config.authenticate``.
+
+    ``GenieAgentChatModel.workspace_client`` is typed ``Any`` and only touches
+    ``.config.host`` and ``.config.authenticate()`` (via ``WorkspaceBearerAuth``),
+    so a plain stub suffices — no need to construct the real SDK client.
+    """
+    ws = MagicMock(name="WorkspaceClient")
+    ws.config.host = HOST
+    ws.config.authenticate.return_value = {"Authorization": "Bearer stub-token"}
+    return ws
+
+
+def _model_with_transport(
+    handler: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    record: dict[str, Any] | None = None,
+) -> GenieAgentChatModel:
+    """Build a GenieAgentChatModel whose httpx clients use a MockTransport."""
+
+    def _mock_handler(request: httpx.Request) -> httpx.Response:
+        if record is not None:
+            record["url"] = str(request.url)
+            record["body"] = json.loads(request.content.decode("utf-8"))
+            record["auth"] = request.headers.get("Authorization")
+        return handler(request)
+
+    transport = httpx.MockTransport(_mock_handler)
+
+    real_async_init = httpx.AsyncClient.__init__
+    real_sync_init = httpx.Client.__init__
+
+    def _async_init(self: httpx.AsyncClient, **kwargs: Any) -> None:
+        kwargs["transport"] = transport
+        real_async_init(self, **kwargs)
+
+    def _sync_init(self: httpx.Client, **kwargs: Any) -> None:
+        kwargs["transport"] = transport
+        real_sync_init(self, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", _async_init)
+    monkeypatch.setattr(httpx.Client, "__init__", _sync_init)
+
+    return GenieAgentChatModel(
+        agent_id=AGENT_ID,
+        workspace_client=_fake_workspace_client(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Streaming aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestStreaming:
+    def test_generate_aggregates_sync(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        record: dict[str, Any] = {}
+        model = _model_with_transport(
+            lambda req: httpx.Response(200, content=_sse(_happy_events())),
+            monkeypatch,
+            record=record,
+        )
+        result = model.invoke([HumanMessage("How many stores by state?")])
+        content = result.content
+        assert "```sql" in content
+        assert "SELECT state, COUNT(*) FROM stores" in content
+        assert "California leads with 42 stores." in content
+        assert "| state | count |" in content
+        # conversation_id stamped on the returned message.
+        assert result.response_metadata[CONVERSATION_ID_METADATA_KEY] == "conv-1"
+        # Request shape: single user turn, no conversation_id on first turn.
+        assert record["url"].endswith(f"/api/2.0/genie/agents/{AGENT_ID}/responses")
+        assert record["body"]["input"][0]["content"][0]["text"] == "How many stores by state?"
+        assert "conversation_id" not in record["body"]
+        assert record["auth"] == "Bearer stub-token"
+
+    def test_astream_yields_chunks_in_order(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        model = _model_with_transport(
+            lambda req: httpx.Response(200, content=_sse(_happy_events())),
+            monkeypatch,
+        )
+
+        async def _collect() -> list[str]:
+            chunks: list[str] = []
+            async for chunk in model.astream([HumanMessage("q")]):
+                chunks.append(chunk.content)
+            return chunks
+
+        chunks = asyncio.run(_collect())
+        joined = "".join(chunks)
+        # SQL precedes table precedes narrative.
+        assert joined.index("```sql") < joined.index("| state | count |") < joined.index("California leads")
+
+    def test_astream_final_chunk_carries_conversation_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        model = _model_with_transport(
+            lambda req: httpx.Response(200, content=_sse(_happy_events())),
+            monkeypatch,
+        )
+
+        async def _accumulate() -> AIMessage:
+            acc = None
+            async for chunk in model.astream([HumanMessage("q")]):
+                acc = chunk if acc is None else acc + chunk
+            return acc
+
+        acc = asyncio.run(_accumulate())
+        assert acc.response_metadata.get(CONVERSATION_ID_METADATA_KEY) == "conv-1"
+
+
+# ---------------------------------------------------------------------------
+# conversation_id is a pure field on the model (no message scanning)
+# ---------------------------------------------------------------------------
+
+
+class TestConversationIdField:
+    def test_conversation_id_field_sent_in_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        record: dict[str, Any] = {}
+        model = _model_with_transport(
+            lambda req: httpx.Response(200, content=_sse(_happy_events("conv-2"))),
+            monkeypatch,
+            record=record,
+        )
+        # The field — not any message metadata — drives the body.
+        model.conversation_id = "conv-existing"
+        model.invoke(
+            [
+                HumanMessage("first"),
+                AIMessage(
+                    "prev answer",
+                    response_metadata={CONVERSATION_ID_METADATA_KEY: "ignored-metadata"},
+                ),
+                HumanMessage("follow-up"),
+            ]
+        )
+        assert record["body"]["conversation_id"] == "conv-existing"
+        # Latest human turn is the one sent.
+        assert record["body"]["input"][0]["content"][0]["text"] == "follow-up"
+
+    def test_no_conversation_id_omits_field(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        record: dict[str, Any] = {}
+        model = _model_with_transport(
+            lambda req: httpx.Response(200, content=_sse(_happy_events())),
+            monkeypatch,
+            record=record,
+        )
+        # Even with a prior AIMessage carrying metadata, the model does not
+        # scan it — with conversation_id unset, no conversation_id is sent.
+        model.invoke(
+            [
+                AIMessage(
+                    "prev", response_metadata={CONVERSATION_ID_METADATA_KEY: "should-not-be-used"}
+                ),
+                HumanMessage("q"),
+            ]
+        )
+        assert "conversation_id" not in record["body"]
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestErrors:
+    def test_http_error_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        model = _model_with_transport(
+            lambda req: httpx.Response(404, content=b'{"error_code":"FEATURE_DISABLED"}'),
+            monkeypatch,
+        )
+        with pytest.raises(GenieAgentError, match="404"):
+            model.invoke([HumanMessage("q")])
+
+    def test_response_failed_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        events = [
+            ("response.created", {"response": {"id": "r", "conversation_id": "c", "status": "in_progress"}}),
+            (
+                "response.failed",
+                {"response": {"id": "r", "conversation_id": "c", "status": "failed", "error": {"code": "sql_execution_error", "message": "Table not found"}}},
+            ),
+        ]
+        model = _model_with_transport(
+            lambda req: httpx.Response(200, content=_sse(events)),
+            monkeypatch,
+        )
+        with pytest.raises(GenieAgentError, match="sql_execution_error"):
+            model.invoke([HumanMessage("q")])
+
+    def test_no_human_message_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        model = _model_with_transport(
+            lambda req: httpx.Response(200, content=_sse(_happy_events())),
+            monkeypatch,
+        )
+        with pytest.raises(GenieAgentError, match="no HumanMessage"):
+            model.invoke([AIMessage("only assistant")])
+
+
+# ---------------------------------------------------------------------------
+# Config surface
+# ---------------------------------------------------------------------------
+
+
+class TestConfigModel:
+    def test_duck_typed_surface(self) -> None:
+        m = GenieAgentModel(genie_room=GenieRoomModel(space_id=AGENT_ID))
+        assert m.name == AGENT_ID
+        assert m.on_behalf_of_user is False
+        # Methods OBOModelMiddleware / create_agent_node rely on exist.
+        assert hasattr(m, "workspace_client_from")
+        assert hasattr(m, "chat_model_for_workspace_client")
+        assert hasattr(m, "as_chat_model")
+
+    def test_agent_id_alias(self) -> None:
+        m = GenieAgentModel.model_validate({"genie_room": {"agent_id": AGENT_ID}})
+        assert m.name == AGENT_ID
+
+    def test_obo_delegates_to_room(self) -> None:
+        m = GenieAgentModel(genie_room=GenieRoomModel(space_id=AGENT_ID, on_behalf_of_user=True))
+        assert m.on_behalf_of_user is True
+
+    def test_parses_through_agent_model_union(self) -> None:
+        agent = AgentModel.model_validate(
+            {"name": "genie_specialist", "model": {"genie_room": {"agent_id": AGENT_ID}}, "tools": []}
+        )
+        assert isinstance(agent.model, GenieAgentModel)
+
+    def test_serving_endpoint_still_parses(self) -> None:
+        agent = AgentModel.model_validate(
+            {"name": "normal", "model": {"name": "databricks-claude-sonnet-4"}, "tools": []}
+        )
+        assert isinstance(agent.model, InferenceEndpointModel)
+
+    def test_unresolvable_agent_id_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A name-only room (no space_id) with no env fallback cannot resolve
+        # an agent_id without a live lookup.
+        monkeypatch.delenv("DATABRICKS_GENIE_SPACE_ID", raising=False)
+        m = GenieAgentModel(genie_room=GenieRoomModel(name="Some Room"))
+        with pytest.raises(ValueError, match="unable to resolve agent_id"):
+            _ = m.name


### PR DESCRIPTION
## Summary

Adds the Databricks **Genie Agent Mode API** (`POST /api/2.0/genie/agents/{agent_id}/responses`, Beta) as an agent's **reasoning model** — not a tool. A `GenieAgentModel` streams Genie's output (SQL + result table + narrative) as `AIMessageChunk`s, so an agent with `tools: []` becomes a natively-streaming "Genie specialist" a supervisor can route to like any other sub-agent.

**Why a model, not a tool:** a LangGraph tool node is atomic — it returns one `ToolMessage` after the whole stream completes, so Genie output can't stream to the end user through the agent's own response. A model node streams natively (`stream_mode="messages"`). The existing `type: genie` tool stays; both point at the same space (`agent_id` ≡ renamed `space_id`) while the Agent Mode API is Beta.

## What's included

- **`GenieAgentChatModel(BaseChatModel)`** (`genie/agent_chat_model.py`) — SSE streaming via `httpx` + `WorkspaceBearerAuth`; `_astream`/`_agenerate`/`_generate`. Pure w.r.t. conversation state: `conversation_id` is a field in, Genie-issued id stamped on `response_metadata` out.
- **`GenieAgentModel`** (`config.py`) — a wrapper around `GenieRoomModel` (composition, **not** a subclass of `InferenceEndpointModel`). Exposes the duck-typed surface `create_agent_node`/middleware need (`name`, `on_behalf_of_user`, `workspace_client_from`, `chat_model_for_workspace_client`, `as_chat_model`). `AgentModel.model` widened to `InferenceEndpointModel | GenieAgentModel`.
- **`GenieAgentMiddleware`** (`middleware/genie_agent.py`) — owns per-request concerns in one model rebuild: OBO (`workspace_client_from(context)`) **and** Genie conversation continuity. Reads the prior `conversation_id` from `session.genie.spaces[agent_id]`, builds the model with it, persists the newly-issued id back via `ExtendedModelResponse(command=Command(update={session}))` through the `merge_session` reducer — the same channel/keying the `type: genie` tool uses. `create_agent_node` attaches it for any `GenieAgentModel`.
- **Two ergonomic forms** — `model: *genie_room_anchor` (bare room auto-wraps to `GenieAgentModel`, default knobs) or `model: {genie_room: *anchor, timeout_seconds: N}` (explicit). A `{name: ...}` serving-endpoint config is unaffected (no `agent_id`/`space_id`), so no union ambiguity.
- **Config validation** — config-load fails if a `GenieAgentModel` agent's room isn't registered under `resources.genie_rooms` (that registration is what emits the deploy `genie-space` grant and the `dashboards.genie` OBO scope).
- **Docs + examples** — `docs/configuration-reference.md` "Genie Agent as a model" section; `genie_agent_model.yaml` + `genie_agent_model_obo.yaml`; examples README.

## Design notes

- **Two independent ids:** the LangGraph `thread_id` (checkpointer key for graph state) vs. the Genie-service-issued `conversation_id` (per-agent, continues the server-side conversation). The Genie id is data *inside* the thread-scoped `session`, not derived from `thread_id`.
- **OBO** lives on the room (`genie_room.on_behalf_of_user`) as the single source of truth — resolved through the shared `workspace_client_from`, so it works for both Databricks Apps (forwarded `x-forwarded-access-token`) and Model Serving (`ModelServingUserCredentials`).

## Testing

- **Unit:** 56 passed, 2 skipped (`test_genie_agent_model.py` + `test_genie_agent_middleware.py` + config regression). SSE aggregation (sync + async) via real `httpx.MockTransport`, chunk ordering, `conversation_id` field, HTTP/`response.failed` errors, middleware read→build→persist cycle, auto-wrap, room-registration validator, union parsing.
- **Live (aws-field-eng, feature enabled):** multi-turn conversation reuse verified against Genie's own conversation-items API as ground truth (both turns in one conversation). Forwarded-token OBO verified via faithful simulation — real token injected as `x-forwarded-access-token`, confirmed `auth_type=pat` (forwarded-token branch, not ambient), Genie queried successfully as the forwarded user.
- **Not verified:** a full App-proxy deploy (workspace is at the 300-app cap). The App proxy's only OBO job — header injection — is what the simulation reproduces.

This pull request and its description were written by Isaac.