### PR TITLE
feat(config): add call_limit tool field for tool-scoped call limits

### DIFF
--- a/config/examples/12_middleware/tool_call_limit_field.yaml
+++ b/config/examples/12_middleware/tool_call_limit_field.yaml
@@ -1,0 +1,178 @@
+# yaml-language-server: $schema=../../../schemas/model_config_schema.json
+
+# =============================================================================
+# PARAMETERS
+# =============================================================================
+parameters:
+  catalog:
+    description: Unity Catalog catalog name
+    default: retail_consumer_goods
+  schema:
+    description: Schema within the catalog
+    default: quick_serve_restaurant
+
+#
+# Example: `call_limit` tool field (tool-scoped call limits)
+#
+# This example demonstrates the `call_limit` shortcut on a tool's `function`.
+# Unlike the explicit `create_tool_call_limit_middleware` MiddlewareModel path
+# (see limit_middleware.yaml), which is declared on each agent's `middleware`
+# list, `call_limit` lives on the tool itself — so EVERY agent that uses the
+# tool inherits the cap automatically, with no per-agent wiring.
+#
+# Two forms are accepted:
+#   - Bare integer:  `call_limit: 3`  -> run_limit=3, exit_behavior=continue
+#   - Object:        `call_limit: { run_limit, thread_limit, exit_behavior }`
+#
+# Use cases:
+# - Budget control for expensive tools (Genie / DB queries, web search)
+# - Preventing runaway loops without touching every agent definition
+# - Sharing one cap across many agents via a single YAML anchor
+#
+# =============================================================================
+# DATABRICKS SCHEMAS
+# =============================================================================
+schemas:
+  retail_schema: &retail_schema
+    catalog_name: ${var.catalog}
+    schema_name: ${var.schema}
+
+# =============================================================================
+# RESOURCES
+# =============================================================================
+resources:
+  models:
+    default_llm: &default_llm
+      name: databricks-claude-sonnet-4
+      temperature: 0.1
+      max_tokens: 4096
+
+  genie_rooms:
+    retail_genie: &retail_genie
+      name: "Retail Genie Room"
+      space_id:
+        env: RETAIL_AI_GENIE_SPACE_ID
+        default_value: 01f01c91f1f414d59daaefd2b7ec82ea
+
+# =============================================================================
+# TOOLS CONFIGURATION
+# =============================================================================
+# The `call_limit` field is declared directly on each tool's `function`.
+# When these tools are shared across agents (via YAML anchors), the limit
+# travels with the tool.
+
+tools:
+  # Expensive Genie query — object form for full control.
+  # Capped at 2 calls per message AND 8 per conversation; hard error when hit.
+  genie_tool: &genie_tool
+    name: genie
+    function:
+      type: genie
+      name: retail_genie_tool
+      description: Query retail data using natural language
+      genie_room: *retail_genie
+      call_limit:
+        run_limit: 2              # Max 2 Genie queries per message
+        thread_limit: 8           # Max 8 Genie queries per conversation
+        exit_behavior: error      # Raise immediately when exceeded
+
+  # Web search — bare-int shorthand: run_limit=3, exit_behavior=continue.
+  search_tool: &search_tool
+    name: search_web
+    function:
+      type: search
+      call_limit: 3               # Shorthand: max 3 searches per message
+
+  # Lightweight time tool — no limit needed.
+  time_tool: &time_tool
+    name: current_time
+    function:
+      type: python
+      name: dao_ai.tools.current_time_tool
+
+# =============================================================================
+# AGENTS CONFIGURATION
+# =============================================================================
+# Neither agent declares any tool-call-limit middleware. The limits are
+# inherited purely from the tools' `call_limit` fields — demonstrating that
+# every agent using genie_tool/search_tool gets the same caps automatically.
+
+agents:
+  # ---------------------------------------------------------------------------
+  # Research Agent — uses all three tools
+  # ---------------------------------------------------------------------------
+  research_agent: &research_agent
+    name: research_agent
+    description: "Research agent; tool limits inherited from tool call_limit"
+    model: *default_llm
+    tools:
+    - *genie_tool
+    - *search_tool
+    - *time_tool
+    prompt: |
+      You are a research assistant that can query retail data (genie),
+      search the web, and check the current time.
+
+      Be efficient with your tool usage. If you hit a limit, try a different
+      approach or answer with the information you already have.
+    handoff_prompt: |
+      Questions requiring research, data queries, or web searches.
+
+  # ---------------------------------------------------------------------------
+  # Support Agent — reuses genie_tool; inherits the SAME Genie cap
+  # ---------------------------------------------------------------------------
+  support_agent: &support_agent
+    name: support_agent
+    description: "Support agent; inherits genie_tool's call_limit automatically"
+    model: *default_llm
+    tools:
+    - *genie_tool
+    - *time_tool
+    prompt: |
+      You are a support assistant. Use the genie tool to look up order and
+      product data. The same query budget applies here as everywhere the
+      genie tool is used.
+    handoff_prompt: |
+      Support questions that may require a data lookup.
+
+# =============================================================================
+# APPLICATION CONFIGURATION
+# =============================================================================
+app:
+  name: tool_call_limit_field_example
+  description: "Example demonstrating the call_limit tool field"
+  log_level: DEBUG
+  registered_model:
+    schema: *retail_schema
+    name: tool_call_limit_field_dao
+  endpoint_name: tool_call_limit_field_demo_dao
+  agents:
+  - *research_agent
+  - *support_agent
+  orchestration:
+    supervisor:
+      model: *default_llm
+  input_example:
+    messages:
+    - role: user
+      content: What products are low on stock?
+    custom_inputs:
+      configurable:
+        thread_id: "call-limit-field-123"
+        user_id: "test_user"
+      session: {}
+
+# =============================================================================
+# NOTES
+# =============================================================================
+#
+# - `call_limit` composes with explicit tool-call-limit MiddlewareModel entries
+#   on an agent: each ToolCallLimitMiddleware gets a unique
+#   ToolCallLimitMiddleware[<tool>] name, so both register.
+# - A single tool config that expands to multiple runtime tool names (e.g. a
+#   Unity Catalog function) gets the limit applied to EACH resolved name.
+# - exit_behavior: "continue" (block + error message, agent continues),
+#   "error" (raise immediately), or "end" (graceful stop, single-tool only).
+# - thread_limit requires a checkpointer, which DAO AI agents have via memory.
+#
+# =============================================================================

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -299,6 +299,22 @@
           "default": null,
           "description": "Optional tamper-evident audit trail for this tool. Presence of this block enables audit-receipt logging on every invocation; absence leaves the runtime path unchanged. Typically declared once as a YAML anchor and referenced from every tool that should be audited. Composes with human_in_the_loop to produce approval receipts with args-hash binding and fail-closed execution."
         },
