### PR TITLE
feat(deploy): consistent --development tri-state + --force→--overwrite rename

### DIFF
--- a/config/examples/07_human_in_the_loop/human_in_the_loop_audited.yaml
+++ b/config/examples/07_human_in_the_loop/human_in_the_loop_audited.yaml
@@ -191,7 +191,7 @@ app:
 # =============================================================================
 #
 # 1. Deploy to Databricks Apps (recommended for OBO capture):
-#      uv run dao-ai generate-bundle --force --development \
+#      uv run dao-ai generate-bundle --overwrite --development \
 #        -c config/examples/07_human_in_the_loop/human_in_the_loop_audited.yaml
 #      databricks bundle deploy -p <profile>
 #      uv run dao-ai link-trace-destination \

--- a/config/examples/21_lakebase_search/README.md
+++ b/config/examples/21_lakebase_search/README.md
@@ -244,7 +244,7 @@ dao-ai validate -c config/examples/21_lakebase_search/hybrid_rrf.yaml
 
 # Deploy as a Databricks App bundle.
 dao-ai generate-bundle -c config/examples/21_lakebase_search/hybrid_rrf.yaml \
-  -o /tmp/lakebase-agent --force --development -p <profile>
+  -o /tmp/lakebase-agent --overwrite --development -p <profile>
 cd /tmp/lakebase-agent
 databricks bundle deploy --target dev -p <profile>
 databricks bundle run dao-ai-lakebase-hybrid-example --target dev -p <profile>

--- a/databricks.yaml.template
+++ b/databricks.yaml.template
@@ -44,6 +44,9 @@ variables:
   deployment_target:
     description: Agent deployment target (model_serving or apps) - defaults to model_serving
     default: model_serving
+  development:
+    description: Source selection (auto, true, false) - true ships local dao-ai wheel, false pins PyPI, auto detects from install type
+    default: auto
 
 resources:
   jobs:
@@ -103,6 +106,7 @@ resources:
             base_parameters:
               config-path: ${var.config_path}
               deployment-target: ${var.deployment_target}
+              development: ${var.development}
           environment_key: dao-ai-env
         - task_key: generate-evaluation-data
           depends_on:

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -523,7 +523,7 @@ Databricks Apps forwards user identity on `X-Forwarded-User` /
 picks these up automatically. Deployment flow:
 
 ```bash
-uv run dao-ai generate-bundle --force --development -c my_config.yaml
+uv run dao-ai generate-bundle --overwrite --development -c my_config.yaml
 databricks bundle deploy -p <profile>
 # Critical: link the trace destination BEFORE bundle run.
 uv run dao-ai link-trace-destination -c my_config.yaml -p <profile>

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -211,10 +211,10 @@ dao-ai create-experiment --name /Shared/my-app/dao-ai-fresh -p <profile>
 
 ### Overwriting Existing Files
 
-If the output directory already contains generated files, they are skipped by default. Use `--force` to overwrite:
+If the output directory already contains generated files, they are skipped by default. Use `--overwrite` to overwrite:
 
 ```bash
-dao-ai generate-bundle -c config/retail.yaml -o ./my-bundle --force
+dao-ai generate-bundle -c config/retail.yaml -o ./my-bundle --overwrite
 ```
 
 ### Using a Databricks Profile
@@ -327,7 +327,7 @@ app:
 
 ```bash
 # 3. Deploy → link → run → restart.
-dao-ai generate-bundle -c my_config.yaml -o ./bundle --force
+dao-ai generate-bundle -c my_config.yaml -o ./bundle --overwrite
 cd ./bundle
 databricks bundle deploy --target dev -p <profile>
 dao-ai link-trace-destination -c ../my_config.yaml -p <profile>
@@ -550,7 +550,7 @@ dao-ai generate-bundle -c config/my_config.yaml -o ./my-bundle [OPTIONS]
 |--------|-------------|
 | `-c, --config FILE` | Path to the dao-ai configuration file (required) |
 | `-o, --output-dir DIR` | Output directory for generated files (default: `.`) |
