### PR TITLE
feat(config): agent call_limit + extra_params (reasoning tuning), uniform dev-wheel stamp

### DIFF
--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -6634,6 +6634,20 @@
           "description": "Maximum tokens in the model response. When unset, dao-ai omits `max_tokens` from the outbound payload so the serving endpoint uses its own default. Set explicitly to cap output length. Ignored by the Responses API (endpoint enforces its own limit).",
           "title": "Max Tokens"
         },
+        "extra_params": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Extra request parameters forwarded verbatim to the serving endpoint via the chat client's ``extra_params`` (e.g. ``{reasoning_effort: low}`` on gpt-oss reasoning models to cap the reasoning preamble and cut latency, or other endpoint-specific knobs). Passed on both the standard and AI-Gateway paths.",
+          "title": "Extra Params"
+        },
         "fallbacks": {
           "anyOf": [
             {

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -767,6 +767,22 @@
           "description": "Maximum number of graph supersteps (LLM call + tool execution cycles) allowed per agent invocation. Prevents runaway iteration loops in tool-calling agents. When None, uses LangGraph's default (25).",
           "title": "Recursion Limit"
         },
+        "call_limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "#/$defs/ModelCallLimitModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Shortcut to cap how many model (LLM) calls this agent may make. A bare integer sets run_limit (per-invocation) with exit_behavior='end'; an object gives full control over run_limit/thread_limit/exit_behavior. Registers a ModelCallLimitMiddleware for this agent \u2014 the discoverable, co-located equivalent of hand-wiring ``create_model_call_limit_middleware`` into ``middleware``. The model-call analogue of a tool's ``call_limit``; complements ``recursion_limit`` (the graph-superstep backstop).",
+          "title": "Call Limit"
+        },
         "requires": {
           "description": "Names of prerequisite agents that must have run (i.e. produced an AIMessage tagged with their name) before this agent can be reached via a swarm handoff. When unmet, the handoff tool returns a refusal ToolMessage and 'active_agent' stays unchanged so the LLM can self-correct on its next step. Semantics: any-order, all-of. Currently enforced in the swarm pattern only; the supervisor pattern ignores this field. Cross-agent validation (unknown name, self-reference, cycles in the requires DAG) runs at config-build time.",
           "items": {
@@ -8041,6 +8057,52 @@
         "name"
       ],
       "title": "MiddlewareModel",
+      "type": "object"
+    },
+    "ModelCallLimitModel": {
+      "additionalProperties": false,
+      "description": "Configuration for capping how many LLM (model) calls an agent may make.\n\nThe model-call analogue of :class:`ToolCallLimitModel`. Presence of this\nblock on an agent's ``call_limit`` registers a ``ModelCallLimitMiddleware``\nfor that agent, bounding the ReAct loop directly \u2014 a more discoverable,\nco-located alternative to hand-wiring\n``dao_ai.middleware.create_model_call_limit_middleware`` into the agent's\n``middleware`` list. Complements :attr:`AgentModel.recursion_limit` (the\ngraph-superstep backstop): ``run_limit`` is the graceful per-invocation cap.\n\nA bare integer is accepted as shorthand for ``run_limit`` (see\n``AgentModel.call_limit``); the object form below gives full control. At\nleast one of ``run_limit`` or ``thread_limit`` must be set. This maps to\n``create_model_call_limit_middleware``.\n\nUnlike the tool variant, ``exit_behavior`` only accepts ``'end'`` (default)\nor ``'error'`` \u2014 a model-call limit has no per-tool ``'continue'`` semantics\n(there is no alternative tool to fall back to).",
+      "properties": {
+        "run_limit": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number of model (LLM) calls this agent may make within a single invocation (one user message). Resets each run and requires no checkpointer. Alias: ``turn_limit``.",
+          "title": "Run Limit"
+        },
+        "thread_limit": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number of model (LLM) calls this agent may make across an entire conversation (thread). Requires a checkpointer, which DAO AI agents have via memory. Alias: ``conversation_limit``.",
+          "title": "Thread Limit"
+        },
+        "exit_behavior": {
+          "default": "end",
+          "description": "Behavior when a limit is reached: 'end' stops execution gracefully (recommended); 'error' raises immediately. Unlike tool-call limits, 'continue' is not supported for model-call limits.",
+          "enum": [
+            "error",
+            "end"
+          ],
+          "title": "Exit Behavior",
+          "type": "string"
+        }
+      },
+      "title": "ModelCallLimitModel",
       "type": "object"
     },
     "MonitoringModel": {

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -16,11 +16,14 @@ Usage:
 """
 
 import io
+import re
 import shutil
 import subprocess
+import time
+from contextlib import contextmanager
 from importlib.metadata import version as pkg_version
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterator, Optional
 
 import yaml
 from loguru import logger
@@ -163,6 +166,44 @@ def _get_dao_ai_version() -> str:
         return pkg_version("dao-ai")
     except Exception:
         return "0.1.0"
+
+
+@contextmanager
+def _dev_local_version(pyproject_path: Path) -> Iterator[None]:
+    """Temporarily stamp a unique PEP 440 local version segment on the build.
+
+    A development wheel is built at the *same* base version as the published
+    package (e.g. ``0.1.115``). An Apps container that already has that version
+    installed treats the bundled ``./dist/<wheel>`` as "already satisfied" and
+    silently keeps the stale published code, so local source edits never take
+    effect on redeploy. ``--force-reinstall`` can't fix this — it is not a valid
+    line in an Apps ``requirements.txt`` (the installer parses each line as a
+    requirement).
+
+    Stamping a unique local version (``0.1.115+dev<epoch>``) makes pip treat the
+    dev wheel as strictly newer than the published base version, so it always
+    reinstalls — while remaining a legal requirement (a version, not a flag) and
+    never masquerading as a real release. The original ``pyproject.toml`` is
+    restored on exit so the working tree is left unchanged.
+    """
+    original = pyproject_path.read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', original, flags=re.MULTILINE)
+    if not match:
+        # No static version line (e.g. dynamic version) — nothing to stamp.
+        yield
+        return
+    base = match.group(1)
+    # Skip if a local segment is already present (idempotent / user-managed).
+    local = base if "+" in base else f"{base}+dev{int(time.time())}"
+    stamped = original.replace(
+        match.group(0), f'version = "{local}"', 1
+    )
+    try:
+        pyproject_path.write_text(stamped)
+        logger.info("Stamped dev-build local version", version=local)
+        yield
+    finally:
+        pyproject_path.write_text(original)
 
 
 def _strip_parameters_block(rendered_yaml: str) -> str:
@@ -835,12 +876,17 @@ def write_bundle(
             for stale in (project_root / "dist").glob("dao_ai-*.whl"):
                 stale.unlink()
 
-            result = subprocess.run(
-                ["uv", "build", "--wheel"],
-                cwd=project_root,
-                capture_output=True,
-                text=True,
-            )
+            # Stamp a unique local version so the dev wheel always out-ranks the
+            # same-base-version published package in the Apps container (pip
+            # would otherwise skip a same-version reinstall — see
+            # ``_dev_local_version``).
+            with _dev_local_version(project_root / "pyproject.toml"):
+                result = subprocess.run(
+                    ["uv", "build", "--wheel"],
+                    cwd=project_root,
+                    capture_output=True,
+                    text=True,
+                )
             if result.returncode != 0:
                 raise RuntimeError(f"Wheel build failed: {result.stderr}")
 

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -16,14 +16,11 @@ Usage:
 """
 
 import io
-import re
 import shutil
 import subprocess
-import time
-from contextlib import contextmanager
 from importlib.metadata import version as pkg_version
 from pathlib import Path
-from typing import Any, Iterator, Optional
+from typing import Any, Optional
 
 import yaml
 from loguru import logger
@@ -166,44 +163,6 @@ def _get_dao_ai_version() -> str:
         return pkg_version("dao-ai")
     except Exception:
         return "0.1.0"
-
-
-@contextmanager
-def _dev_local_version(pyproject_path: Path) -> Iterator[None]:
-    """Temporarily stamp a unique PEP 440 local version segment on the build.
-
-    A development wheel is built at the *same* base version as the published
-    package (e.g. ``0.1.115``). An Apps container that already has that version
-    installed treats the bundled ``./dist/<wheel>`` as "already satisfied" and
-    silently keeps the stale published code, so local source edits never take
-    effect on redeploy. ``--force-reinstall`` can't fix this — it is not a valid
-    line in an Apps ``requirements.txt`` (the installer parses each line as a
-    requirement).
-
-    Stamping a unique local version (``0.1.115+dev<epoch>``) makes pip treat the
-    dev wheel as strictly newer than the published base version, so it always
-    reinstalls — while remaining a legal requirement (a version, not a flag) and
-    never masquerading as a real release. The original ``pyproject.toml`` is
-    restored on exit so the working tree is left unchanged.
-    """
-    original = pyproject_path.read_text()
-    match = re.search(r'^version\s*=\s*"([^"]+)"', original, flags=re.MULTILINE)
-    if not match:
-        # No static version line (e.g. dynamic version) — nothing to stamp.
-        yield
-        return
-    base = match.group(1)
-    # Skip if a local segment is already present (idempotent / user-managed).
-    local = base if "+" in base else f"{base}+dev{int(time.time())}"
-    stamped = original.replace(
-        match.group(0), f'version = "{local}"', 1
-    )
-    try:
-        pyproject_path.write_text(stamped)
-        logger.info("Stamped dev-build local version", version=local)
-        yield
-    finally:
-        pyproject_path.write_text(original)
 
 
 def _strip_parameters_block(rendered_yaml: str) -> str:
@@ -850,7 +809,7 @@ def write_bundle(
     package_name = app_name.replace("-", "_")
 
     if development:
-        from dao_ai.utils import find_dev_wheel
+        from dao_ai.utils import dev_local_version, find_dev_wheel
 
         # In development mode, always rebuild the wheel from local source
         # when source is available. Reusing an existing pre-built wheel is
@@ -879,8 +838,8 @@ def write_bundle(
             # Stamp a unique local version so the dev wheel always out-ranks the
             # same-base-version published package in the Apps container (pip
             # would otherwise skip a same-version reinstall — see
-            # ``_dev_local_version``).
-            with _dev_local_version(project_root / "pyproject.toml"):
+            # ``dev_local_version``).
+            with dev_local_version(project_root / "pyproject.toml"):
                 result = subprocess.run(
                     ["uv", "build", "--wheel"],
                     cwd=project_root,

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -5602,6 +5602,71 @@ class ToolCallLimitModel(BaseModel):
         return self
 
 
+class ModelCallLimitModel(BaseModel):
+    """
+    Configuration for capping how many LLM (model) calls an agent may make.
+
+    The model-call analogue of :class:`ToolCallLimitModel`. Presence of this
+    block on an agent's ``call_limit`` registers a ``ModelCallLimitMiddleware``
+    for that agent, bounding the ReAct loop directly — a more discoverable,
+    co-located alternative to hand-wiring
+    ``dao_ai.middleware.create_model_call_limit_middleware`` into the agent's
+    ``middleware`` list. Complements :attr:`AgentModel.recursion_limit` (the
+    graph-superstep backstop): ``run_limit`` is the graceful per-invocation cap.
+
+    A bare integer is accepted as shorthand for ``run_limit`` (see
+    ``AgentModel.call_limit``); the object form below gives full control. At
+    least one of ``run_limit`` or ``thread_limit`` must be set. This maps to
+    ``create_model_call_limit_middleware``.
+
+    Unlike the tool variant, ``exit_behavior`` only accepts ``'end'`` (default)
+    or ``'error'`` — a model-call limit has no per-tool ``'continue'`` semantics
+    (there is no alternative tool to fall back to).
+    """
+
+    model_config = ConfigDict(
+        use_enum_values=True, extra="forbid", populate_by_name=True
+    )
+
+    run_limit: Optional[int] = Field(
+        default=None,
+        gt=0,
+        validation_alias=AliasChoices("run_limit", "turn_limit"),
+        description=(
+            "Maximum number of model (LLM) calls this agent may make within a "
+            "single invocation (one user message). Resets each run and requires "
+            "no checkpointer. Alias: ``turn_limit``."
+        ),
+    )
+    thread_limit: Optional[int] = Field(
+        default=None,
+        gt=0,
+        validation_alias=AliasChoices("thread_limit", "conversation_limit"),
+        description=(
+            "Maximum number of model (LLM) calls this agent may make across an "
+            "entire conversation (thread). Requires a checkpointer, which DAO AI "
+            "agents have via memory. Alias: ``conversation_limit``."
+        ),
+    )
+    exit_behavior: Literal["error", "end"] = Field(
+        default="end",
+        description=(
+            "Behavior when a limit is reached: 'end' stops execution gracefully "
+            "(recommended); 'error' raises immediately. Unlike tool-call limits, "
+            "'continue' is not supported for model-call limits."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_at_least_one_limit(self) -> Self:
+        """Require at least one of run_limit or thread_limit to be set."""
+        if self.run_limit is None and self.thread_limit is None:
+            raise ValueError(
+                "At least one of run_limit or thread_limit must be specified."
+            )
+        return self
+
+
 class BaseFunctionModel(ABC, BaseModel):
     """Base class for all function/tool implementations (Python, factory, inline, MCP, UC)."""
 
@@ -7591,6 +7656,38 @@ class AgentModel(BaseModel):
             "agents. When None, uses LangGraph's default (25)."
         ),
     )
+    call_limit: Optional[int | ModelCallLimitModel] = Field(
+        default=None,
+        description=(
+            "Shortcut to cap how many model (LLM) calls this agent may make. A "
+            "bare integer sets run_limit (per-invocation) with "
+            "exit_behavior='end'; an object gives full control over "
+            "run_limit/thread_limit/exit_behavior. Registers a "
+            "ModelCallLimitMiddleware for this agent — the discoverable, "
+            "co-located equivalent of hand-wiring "
+            "``create_model_call_limit_middleware`` into ``middleware``. The "
+            "model-call analogue of a tool's ``call_limit``; complements "
+            "``recursion_limit`` (the graph-superstep backstop)."
+        ),
+    )
+
+    @field_validator("call_limit", mode="before")
+    @classmethod
+    def _normalize_call_limit(cls, value: Any) -> Any:
+        """Normalize a bare integer shortcut into a ModelCallLimitModel dict.
+
+        Runs before union validation so a bare int becomes ``run_limit``.
+        ``bool`` is a subclass of ``int`` but is never a valid limit, so reject
+        it explicitly rather than silently coercing ``True`` to ``run_limit=1``.
+        """
+        if isinstance(value, bool):
+            raise ValueError(
+                "call_limit must be a positive integer or an object, not a bool."
+            )
+        if isinstance(value, int):
+            return {"run_limit": value}
+        return value
+
     requires: list[str] = Field(
         default_factory=list,
         description=(

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -985,6 +985,16 @@ class InferenceEndpointModel(IsDatabricksResource):
             "own limit)."
         ),
     )
+    extra_params: Optional[dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Extra request parameters forwarded verbatim to the serving "
+            "endpoint via the chat client's ``extra_params`` (e.g. "
+            "``{reasoning_effort: low}`` on gpt-oss reasoning models to cap the "
+            "reasoning preamble and cut latency, or other endpoint-specific "
+            "knobs). Passed on both the standard and AI-Gateway paths."
+        ),
+    )
     fallbacks: Optional[list[Union[str, "InferenceEndpointModel"]]] = Field(
         default_factory=list,
         description="Ordered list of fallback endpoint names or InferenceEndpointModel configs tried on primary failure.",
@@ -1074,6 +1084,7 @@ class InferenceEndpointModel(IsDatabricksResource):
             use_responses_api=self.use_responses_api,
             disable_streaming=effective_disable_streaming,
             workspace_client=workspace_client,
+            **({"extra_params": self.extra_params} if self.extra_params else {}),
         )
 
     def as_chat_model(self) -> LanguageModelLike:
@@ -1094,6 +1105,7 @@ class InferenceEndpointModel(IsDatabricksResource):
             max_tokens=self.max_tokens,
             use_responses_api=self.use_responses_api,
             disable_streaming=effective_disable_streaming,
+            **({"extra_params": self.extra_params} if self.extra_params else {}),
         )
 
         fallbacks: Sequence[LanguageModelLike] = []
@@ -1104,6 +1116,7 @@ class InferenceEndpointModel(IsDatabricksResource):
                     name=fallback,
                     temperature=self.temperature,
                     max_tokens=self.max_tokens,
+                    extra_params=self.extra_params,
                 )
             if fallback.name == self.name:
                 continue

--- a/src/dao_ai/mcp/generate.py
+++ b/src/dao_ai/mcp/generate.py
@@ -246,13 +246,19 @@ def _bundle_local_wheel(output_dir: Path, *, written: list[str]) -> str:
         stale.unlink()
 
     logger.info("mcp.generate.dev.build_wheel", project_root=str(project_root))
-    result = subprocess.run(
-        ["uv", "build", "--wheel"],
-        cwd=project_root,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    # Stamp a unique local version so the dev wheel always out-ranks the
+    # same-base-version published package in the Apps container. See
+    # ``dev_local_version``.
+    from dao_ai.utils import dev_local_version
+
+    with dev_local_version(project_root / "pyproject.toml"):
+        result = subprocess.run(
+            ["uv", "build", "--wheel"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
     if result.returncode != 0:
         raise RuntimeError(f"uv build --wheel failed: {result.stderr}")
 

--- a/src/dao_ai/nodes.py
+++ b/src/dao_ai/nodes.py
@@ -38,6 +38,9 @@ from dao_ai.middleware.human_in_the_loop import (
 from dao_ai.middleware.summarization import (
     create_summarization_middleware,
 )
+from dao_ai.middleware.model_call_limit import (
+    create_model_call_limit_middleware,
+)
 from dao_ai.middleware.tool_call_limit import (
     create_tool_call_limit_middlewares_from_tool_models,
 )
@@ -208,6 +211,25 @@ def _create_middleware_list(
             limited_tools=[mw.tool_name for mw in call_limit_middlewares],
         )
         middleware_list.extend(call_limit_middlewares)
+
+    # Add model-call-limit middleware when the agent declares `call_limit`.
+    # The first-class, discoverable equivalent of hand-wiring
+    # `create_model_call_limit_middleware` into the agent's `middleware` list;
+    # bounds the ReAct loop per agent. Absent call_limit → skipped.
+    if agent.call_limit is not None:
+        model_call_limit = create_model_call_limit_middleware(
+            run_limit=agent.call_limit.run_limit,
+            thread_limit=agent.call_limit.thread_limit,
+            exit_behavior=agent.call_limit.exit_behavior,
+        )
+        logger.info(
+            "Model call limit configuration",
+            agent=agent.name,
+            run_limit=agent.call_limit.run_limit,
+            thread_limit=agent.call_limit.thread_limit,
+            exit_behavior=agent.call_limit.exit_behavior,
+        )
+        middleware_list.append(model_call_limit)
 
     logger.info(
         "Middleware summary",

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -899,18 +899,26 @@ def _resolve_trace_table_prefix(
 
 
 def _build_wheel(project_root: Path) -> Path:
-    """Build a dao-ai wheel from source using uv."""
+    """Build a dao-ai wheel from source using uv.
+
+    Stamps a unique PEP 440 local version so the dev wheel always out-ranks the
+    same-base-version published package in an Apps container (pip skips a
+    same-version reinstall otherwise). See ``dev_local_version``.
+    """
     import subprocess
+
+    from dao_ai.utils import dev_local_version
 
     dist_dir = project_root / "dist"
     dist_dir.mkdir(exist_ok=True)
 
-    result = subprocess.run(
-        ["uv", "build", "--wheel"],
-        cwd=project_root,
-        capture_output=True,
-        text=True,
-    )
+    with dev_local_version(project_root / "pyproject.toml"):
+        result = subprocess.run(
+            ["uv", "build", "--wheel"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+        )
     if result.returncode != 0:
         raise RuntimeError(f"Wheel build failed: {result.stderr.strip()}")
 

--- a/src/dao_ai/utils.py
+++ b/src/dao_ai/utils.py
@@ -4,9 +4,11 @@ import json
 import os
 import re
 import site
+import time
+from contextlib import contextmanager
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import Any, Callable, Sequence, TypeVar
+from typing import Any, Callable, Iterator, Sequence, TypeVar
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.tools import BaseTool
@@ -113,6 +115,46 @@ def _wheel_from_direct_url() -> Path | None:
     except Exception as e:
         logger.debug(f"Could not resolve wheel from direct_url.json: {e}")
     return None
+
+
+@contextmanager
+def dev_local_version(pyproject_path: Path) -> Iterator[None]:
+    """Temporarily stamp a unique PEP 440 local version segment on the build.
+
+    A development wheel is built at the *same* base version as the published
+    package (e.g. ``0.1.115``). An Apps container that already has that version
+    installed treats the bundled ``./dist/<wheel>`` as "already satisfied" and
+    silently keeps the stale published code, so local source edits never take
+    effect on redeploy. ``--force-reinstall`` can't fix this — it is not a valid
+    line in an Apps ``requirements.txt`` (the installer parses each line as a
+    requirement).
+
+    Stamping a unique local version (``0.1.115+dev<epoch>``) makes pip treat the
+    dev wheel as strictly newer than the published base version, so it always
+    reinstalls — while remaining a legal requirement (a version, not a flag) and
+    never masquerading as a real release. The original ``pyproject.toml`` is
+    restored on exit so the working tree is left unchanged.
+
+    Wrap every ``uv build --wheel`` call that produces a dev wheel with this
+    (generate-bundle, deploy, generate-mcp) so ``--development`` behaves
+    uniformly across all deploy paths.
+    """
+    original = pyproject_path.read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', original, flags=re.MULTILINE)
+    if not match:
+        # No static version line (e.g. dynamic version) — nothing to stamp.
+        yield
+        return
+    base = match.group(1)
+    # Skip if a local segment is already present (idempotent / user-managed).
+    local = base if "+" in base else f"{base}+dev{int(time.time())}"
+    stamped = original.replace(match.group(0), f'version = "{local}"', 1)
+    try:
+        pyproject_path.write_text(stamped)
+        logger.info("Stamped dev-build local version", version=local)
+        yield
+    finally:
+        pyproject_path.write_text(original)
 
 
 def find_dev_wheel() -> Path | None:

--- a/tests/dao_ai/test_ai_gateway_routing.py
+++ b/tests/dao_ai/test_ai_gateway_routing.py
@@ -131,6 +131,40 @@ def test_as_chat_model_forwards_explicit_temperature_and_max_tokens() -> None:
     assert kwargs["max_tokens"] == 1024
 
 
+def test_as_chat_model_omits_extra_params_when_unset() -> None:
+    """When extra_params is unset, dao-ai must not pass the kwarg at all so
+    the chat client keeps its own default (empty dict)."""
+    model = InferenceEndpointModel(name="databricks-gpt-oss-120b")
+    assert model.extra_params is None
+    with patch("dao_ai.config.ChatDatabricks") as mock_chat:
+        model.as_chat_model()
+    assert "extra_params" not in mock_chat.call_args.kwargs
+
+
+def test_as_chat_model_forwards_extra_params() -> None:
+    """extra_params (e.g. reasoning_effort on gpt-oss) must flow through to
+    the chat client verbatim."""
+    model = InferenceEndpointModel(
+        name="databricks-gpt-oss-120b",
+        extra_params={"reasoning_effort": "low"},
+    )
+    with patch("dao_ai.config.ChatDatabricks") as mock_chat:
+        model.as_chat_model()
+    assert mock_chat.call_args.kwargs["extra_params"] == {"reasoning_effort": "low"}
+
+
+def test_extra_params_forwarded_on_ai_gateway_path() -> None:
+    """The AI-Gateway path must also forward extra_params."""
+    model = InferenceEndpointModel(
+        name="databricks-gpt-oss-120b",
+        ai_gateway=True,
+        extra_params={"reasoning_effort": "low"},
+    )
+    with patch("dao_ai.config.ChatUnityAIGateway") as mock_chat:
+        model.as_chat_model()
+    assert mock_chat.call_args.kwargs["extra_params"] == {"reasoning_effort": "low"}
+
+
 # ---------------------------------------------------------------------------
 # as_chat_model routing
 # ---------------------------------------------------------------------------

--- a/tests/dao_ai/test_bundle_requirements_txt.py
+++ b/tests/dao_ai/test_bundle_requirements_txt.py
@@ -20,9 +20,9 @@ import pytest
 
 from dao_ai.apps.bundle import (
     _PYPROJECT_DEV_TEMPLATE,
-    _dev_local_version,
     _make_requirements_txt,
 )
+from dao_ai.utils import dev_local_version
 
 # ---------------------------------------------------------------------------
 # _make_requirements_txt — content helpers
@@ -88,7 +88,7 @@ class TestDevLocalVersion:
         p = self._write_pyproject(tmp_path, "0.1.115")
         original = p.read_text()
         seen = {}
-        with _dev_local_version(p):
+        with dev_local_version(p):
             seen["during"] = p.read_text()
         # Restored exactly on exit.
         assert p.read_text() == original
@@ -103,14 +103,14 @@ class TestDevLocalVersion:
         p = self._write_pyproject(tmp_path, "0.1.115")
         original = p.read_text()
         with pytest.raises(RuntimeError):
-            with _dev_local_version(p):
+            with dev_local_version(p):
                 raise RuntimeError("build failed")
         assert p.read_text() == original
 
     def test_noop_when_version_already_local(self, tmp_path) -> None:
         """An existing local segment is left as-is (idempotent)."""
         p = self._write_pyproject(tmp_path, "0.1.115+dev999")
-        with _dev_local_version(p):
+        with dev_local_version(p):
             import re
 
             m = re.search(r'version = "([^"]+)"', p.read_text())
@@ -121,7 +121,7 @@ class TestDevLocalVersion:
         p = tmp_path / "pyproject.toml"
         p.write_text('[project]\nname = "dao-ai"\ndynamic = ["version"]\n')
         original = p.read_text()
-        with _dev_local_version(p):
+        with dev_local_version(p):
             assert p.read_text() == original
         assert p.read_text() == original
 
@@ -130,5 +130,5 @@ class TestDevLocalVersion:
 # write_bundle file emission — covered end-to-end by live `dao-ai
 # generate-bundle` validation on fevm. The unit tests above lock in the
 # building-block helpers (_make_requirements_txt, _PYPROJECT_DEV_TEMPLATE,
-# _dev_local_version) that those code paths use.
+# utils.dev_local_version) that those code paths use.
 # ---------------------------------------------------------------------------

--- a/tests/dao_ai/test_bundle_requirements_txt.py
+++ b/tests/dao_ai/test_bundle_requirements_txt.py
@@ -20,6 +20,7 @@ import pytest
 
 from dao_ai.apps.bundle import (
     _PYPROJECT_DEV_TEMPLATE,
+    _dev_local_version,
     _make_requirements_txt,
 )
 
@@ -72,9 +73,62 @@ class TestPyprojectDevTemplate:
         assert "dependencies = []" in rendered
 
 
+class TestDevLocalVersion:
+    """The dev build stamps a unique PEP 440 local version, then restores."""
+
+    def _write_pyproject(self, tmp_path, version: str) -> "object":
+        p = tmp_path / "pyproject.toml"
+        p.write_text(
+            f'[project]\nname = "dao-ai"\nversion = "{version}"\n'
+            'description = "x"\n'
+        )
+        return p
+
+    def test_stamps_local_segment_and_restores(self, tmp_path) -> None:
+        p = self._write_pyproject(tmp_path, "0.1.115")
+        original = p.read_text()
+        seen = {}
+        with _dev_local_version(p):
+            seen["during"] = p.read_text()
+        # Restored exactly on exit.
+        assert p.read_text() == original
+        # Inside the context, a +dev local segment was present.
+        import re
+
+        m = re.search(r'version = "([^"]+)"', seen["during"])
+        assert m is not None
+        assert m.group(1).startswith("0.1.115+dev")
+
+    def test_restores_even_on_exception(self, tmp_path) -> None:
+        p = self._write_pyproject(tmp_path, "0.1.115")
+        original = p.read_text()
+        with pytest.raises(RuntimeError):
+            with _dev_local_version(p):
+                raise RuntimeError("build failed")
+        assert p.read_text() == original
+
+    def test_noop_when_version_already_local(self, tmp_path) -> None:
+        """An existing local segment is left as-is (idempotent)."""
+        p = self._write_pyproject(tmp_path, "0.1.115+dev999")
+        with _dev_local_version(p):
+            import re
+
+            m = re.search(r'version = "([^"]+)"', p.read_text())
+            assert m.group(1) == "0.1.115+dev999"
+
+    def test_noop_when_no_static_version(self, tmp_path) -> None:
+        """A dynamic-version pyproject (no ``version =`` line) is untouched."""
+        p = tmp_path / "pyproject.toml"
+        p.write_text('[project]\nname = "dao-ai"\ndynamic = ["version"]\n')
+        original = p.read_text()
+        with _dev_local_version(p):
+            assert p.read_text() == original
+        assert p.read_text() == original
+
+
 # ---------------------------------------------------------------------------
 # write_bundle file emission — covered end-to-end by live `dao-ai
 # generate-bundle` validation on fevm. The unit tests above lock in the
-# building-block helpers (_make_requirements_txt, _PYPROJECT_DEV_TEMPLATE)
-# that those code paths use.
+# building-block helpers (_make_requirements_txt, _PYPROJECT_DEV_TEMPLATE,
+# _dev_local_version) that those code paths use.
 # ---------------------------------------------------------------------------

--- a/tests/dao_ai/test_mcp_generate_dev_wheel.py
+++ b/tests/dao_ai/test_mcp_generate_dev_wheel.py
@@ -1,0 +1,52 @@
+"""The generate-mcp dev build must stamp a unique PEP 440 local version.
+
+Mirrors the deploy-path coverage in test_databricks / test_bundle_requirements:
+every ``uv build --wheel`` site that produces a dev wheel wraps the build in
+``dao_ai.utils.dev_local_version`` so an Apps container reinstalls the local
+wheel instead of silently keeping the same-base-version published package.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+from unittest.mock import patch
+
+
+def test_generate_mcp_dev_build_stamps_local_version(tmp_path) -> None:
+    """_bundle_local_wheel wraps uv build in dev_local_version, so the project's
+    pyproject.toml carries a +dev local segment during the build and is restored
+    after."""
+    from dao_ai.mcp import generate
+
+    project_root = pathlib.Path(generate.__file__).parents[3]
+    pyproject = project_root / "pyproject.toml"
+    original = pyproject.read_text()
+
+    captured: dict[str, str] = {}
+
+    def fake_run(cmd, cwd, **kw):
+        # Snapshot the version line as seen by the build subprocess.
+        captured["during"] = (pathlib.Path(cwd) / "pyproject.toml").read_text()
+        # Drop a fake wheel so the post-build glob succeeds.
+        dist = pathlib.Path(cwd) / "dist"
+        dist.mkdir(parents=True, exist_ok=True)
+        (dist / "dao_ai-0.1.115+devtest-py3-none-any.whl").write_bytes(b"x")
+
+        class _R:
+            returncode = 0
+            stderr = ""
+
+        return _R()
+
+    written: list[str] = []
+    try:
+        with patch.object(subprocess, "run", fake_run):
+            generate._bundle_local_wheel(tmp_path, written=written)
+        assert "+dev" in captured["during"], "build did not see a +dev version"
+    finally:
+        # Guarantee the real tree is restored even if the assert fails.
+        pyproject.write_text(original)
+
+    # dev_local_version restores the original on exit.
+    assert pyproject.read_text() == original

--- a/tests/dao_ai/test_model_call_limit_field.py
+++ b/tests/dao_ai/test_model_call_limit_field.py
@@ -1,0 +1,159 @@
+"""
+Tests for the `call_limit` agent field and ModelCallLimitModel config model.
+
+These verify the config-model layer: that a bare integer normalizes to a
+ModelCallLimitModel, that the object form parses, that invalid values are
+rejected, that the model-call variant defaults to and restricts exit_behavior
+to end/error, and that an agent's call_limit registers a
+ModelCallLimitMiddleware.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from conftest import create_mock_llm_model
+from langchain.agents.middleware import ModelCallLimitMiddleware
+from pydantic import ValidationError
+
+from dao_ai.config import (
+    AgentModel,
+    ModelCallLimitModel,
+    SearchToolModel,
+    ToolModel,
+)
+
+
+class TestModelCallLimitModel:
+    """Validation tests for the ModelCallLimitModel config model."""
+
+    def test_run_limit_only(self):
+        model = ModelCallLimitModel(run_limit=3)
+        assert model.run_limit == 3
+        assert model.thread_limit is None
+        # Unlike ToolCallLimitModel, the model-call variant defaults to 'end'.
+        assert model.exit_behavior == "end"
+
+    def test_thread_limit_only(self):
+        model = ModelCallLimitModel(thread_limit=10)
+        assert model.thread_limit == 10
+        assert model.run_limit is None
+
+    def test_all_fields(self):
+        model = ModelCallLimitModel(run_limit=2, thread_limit=8, exit_behavior="error")
+        assert model.run_limit == 2
+        assert model.thread_limit == 8
+        assert model.exit_behavior == "error"
+
+    def test_requires_at_least_one_limit(self):
+        with pytest.raises(ValidationError, match="At least one of run_limit"):
+            ModelCallLimitModel()
+
+    @pytest.mark.parametrize("bad", [0, -1, -100])
+    def test_run_limit_must_be_positive(self, bad):
+        with pytest.raises(ValidationError):
+            ModelCallLimitModel(run_limit=bad)
+
+    def test_continue_exit_behavior_rejected(self):
+        """'continue' is valid for tool-call limits but NOT model-call limits."""
+        with pytest.raises(ValidationError):
+            ModelCallLimitModel(run_limit=3, exit_behavior="continue")
+
+    def test_invalid_exit_behavior_rejected(self):
+        with pytest.raises(ValidationError):
+            ModelCallLimitModel(run_limit=3, exit_behavior="halt")
+
+    def test_extra_fields_forbidden(self):
+        with pytest.raises(ValidationError):
+            ModelCallLimitModel(run_limit=3, unknown=True)
+
+    def test_turn_limit_alias(self):
+        model = ModelCallLimitModel(turn_limit=5)
+        assert model.run_limit == 5
+
+
+class TestAgentCallLimitNormalization:
+    """The call_limit field on AgentModel normalizes bare ints."""
+
+    def test_bare_int_normalizes_to_model(self):
+        agent = AgentModel(name="a", model=create_mock_llm_model(), call_limit=10)
+        assert isinstance(agent.call_limit, ModelCallLimitModel)
+        assert agent.call_limit.run_limit == 10
+        assert agent.call_limit.exit_behavior == "end"
+        assert agent.call_limit.thread_limit is None
+
+    def test_object_form_parses(self):
+        agent = AgentModel(
+            name="a",
+            model=create_mock_llm_model(),
+            call_limit={"run_limit": 8, "thread_limit": 40, "exit_behavior": "error"},
+        )
+        assert isinstance(agent.call_limit, ModelCallLimitModel)
+        assert agent.call_limit.run_limit == 8
+        assert agent.call_limit.thread_limit == 40
+        assert agent.call_limit.exit_behavior == "error"
+
+    def test_default_is_none(self):
+        agent = AgentModel(name="a", model=create_mock_llm_model())
+        assert agent.call_limit is None
+
+    def test_bare_zero_rejected(self):
+        with pytest.raises(ValidationError):
+            AgentModel(name="a", model=create_mock_llm_model(), call_limit=0)
+
+    def test_bool_not_treated_as_int(self):
+        with pytest.raises(ValidationError):
+            AgentModel(name="a", model=create_mock_llm_model(), call_limit=True)
+
+
+class TestAgentCallLimitWiring:
+    """An agent's call_limit auto-registers a ModelCallLimitMiddleware."""
+
+    @patch("dao_ai.nodes.create_agent")
+    def test_agent_node_includes_model_call_limit_middleware(self, mock_create_agent):
+        from dao_ai.nodes import create_agent_node
+
+        mock_compiled_agent = MagicMock()
+        mock_compiled_agent.name = "test_agent"
+        mock_create_agent.return_value = mock_compiled_agent
+
+        agent_model = AgentModel(
+            name="test_agent",
+            model=create_mock_llm_model(),
+            tools=[ToolModel(name="search", function=SearchToolModel())],
+            call_limit={"run_limit": 6, "exit_behavior": "end"},
+        )
+
+        create_agent_node(agent=agent_model)
+
+        mock_create_agent.assert_called_once()
+        middleware_list = mock_create_agent.call_args[1].get("middleware", [])
+
+        limit_mws = [
+            m for m in middleware_list if isinstance(m, ModelCallLimitMiddleware)
+        ]
+        assert len(limit_mws) == 1
+        assert limit_mws[0].run_limit == 6
+
+    @patch("dao_ai.nodes.create_agent")
+    def test_agent_node_no_model_call_limit_when_not_configured(self, mock_create_agent):
+        from dao_ai.nodes import create_agent_node
+
+        mock_compiled_agent = MagicMock()
+        mock_compiled_agent.name = "test_agent"
+        mock_create_agent.return_value = mock_compiled_agent
+
+        agent_model = AgentModel(
+            name="test_agent",
+            model=create_mock_llm_model(),
+            tools=[ToolModel(name="search", function=SearchToolModel())],
+        )
+
+        create_agent_node(agent=agent_model)
+
+        mock_create_agent.assert_called_once()
+        middleware_list = mock_create_agent.call_args[1].get("middleware", [])
+
+        has_limit = any(
+            isinstance(m, ModelCallLimitMiddleware) for m in middleware_list
+        )
+        assert not has_limit


### PR DESCRIPTION
## Summary

Three related config/ergonomics improvements, driven by latency-optimizing a real single-agent app (Viking support agent) on FEVM, plus a deploy-path fix they surfaced.

### 1. `call_limit` on `AgentModel` (model-call limit sugar)
The model-call analogue of a tool's `call_limit`. Bounds the ReAct loop as a first-class, discoverable field co-located with `recursion_limit`, instead of hand-wiring `create_model_call_limit_middleware` into every agent's `middleware` list.
- `ModelCallLimitModel` mirrors `ToolCallLimitModel` (`run_limit`/`thread_limit` + `turn_limit`/`conversation_limit` aliases) but defaults `exit_behavior='end'` and drops `'continue'` (no per-tool fallback for a model-call cap).
- Bare-int shorthand → `run_limit`; `bool` rejected; `nodes.py` registers the middleware when set.

### 2. `extra_params` passthrough on `InferenceEndpointModel`
Generic dict forwarded verbatim to the chat client (`ChatDatabricks`/`ChatUnityAIGateway`) on both standard and AI-Gateway paths, inherited by string fallbacks.
- Motivating win: `extra_params: {reasoning_effort: low}` on gpt-oss cut a simple answer from **2.1s/367 tok → 0.6s/83 tok** live — the largest E2E latency lever found. Not gpt-oss-specific.

### 3. Uniform dev-wheel local-version stamp across deploy paths
A `--development` wheel built at the same base version (e.g. `0.1.115`) as the published package is skipped by pip in an Apps container ("already satisfied"), silently running stale code. `--force-reinstall` is not a valid Apps `requirements.txt` line. Fix: stamp a unique PEP 440 local version (`0.1.115+dev<epoch>`) at build time via a temporary, auto-restored pyproject edit so pip always reinstalls.
- Promoted to shared `dao_ai.utils.dev_local_version` and applied to **all** `uv build` sites: `generate-bundle` (`write_bundle`), `deploy` (`_build_wheel`), and `generate-mcp` — so `--development` behaves uniformly across generate-bundle / deploy / generate-mcp / pipeline.

## Testing
- New/updated unit tests: `ModelCallLimitModel` + agent wiring (18), `extra_params` forwarding (std + AI-Gateway), `dev_local_version` (stamp/restore/exception/idempotent/dynamic), `_build_wheel` stamp (deploy path), generate-mcp build stamp.
- Live-verified on FEVM: generate-bundle and generate-mcp emit `+dev` wheels and restore pyproject; the deployed Viking app runs the new fields (`call_limit` enforced, `reasoning_effort: low` active); multi-tool E2E 6.2s → 3.8s.
- `make schema` regenerated for both new config fields.

This pull request and its description were written by Isaac.