+        "call_limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "#/$defs/ToolCallLimitModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Shortcut to cap how many times this tool may be called. A bare integer sets run_limit (per-invocation) with exit_behavior='continue'; an object gives full control over run_limit/thread_limit/exit_behavior. Applied automatically to every agent that uses this tool, in addition to any explicit tool-call-limit middleware configured on the agent.",
+          "title": "Call Limit"
+        },
         "endpoint": {
           "anyOf": [
             {
@@ -930,6 +946,22 @@
           ],
           "default": null,
           "description": "Optional tamper-evident audit trail for this tool. Presence of this block enables audit-receipt logging on every invocation; absence leaves the runtime path unchanged. Typically declared once as a YAML anchor and referenced from every tool that should be audited. Composes with human_in_the_loop to produce approval receipts with args-hash binding and fail-closed execution."
+        },
+        "call_limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "#/$defs/ToolCallLimitModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Shortcut to cap how many times this tool may be called. A bare integer sets run_limit (per-invocation) with exit_behavior='continue'; an object gives full control over run_limit/thread_limit/exit_behavior. Applied automatically to every agent that uses this tool, in addition to any explicit tool-call-limit middleware configured on the agent.",
+          "title": "Call Limit"
         },
         "retriever": {
           "anyOf": [
@@ -1803,6 +1835,22 @@
           ],
           "default": null,
           "description": "Optional tamper-evident audit trail for this tool. Presence of this block enables audit-receipt logging on every invocation; absence leaves the runtime path unchanged. Typically declared once as a YAML anchor and referenced from every tool that should be audited. Composes with human_in_the_loop to produce approval receipts with args-hash binding and fail-closed execution."
+        },
+        "call_limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "#/$defs/ToolCallLimitModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Shortcut to cap how many times this tool may be called. A bare integer sets run_limit (per-invocation) with exit_behavior='continue'; an object gives full control over run_limit/thread_limit/exit_behavior. Applied automatically to every agent that uses this tool, in addition to any explicit tool-call-limit middleware configured on the agent.",
+          "title": "Call Limit"
         },
         "app": {
           "$ref": "#/$defs/DatabricksAppModel",
@@ -4113,6 +4161,22 @@
           "default": null,
           "description": "Optional tamper-evident audit trail for this tool. Presence of this block enables audit-receipt logging on every invocation; absence leaves the runtime path unchanged. Typically declared once as a YAML anchor and referenced from every tool that should be audited. Composes with human_in_the_loop to produce approval receipts with args-hash binding and fail-closed execution."
         },
+        "call_limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "#/$defs/ToolCallLimitModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Shortcut to cap how many times this tool may be called. A bare integer sets run_limit (per-invocation) with exit_behavior='continue'; an object gives full control over run_limit/thread_limit/exit_behavior. Applied automatically to every agent that uses this tool, in addition to any explicit tool-call-limit middleware configured on the agent.",
+          "title": "Call Limit"
+        },
         "name": {
           "description": "Fully qualified factory function name that returns a tool or list of tools.",
           "title": "Name",
@@ -5695,6 +5759,22 @@
           "default": null,
           "description": "Optional tamper-evident audit trail for this tool. Presence of this block enables audit-receipt logging on every invocation; absence leaves the runtime path unchanged. Typically declared once as a YAML anchor and referenced from every tool that should be audited. Composes with human_in_the_loop to produce approval receipts with args-hash binding and fail-closed execution."
         },
+        "call_limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "#/$defs/ToolCallLimitModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Shortcut to cap how many times this tool may be called. A bare integer sets run_limit (per-invocation) with exit_behavior='continue'; an object gives full control over run_limit/thread_limit/exit_behavior. Applied automatically to every agent that uses this tool, in addition to any explicit tool-call-limit middleware configured on the agent.",
+          "title": "Call Limit"
+        },
         "genie_room": {
           "$ref": "#/$defs/GenieRoomModel",
           "description": "Genie space configuration."
@@ -6639,6 +6719,22 @@
           "default": null,
           "description": "Optional tamper-evident audit trail for this tool. Presence of this block enables audit-receipt logging on every invocation; absence leaves the runtime path unchanged. Typically declared once as a YAML anchor and referenced from every tool that should be audited. Composes with human_in_the_loop to produce approval receipts with args-hash binding and fail-closed execution."
         },
+        "call_limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "#/$defs/ToolCallLimitModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Shortcut to cap how many times this tool may be called. A bare integer sets run_limit (per-invocation) with exit_behavior='continue'; an object gives full control over run_limit/thread_limit/exit_behavior. Applied automatically to every agent that uses this tool, in addition to any explicit tool-call-limit middleware configured on the agent.",
+          "title": "Call Limit"
+        },
         "code": {
           "description": "Python code defining a tool function decorated with @tool",
           "title": "Code",
@@ -6890,6 +6986,22 @@
           ],
           "default": null,
           "description": "Optional tamper-evident audit trail for this tool. Presence of this block enables audit-receipt logging on every invocation; absence leaves the runtime path unchanged. Typically declared once as a YAML anchor and referenced from every tool that should be audited. Composes with human_in_the_loop to produce approval receipts with args-hash binding and fail-closed execution."
