### PR TITLE
fix(data): make Vector Search source-table DDL idempotent (IF NOT EXISTS)

### DIFF
--- a/data/brickstore/dim_stores.sql
+++ b/data/brickstore/dim_stores.sql
@@ -1,6 +1,6 @@
 USE IDENTIFIER(:database);
 
-CREATE OR REPLACE TABLE dim_stores (
+CREATE TABLE IF NOT EXISTS dim_stores (
     store_id INT COMMENT 'Unique identifier for each store location (e.g., 1, 2)',
     store_name STRING COMMENT 'Display name of the store location (e.g., Downtown, Uptown)',
     store_address STRING COMMENT 'Street address of the store location',

--- a/data/brickstore/products.sql
+++ b/data/brickstore/products.sql
@@ -1,6 +1,6 @@
 USE IDENTIFIER(:database);
 
-CREATE OR REPLACE TABLE products (
+CREATE TABLE IF NOT EXISTS products (
   -- Core product identification
   product_id BIGINT COMMENT 'Unique identifier for each product in the catalog'
   ,sku STRING COMMENT 'Stock Keeping Unit - unique internal product identifier code'

--- a/data/sporting_goods_store/dim_stores.sql
+++ b/data/sporting_goods_store/dim_stores.sql
@@ -1,6 +1,6 @@
 USE IDENTIFIER(:database);
 
-CREATE OR REPLACE TABLE dim_stores (
+CREATE TABLE IF NOT EXISTS dim_stores (
   store_id INT COMMENT 'Unique identifier for each store location'
   ,store_name STRING COMMENT 'Display name of the store location'
   ,store_address STRING COMMENT 'Street address of the store location'

--- a/data/sporting_goods_store/products.sql
+++ b/data/sporting_goods_store/products.sql
@@ -1,6 +1,6 @@
 USE IDENTIFIER(:database);
 
-CREATE OR REPLACE TABLE products (
+CREATE TABLE IF NOT EXISTS products (
   -- Core product identification
   product_id BIGINT COMMENT 'Unique identifier for each product in the catalog'
   ,sku STRING COMMENT 'Stock Keeping Unit - unique internal product identifier code'


### PR DESCRIPTION
## Summary

Makes the Vector Search **source-table** DDL idempotent to stop the recurring stale
Delta-Sync checkpoint failure.

`products` and `dim_stores` (brickstore, sporting_goods) shipped `CREATE OR REPLACE
TABLE` DDL. On any pipeline re-run — or a failed-then-retried `ingest-and-transform` —
`OR REPLACE` drops+recreates the table with a **new Delta table UUID**, while the
pre-existing VS Delta-Sync index still holds a checkpoint pointing at the **old UUID**.
The sync then fails with `DIFFERENT_DELTA_TABLE_READ_BY_STREAMING_SOURCE` and
`provision-vector-search` hangs in `wait_until_ready` (observed live during 0.1.114
validation — a ~2h stall).

## Change

Convert the 4 VS-source DDL files to `CREATE TABLE IF NOT EXISTS` so re-runs preserve
table identity and the index checkpoint stays valid:
- `data/brickstore/products.sql`, `data/brickstore/dim_stores.sql`
- `data/sporting_goods_store/products.sql`, `data/sporting_goods_store/dim_stores.sql`

Scoped to vector_search source tables only. Left as-is intentionally:
- `hardware_store/products.sql`, `commerce_swarm/{products,faqs,policies}.sql`, loyalty `offer_catalog.sql` — already `IF NOT EXISTS`.
- loyalty `customer_features` / `customers_x_eligible_offers` — CTAS materialized tables (UC-function sources, meant to recompute on refresh), correctly stay `CREATE OR REPLACE`.
- non-VS tables (`inventory`, `orders`, `sales_orders`, etc.) — keep `OR REPLACE`.

## Note

This is a **partial mitigation** — it prevents the DDL from resetting table identity,
but does not address a checkpoint going stale via data-load overwrite or Delta
time-travel retention. The durable fix is a source-UUID-mismatch detect +
drop/recreate-index self-heal in `create_vector_store` (tracked separately).

This pull request and its description were written by Isaac.
