### PR TITLE
refactor(tools): share tool-name resolution + reuse build-time registry

### DIFF
--- a/src/dao_ai/middleware/human_in_the_loop.py
+++ b/src/dao_ai/middleware/human_in_the_loop.py
@@ -211,6 +211,7 @@ def create_hitl_middleware_from_tool_models(
         middleware = create_hitl_middleware_from_tool_models(tool_models)
     """
     from dao_ai.config import BaseFunctionModel
+    from dao_ai.tools import resolve_tool_names
 
     interrupt_on: dict[str, HumanInTheLoopModel] = {}
     hitl_configs_by_tool: dict[str, HumanInTheLoopModel] = {}
@@ -228,9 +229,9 @@ def create_hitl_middleware_from_tool_models(
 
         audit_config: AuditModel | None = function.audit
 
-        # Get tool names created by this function
-        for func_tool in function.as_tools():
-            tool_name: str | None = getattr(func_tool, "name", None)
+        # Get tool names created by this function (reuses the agent-build tool
+        # registry when available; see dao_ai.tools.resolve_tool_names).
+        for tool_name in resolve_tool_names(tool_model):
             if not tool_name:
                 continue
             interrupt_on[tool_name] = hitl_config

--- a/src/dao_ai/middleware/tool_call_limit.py
+++ b/src/dao_ai/middleware/tool_call_limit.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 from typing import Any, Literal, Sequence
 
 from langchain.agents.middleware import ToolCallLimitMiddleware
-from langchain_core.tools import BaseTool
 from loguru import logger
 
 from dao_ai.config import BaseFunctionModel, ToolModel
@@ -80,46 +79,15 @@ def _extract_tool_names(tool_model: ToolModel) -> list[str]:
     """
     Extract actual tool names from a ToolModel.
 
-    A single ToolModel can produce multiple tools (e.g., UC functions).
-    Falls back to ToolModel.name if extraction fails.
+    A single ToolModel can produce multiple tools (e.g., UC functions, MCP
+    servers). Delegates to the shared ``resolve_tool_names`` so tool-name
+    resolution reuses already-built tools from the agent-build registry
+    (avoiding a second connect-and-enumerate for toolkit functions) and stays
+    consistent with the HITL/audit scans. Falls back to ``ToolModel.name``.
     """
-    function = tool_model.function
+    from dao_ai.tools import resolve_tool_names
 
-    # String function references can't be introspected
-    if not isinstance(function, BaseFunctionModel):
-        logger.debug(
-            "Cannot extract names from string function, using ToolModel.name",
-            tool_model_name=tool_model.name,
-        )
-        return [tool_model.name]
-
-    # Try to extract names from created tools
-    try:
-        tool_names = [
-            tool.name
-            for tool in function.as_tools()
-            if isinstance(tool, BaseTool) and tool.name
-        ]
-        if tool_names:
-            logger.trace(
-                "Extracted tool names",
-                tool_model_name=tool_model.name,
-                tool_names=tool_names,
-            )
-            return tool_names
-    except Exception as e:
-        logger.warning(
-            "Error extracting tool names from ToolModel",
-            tool_model_name=tool_model.name,
-            error=str(e),
-        )
-
-    # Fallback to ToolModel.name
-    logger.debug(
-        "Falling back to ToolModel.name",
-        tool_model_name=tool_model.name,
-    )
-    return [tool_model.name]
+    return resolve_tool_names(tool_model)
 
 
 def create_tool_call_limit_middleware(

--- a/src/dao_ai/tools/__init__.py
+++ b/src/dao_ai/tools/__init__.py
@@ -11,9 +11,10 @@ from dao_ai.tools.agent import create_agent_endpoint_tool
 from dao_ai.tools.app_agent_dispatcher import create_app_dispatcher
 from dao_ai.tools.app_info import create_app_info_tool
 from dao_ai.tools.chat_completions_agent import create_chat_completions_agent_tool
-from dao_ai.tools.core import create_tools, say_hello_tool
+from dao_ai.tools.core import create_tools, resolve_tool_names, say_hello_tool
 from dao_ai.tools.email import create_send_email_tool
 from dao_ai.tools.genie import GenieToolkit, create_genie_tool, create_genie_toolkit
+from dao_ai.tools.lakebase_search import create_lakebase_search_tool
 from dao_ai.tools.mcp import MCPToolInfo, create_mcp_tools, list_mcp_tools
 from dao_ai.tools.memory import (
     create_manage_memory_tool,
@@ -38,7 +39,6 @@ from dao_ai.tools.time import (
     time_until_tool,
 )
 from dao_ai.tools.unity_catalog import create_uc_tools
-from dao_ai.tools.lakebase_search import create_lakebase_search_tool
 from dao_ai.tools.vector_search import (
     create_ai_search_tool,
     create_vector_search_tool,
@@ -79,6 +79,7 @@ __all__ = [
     "create_send_slack_message_tool",
     "create_send_teams_message_tool",
     "create_tools",
+    "resolve_tool_names",
     "create_uc_tools",
     "create_ai_search_tool",
     "create_lakebase_search_tool",

--- a/src/dao_ai/tools/core.py
+++ b/src/dao_ai/tools/core.py
@@ -15,10 +15,12 @@ from typing import Sequence
 
 from langchain.tools import ToolRuntime, tool
 from langchain_core.runnables.base import RunnableLike
+from langchain_core.tools import BaseTool
 from loguru import logger
 
 from dao_ai.config import (
     AnyTool,
+    BaseFunctionModel,
     ToolModel,
 )
 from dao_ai.hooks.core import create_hooks
@@ -26,6 +28,71 @@ from dao_ai.state import Context
 
 # Module-level tool registry for caching created tools
 tool_registry: dict[str, Sequence[RunnableLike]] = {}
+
+
+def _tool_names(tools: Sequence[RunnableLike]) -> list[str]:
+    """Extract the ``.name`` of every BaseTool in a sequence."""
+    return [tool.name for tool in tools if isinstance(tool, BaseTool) and tool.name]
+
+
+def resolve_tool_names(tool_model: ToolModel) -> list[str]:
+    """
+    Resolve a ToolModel to the runtime tool names it produces.
+
+    Per-tool middleware (call limits, HITL, audit) must key on the actual tool
+    names the LLM calls, which a single ToolModel can expand to several of
+    (e.g. an MCP server or a wildcard Unity Catalog function). This is the one
+    resolution path those scans should share.
+
+    Resolution order, cheapest and most authoritative first:
+
+    1. ``tool_registry`` — if ``create_tools`` already built this tool during
+       the same agent build, reuse those exact objects. This avoids a second
+       connect-and-enumerate round-trip for toolkit functions and guarantees
+       the names match the tools the agent will actually run.
+    2. ``function.as_tools()`` — build the tools to read their names. Used when
+       the registry has no entry (e.g. resolution outside the agent-build path).
+    3. ``tool_model.name`` — last-resort fallback when the function is a bare
+       string reference or ``as_tools()`` yields nothing / raises.
+
+    Args:
+        tool_model: The tool configuration to resolve.
+
+    Returns:
+        A list of runtime tool-name strings (never empty; falls back to the
+        ToolModel's own name).
+    """
+    # 1. Reuse already-built tools from this agent build when available.
+    cached = tool_registry.get(tool_model.name)
+    if cached is not None:
+        names = _tool_names(cached)
+        if names:
+            return names
+
+    function = tool_model.function
+
+    # String function references can't be introspected.
+    if not isinstance(function, BaseFunctionModel):
+        return [tool_model.name]
+
+    # 2. Build the tools to read their names.
+    try:
+        names = _tool_names(function.as_tools())
+        if names:
+            return names
+    except Exception as e:
+        logger.warning(
+            "Error resolving tool names from ToolModel",
+            tool_model_name=tool_model.name,
+            error=str(e),
+        )
+
+    # 3. Fall back to the ToolModel's configured name.
+    logger.debug(
+        "Falling back to ToolModel.name for tool-name resolution",
+        tool_model_name=tool_model.name,
+    )
+    return [tool_model.name]
 
 
 def create_tools(tool_models: Sequence[ToolModel]) -> Sequence[RunnableLike]:

--- a/tests/dao_ai/test_tools.py
+++ b/tests/dao_ai/test_tools.py
@@ -1,9 +1,17 @@
 from typing import Sequence
+from unittest.mock import patch
 
 import pytest
 
-from dao_ai.config import AppConfig, FunctionType, ToolModel
-from dao_ai.tools import create_tools
+from dao_ai.config import (
+    AppConfig,
+    FunctionType,
+    PythonFunctionModel,
+    SearchToolModel,
+    ToolModel,
+)
+from dao_ai.tools import create_tools, resolve_tool_names
+from dao_ai.tools.core import tool_registry
 
 excluded_tools: Sequence[str] = [
     "vector_search",
@@ -33,3 +41,61 @@ def test_create_tools_empty_list() -> None:
     tools = create_tools([])
     assert tools is not None
     assert len(tools) == 0
+
+
+class TestResolveToolNames:
+    """Tests for the shared resolve_tool_names helper (registry reuse)."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_registry(self):
+        """Isolate each test from registry state left by other tests."""
+        tool_registry.clear()
+        yield
+        tool_registry.clear()
+
+    @pytest.mark.unit
+    def test_registry_miss_falls_back_to_as_tools(self) -> None:
+        """With an empty registry, names come from function.as_tools()."""
+        tm = ToolModel(name="search", function=SearchToolModel())
+        assert resolve_tool_names(tm) == ["duckduckgo_search"]
+
+    @pytest.mark.unit
+    def test_registry_hit_reuses_without_calling_as_tools(self) -> None:
+        """After create_tools populates the registry, no second as_tools()."""
+        tm = ToolModel(name="search", function=SearchToolModel())
+        create_tools([tm])  # populates tool_registry["search"]
+
+        with patch.object(
+            type(tm.function), "as_tools", wraps=tm.function.as_tools
+        ) as spy:
+            names = resolve_tool_names(tm)
+
+        assert names == ["duckduckgo_search"]
+        assert spy.call_count == 0, "should reuse registry, not rebuild tools"
+
+    @pytest.mark.unit
+    def test_string_function_falls_back_to_tool_model_name(self) -> None:
+        """A bare string function reference resolves to the ToolModel name."""
+        tm = ToolModel(name="some_reference", function="some_reference")
+        assert resolve_tool_names(tm) == ["some_reference"]
+
+    @pytest.mark.unit
+    def test_as_tools_exception_falls_back_to_tool_model_name(self) -> None:
+        """If as_tools() raises, resolution falls back to the ToolModel name."""
+        tm = ToolModel(
+            name="boom",
+            function=PythonFunctionModel(name="dao_ai.tools.current_time_tool"),
+        )
+        with patch.object(
+            type(tm.function), "as_tools", side_effect=RuntimeError("no server")
+        ):
+            assert resolve_tool_names(tm) == ["boom"]
+
+    @pytest.mark.unit
+    def test_python_tool_resolves_runtime_name(self) -> None:
+        """A python function resolves to the underlying tool's runtime name."""
+        tm = ToolModel(
+            name="clock",
+            function=PythonFunctionModel(name="dao_ai.tools.current_time_tool"),
+        )
+        assert resolve_tool_names(tm) == ["current_time_tool"]


### PR DESCRIPTION
Follow-up to #193 (merged). Optimizes the tool-name resolution that #193's `call_limit` scan and the existing HITL/audit scan both perform.

## What

Introduces `dao_ai.tools.resolve_tool_names` — one shared path that resolves a `ToolModel` to the runtime tool names it produces — and routes both the `call_limit` scan and the HITL/audit scan through it. Resolution reads the build-time `tool_registry` first, so toolkit functions (MCP servers, wildcard UC functions) are not re-enumerated.

## Why

Per-tool middleware must key on the real runtime tool names a `ToolModel` expands to. Both `_extract_tool_names` (call_limit) and `create_hitl_middleware_from_tool_models` (HITL) resolved these by calling `function.as_tools()` independently. For a toolkit function that's a live connect-and-enumerate — and `create_tools` had **already built** those exact tools moments earlier in the same synchronous `create_agent_node`, caching them in `tool_registry`. So each MCP/UC toolkit incurred a redundant second discovery round-trip per scan, with a second chance for one call to disagree with the other.

## How

`resolve_tool_names(tool_model)` resolves in order:
1. **`tool_registry`** — reuse the exact tool objects `create_tools` built this agent build (guarantees name identity with what the agent runs; no extra round-trip).
2. **`function.as_tools()`** — build to read names, when the registry has no entry (resolution outside the build path).
3. **`tool_model.name`** — last-resort fallback (bare string reference, or `as_tools()` empty/raises).

Both scans now call it. Behavior is unchanged when the registry is cold (the previous `as_tools()` path still runs); the win is purely avoiding the duplicate fetch when it's warm.

## Testing

- Unit (`test_tools.py::TestResolveToolNames`): registry **hit reuses without calling `as_tools()`** (a spy asserts 0 calls), registry miss falls back to `as_tools()`, string-function and `as_tools()`-raises paths fall back to `tool_model.name`.
- Existing call_limit + HITL suites pass unchanged (69 tests green).
- **Live-verified on FEVM** with a UC Functions MCP toolkit (`retail_consumer_goods.hardware_store`, 6 discovered functions) using the `retail_consumer_goods` SP secret scope: `call_limit: 1` produced **6 `ToolCallLimitMiddleware[<real MCP tool name>]` spans** in MLflow OTEL traces; the first `find_product_by_sku` call succeeded and the repeat was blocked (`STATUS_CODE_ERROR`), with the model acknowledging the limit. This is the multi-tool discovery path the optimization targets.

ruff clean.

This pull request and its description were written by Isaac.