+        },
+        "call_limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "#/$defs/ToolCallLimitModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Shortcut to cap how many times this tool may be called. A bare integer sets run_limit (per-invocation) with exit_behavior='continue'; an object gives full control over run_limit/thread_limit/exit_behavior. Applied automatically to every agent that uses this tool, in addition to any explicit tool-call-limit middleware configured on the agent.",
+          "title": "Call Limit"
         },
         "retriever": {
           "anyOf": [
@@ -7304,6 +7416,22 @@
           ],
           "default": null,
           "description": "Optional tamper-evident audit trail for this tool. Presence of this block enables audit-receipt logging on every invocation; absence leaves the runtime path unchanged. Typically declared once as a YAML anchor and referenced from every tool that should be audited. Composes with human_in_the_loop to produce approval receipts with args-hash binding and fail-closed execution."
+        },
+        "call_limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "#/$defs/ToolCallLimitModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Shortcut to cap how many times this tool may be called. A bare integer sets run_limit (per-invocation) with exit_behavior='continue'; an object gives full control over run_limit/thread_limit/exit_behavior. Applied automatically to every agent that uses this tool, in addition to any explicit tool-call-limit middleware configured on the agent.",
+          "title": "Call Limit"
         },
         "transport": {
           "$ref": "#/$defs/TransportType",
@@ -8491,6 +8619,22 @@
           "default": null,
           "description": "Optional tamper-evident audit trail for this tool. Presence of this block enables audit-receipt logging on every invocation; absence leaves the runtime path unchanged. Typically declared once as a YAML anchor and referenced from every tool that should be audited. Composes with human_in_the_loop to produce approval receipts with args-hash binding and fail-closed execution."
         },
+        "call_limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "#/$defs/ToolCallLimitModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Shortcut to cap how many times this tool may be called. A bare integer sets run_limit (per-invocation) with exit_behavior='continue'; an object gives full control over run_limit/thread_limit/exit_behavior. Applied automatically to every agent that uses this tool, in addition to any explicit tool-call-limit middleware configured on the agent.",
+          "title": "Call Limit"
+        },
         "name": {
           "description": "Fully qualified Python function name (e.g., 'my_package.tools.my_tool').",
           "title": "Name",
@@ -8934,6 +9078,22 @@
           ],
           "default": null,
           "description": "Optional tamper-evident audit trail for this tool. Presence of this block enables audit-receipt logging on every invocation; absence leaves the runtime path unchanged. Typically declared once as a YAML anchor and referenced from every tool that should be audited. Composes with human_in_the_loop to produce approval receipts with args-hash binding and fail-closed execution."
+        },
+        "call_limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "#/$defs/ToolCallLimitModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Shortcut to cap how many times this tool may be called. A bare integer sets run_limit (per-invocation) with exit_behavior='continue'; an object gives full control over run_limit/thread_limit/exit_behavior. Applied automatically to every agent that uses this tool, in addition to any explicit tool-call-limit middleware configured on the agent.",
+          "title": "Call Limit"
         }
       },
       "title": "SearchToolModel",
@@ -9096,6 +9256,22 @@
           ],
           "default": null,
           "description": "Optional tamper-evident audit trail for this tool. Presence of this block enables audit-receipt logging on every invocation; absence leaves the runtime path unchanged. Typically declared once as a YAML anchor and referenced from every tool that should be audited. Composes with human_in_the_loop to produce approval receipts with args-hash binding and fail-closed execution."
+        },
+        "call_limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "#/$defs/ToolCallLimitModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Shortcut to cap how many times this tool may be called. A bare integer sets run_limit (per-invocation) with exit_behavior='continue'; an object gives full control over run_limit/thread_limit/exit_behavior. Applied automatically to every agent that uses this tool, in addition to any explicit tool-call-limit middleware configured on the agent.",
+          "title": "Call Limit"
         },
         "endpoint": {
           "anyOf": [
@@ -9744,6 +9920,53 @@
       "title": "TableModel",
       "type": "object"
     },
+    "ToolCallLimitModel": {
+      "additionalProperties": false,
+      "description": "Configuration for capping how many times a tool may be called.\n\nPresence of this block on a tool's ``function`` registers a\n``ToolCallLimitMiddleware`` for that tool on every agent that uses it, so\nthe limit follows the tool rather than being re-declared on each agent's\n``middleware`` list. Typically declared once as a YAML anchor\n(``call_limit: &tool_limit { ... }``) and referenced from every tool that\nshould share the same cap.\n\nA bare integer is accepted as shorthand for ``run_limit`` with\n``exit_behavior='continue'`` (see ``BaseFunctionModel.call_limit``); the\nobject form below gives full control. At least one of ``run_limit`` or\n``thread_limit`` must be set. This maps to LangChain's\n``ToolCallLimitMiddleware`` via ``create_tool_call_limit_middleware``.",
+      "properties": {
+        "run_limit": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number of times this tool may be called within a single agent invocation (one user message). Resets each run and requires no checkpointer.",
+          "title": "Run Limit"
+        },
+        "thread_limit": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number of times this tool may be called across an entire conversation (thread). Requires a checkpointer, which DAO AI agents have via memory.",
+          "title": "Thread Limit"
+        },
+        "exit_behavior": {
+          "default": "continue",
+          "description": "Behavior when a limit is reached: 'continue' blocks the call and returns an error message so the agent can try another approach (recommended); 'error' raises immediately; 'end' stops execution gracefully (single-tool scenarios only).",
+          "enum": [
+            "continue",
+            "error",
+            "end"
+          ],
+          "title": "Exit Behavior",
+          "type": "string"
+        }
+      },
+      "title": "ToolCallLimitModel",
+      "type": "object"
+    },
     "ToolModel": {
       "additionalProperties": false,
       "description": "A named tool binding an identifier to a function implementation.",
@@ -9932,6 +10155,22 @@
           ],
           "default": null,
           "description": "Optional tamper-evident audit trail for this tool. Presence of this block enables audit-receipt logging on every invocation; absence leaves the runtime path unchanged. Typically declared once as a YAML anchor and referenced from every tool that should be audited. Composes with human_in_the_loop to produce approval receipts with args-hash binding and fail-closed execution."
+        },
+        "call_limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "#/$defs/ToolCallLimitModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Shortcut to cap how many times this tool may be called. A bare integer sets run_limit (per-invocation) with exit_behavior='continue'; an object gives full control over run_limit/thread_limit/exit_behavior. Applied automatically to every agent that uses this tool, in addition to any explicit tool-call-limit middleware configured on the agent.",
+          "title": "Call Limit"
         },
         "resource": {
           "$ref": "#/$defs/FunctionModel",
@@ -10691,7 +10930,7 @@
       "additionalProperties": {
         "$ref": "#/$defs/PromptModel"
       },
-      "description": "Named prompt definitions backed by the MLflow Prompt Registry.",
+      "description": "Named, reusable prompt definitions referenced by agents via YAML anchors.",
       "title": "Prompts",
       "type": "object"
     },

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -1200,10 +1200,7 @@ class AiSearchEndpoint(BaseModel):
     @model_validator(mode="after")
     def validate_target_qps_only_on_standard(self) -> Self:
         """Reject target_qps on non-STANDARD endpoints (SDK constraint)."""
