### PR TITLE
feat(genie): add verbatim option to preserve the user's question

### DIFF
--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -5737,6 +5737,12 @@
           "title": "Truncate Results",
           "type": "boolean"
         },
+        "verbatim": {
+          "default": false,
+          "description": "When true, instruct the calling LLM to pass the user's question to Genie exactly as asked \u2014 no rephrasing, decomposition, or added qualifiers. Shapes the tool description and the question-argument annotation. Default false preserves the existing 'ask simple, clear questions' behavior.",
+          "title": "Verbatim",
+          "type": "boolean"
+        },
         "lru_cache": {
           "anyOf": [
             {

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -6291,6 +6291,16 @@ class GenieToolModel(BaseFunctionModel):
         default=False,
         description="Truncate large query results returned by Genie.",
     )
+    verbatim: bool = Field(
+        default=False,
+        description=(
+            "When true, instruct the calling LLM to pass the user's question to "
+            "Genie exactly as asked — no rephrasing, decomposition, or added "
+            "qualifiers. Shapes the tool description and the question-argument "
+            "annotation. Default false preserves the existing 'ask simple, clear "
+            "questions' behavior."
+        ),
+    )
     lru_cache: Optional[GenieLRUCacheParametersModel] = Field(
         default=None,
         description="LRU cache configuration for fast exact-match SQL caching.",
@@ -6330,6 +6340,7 @@ class GenieToolModel(BaseFunctionModel):
             description=self.description,
             persist_conversation=self.persist_conversation,
             truncate_results=self.truncate_results,
+            verbatim=self.verbatim,
             lru_cache_parameters=self.lru_cache,
             context_aware_cache_parameters=self.context_aware_cache,
             in_memory_context_aware_cache_parameters=self.in_memory_context_aware_cache,

--- a/src/dao_ai/tools/genie.py
+++ b/src/dao_ai/tools/genie.py
@@ -233,6 +233,47 @@ question (str): The question to ask to ask Genie about your data. Ask simple, cl
 Returns:
 GenieResponse: A response object containing the conversation ID and result from Genie."""
 
+# Question-argument annotations. The default nudges the model to shape the
+# question; the verbatim variant instructs it to preserve every qualifier and
+# scope statement that belongs to the portion routed to THIS tool — while still
+# allowing a genuinely multi-tool request to be split across tools.
+_QUESTION_ARG_DEFAULT: str = "The question to ask Genie about your data"
+_QUESTION_ARG_VERBATIM: str = (
+    "The user's question for this tool, kept COMPLETE and word-for-word. "
+    "Preserve every qualifier, scope statement, constraint, and clarification "
+    "the user attached to it (e.g. 'include the entire team organization, not "
+    "just direct reports') — do NOT drop, rephrase, or summarize that refining "
+    "context. If the overall request spans multiple tools, you may route each "
+    "part to its tool, but the part sent here must stay verbatim and complete."
+)
+
+# Appended to the tool description when ``verbatim=True`` so the preserve-exact
+# instruction is present on both surfaces the LLM reads at tool-call time.
+_VERBATIM_TOOL_CLAUSE: str = (
+    "IMPORTANT — question handling: send this tool the user's COMPLETE question "
+    "for its topic, preserving every qualifier, scope statement, constraint, and "
+    "clarification exactly as written (e.g. a trailing 'this should include the "
+    "entire team organization, not just direct reports' must be kept, not "
+    "dropped). Do NOT summarize, truncate, or strip refining context. You MAY "
+    "split a request that genuinely spans multiple tools and route each part to "
+    "the appropriate tool — but the portion you pass here must remain verbatim "
+    "and complete, never reduced to a shorter paraphrase."
+)
+
+
+def _build_tool_description(description: str | None, verbatim: bool) -> str:
+    """Assemble the ``@tool`` description string.
+
+    Starts from the caller-supplied ``description`` (or ``_DEFAULT_DESCRIPTION``),
+    appends the verbatim clause when ``verbatim`` is set — even for a
+    user-supplied description, so the flag always takes effect — then the
+    function-args docs. Shared by both tool-builder impls.
+    """
+    base: str = description if description is not None else _DEFAULT_DESCRIPTION
+    if verbatim:
+        base = base + "\n" + _VERBATIM_TOOL_CLAUSE
+    return base + _FUNCTION_DOCS
+
 
 def _resolve_genie_room(
     genie_room: GenieRoomModel | dict[str, Any],
@@ -261,6 +302,7 @@ def create_genie_tool(
     description: str | None = None,
     persist_conversation: bool = True,
     truncate_results: bool = False,
+    verbatim: bool = False,
     lru_cache_parameters: GenieLRUCacheParametersModel | dict[str, Any] | None = None,
     context_aware_cache_parameters: (
         GenieContextAwareCacheParametersModel | dict[str, Any] | None
@@ -299,6 +341,11 @@ def create_genie_tool(
         description: Custom tool description. Defaults to a generic prompt.
         persist_conversation: Persist conversation IDs across calls for multi-turn.
         truncate_results: Truncate large query results.
+        verbatim: When ``True``, instruct the calling LLM (via the tool
+            description and the ``question`` argument annotation) to pass the
+            user's question through exactly as asked — no rephrasing,
+            decomposition, or added qualifiers. Default ``False`` preserves the
+            existing behavior.
         lru_cache_parameters: LRU cache config for fast exact-match SQL caching.
         context_aware_cache_parameters: PostgreSQL/Lakebase context-aware cache config.
         in_memory_context_aware_cache_parameters: In-memory context-aware cache config.
@@ -329,6 +376,7 @@ def create_genie_tool(
             description=description,
             persist_conversation=persist_conversation,
             truncate_results=truncate_results,
+            verbatim=verbatim,
         )
 
     return _create_genie_toolkit_impl(
@@ -337,6 +385,7 @@ def create_genie_tool(
         description=description,
         persist_conversation=persist_conversation,
         truncate_results=truncate_results,
+        verbatim=verbatim,
         lru_cache_parameters=lru_cache_parameters,
         context_aware_cache_parameters=context_aware_cache_parameters,
         in_memory_context_aware_cache_parameters=in_memory_context_aware_cache_parameters,
@@ -350,6 +399,7 @@ def create_genie_toolkit(
     description: str | None = None,
     persist_conversation: bool = True,
     truncate_results: bool = False,
+    verbatim: bool = False,
     lru_cache_parameters: GenieLRUCacheParametersModel | dict[str, Any] | None = None,
     context_aware_cache_parameters: (
         GenieContextAwareCacheParametersModel | dict[str, Any] | None
@@ -371,6 +421,7 @@ def create_genie_toolkit(
         description=description,
         persist_conversation=persist_conversation,
         truncate_results=truncate_results,
+        verbatim=verbatim,
         lru_cache_parameters=lru_cache_parameters,
         context_aware_cache_parameters=context_aware_cache_parameters,
         in_memory_context_aware_cache_parameters=in_memory_context_aware_cache_parameters,
@@ -392,6 +443,7 @@ def _create_simple_genie_tool(
     description: str | None,
     persist_conversation: bool,
     truncate_results: bool,
+    verbatim: bool = False,
 ) -> Callable[..., Command]:
     """Build the uncached single-tool variant (no cache, no feedback tool)."""
     logger.debug(
@@ -399,14 +451,16 @@ def _create_simple_genie_tool(
         genie_room_type=type(genie_room).__name__,
         persist_conversation=persist_conversation,
         name=name,
+        verbatim=verbatim,
     )
 
     genie_room_model, space_id_str = _resolve_genie_room(genie_room)
 
     tool_name: str = name if name is not None else "genie_tool"
-    tool_description: str = (
-        description if description is not None else _DEFAULT_DESCRIPTION
-    ) + _FUNCTION_DOCS
+    tool_description: str = _build_tool_description(description, verbatim)
+    question_desc: str = (
+        _QUESTION_ARG_VERBATIM if verbatim else _QUESTION_ARG_DEFAULT
+    )
 
     _cached_genie_service: GenieServiceBase | None = None
 
@@ -433,7 +487,7 @@ def _create_simple_genie_tool(
 
     @tool(name_or_callable=tool_name, description=tool_description)
     def genie_tool(
-        question: Annotated[str, "The question to ask Genie about your data"],
+        question: Annotated[str, question_desc],
         runtime: ToolRuntime[Context, AgentState],
     ) -> Command:
         """Process a natural language question through Databricks Genie."""
@@ -497,6 +551,7 @@ def _create_genie_toolkit_impl(
         GenieInMemoryContextAwareCacheParametersModel | dict[str, Any] | None
     ),
     max_consecutive_cache_hits: int | None,
+    verbatim: bool = False,
 ) -> GenieToolkit:
     """Build the cached toolkit variant (query + feedback, optional cache layers)."""
     logger.debug(
@@ -505,6 +560,7 @@ def _create_genie_toolkit_impl(
         persist_conversation=persist_conversation,
         truncate_results=truncate_results,
         name=name,
+        verbatim=verbatim,
         has_lru_cache=lru_cache_parameters is not None,
         has_context_aware_cache=context_aware_cache_parameters is not None,
         has_in_memory_context_aware_cache=in_memory_context_aware_cache_parameters
@@ -528,9 +584,10 @@ def _create_genie_toolkit_impl(
         )
 
     tool_name: str = name if name is not None else "genie_tool"
-    tool_description: str = (
-        description if description is not None else _DEFAULT_DESCRIPTION
-    ) + _FUNCTION_DOCS
+    tool_description: str = _build_tool_description(description, verbatim)
+    question_desc: str = (
+        _QUESTION_ARG_VERBATIM if verbatim else _QUESTION_ARG_DEFAULT
+    )
 
     # ---- Shared service stack (one LRU, one closure) ----
 
@@ -611,7 +668,7 @@ def _create_genie_toolkit_impl(
 
     @tool(name_or_callable=tool_name, description=tool_description)
     def genie_tool(
-        question: Annotated[str, "The question to ask Genie about your data"],
+        question: Annotated[str, question_desc],
         runtime: ToolRuntime[Context, AgentState],
     ) -> Command:
         """Process a natural language question through Databricks Genie."""

--- a/tests/dao_ai/test_genie.py
+++ b/tests/dao_ai/test_genie.py
@@ -236,6 +236,94 @@ def test_create_genie_tool_parameters() -> None:
     assert "GenieResponse" in tool_custom.description
 
 
+def _question_arg_description(tool: StructuredTool) -> str:
+    """Read the description of the tool's ``question`` argument."""
+    field = tool.args_schema.model_fields["question"]
+    return getattr(field, "description", "") or ""
+
+
+def test_create_genie_tool_verbatim_default_off() -> None:
+    """Default (verbatim=False) must not add any verbatim wording — the
+    tool description and question-arg annotation stay byte-for-byte as before."""
+    from dao_ai.tools.genie import _QUESTION_ARG_VERBATIM, _VERBATIM_TOOL_CLAUSE
+
+    room = GenieRoomModel(name="Room", space_id="0" * 32)
+
+    tool = create_genie_tool(genie_room=room, name="ask_genie")
+    assert isinstance(tool, StructuredTool)
+    assert _VERBATIM_TOOL_CLAUSE not in tool.description
+    assert _QUESTION_ARG_VERBATIM not in _question_arg_description(tool)
+    # The default question-arg wording is preserved.
+    assert "The question to ask Genie about your data" == _question_arg_description(
+        tool
+    )
+
+
+def test_create_genie_tool_verbatim_on_simple_path() -> None:
+    """verbatim=True stamps the preserve-exact instruction onto BOTH the tool
+    description and the question-arg annotation (uncached simple-tool path)."""
+    from dao_ai.tools.genie import _QUESTION_ARG_VERBATIM, _VERBATIM_TOOL_CLAUSE
+
+    room = GenieRoomModel(name="Room", space_id="0" * 32)
+
+    tool = create_genie_tool(genie_room=room, name="ask_genie", verbatim=True)
+    assert isinstance(tool, StructuredTool)
+    assert _VERBATIM_TOOL_CLAUSE in tool.description
+    assert _QUESTION_ARG_VERBATIM == _question_arg_description(tool)
+    # Multi-tool routing is still explicitly permitted (not a hard "never split").
+    assert "multiple tools" in tool.description or "spans multiple tools" in (
+        tool.description
+    )
+
+
+def test_create_genie_tool_verbatim_on_toolkit_path() -> None:
+    """verbatim=True flows through the toolkit path too (enable_feedback forces
+    toolkit mode). The query tool carries the verbatim wording."""
+    from dao_ai.tools.genie import (
+        _QUESTION_ARG_VERBATIM,
+        _VERBATIM_TOOL_CLAUSE,
+        GenieToolkit,
+    )
+
+    room = GenieRoomModel(name="Room", space_id="0" * 32)
+
+    result = create_genie_tool(
+        genie_room=room, name="ask_genie", verbatim=True, enable_feedback=True
+    )
+    assert isinstance(result, GenieToolkit)
+    query_tool = result.get_tools()[0]
+    assert _VERBATIM_TOOL_CLAUSE in query_tool.description
+    assert _QUESTION_ARG_VERBATIM == _question_arg_description(query_tool)
+
+
+def test_create_genie_tool_verbatim_appends_to_custom_description() -> None:
+    """A user-supplied description still gets the verbatim clause appended, so
+    the flag always takes effect regardless of custom wording."""
+    from dao_ai.tools.genie import _VERBATIM_TOOL_CLAUSE
+
+    room = GenieRoomModel(name="Room", space_id="0" * 32)
+    custom = "Answers questions about GSS indirect procurement spend."
+
+    tool = create_genie_tool(
+        genie_room=room, name="ask_genie", description=custom, verbatim=True
+    )
+    assert custom in tool.description
+    assert _VERBATIM_TOOL_CLAUSE in tool.description
+
+
+def test_genie_tool_model_verbatim_field() -> None:
+    """GenieToolModel exposes verbatim (default False) and passes it through."""
+    from dao_ai.config import GenieToolModel
+
+    m = GenieToolModel(genie_room=GenieRoomModel(name="Room", space_id="0" * 32))
+    assert m.verbatim is False
+
+    m_on = GenieToolModel(
+        genie_room=GenieRoomModel(name="Room", space_id="0" * 32), verbatim=True
+    )
+    assert m_on.verbatim is True
+
+
 @pytest.mark.integration
 @pytest.mark.skipif(not has_retail_ai_env(), reason="Retail AI env vars not set")
 def test_genie_tool_error_handling() -> None:


### PR DESCRIPTION
## Context

When a Genie space is used as a dao-ai **tool** (`function.type: genie`), the agent's reasoning LLM decides what string to pass as the tool's `question` argument. "Ambitious" models (Claude, GPT) frequently **rewrite, decompose, or drop qualifiers** from the user's question before calling Genie — and the current tool encourages this (the `question` annotation is a bare "The question to ask Genie about your data", and `_DEFAULT_DESCRIPTION` says "ask simple clear questions" / "prefer to call this tool multiple times").

Concretely: for a compound question like *"What is Rajendra Jain team's spend for 2025? This should include the entire team organization, not just direct reports."*, the agent sends only *"What is Rajendra Jain team's spend for 2025?"* to Genie — dropping the scope qualifier, which changes the answer.

The clean fix (`GenieAgentModel` — Genie as the agent's model) requires the Genie Agent Mode API Beta, which isn't available on the target platform, so Genie must be used as a **tool**. There was no existing `verbatim`/passthrough affordance.

## Change

Add opt-in `verbatim: bool = False` to `GenieToolModel`, threaded through `create_genie_tool` and both tool-builder impls (`_create_simple_genie_tool`, `_create_genie_toolkit_impl`). When `true`, the preserve-exact instruction is stamped onto **both** surfaces the LLM reads at tool-call-construction time:
- the tool **description** (`_VERBATIM_TOOL_CLAUSE`, appended even to a user-supplied description), and
- the **`question` argument annotation** (`_QUESTION_ARG_VERBATIM`).

The wording is **segment-aware**: it preserves every qualifier/scope/constraint on the part routed to *this* tool, while still allowing a genuinely multi-tool request to be split and routed per tool (so it doesn't break legitimate multi-tool decomposition).

Default `false` is byte-for-byte unchanged behavior.

## Validation

- **Unit**: 5 new tests (default-off unchanged; verbatim wording on description + `question` arg for simple & toolkit paths; clause appended to custom descriptions; config field). Full genie suite (192) passes. `make schema` regenerated (`verbatim` under `GenieToolModel`).
- **Live Genie (FEVM, Sales & Pricing - Sporting Goods space)**, verified via the `genie_core_ask_question` trace span:
  - `verbatim=false` sent: *"What were the total sales for 2025 across all products and categories?"* (qualifier dropped)
  - `verbatim=true` sent: *"What were total sales for 2025? This should include the entire product catalog across all categories, not just the top sellers."* (verbatim, complete)
- **Model Serving**: deployed via `dao-ai pipeline` (bundle deploy_job); endpoint READY; live inference HTTP 200 with the full compound question reaching Genie.

This pull request and its description were written by Isaac.