-| `--force` | Overwrite existing files in the output directory |
+| `--overwrite` | Overwrite existing files in the output directory |
 | `--development` | Bundle a local dao-ai wheel instead of a PyPI dependency |
 | `-p, --profile NAME` | Databricks profile for config loading and resource resolution |
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -203,7 +203,7 @@ databricks bundle deploy
 databricks bundle run <app-name>
 ```
 
-`generate-bundle` writes a complete, deployable Databricks Apps bundle directory (`databricks.yaml`, `app.yaml`, `pyproject.toml`, scaffolding). Useful when you want the bundle under version control, need to hand-tune anything the generator produced, or want to deploy from CI outside of Python. Add `--development` to bundle local dao-ai source instead of the pinned PyPI wheel; add `--force` to overwrite an existing output directory.
+`generate-bundle` writes a complete, deployable Databricks Apps bundle directory (`databricks.yaml`, `app.yaml`, `pyproject.toml`, scaffolding). Useful when you want the bundle under version control, need to hand-tune anything the generator produced, or want to deploy from CI outside of Python. Add `--development` to bundle local dao-ai source instead of the pinned PyPI wheel; add `--overwrite` to overwrite an existing output directory.
 
 **Learn more:** [`docs/cli-reference.md`](cli-reference.md) · [`docs/python-api.md`](python-api.md)
 

--- a/docs/mcp_server.md
+++ b/docs/mcp_server.md
@@ -450,7 +450,7 @@ launches the server via module invocation — no console script required.
 |---|---|
 | `-c / --config` | Path to your dao-ai config YAML. |
 | `-o / --output-dir` | Where to write the bundle. |
-| `--force` | Overwrite existing files in the output directory. |
+| `--overwrite` | Overwrite existing files in the output directory. |
 | `--development` | Build the local dao-ai wheel and bundle it under `output/dist/`; the generated pyproject installs from there. Use when dao-ai changes haven't shipped to PyPI yet. |
 | `-p / --profile` | Databricks CLI profile — drives `_resolve_all_resources` so generated bundle paths (e.g. Lakebase database IDs) come from the target workspace. Always pass this when your config references resources resolved at generate time. |
 | `--var KEY=VALUE` / `--param KEY=VALUE` | Override declared `${var.KEY}` substitutions. Repeatable. |

--- a/notebooks/06_deploy_agent.py
+++ b/notebooks/06_deploy_agent.py
@@ -32,6 +32,11 @@ dbutils.widgets.dropdown(
     choices=["", "model_serving", "apps", "both"],
     defaultValue="",
 )
+dbutils.widgets.dropdown(
+    name="development",
+    choices=["auto", "true", "false"],
+    defaultValue="auto",
+)
 
 config_files: Sequence[str] = find_yaml_files_os_walk("../config")
 dbutils.widgets.dropdown(name="config-paths", choices=config_files, defaultValue=next(iter(config_files), ""))
@@ -106,8 +111,22 @@ from dao_ai.config import AppConfig, DeploymentTarget
 config_path: str = dbutils.widgets.get("config-path") or dbutils.widgets.get("config-paths")
 deployment_target_str: str | None = dbutils.widgets.get("deployment-target") or None
 
+# Source selection tri-state forwarded by `dao-ai pipeline` via the
+# `development` bundle var: "true" ships local dao-ai source/wheel, "false"
+# pins the published PyPI package, "auto"/"" auto-detects from the install
+# type (None -> create_agent/deploy_agent resolve via is_published()).
+development_str: str = (dbutils.widgets.get("development") or "auto").lower()
+development: bool | None
+if development_str == "true":
+    development = True
+elif development_str == "false":
+    development = False
+else:
+    development = None
+
 print(f"Config path: {config_path}")
 print(f"Deployment target: {deployment_target_str or '(using config default)'}")
+print(f"Development source: {development_str}")
 
 # Pull any resolved parameter values that upstream provisioning tasks
 # (e.g. provision-genie) forwarded via job taskValues. AppConfig.from_file
@@ -140,12 +159,12 @@ config.display_graph()
 # Only log/register the MLflow model for Model Serving deployments.
 # Apps deploy directly from the config + PyPI package.
 if deployment_target != DeploymentTarget.APPS:
-    config.create_agent()
+    config.create_agent(development=development)
 
 # COMMAND ----------
 
 if deployment_target == DeploymentTarget.BOTH:
-    config.deploy_agent(target=DeploymentTarget.MODEL_SERVING)
-    config.deploy_agent(target=DeploymentTarget.APPS)
+    config.deploy_agent(target=DeploymentTarget.MODEL_SERVING, development=development)
+    config.deploy_agent(target=DeploymentTarget.APPS, development=development)
 else:
-    config.deploy_agent(target=deployment_target)
+    config.deploy_agent(target=deployment_target, development=development)

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -12,7 +12,7 @@ Usage:
     from dao_ai.config import AppConfig
 
     config = AppConfig.from_file("my_config.yaml")
-    write_bundle(config, Path("./my-bundle"), force=False)
+    write_bundle(config, Path("./my-bundle"), overwrite=False)
 """
 
 import io
@@ -646,11 +646,11 @@ def generate_resources_app_yaml(
     return yaml.dump(resources_doc, default_flow_style=False, sort_keys=False)
 
 
-def _write_file(path: Path, content: str, force: bool) -> bool:
-    """Write content to a file, respecting the force flag. Returns True if written."""
-    if path.exists() and not force:
+def _write_file(path: Path, content: str, overwrite: bool) -> bool:
+    """Write content to a file, respecting overwrite. Returns True if written."""
+    if path.exists() and not overwrite:
         print(
-            f"  WARNING: Skipping {path.name} (already exists, use --force to overwrite)"
+            f"  WARNING: Skipping {path.name} (already exists; use --overwrite)"
         )
         return False
     path.write_text(content)
@@ -661,7 +661,7 @@ def _write_file(path: Path, content: str, force: bool) -> bool:
 def write_bundle(
     config: AppConfig,
     output_dir: Path,
-    force: bool = False,
+    overwrite: bool = False,
     development: bool = False,
 ) -> None:
     """Write a complete, deployable Databricks Apps bundle directory.
@@ -716,7 +716,7 @@ def write_bundle(
         print(f"\n  ⚠  {_trace_location_warning}\n")
 
     def _track(path: Path, content: str) -> None:
-        if _write_file(path, content, force):
+        if _write_file(path, content, overwrite):
             written.append(path.name)
         else:
             skipped.append(path.name)
@@ -747,9 +747,9 @@ def write_bundle(
 
     if source_config:
         dest = output_dir / config_filename
-        if dest.exists() and not force:
+        if dest.exists() and not overwrite:
             print(
-                f"  WARNING: Skipping {config_filename} (already exists, use --force to overwrite)"
+                f"  WARNING: Skipping {config_filename} (exists; use --overwrite)"
             )
             skipped.append(config_filename)
         else:
@@ -792,9 +792,9 @@ def write_bundle(
             # via the rendered absolute path in the deployed config.
             rel = Path("skills") / src_dir.name
         dest = output_dir / rel
-        if dest.exists() and not force:
+        if dest.exists() and not overwrite:
             logger.info(
-                "Skipping skill directory copy (exists; use --force)",
+                "Skipping skill directory copy (exists; use --overwrite)",
                 skill=str(rel),
             )
             skipped.append(str(rel))
@@ -892,7 +892,7 @@ def write_bundle(
         # Create stub package for user's custom code additions
         stub_dir = output_dir / "src" / package_name
         stub_init = stub_dir / "__init__.py"
-        if not stub_init.exists() or force:
+        if not stub_init.exists() or overwrite:
             stub_dir.mkdir(parents=True, exist_ok=True)
             stub_init.write_text("")
             logger.info(f"Created stub package src/{package_name}/")
@@ -919,7 +919,7 @@ def write_bundle(
         # Create stub package so the wheel builds and users can add custom code
         stub_dir = output_dir / "src" / package_name
         stub_init = stub_dir / "__init__.py"
-        if not stub_init.exists() or force:
+        if not stub_init.exists() or overwrite:
             stub_dir.mkdir(parents=True, exist_ok=True)
             stub_init.write_text("")
             logger.info(f"Created stub package src/{package_name}/")
@@ -938,7 +938,7 @@ def write_bundle(
         print(f"  {name:<20s} (skipped, already exists)")
 
     if skipped:
-        print("\n  Re-run with --force to overwrite existing files.")
+        print("\n  Re-run with --overwrite to overwrite existing files.")
 
     print("\nNext steps:")
     print(f"  cd {output_dir}")

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -667,6 +667,23 @@ Examples:
         "If not specified, uses app.deployment_target from config file, "
         "or defaults to 'model_serving'. Passed to the deploy notebook.",
     )
+    pipeline_parser.add_argument(
+        "--development",
+        dest="development",
+        default=None,
+        action="store_true",
+        help="Ship local dao-ai source/wheel instead of the published PyPI "
+        "package. Rebuild the wheel first with 'uv build --wheel'. "
+        "Defaults to auto-detect from the install type. Passed to the deploy "
+        "notebook.",
+    )
+    pipeline_parser.add_argument(
+        "--no-development",
+        dest="development",
+        action="store_false",
+        help="Force the published PyPI dao-ai package even from a local/editable "
+        "install. Passed to the deploy notebook.",
+    )
 
     # Generate bundle command
     generate_bundle_parser: ArgumentParser = subparsers.add_parser(
@@ -706,8 +723,19 @@ Examples:
     )
     generate_bundle_parser.add_argument(
         "--development",
+        dest="development",
+        default=None,
         action="store_true",
-        help="Include local dao-ai source code in the bundle for development testing",
+        help="Bundle local dao-ai source/wheel instead of pinning the published "
+        "PyPI package. Rebuild the wheel first with 'uv build --wheel'. "
+        "Defaults to auto-detect from the install type.",
+    )
+    generate_bundle_parser.add_argument(
+        "--no-development",
+        dest="development",
+        action="store_false",
+        help="Force the published PyPI dao-ai package even from a local/editable "
+        "install.",
     )
     generate_bundle_parser.add_argument(
         "-p",
@@ -756,8 +784,19 @@ Examples:
     )
     generate_mcp_parser.add_argument(
         "--development",
+        dest="development",
+        default=None,
         action="store_true",
-        help="Reserved for parity with generate-bundle (no effect today).",
+        help="Bundle local dao-ai source/wheel instead of pinning the published "
+        "PyPI package. Rebuild the wheel first with 'uv build --wheel'. "
+        "Defaults to auto-detect from the install type.",
+    )
+    generate_mcp_parser.add_argument(
+        "--no-development",
+        dest="development",
+        action="store_false",
+        help="Force the published PyPI dao-ai package even from a local/editable "
+        "install.",
     )
     generate_mcp_parser.add_argument(
         "-p",
@@ -2230,6 +2269,7 @@ def run_databricks_command(
     cloud: Optional[str] = None,
     dry_run: bool = False,
     deployment_target: Optional[str] = None,
+    development: bool | None = None,
     config_vars: Optional[dict[str, str]] = None,
 ) -> None:
     """Execute a databricks CLI command with optional profile, target, and cloud.
@@ -2243,6 +2283,11 @@ def run_databricks_command(
         dry_run: If True, print the command without executing
         deployment_target: Optional agent deployment target ('model_serving' or 'apps').
             Passed to the deploy notebook via bundle variable.
+        development: Optional tri-state source selection passed to the deploy
+            notebook via the ``development`` bundle variable — ``True`` ships
+            local dao-ai source/wheel, ``False`` the published PyPI package,
+            ``None`` (default) auto-detects from the install type. Emitted as
+            ``"true"``/``"false"``/``"auto"``.
         config_vars: Optional ``${param.NAME}`` overrides for the dao-ai config.
             Forwarded to ``AppConfig.from_file`` and to the underlying
             ``databricks bundle`` command as ``--var name=value`` so the
@@ -2343,6 +2388,15 @@ def run_databricks_command(
 
     cmd.append(f'--var="deployment_target={resolved_deployment_target}"')
 
+    # Forward the development tri-state to the deploy notebook via a bundle var.
+    # Always emit (mirrors deployment_target) so the notebook widget default
+    # never diverges from the CLI intent. None → "auto" (notebook resolves via
+    # is_published()), True → "true" (local source/wheel), False → "false" (PyPI).
+    resolved_development: str = (
+        "auto" if development is None else ("true" if development else "false")
+    )
+    cmd.append(f'--var="development={resolved_development}"')
+
     logger.debug(f"Executing command: {' '.join(cmd)}")
 
     if dry_run:
@@ -2392,6 +2446,7 @@ def handle_pipeline_command(options: Namespace) -> None:
     cloud: Optional[str] = options.cloud
     dry_run: bool = options.dry_run
     deployment_target: Optional[str] = options.deployment_target
+    development: bool | None = getattr(options, "development", None)
     config_vars: dict[str, str] = _parse_var_args(options.var)
 
     if options.deploy:
@@ -2404,6 +2459,7 @@ def handle_pipeline_command(options: Namespace) -> None:
             cloud=cloud,
             dry_run=dry_run,
             deployment_target=deployment_target,
+            development=development,
             config_vars=config_vars,
         )
     if options.run:
@@ -2416,6 +2472,7 @@ def handle_pipeline_command(options: Namespace) -> None:
             cloud=cloud,
             dry_run=dry_run,
             deployment_target=deployment_target,
+            development=development,
             config_vars=config_vars,
         )
     if options.destroy:
@@ -2428,6 +2485,7 @@ def handle_pipeline_command(options: Namespace) -> None:
             cloud=cloud,
             dry_run=dry_run,
             deployment_target=deployment_target,
+            development=development,
             config_vars=config_vars,
         )
     if not any([options.deploy, options.run, options.destroy]):
@@ -2439,7 +2497,12 @@ def handle_generate_bundle_command(options: Namespace) -> None:
     config_path: str = options.config
     output_dir: str = options.output_dir
     force: bool = options.force
-    development: bool = options.development
+    # Resolve the --development/--no-development tri-state to a concrete bool
+    # (None -> auto-detect via is_published()) so write_bundle's bool contract
+    # matches deploy's source-selection semantics.
+    from dao_ai.utils import resolve_use_local_source
+
+    development: bool = resolve_use_local_source(options.development)
     profile: str | None = options.profile
 
     _apply_profile_context(profile)
@@ -2475,7 +2538,12 @@ def handle_generate_mcp_command(options: Namespace) -> None:
     config_path: str = options.config
     output_dir: str = options.output_dir
     force: bool = options.force
-    development: bool = options.development
+    # Resolve the --development/--no-development tri-state to a concrete bool
+    # (None -> auto-detect via is_published()) so write_mcp_bundle's bool
+    # contract matches deploy's source-selection semantics.
+    from dao_ai.utils import resolve_use_local_source
+
+    development: bool = resolve_use_local_source(options.development)
     profile: str | None = options.profile
 
     _apply_profile_context(profile)

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -696,7 +696,7 @@ Creates databricks.yaml, app.yaml, pyproject.toml, and scaffolding files.
         epilog="""
 Examples:
   dao-ai generate-bundle -c config/retail.yaml -o ./my-bundle
-  dao-ai generate-bundle -c config/retail.yaml -o ./my-bundle --force
+  dao-ai generate-bundle -c config/retail.yaml -o ./my-bundle --overwrite
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -717,7 +717,7 @@ Examples:
         help="Directory to write the generated bundle files to (default: current directory)",
     )
     generate_bundle_parser.add_argument(
-        "--force",
+        "--overwrite",
         action="store_true",
         help="Overwrite existing files in the output directory",
     )
@@ -757,7 +757,7 @@ Streamable HTTP. Mirrors `generate-bundle` but emits the MCP-only artifact
         epilog="""
 Examples:
   dao-ai generate-mcp -c config/retail.yaml -o ./retail-mcp
-  dao-ai generate-mcp -c config/retail.yaml -o ./retail-mcp --force
+  dao-ai generate-mcp -c config/retail.yaml -o ./retail-mcp --overwrite
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -778,7 +778,7 @@ Examples:
         help="Directory to write the generated MCP bundle files to (default: current directory)",
     )
     generate_mcp_parser.add_argument(
-        "--force",
+        "--overwrite",
         action="store_true",
         help="Overwrite existing files in the output directory",
     )
@@ -2496,7 +2496,7 @@ def handle_generate_bundle_command(options: Namespace) -> None:
     logger.debug("Generating bundle...")
     config_path: str = options.config
     output_dir: str = options.output_dir
-    force: bool = options.force
+    overwrite: bool = options.overwrite
     # Resolve the --development/--no-development tri-state to a concrete bool
     # (None -> auto-detect via is_published()) so write_bundle's bool contract
     # matches deploy's source-selection semantics.
@@ -2523,7 +2523,9 @@ def handle_generate_bundle_command(options: Namespace) -> None:
 
     from dao_ai.apps.bundle import write_bundle
 
-    write_bundle(config, Path(output_dir), force=force, development=development)
+    write_bundle(
+        config, Path(output_dir), overwrite=overwrite, development=development
+    )
 
 
 def handle_generate_mcp_command(options: Namespace) -> None:
@@ -2537,7 +2539,7 @@ def handle_generate_mcp_command(options: Namespace) -> None:
     logger.debug("Generating MCP bundle...")
     config_path: str = options.config
     output_dir: str = options.output_dir
-    force: bool = options.force
+    overwrite: bool = options.overwrite
     # Resolve the --development/--no-development tri-state to a concrete bool
     # (None -> auto-detect via is_published()) so write_mcp_bundle's bool
     # contract matches deploy's source-selection semantics.
@@ -2561,7 +2563,9 @@ def handle_generate_mcp_command(options: Namespace) -> None:
 
     from dao_ai.mcp.generate import write_mcp_bundle
 
-    write_mcp_bundle(config, Path(output_dir), force=force, development=development)
+    write_mcp_bundle(
+        config, Path(output_dir), overwrite=overwrite, development=development
+    )
 
 
 def handle_vars_command(options: Namespace) -> None:

--- a/src/dao_ai/mcp/generate.py
+++ b/src/dao_ai/mcp/generate.py
@@ -59,7 +59,7 @@ def write_mcp_bundle(
     config: AppConfig,
     output_dir: Path,
     *,
-    force: bool = False,
+    overwrite: bool = False,
     development: bool = False,
 ) -> None:
     """Write an MCP-server deploy bundle into ``output_dir``.
@@ -98,7 +98,7 @@ def write_mcp_bundle(
     skipped: list[str] = []
 
     def _write(path: Path, content: str) -> None:
-        if path.exists() and not force:
+        if path.exists() and not overwrite:
             skipped.append(str(path.relative_to(output_dir)))
             return
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -169,7 +169,7 @@ def write_mcp_bundle(
     for name in written:
         print(f"  {name:<32s} (created)")
     for name in skipped:
-        print(f"  {name:<32s} (skipped — re-run with --force to overwrite)")
+        print(f"  {name:<32s} (skipped — re-run with --overwrite to overwrite)")
 
     print(f"\nMCP tool exposed: {tool_name}")
     print("\nNext steps:")

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -1025,9 +1025,18 @@ class DatabricksProvider(ServiceProvider):
                         directories=[d.name for d in directories],
                     )
                 else:
-                    logger.warning(
-                        "No dev wheel found and dao-ai is in site-packages. "
-                        "Build a wheel with 'uv build --wheel' for reliable deployment.",
+                    # Local-source mode was requested (explicit --development or
+                    # auto-detect said "not published"), but there is neither a
+                    # pre-built wheel nor a source tree to ship — dao-ai is
+                    # installed into site-packages. Continuing would log a model
+                    # with NO dao-ai (only its transitive deps), which fails to
+                    # import at serving load. Fail loud, matching the Apps and
+                    # generate-bundle paths, instead of shipping a broken model.
+                    raise RuntimeError(
+                        "No dao-ai wheel found and project source not available "
+                        "(dao-ai is installed from a package index). Build a "
+                        "wheel first with 'uv build --wheel', or pass "
+                        "--no-development to deploy the published PyPI package."
                     )
 
             pip_requirements += get_installed_packages()

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -76,10 +76,10 @@ from dao_ai.utils import (
     find_dev_wheel,
     get_installed_packages,
     is_lib_provided,
-    is_published,
     is_source_layout,
     normalize_host,
     normalize_name,
+    resolve_use_local_source,
 )
 from dao_ai.vector_search import endpoint_exists, index_exists
 
@@ -267,16 +267,11 @@ def build_auth_policy(config: AppConfig) -> AuthPolicy:
 def _use_local_source(development: bool | None) -> bool:
     """Decide whether a deploy should ship local dao-ai source/wheel vs PyPI.
 
-    - ``development=True``  → force local source/wheel (test unreleased code).
-    - ``development=False`` → force the published PyPI package.
-    - ``development=None``  → auto: local when dao-ai is a local/editable install
-      (``not is_published()``), PyPI otherwise. This preserves the historical
-      default while letting the CLI ``--development/--no-development`` flag
-      override it explicitly.
+    Thin wrapper over ``resolve_use_local_source`` (the shared tri-state resolver
+    in ``dao_ai.utils``) so the provider, CLI handlers, and deploy notebook all
+    agree on the ``--development`` semantics.
     """
-    if development is not None:
-        return development
-    return not is_published()
+    return resolve_use_local_source(development)
 
 
 def _warn_if_stale_dev_wheel(dev_wheel: Path | None) -> None:

--- a/src/dao_ai/utils.py
+++ b/src/dao_ai/utils.py
@@ -67,6 +67,24 @@ def is_published() -> bool:
     return True
 
 
+def resolve_use_local_source(development: bool | None) -> bool:
+    """Decide whether a deploy should ship local dao-ai source/wheel vs PyPI.
+
+    Single source of truth for the ``--development`` tri-state shared by the
+    CLI handlers, the deploy notebook, and the Databricks provider so they all
+    agree:
+
+    - ``development=True``  → force local source/wheel (test unreleased code).
+    - ``development=False`` → force the published PyPI package.
+    - ``development=None``  → auto: local when dao-ai is a local/editable install
+      (``not is_published()``), PyPI otherwise. Preserves the historical default
+      while letting the ``--development/--no-development`` flag override it.
+    """
+    if development is not None:
+        return development
+    return not is_published()
+
+
 def _wheel_from_direct_url() -> Path | None:
     """Return the wheel file dao-ai was installed from, if any.
 

--- a/tests/dao_ai/mcp/test_mcp_generate.py
+++ b/tests/dao_ai/mcp/test_mcp_generate.py
@@ -19,7 +19,7 @@ def test_write_mcp_bundle_emits_expected_files(tmp_path: Path) -> None:
     with mcp_config(tmp_path) as path:
         config = load_app_config(path, initialize=False)
     out = tmp_path / "out"
-    write_mcp_bundle(config, out, force=True)
+    write_mcp_bundle(config, out, overwrite=True)
 
     # Layout mirrors generate-bundle: databricks.yaml + resources/app.yml
     # (no standalone app.yaml — the App's runtime command/env is embedded
@@ -110,7 +110,7 @@ def test_write_mcp_bundle_readme_names_the_agent_tool(tmp_path: Path) -> None:
     with mcp_config(tmp_path) as path:
         config = load_app_config(path, initialize=False)
     out = tmp_path / "out"
-    write_mcp_bundle(config, out, force=True)
+    write_mcp_bundle(config, out, overwrite=True)
 
     readme = (out / "README.md").read_text()
     # `app.name: mcp-dao-ai-test` in the fixture → slugified tool name.
@@ -128,7 +128,7 @@ def test_write_mcp_bundle_requires_app_name(tmp_path: Path) -> None:
         parameters: dict = {}
 
     with pytest.raises(ValueError, match="config.app.name"):
-        write_mcp_bundle(_StubConfig(), tmp_path / "out", force=True)
+        write_mcp_bundle(_StubConfig(), tmp_path / "out", overwrite=True)
 
 
 @pytest.mark.unit
@@ -147,7 +147,7 @@ def test_write_mcp_bundle_wires_mlflow_experiment(tmp_path: Path) -> None:
     with mcp_config(tmp_path) as path:
         config = load_app_config(path, initialize=False)
     out = tmp_path / "out"
-    write_mcp_bundle(config, out, force=True)
+    write_mcp_bundle(config, out, overwrite=True)
 
     app_yml = (out / "resources" / "app.yml").read_text()
 

--- a/tests/dao_ai/test_config_vars.py
+++ b/tests/dao_ai/test_config_vars.py
@@ -1043,7 +1043,7 @@ def test_write_bundle_bakes_resolved_values_and_drops_parameters(
     out_dir = tmp_path / "bundle"
     out_dir.mkdir()
 
-    write_bundle(config, out_dir, force=True, development=False)
+    write_bundle(config, out_dir, overwrite=True, development=False)
 
     rendered_path = out_dir / "cfg.yaml"
     assert rendered_path.exists()
@@ -1081,7 +1081,7 @@ def test_write_bundle_ships_requirements_txt_no_uv_lock(
     out_dir = tmp_path / "bundle"
     out_dir.mkdir()
 
-    write_bundle(config, out_dir, force=True, development=False)
+    write_bundle(config, out_dir, overwrite=True, development=False)
 
     assert (out_dir / "requirements.txt").exists(), (
         "Generated bundle must ship requirements.txt — Apps build installs "
@@ -1150,7 +1150,7 @@ def test_write_bundle_attaches_trace_location_resources(
 
     out_dir = tmp_path / "bundle"
     out_dir.mkdir()
-    write_bundle(config, out_dir, force=True, development=False)
+    write_bundle(config, out_dir, overwrite=True, development=False)
 
     app_yaml = _yaml.safe_load((out_dir / "resources" / "app.yml").read_text())
     app_name = next(iter(app_yaml["resources"]["apps"]))
@@ -1196,7 +1196,7 @@ def test_write_bundle_preserves_user_resources_yml(
     """A user-authored resources/jobs.yml must survive a re-run of write_bundle.
 
     The whole point of the wildcard include is that users can drop sibling
-    resources/*.yml files into the bundle without `--force` clobbering them.
+    resources/*.yml files into the bundle without `--overwrite` clobbering them.
     """
     from dao_ai.apps.bundle import write_bundle
 
@@ -1208,7 +1208,7 @@ def test_write_bundle_preserves_user_resources_yml(
     out_dir = tmp_path / "bundle"
     out_dir.mkdir()
 
-    write_bundle(config, out_dir, force=True, development=False)
+    write_bundle(config, out_dir, overwrite=True, development=False)
 
     user_resource = out_dir / "resources" / "jobs.yml"
     user_payload = (
@@ -1216,7 +1216,7 @@ def test_write_bundle_preserves_user_resources_yml(
     )
     user_resource.write_text(user_payload)
 
-    write_bundle(config, out_dir, force=True, development=False)
+    write_bundle(config, out_dir, overwrite=True, development=False)
 
     assert user_resource.exists(), (
         "User-authored resources/jobs.yml must not be deleted by write_bundle"
@@ -1306,7 +1306,7 @@ def _emitted_config_text(
 
     config = AppConfig.from_file(config_path, params=params, initialize=False)
     out_dir.mkdir(exist_ok=True)
-    write_bundle(config, out_dir, force=True, development=False)
+    write_bundle(config, out_dir, overwrite=True, development=False)
     return (out_dir / config_path.name).read_text()
 
 

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -359,7 +359,7 @@ def test_create_agent_sets_experiment():
         patch.object(mlflow.pyfunc, "log_model") as mock_log_model,
         patch.object(mlflow, "register_model"),
         patch("dao_ai.providers.databricks.MlflowClient"),
-        patch("dao_ai.providers.databricks.is_published", return_value=True),
+        patch("dao_ai.utils.is_published", return_value=True),
         patch(
             "dao_ai.providers.databricks.is_lib_provided",
             return_value=True,
@@ -468,7 +468,7 @@ def test_create_agent_uses_configured_python_version():
         patch.object(mlflow.pyfunc, "log_model") as mock_log_model,
         patch.object(mlflow, "register_model"),
         patch("dao_ai.providers.databricks.MlflowClient"),
-        patch("dao_ai.providers.databricks.is_published", return_value=True),
+        patch("dao_ai.utils.is_published", return_value=True),
         patch(
             "dao_ai.providers.databricks.is_lib_provided",
             return_value=True,
@@ -496,6 +496,71 @@ def test_create_agent_uses_configured_python_version():
             d for d in conda_env["dependencies"] if isinstance(d, dict) and "pip" in d
         )
         assert "test-package==1.0.0" in pip_deps["pip"]
+
+
+@pytest.mark.unit
+def test_create_agent_local_source_no_wheel_no_source_raises():
+    """create_agent must fail loud when local-source is forced but nothing to ship.
+
+    ``--development`` (or auto-detect on a non-published install) forces
+    ``_use_local_source`` True, but if there is neither a pre-built wheel
+    (``find_dev_wheel() is None``) nor a source tree (``is_source_layout``
+    False — dao-ai is in site-packages), continuing would log a model with NO
+    dao-ai. This must raise instead of silently shipping a broken model, so it
+    matches the Apps + generate-bundle paths.
+    """
+    from unittest.mock import MagicMock, patch
+
+    import mlflow
+
+    from dao_ai.config import AppConfig
+    from dao_ai.providers.databricks import DatabricksProvider
+
+    mock_config = MagicMock(spec=AppConfig)
+    mock_app = MagicMock()
+    mock_app.name = "test_app"
+    mock_app.code_paths = []
+    mock_app.pip_requirements = []
+    mock_app.input_example = None
+    mock_app.trace_location = None
+    mock_config.app = mock_app
+
+    mock_resources = MagicMock()
+    for attr in (
+        "llms",
+        "vector_stores",
+        "warehouses",
+        "genie_rooms",
+        "tables",
+        "functions",
+        "connections",
+        "databases",
+        "volumes",
+    ):
+        setattr(mock_resources, attr, MagicMock(values=lambda: []))
+    mock_config.resources = mock_resources
+    mock_config.guardrails = {}
+    mock_config.agents = {}
+
+    mock_experiment = MagicMock()
+    mock_experiment.experiment_id = "exp123"
+    mock_experiment.name = "/Users/test_user/test_app"
+
+    with (
+        patch.object(
+            DatabricksProvider, "get_or_create_experiment", return_value=mock_experiment
+        ),
+        patch.object(mlflow, "set_experiment"),
+        patch.object(mlflow, "set_registry_uri"),
+        patch.object(mlflow, "set_tag"),
+        patch("dao_ai.providers.databricks.MlflowClient"),
+        # Local-source forced, but no wheel and dao-ai lives in site-packages.
+        patch("dao_ai.providers.databricks.find_dev_wheel", return_value=None),
+        patch("dao_ai.providers.databricks.is_source_layout", return_value=False),
+    ):
+        provider = DatabricksProvider()
+        with pytest.raises(RuntimeError, match="Build a wheel first"):
+            provider.create_agent(config=mock_config, development=True)
 
 
 @pytest.mark.unit
@@ -2404,7 +2469,7 @@ def test_deploy_apps_agent_uploads_pyproject_with_dao_ai_version_pin(tmp_path):
 
     with (
         patch.object(DatabricksProvider, "__init__", return_value=None),
-        patch("dao_ai.providers.databricks.is_published", return_value=True),
+        patch("dao_ai.utils.is_published", return_value=True),
     ):
         provider = DatabricksProvider()
         provider.w = MagicMock()
@@ -2527,7 +2592,7 @@ def test_deploy_apps_agent_dev_path_ships_requirements_txt(tmp_path):
 
     with (
         patch.object(DatabricksProvider, "__init__", return_value=None),
-        patch("dao_ai.providers.databricks.is_published", return_value=False),
+        patch("dao_ai.utils.is_published", return_value=False),
         patch("dao_ai.providers.databricks.find_dev_wheel", return_value=stub_wheel),
     ):
         provider = DatabricksProvider()

--- a/tests/dao_ai/test_deep_agent_bundle_integration.py
+++ b/tests/dao_ai/test_deep_agent_bundle_integration.py
@@ -70,7 +70,7 @@ class TestBundleShipsSkills:
             str(project_root_with_skills / "deep_agent_with_skills.yaml")
         )
         out = tmp_path / "bundle_out"
-        write_bundle(cfg, out, force=True)
+        write_bundle(cfg, out, overwrite=True)
 
         # Local skill files end up under <bundle>/skills/<vertical>/<skill>/.
         assert (
@@ -89,7 +89,7 @@ class TestBundleShipsSkills:
             str(project_root_with_skills / "deep_agent_with_skills.yaml")
         )
         out = tmp_path / "bundle_out"
-        write_bundle(cfg, out, force=True)
+        write_bundle(cfg, out, overwrite=True)
 
         # The volume-backed skill is under product_lookup/. We DO have a
         # local placeholder skills/sporting_goods_store/product_lookup/ but
@@ -121,7 +121,7 @@ class TestBundleEmitsVolumePermission:
             str(project_root_with_skills / "deep_agent_with_skills.yaml")
         )
         out = tmp_path / "bundle_out"
-        write_bundle(cfg, out, force=True)
+        write_bundle(cfg, out, overwrite=True)
 
         app_yml = (out / "resources" / "app.yml").read_text()
         # Volume must show up as a uc_securable with VOLUME type and READ_VOLUME perm.
@@ -180,7 +180,7 @@ class TestRuntimeResolutionMatchesBundleLayout:
             str(project_root_with_skills / "deep_agent_with_skills.yaml")
         )
         out = tmp_path / "bundle_out"
-        write_bundle(cfg, out, force=True)
+        write_bundle(cfg, out, overwrite=True)
 
         # Reload the rendered config from the bundle (this is what the deployed
         # app actually runs) and resolve skills against the bundle root.

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -1,0 +1,89 @@
+"""Tests for the --development / --no-development tri-state across CLI commands.
+
+The flag must resolve identically on every deploy-capable command:
+``deploy``, ``pipeline``, ``generate-bundle``, ``generate-mcp`` —
+``--development`` -> True, ``--no-development`` -> False, omitted -> None
+(auto-detect). For ``pipeline`` it is additionally forwarded to the deploy
+notebook as a ``--var development=auto|true|false`` bundle variable.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from dao_ai import cli
+from dao_ai.cli import parse_args, run_databricks_command
+
+
+def _base(cmd: str) -> list[str]:
+    return [cmd, "-c", "config.yaml"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "command", ["deploy", "pipeline", "generate-bundle", "generate-mcp"]
+)
+class TestDevelopmentTriState:
+    def test_development_true(self, command: str) -> None:
+        opts = parse_args(_base(command) + ["--development"])
+        assert opts.development is True
+
+    def test_no_development_false(self, command: str) -> None:
+        opts = parse_args(_base(command) + ["--no-development"])
+        assert opts.development is False
+
+    def test_omitted_none(self, command: str) -> None:
+        opts = parse_args(_base(command))
+        assert opts.development is None
+
+
+@pytest.mark.unit
+class TestPipelineEmitsDevelopmentVar:
+    """run_databricks_command forwards development as a bundle --var."""
+
+    @pytest.mark.parametrize(
+        "development,expected",
+        [
+            (True, "development=true"),
+            (False, "development=false"),
+            (None, "development=auto"),
+        ],
+    )
+    def test_var_emitted(self, development: bool | None, expected: str) -> None:
+        captured: dict[str, str] = {}
+
+        def _capture(msg: str) -> None:
+            if msg.startswith("[DRY RUN]"):
+                captured["cmd"] = msg
+
+        # config=None skips the config/template machinery; mock cloud detection
+        # so we deterministically reach the var-emission + dry-run return.
+        with (
+            patch.object(cli, "detect_cloud_provider", return_value="aws"),
+            patch.object(cli.logger, "info", side_effect=_capture),
+        ):
+            run_databricks_command(
+                ["bundle", "deploy"],
+                config=None,
+                dry_run=True,
+                development=development,
+            )
+
+        assert expected in captured["cmd"]
+
+    def test_default_is_auto(self) -> None:
+        captured: dict[str, str] = {}
+
+        def _capture(msg: str) -> None:
+            if msg.startswith("[DRY RUN]"):
+                captured["cmd"] = msg
+
+        with (
+            patch.object(cli, "detect_cloud_provider", return_value="aws"),
+            patch.object(cli.logger, "info", side_effect=_capture),
+        ):
+            run_databricks_command(["bundle", "deploy"], config=None, dry_run=True)
+
+        assert "development=auto" in captured["cmd"]

--- a/tests/dao_ai/test_use_local_source.py
+++ b/tests/dao_ai/test_use_local_source.py
@@ -1,4 +1,10 @@
-"""Unit tests for the --development / _use_local_source deploy resolution."""
+"""Unit tests for the --development source resolution.
+
+``resolve_use_local_source`` (in ``dao_ai.utils``) is the single source of
+truth for the ``--development`` / ``--no-development`` tri-state shared by the
+CLI handlers, the deploy notebook, and the Databricks provider. The provider's
+``_use_local_source`` is a thin wrapper that must stay in lock-step with it.
+"""
 
 from __future__ import annotations
 
@@ -6,25 +12,41 @@ from unittest.mock import patch
 
 import pytest
 
+from dao_ai import utils
 from dao_ai.providers import databricks as dbx
 
 
 @pytest.mark.unit
-class TestUseLocalSource:
+class TestResolveUseLocalSource:
     def test_explicit_true_forces_local(self) -> None:
         # Even when installed from PyPI, --development wins.
-        with patch.object(dbx, "is_published", return_value=True):
-            assert dbx._use_local_source(True) is True
+        with patch.object(utils, "is_published", return_value=True):
+            assert utils.resolve_use_local_source(True) is True
 
     def test_explicit_false_forces_pypi(self) -> None:
         # Even from an editable install, --no-development wins.
-        with patch.object(dbx, "is_published", return_value=False):
-            assert dbx._use_local_source(False) is False
+        with patch.object(utils, "is_published", return_value=False):
+            assert utils.resolve_use_local_source(False) is False
 
     def test_none_auto_local_when_editable(self) -> None:
-        with patch.object(dbx, "is_published", return_value=False):
-            assert dbx._use_local_source(None) is True
+        with patch.object(utils, "is_published", return_value=False):
+            assert utils.resolve_use_local_source(None) is True
 
     def test_none_auto_pypi_when_published(self) -> None:
-        with patch.object(dbx, "is_published", return_value=True):
-            assert dbx._use_local_source(None) is False
+        with patch.object(utils, "is_published", return_value=True):
+            assert utils.resolve_use_local_source(None) is False
+
+
+@pytest.mark.unit
+class TestProviderWrapperDelegates:
+    """``_use_local_source`` must return exactly what the shared resolver does."""
+
+    @pytest.mark.parametrize("published", [True, False])
+    @pytest.mark.parametrize("development", [True, False, None])
+    def test_wrapper_matches_resolver(
+        self, development: bool | None, published: bool
+    ) -> None:
+        with patch.object(utils, "is_published", return_value=published):
+            assert dbx._use_local_source(development) is utils.resolve_use_local_source(
+                development
+            )


### PR DESCRIPTION
## Summary

Makes the `--development` deployment mode **uniform across every deploy-capable command**, closes the gap where `dao-ai pipeline` had no source-selection control, and renames the bundle subcommands' `--force` flag to `--overwrite`.

`--development` / `--no-development` is a tri-state (local wheel / published PyPI / auto-detect via `is_published()`). Before this PR only `dao-ai deploy` had it; `pipeline` always fell to auto-detect with no override, and `generate-bundle` / `generate-mcp` used a bare `store_true`.

## What changed

**1. Single source of truth** — new `resolve_use_local_source(bool|None)` in `utils.py`; `providers/databricks.py:_use_local_source` delegates to it.

**2. `pipeline` gains the flag (the main gap)** — `--development`/`--no-development` → `run_databricks_command` emits `--var development=auto|true|false` → new `development` bundle var in `databricks.yaml.template` → new widget in `notebooks/06_deploy_agent.py` → `create_agent`/`deploy_agent`. Honored for Model Serving, Apps, and both.

**3. `generate-bundle` / `generate-mcp` tri-state parity** — replaced `store_true` with the same tri-state. Fixed the stale `generate-mcp --development` help text ("no effect today" — it does take effect).

**4. Fail-loud hardening** — `create_agent`'s Model-Serving path used to warn-and-continue when local-source was forced but there was neither a wheel nor a source tree (e.g. `pip install dao-ai` + `--development`), silently logging a model **missing dao-ai** that breaks at serving load. Now raises `RuntimeError`, matching the Apps and generate-bundle paths.

**5. `--force` → `--overwrite` rename** — hard rename (no alias) on `generate-bundle` / `generate-mcp`. `write_bundle`/`write_mcp_bundle`'s `force` param, skip-warning messages, all callers, docs, and config-example READMEs updated.

## Behavior changes to note

- `generate-bundle` / `generate-mcp` `--development` default flipped from `False` (PyPI) to `None` (auto-detect) — from a local/editable checkout they now default to baking the wheel, matching `deploy`.
- `--force` no longer works on `generate-bundle` / `generate-mcp`; use `--overwrite`.

## Testing

- New `test_use_local_source.py` (resolver + provider-wrapper parity), `test_development_flag_cli.py` (tri-state across all four commands + `--var` emission), and `test_create_agent_local_source_no_wheel_no_source_raises`: pass.
- Repointed 4 `is_published` test patches to `dao_ai.utils.is_published` (the resolver's scope).
- Repointed writer test callers + docs from `--force` to `--overwrite`; 104 bundle/CLI/mcp tests pass.
- Full `test_databricks.py`: **identical 12 pre-existing failures on `main` and this branch** (MagicMock-spec issues, unrelated) — verified via a clean `main` worktree. No regressions.
- Verified locally on `fevm`: `pipeline --deploy --dry-run` emits `development=true|false|auto`; `generate-bundle`/`-mcp --development` ship the local dist wheel, `--no-development` pin PyPI; `--overwrite` writes and `--force` is rejected.

## Follow-up (not blocking)

Full deploy × target × trace-location validation matrix runs against the release that contains this change. The `--no-development` cells pinning the just-cut version are blocked ~7 days by the company pip-mirror quarantine.

This pull request and its description were written by Isaac.