-        if (
-            self.target_qps is not None
-            and self.type != AiSearchEndpointType.STANDARD
-        ):
+        if self.target_qps is not None and self.type != AiSearchEndpointType.STANDARD:
             raise ValueError(
                 f"target_qps is only supported on STANDARD endpoints, not {self.type!r}"
             )
@@ -5198,9 +5195,7 @@ class LakebaseVectorStoreModel(BaseModel):
         rebuild from scratch, drop the table manually first.
         """
         if dimension <= 0:
-            raise ValueError(
-                f"dimension must be a positive int; got {dimension!r}"
-            )
+            raise ValueError(f"dimension must be a positive int; got {dimension!r}")
         meta_types = metadata_column_types or {}
         qualified = f"{self.schema_name}.{self.table}"
 
@@ -5302,9 +5297,7 @@ def _retriever_discriminator(v: Any) -> str:
         if raw is None:
             return RetrieverType.AI_SEARCH.value
         return raw.value if isinstance(raw, RetrieverType) else str(raw)
-    raise ValueError(
-        f"cannot infer retriever discriminator from {type(v).__name__}"
-    )
+    raise ValueError(f"cannot infer retriever discriminator from {type(v).__name__}")
 
 
 # Discriminated union — Pydantic dispatches to the concrete class using the
@@ -5337,9 +5330,7 @@ def _vector_store_discriminator(v: Any) -> str:
         if raw is None:
             return "ai_search"
         return raw.value if hasattr(raw, "value") else str(raw)
-    raise ValueError(
-        f"cannot infer vector_store discriminator from {type(v).__name__}"
-    )
+    raise ValueError(f"cannot infer vector_store discriminator from {type(v).__name__}")
 
 
 # Discriminated union — Pydantic dispatches to the concrete class using
@@ -5495,6 +5486,64 @@ class AuditModel(BaseModel):
         return AuditSinkManager.for_config(self)
 
 
+class ToolCallLimitModel(BaseModel):
+    """
+    Configuration for capping how many times a tool may be called.
+
+    Presence of this block on a tool's ``function`` registers a
+    ``ToolCallLimitMiddleware`` for that tool on every agent that uses it, so
+    the limit follows the tool rather than being re-declared on each agent's
+    ``middleware`` list. Typically declared once as a YAML anchor
+    (``call_limit: &tool_limit { ... }``) and referenced from every tool that
+    should share the same cap.
+
+    A bare integer is accepted as shorthand for ``run_limit`` with
+    ``exit_behavior='continue'`` (see ``BaseFunctionModel.call_limit``); the
+    object form below gives full control. At least one of ``run_limit`` or
+    ``thread_limit`` must be set. This maps to LangChain's
+    ``ToolCallLimitMiddleware`` via ``create_tool_call_limit_middleware``.
+    """
+
+    model_config = ConfigDict(use_enum_values=True, extra="forbid")
+
+    run_limit: Optional[int] = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Maximum number of times this tool may be called within a single "
+            "agent invocation (one user message). Resets each run and requires "
+            "no checkpointer."
+        ),
+    )
+    thread_limit: Optional[int] = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Maximum number of times this tool may be called across an entire "
+            "conversation (thread). Requires a checkpointer, which DAO AI "
+            "agents have via memory."
+        ),
+    )
+    exit_behavior: Literal["continue", "error", "end"] = Field(
+        default="continue",
+        description=(
+            "Behavior when a limit is reached: 'continue' blocks the call and "
+            "returns an error message so the agent can try another approach "
+            "(recommended); 'error' raises immediately; 'end' stops execution "
+            "gracefully (single-tool scenarios only)."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_at_least_one_limit(self) -> Self:
+        """Require at least one of run_limit or thread_limit to be set."""
+        if self.run_limit is None and self.thread_limit is None:
+            raise ValueError(
+                "At least one of run_limit or thread_limit must be specified."
+            )
+        return self
+
+
 class BaseFunctionModel(ABC, BaseModel):
     """Base class for all function/tool implementations (Python, factory, inline, MCP, UC)."""
 
@@ -5521,6 +5570,35 @@ class BaseFunctionModel(ABC, BaseModel):
             "execution."
         ),
     )
+    call_limit: Optional[int | ToolCallLimitModel] = Field(
+        default=None,
+        description=(
+            "Shortcut to cap how many times this tool may be called. A bare "
+            "integer sets run_limit (per-invocation) with "
+            "exit_behavior='continue'; an object gives full control over "
+            "run_limit/thread_limit/exit_behavior. Applied automatically to "
+            "every agent that uses this tool, in addition to any explicit "
+            "tool-call-limit middleware configured on the agent."
+        ),
+    )
+
+    @field_validator("call_limit", mode="before")
+    @classmethod
+    def _normalize_call_limit(cls, value: Any) -> Any:
+        """Normalize a bare integer shortcut into a ToolCallLimitModel dict.
+
+        Runs before union validation so a bare int becomes ``run_limit``.
+        ``bool`` is a subclass of ``int`` but is never a valid limit, so
+        reject it explicitly rather than silently coercing ``True`` to
+        ``run_limit=1``.
+        """
+        if isinstance(value, bool):
+            raise ValueError(
+                "call_limit must be a positive integer or an object, not a bool."
+            )
+        if isinstance(value, int):
+            return {"run_limit": value}
+        return value
 
     @abstractmethod
     def as_tools(self, **kwargs: Any) -> Sequence[RunnableLike]: ...
@@ -7777,9 +7855,7 @@ class SwarmModel(BaseModel):
                 if not isinstance(entry, HandoffRouteModel) or entry.agents is None:
                     continue
                 # Cohort entry.
-                sibling_names: list[str] = [
-                    self._target_name(a) for a in entry.agents
-                ]
+                sibling_names: list[str] = [self._target_name(a) for a in entry.agents]
                 join_name: str = self._target_name(entry.join)
                 if source in sibling_names:
                     raise ValueError(
@@ -10741,9 +10817,7 @@ class AppConfig(BaseModel):
 
         graph: CompiledStateGraph = self.as_graph()
         tool_models: list[ToolModel] = [
-            tool
-            for agent in self.agents.values()
-            for tool in agent.tools
+            tool for agent in self.agents.values() for tool in agent.tools
         ]
         app: ResponsesAgent = create_responses_agent(
             graph,

--- a/src/dao_ai/middleware/__init__.py
+++ b/src/dao_ai/middleware/__init__.py
@@ -110,7 +110,10 @@ from dao_ai.middleware.tool_call_id_sanitizer import (
     ToolCallIdSanitizerMiddleware,
     create_tool_call_id_sanitizer_middleware,
 )
-from dao_ai.middleware.tool_call_limit import create_tool_call_limit_middleware
+from dao_ai.middleware.tool_call_limit import (
+    create_tool_call_limit_middleware,
+    create_tool_call_limit_middlewares_from_tool_models,
+)
 from dao_ai.middleware.tool_call_observability import (
     ToolCallObservabilityMiddleware,
     create_tool_call_observability_middleware,
@@ -201,6 +204,7 @@ __all__ = [
     "create_refine_middleware",
     # Limit and retry middleware factory functions
     "create_tool_call_limit_middleware",
+    "create_tool_call_limit_middlewares_from_tool_models",
     "create_model_call_limit_middleware",
     "create_tool_retry_middleware",
     "create_model_retry_middleware",

--- a/src/dao_ai/middleware/tool_call_limit.py
+++ b/src/dao_ai/middleware/tool_call_limit.py
@@ -23,7 +23,7 @@ Example:
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Literal, Sequence
 
 from langchain.agents.middleware import ToolCallLimitMiddleware
 from langchain_core.tools import BaseTool
@@ -34,6 +34,7 @@ from dao_ai.config import BaseFunctionModel, ToolModel
 __all__ = [
     "ToolCallLimitMiddleware",
     "create_tool_call_limit_middleware",
+    "create_tool_call_limit_middlewares_from_tool_models",
 ]
 
 
@@ -208,3 +209,73 @@ def create_tool_call_limit_middleware(
         run_limit=run_limit,
         exit_behavior=exit_behavior,
     )
+
+
+def create_tool_call_limit_middlewares_from_tool_models(
+    tool_models: Sequence[ToolModel],
+) -> list[ToolCallLimitMiddleware]:
+    """
+    Create ToolCallLimitMiddleware instances from ToolModel configurations.
+
+    Scans tool_models for functions that declare a ``call_limit`` and creates
+    one ToolCallLimitMiddleware per resolved runtime tool name. This is the
+    primary entry point used by agent node creation — it lets a limit follow a
+    tool (declared once on the tool's ``function``) rather than being repeated
+    on every agent's ``middleware`` list.
+
+    Unlike passing a ToolModel straight to ``create_tool_call_limit_middleware``
+    (which limits only the first resolved tool name), this scan resolves every
+    name a function expands to via ``function.as_tools()`` and limits each one.
+
+    Args:
+        tool_models: List of ToolModel configurations from agent config
+
+    Returns:
+        A list of ToolCallLimitMiddleware, one per resolved tool name that has
+        a call_limit configured. Empty if no tool declares a call_limit.
+
+    Example:
+        from dao_ai.config import ToolModel, PythonFunctionModel, ToolCallLimitModel
+
+        tool_models = [
+            ToolModel(
+                name="search",
+                function=SearchToolModel(call_limit=ToolCallLimitModel(run_limit=3)),
+            ),
+        ]
+
+        middlewares = create_tool_call_limit_middlewares_from_tool_models(tool_models)
+    """
+    middlewares: list[ToolCallLimitMiddleware] = []
+
+    for tool_model in tool_models:
+        function = tool_model.function
+
+        if not isinstance(function, BaseFunctionModel):
+            continue
+
+        call_limit = function.call_limit
+        if call_limit is None:
+            continue
+
+        # Resolve every runtime tool name this function expands to and limit
+        # each one independently (each gets a unique
+        # ToolCallLimitMiddleware[<tool>] name in LangChain).
+        for tool_name in _extract_tool_names(tool_model):
+            middleware = create_tool_call_limit_middleware(
+                tool=tool_name,
+                thread_limit=call_limit.thread_limit,
+                run_limit=call_limit.run_limit,
+                exit_behavior=call_limit.exit_behavior,
+            )
+            middlewares.append(middleware)
+            logger.trace(
+                "Registered tool call limit from tool model",
+                tool_model_name=tool_model.name,
+                tool_name=tool_name,
+                run_limit=call_limit.run_limit,
+                thread_limit=call_limit.thread_limit,
+                exit_behavior=call_limit.exit_behavior,
+            )
+
+    return middlewares

--- a/src/dao_ai/nodes.py
+++ b/src/dao_ai/nodes.py
@@ -38,6 +38,9 @@ from dao_ai.middleware.human_in_the_loop import (
 from dao_ai.middleware.summarization import (
     create_summarization_middleware,
 )
+from dao_ai.middleware.tool_call_limit import (
+    create_tool_call_limit_middlewares_from_tool_models,
+)
 from dao_ai.prompts import make_prompt
 from dao_ai.state import AgentState, Context
 from dao_ai.tools import create_tools
@@ -189,6 +192,22 @@ def _create_middleware_list(
             audited_tools=list(audit_middleware.audited_tools),
         )
         middleware_list.append(audit_middleware)
+
+    # Add tool-call-limit middleware for tools with `call_limit` configured.
+    # The limit follows the tool, so every agent using it inherits the cap
+    # without re-declaring middleware. Coexists with any explicit per-agent
+    # tool-call-limit middleware — each instance has a unique
+    # ToolCallLimitMiddleware[<tool>] name. Absent call_limit → empty list.
+    call_limit_middlewares = create_tool_call_limit_middlewares_from_tool_models(
+        tool_models
+    )
+    if call_limit_middlewares:
+        logger.info(
+            "Tool call limit configuration",
+            agent=agent.name,
+            limited_tools=[mw.tool_name for mw in call_limit_middlewares],
+        )
+        middleware_list.extend(call_limit_middlewares)
 
     logger.info(
         "Middleware summary",

--- a/tests/dao_ai/middleware/test_tool_call_limit.py
+++ b/tests/dao_ai/middleware/test_tool_call_limit.py
@@ -5,8 +5,16 @@ Tests for tool call limit middleware factory.
 import pytest
 from langchain.agents.middleware import ToolCallLimitMiddleware
 
-from dao_ai.config import PythonFunctionModel, ToolModel
-from dao_ai.middleware import create_tool_call_limit_middleware
+from dao_ai.config import (
+    PythonFunctionModel,
+    SearchToolModel,
+    ToolCallLimitModel,
+    ToolModel,
+)
+from dao_ai.middleware import (
+    create_tool_call_limit_middleware,
+    create_tool_call_limit_middlewares_from_tool_models,
+)
 
 
 class TestCreateToolCallLimitMiddleware:
@@ -226,3 +234,103 @@ class TestCreateToolCallLimitMiddleware:
         # Should be composable into list manually
         all_middlewares = [global_limits, tool_limits]
         assert len(all_middlewares) == 2
+
+
+class TestCreateToolCallLimitMiddlewaresFromToolModels:
+    """Tests for the create_tool_call_limit_middlewares_from_tool_models scan."""
+
+    def test_no_tools_returns_empty(self):
+        """No tool models at all -> empty list."""
+        assert create_tool_call_limit_middlewares_from_tool_models([]) == []
+
+    def test_no_call_limit_returns_empty(self):
+        """Tools without a call_limit produce no middleware."""
+        tool_models = [
+            ToolModel(
+                name="time",
+                function=PythonFunctionModel(name="dao_ai.tools.current_time_tool"),
+            ),
+            ToolModel(name="search", function=SearchToolModel()),
+        ]
+
+        assert create_tool_call_limit_middlewares_from_tool_models(tool_models) == []
+
+    def test_bare_int_call_limit(self):
+        """A bare-int call_limit (normalized on the model) yields run_limit."""
+        tool_models = [
+            ToolModel(
+                name="search",
+                function=SearchToolModel(call_limit=3),
+            ),
+        ]
+
+        middlewares = create_tool_call_limit_middlewares_from_tool_models(tool_models)
+
+        assert len(middlewares) == 1
+        mw = middlewares[0]
+        assert isinstance(mw, ToolCallLimitMiddleware)
+        # SearchToolModel resolves to the duckduckgo_search runtime tool name.
+        assert mw.tool_name == "duckduckgo_search"
+        assert mw.run_limit == 3
+        assert mw.thread_limit is None
+        assert mw.exit_behavior == "continue"
+
+    def test_object_call_limit(self):
+        """An object call_limit passes through all fields."""
+        tool_models = [
+            ToolModel(
+                name="t",
+                function=PythonFunctionModel(
+                    name="dao_ai.tools.current_time_tool",
+                    call_limit=ToolCallLimitModel(
+                        run_limit=2,
+                        thread_limit=10,
+                        exit_behavior="error",
+                    ),
+                ),
+            ),
+        ]
+
+        middlewares = create_tool_call_limit_middlewares_from_tool_models(tool_models)
+
+        assert len(middlewares) == 1
+        mw = middlewares[0]
+        assert mw.tool_name == "current_time_tool"
+        assert mw.run_limit == 2
+        assert mw.thread_limit == 10
+        assert mw.exit_behavior == "error"
+
+    def test_only_limited_tools_produce_middleware(self):
+        """Mixed list: only tools with call_limit are limited."""
+        tool_models = [
+            ToolModel(name="search", function=SearchToolModel(call_limit=5)),
+            ToolModel(
+                name="time",
+                function=PythonFunctionModel(name="dao_ai.tools.current_time_tool"),
+            ),
+        ]
+
+        middlewares = create_tool_call_limit_middlewares_from_tool_models(tool_models)
+
+        assert len(middlewares) == 1
+        assert middlewares[0].tool_name == "duckduckgo_search"
+
+    def test_multiple_limited_tools(self):
+        """Multiple tools each with a call_limit produce one middleware each."""
+        tool_models = [
+            ToolModel(name="search", function=SearchToolModel(call_limit=5)),
+            ToolModel(
+                name="t",
+                function=PythonFunctionModel(
+                    name="dao_ai.tools.current_time_tool",
+                    call_limit=2,
+                ),
+            ),
+        ]
+
+        middlewares = create_tool_call_limit_middlewares_from_tool_models(tool_models)
+
+        assert len(middlewares) == 2
+        by_name = {mw.tool_name: mw for mw in middlewares}
+        assert by_name["duckduckgo_search"].run_limit == 5
+        assert by_name["current_time_tool"].run_limit == 2

--- a/tests/dao_ai/test_tool_call_limit_field.py
+++ b/tests/dao_ai/test_tool_call_limit_field.py
@@ -1,0 +1,184 @@
+"""
+Tests for the `call_limit` tool field and ToolCallLimitModel config model.
+
+These verify the config-model layer: that a bare integer normalizes to a
+ToolCallLimitModel, that the object form parses, that invalid values are
+rejected, and that the field is inherited by the tool function subtypes.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from conftest import create_mock_llm_model
+from langchain.agents.middleware import ToolCallLimitMiddleware
+from pydantic import ValidationError
+
+from dao_ai.config import (
+    AgentModel,
+    GenieToolModel,
+    PythonFunctionModel,
+    SearchToolModel,
+    ToolCallLimitModel,
+    ToolModel,
+)
+
+
+class TestToolCallLimitModel:
+    """Validation tests for the ToolCallLimitModel config model."""
+
+    def test_run_limit_only(self):
+        model = ToolCallLimitModel(run_limit=3)
+        assert model.run_limit == 3
+        assert model.thread_limit is None
+        assert model.exit_behavior == "continue"
+
+    def test_thread_limit_only(self):
+        model = ToolCallLimitModel(thread_limit=10)
+        assert model.thread_limit == 10
+        assert model.run_limit is None
+
+    def test_all_fields(self):
+        model = ToolCallLimitModel(run_limit=2, thread_limit=8, exit_behavior="error")
+        assert model.run_limit == 2
+        assert model.thread_limit == 8
+        assert model.exit_behavior == "error"
+
+    def test_requires_at_least_one_limit(self):
+        with pytest.raises(ValidationError, match="At least one of run_limit"):
+            ToolCallLimitModel()
+
+    def test_requires_at_least_one_limit_with_only_exit_behavior(self):
+        with pytest.raises(ValidationError, match="At least one of run_limit"):
+            ToolCallLimitModel(exit_behavior="error")
+
+    @pytest.mark.parametrize("bad", [0, -1, -100])
+    def test_run_limit_must_be_positive(self, bad):
+        with pytest.raises(ValidationError):
+            ToolCallLimitModel(run_limit=bad)
+
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_thread_limit_must_be_positive(self, bad):
+        with pytest.raises(ValidationError):
+            ToolCallLimitModel(thread_limit=bad)
+
+    def test_invalid_exit_behavior_rejected(self):
+        with pytest.raises(ValidationError):
+            ToolCallLimitModel(run_limit=3, exit_behavior="halt")
+
+    def test_extra_fields_forbidden(self):
+        with pytest.raises(ValidationError):
+            ToolCallLimitModel(run_limit=3, unknown=True)
+
+
+class TestCallLimitFieldNormalization:
+    """The call_limit field on tool functions normalizes bare ints."""
+
+    def test_bare_int_normalizes_to_model(self):
+        fn = PythonFunctionModel(name="dao_ai.tools.current_time_tool", call_limit=3)
+        assert isinstance(fn.call_limit, ToolCallLimitModel)
+        assert fn.call_limit.run_limit == 3
+        assert fn.call_limit.exit_behavior == "continue"
+        assert fn.call_limit.thread_limit is None
+
+    def test_object_form_parses(self):
+        fn = PythonFunctionModel(
+            name="dao_ai.tools.current_time_tool",
+            call_limit={"run_limit": 2, "thread_limit": 10, "exit_behavior": "error"},
+        )
+        assert isinstance(fn.call_limit, ToolCallLimitModel)
+        assert fn.call_limit.run_limit == 2
+        assert fn.call_limit.thread_limit == 10
+        assert fn.call_limit.exit_behavior == "error"
+
+    def test_default_is_none(self):
+        fn = PythonFunctionModel(name="dao_ai.tools.current_time_tool")
+        assert fn.call_limit is None
+
+    def test_bare_zero_rejected_via_normalization(self):
+        """A bare 0 int normalizes into ToolCallLimitModel(run_limit=0) and fails gt=0."""
+        with pytest.raises(ValidationError):
+            PythonFunctionModel(name="dao_ai.tools.current_time_tool", call_limit=0)
+
+    def test_bool_not_treated_as_int(self):
+        """bool is a subclass of int; True must not become run_limit=1."""
+        with pytest.raises(ValidationError):
+            PythonFunctionModel(name="dao_ai.tools.current_time_tool", call_limit=True)
+
+
+class TestCallLimitInheritedBySubtypes:
+    """call_limit is defined on BaseFunctionModel, so every subtype has it."""
+
+    def test_search_tool_has_call_limit(self):
+        fn = SearchToolModel(call_limit=4)
+        assert isinstance(fn.call_limit, ToolCallLimitModel)
+        assert fn.call_limit.run_limit == 4
+
+    def test_genie_tool_has_call_limit(self):
+        fn = GenieToolModel(
+            name="retail_genie_tool",
+            genie_room={"space_id": "01f0abc"},
+            call_limit={"run_limit": 2, "exit_behavior": "error"},
+        )
+        assert isinstance(fn.call_limit, ToolCallLimitModel)
+        assert fn.call_limit.run_limit == 2
+        assert fn.call_limit.exit_behavior == "error"
+
+    def test_python_tool_defaults_none(self):
+        fn = PythonFunctionModel(name="dao_ai.tools.current_time_tool")
+        assert fn.call_limit is None
+
+
+class TestCallLimitAgentWiring:
+    """A tool's call_limit auto-registers ToolCallLimitMiddleware on the agent."""
+
+    @patch("dao_ai.nodes.create_agent")
+    def test_agent_node_includes_call_limit_middleware(self, mock_create_agent):
+        """An agent whose tool has call_limit gets a ToolCallLimitMiddleware."""
+        from dao_ai.nodes import create_agent_node
+
+        mock_compiled_agent = MagicMock()
+        mock_compiled_agent.name = "test_agent"
+        mock_create_agent.return_value = mock_compiled_agent
+
+        agent_model = AgentModel(
+            name="test_agent",
+            model=create_mock_llm_model(),
+            tools=[
+                ToolModel(name="search", function=SearchToolModel(call_limit=3)),
+            ],
+        )
+
+        create_agent_node(agent=agent_model)
+
+        mock_create_agent.assert_called_once()
+        middleware_list = mock_create_agent.call_args[1].get("middleware", [])
+
+        limit_mws = [
+            m for m in middleware_list if isinstance(m, ToolCallLimitMiddleware)
+        ]
+        assert len(limit_mws) == 1
+        assert limit_mws[0].tool_name == "duckduckgo_search"
+        assert limit_mws[0].run_limit == 3
+
+    @patch("dao_ai.nodes.create_agent")
+    def test_agent_node_no_call_limit_when_not_configured(self, mock_create_agent):
+        """No tool has call_limit -> no ToolCallLimitMiddleware."""
+        from dao_ai.nodes import create_agent_node
+
+        mock_compiled_agent = MagicMock()
+        mock_compiled_agent.name = "test_agent"
+        mock_create_agent.return_value = mock_compiled_agent
+
+        agent_model = AgentModel(
+            name="test_agent",
+            model=create_mock_llm_model(),
+            tools=[ToolModel(name="search", function=SearchToolModel())],
+        )
+
+        create_agent_node(agent=agent_model)
+
+        mock_create_agent.assert_called_once()
+        middleware_list = mock_create_agent.call_args[1].get("middleware", [])
+
+        has_limit = any(isinstance(m, ToolCallLimitMiddleware) for m in middleware_list)
+        assert not has_limit

--- a/tests/dao_ai/test_tool_call_limit_field_integration.py
+++ b/tests/dao_ai/test_tool_call_limit_field_integration.py
@@ -1,0 +1,100 @@
+"""
+Integration tests for the `call_limit` tool field against live Databricks endpoints.
+
+These tests load tool_call_limit_field.yaml end-to-end, create a ResponsesAgent,
+and validate that a tool's `call_limit` auto-registers a ToolCallLimitMiddleware
+on every agent that uses the tool — without any per-agent middleware wiring.
+
+Run with:
+    pytest tests/dao_ai/test_tool_call_limit_field_integration.py -v -m integration -s
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from conftest import has_databricks_env
+from langchain.agents.middleware import ToolCallLimitMiddleware
+
+from dao_ai.config import AppConfig
+from dao_ai.middleware.tool_call_limit import (
+    create_tool_call_limit_middlewares_from_tool_models,
+)
+from dao_ai.models import ResponsesAgent
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def call_limit_config_path() -> Path:
+    """Path to the tool_call_limit_field.yaml example configuration."""
+    return (
+        Path(__file__).parents[2]
+        / "config"
+        / "examples"
+        / "12_middleware"
+        / "tool_call_limit_field.yaml"
+    )
+
+
+@pytest.fixture
+def app_config(call_limit_config_path: Path) -> AppConfig:
+    """AppConfig loaded from the call_limit example."""
+    return AppConfig.from_file(call_limit_config_path)
+
+
+# =============================================================================
+# Test Cases
+# =============================================================================
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not has_databricks_env(), reason="Databricks env vars not set")
+def test_call_limit_config_loads_and_registers_middleware(
+    app_config: AppConfig,
+) -> None:
+    """
+    Config loads, and each agent using a call_limited tool derives a
+    ToolCallLimitMiddleware from the tool's call_limit — even though no agent
+    declares any tool-call-limit middleware explicitly.
+    """
+    assert app_config is not None
+    assert app_config.app is not None
+    assert len(app_config.agents) >= 2
+
+    for agent in app_config.agents.values():
+        # No explicit tool-call-limit middleware on the agent.
+        limit_mws = create_tool_call_limit_middlewares_from_tool_models(agent.tools)
+        limited = {mw.tool_name for mw in limit_mws}
+        print(f"Agent '{agent.name}' auto-limited tools: {limited}", file=sys.stderr)
+
+        # Every agent in this example uses genie_tool, which is call-limited.
+        assert any(isinstance(m, ToolCallLimitMiddleware) for m in limit_mws), (
+            f"Agent '{agent.name}' should inherit a tool call limit"
+        )
+        # Genie tool object-form limit: run_limit=2, thread_limit=8, error.
+        genie_mw = next(
+            (mw for mw in limit_mws if mw.tool_name == "retail_genie_tool"), None
+        )
+        assert genie_mw is not None
+        assert genie_mw.run_limit == 2
+        assert genie_mw.thread_limit == 8
+        assert genie_mw.exit_behavior == "error"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not has_databricks_env(), reason="Databricks env vars not set")
+def test_call_limit_agent_builds_with_middleware(app_config: AppConfig) -> None:
+    """
+    The ResponsesAgent builds successfully with call-limit middleware attached,
+    confirming the wiring path (nodes._create_middleware_list) runs end-to-end.
+    """
+    responses_agent: ResponsesAgent = app_config.as_responses_agent()
+    assert responses_agent is not None
+    assert hasattr(responses_agent, "predict")
+    print(
+        f"Successfully created ResponsesAgent: {type(responses_agent)}",
+        file=sys.stderr,
+    )


### PR DESCRIPTION
## What

Adds a `call_limit` field on `BaseFunctionModel` (a sibling of `human_in_the_loop` and `audit`) that auto-registers a `ToolCallLimitMiddleware` for the tool on **every agent that uses it**. The limit follows the *tool*, so it no longer has to be re-declared on each agent's `middleware:` list. This is syntactic sugar over the existing `create_tool_call_limit_middleware` factory — no new enforcement logic.

## Why

Today, capping how many times an agent may call a tool means authoring an explicit `MiddlewareModel` per tool and wiring it into each agent (see `config/examples/12_middleware/limit_middleware.yaml`). That's verbose and easy to forget — every agent that gets a tool must separately remember to attach its limit. Putting `call_limit` on the tool makes the cap travel with the tool.

## How

- **`ToolCallLimitModel`** (`config.py`): `run_limit` / `thread_limit` (`gt=0`), `exit_behavior` (`continue`/`error`/`end`); a model-validator requires at least one limit.
- **`call_limit: Optional[int | ToolCallLimitModel]`** on `BaseFunctionModel`: a bare int is shorthand for `run_limit` with `exit_behavior=continue`; the object form gives full control. A `before` field-validator normalizes the int and explicitly rejects `bool`.
- **`create_tool_call_limit_middlewares_from_tool_models`** (`middleware/tool_call_limit.py`): scans tool models, resolves **all** runtime tool names via `function.as_tools()`, and builds one `ToolCallLimitMiddleware` per name. This fixes the standalone factory's limitation where a tool expanding to multiple names only limited the first. Wired into `nodes._create_middleware_list` alongside the HITL/audit scans.
- Regenerated `schemas/model_config_schema.json`; added `config/examples/12_middleware/tool_call_limit_field.yaml`.

Composes with explicit per-agent limit middleware — each instance gets a unique `ToolCallLimitMiddleware[<tool>]` name, so both register.

## Multi-tool / MCP behavior

Because the scan uses the same `as_tools()` path that builds the agent's real runtime tools, a toolkit-style function (MCP server, wildcard UC function) that discovers N tools produces N `ToolCallLimitMiddleware` instances keyed on the real discovered tool names — the same names the LLM calls at inference. The limit therefore applies **per discovered tool**. Known edge cases (documented for follow-up, not blocking): the scan re-invokes `as_tools()` rather than reading the cached `tool_registry`, so an MCP function incurs a second build-time discovery connection; and if discovery returns *empty* (all tools filtered out), the scan falls back to the config-level tool name. See the follow-up note in the PR discussion.

## Testing

- Unit: config-model validation (int normalization, object form, `gt=0`, empty-object rejection, bool rejection, subtype inheritance), the scan helper (multi-name, empty), and agent wiring (middleware lands / absent).
- Integration (`@pytest.mark.integration`, gated on `has_databricks_env()`): loads the example config and asserts the middleware is derived per agent.
- **Live-verified on FEVM** (App): with `call_limit: 1` on a search tool and *no* agent middleware, MLflow OTEL traces show `duckduckgo_search` executing exactly once and the over-limit call blocked by `ToolCallLimitMiddleware[duckduckgo_search]`, with the model acknowledging the limit in its response.

`make schema` regenerated; ruff clean. Pre-existing unrelated unit-test failures (deploy/autolog harness) are unchanged.

This pull request and its description were written by Isaac.