### PR TITLE
feat(apps): configurable uvicorn worker count for the Apps backend

### DIFF
--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -1525,6 +1525,20 @@
           "default": "Small",
           "description": "Model Serving workload size (Small, Medium, Large)."
         },
+        "workers": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 2,
+          "description": "Number of uvicorn worker processes for the Databricks Apps backend server. Each worker is a separate process, raising the app's concurrent-request ceiling on multi-core Apps compute. Defaults to 2 (a modest bump over uvicorn's single-worker default that is safe on the small default Apps compute); raise it to match larger compute cores. Emitted to the app as the ``DAO_AI_APP_WORKERS`` env var and forwarded to the backend as ``--workers``. Too many workers on a small instance contends for CPU. Apps-target only (no effect on Model Serving, which manages its own worker pool via workload_size).",
+          "title": "Workers"
+        },
         "permissions": {
           "anyOf": [
             {

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -402,6 +402,14 @@ def _build_app_block(
             }
         )
 
+    # Forward the uvicorn worker count to the backend server (start_app reads
+    # DAO_AI_APP_WORKERS and passes it as --workers). Raises the concurrent-
+    # request ceiling on multi-core Apps compute.
+    if config.app and config.app.workers:
+        env_vars.append(
+            {"name": "DAO_AI_APP_WORKERS", "value": str(config.app.workers)}
+        )
+
     if enable_chat_proxy and include_chat_ui:
         from dao_ai.apps.chat_ui import chat_ui_env_vars
 

--- a/src/dao_ai/apps/start_app.py
+++ b/src/dao_ai/apps/start_app.py
@@ -243,6 +243,11 @@ class ProcessManager:
                 "--port",
                 str(self.port),
             ]
+            # Forward the configured uvicorn worker count (AppModel.workers ->
+            # DAO_AI_APP_WORKERS env at deploy time). Unset -> server default (1).
+            workers = os.environ.get("DAO_AI_APP_WORKERS")
+            if workers:
+                backend_cmd.extend(["--workers", workers])
             if backend_args:
                 backend_cmd.extend(backend_args)
 

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -9359,6 +9359,21 @@ class AppModel(BaseModel):
         default="Small",
         description="Model Serving workload size (Small, Medium, Large).",
     )
+    workers: Optional[int] = Field(
+        default=2,
+        gt=0,
+        description=(
+            "Number of uvicorn worker processes for the Databricks Apps backend "
+            "server. Each worker is a separate process, raising the app's "
+            "concurrent-request ceiling on multi-core Apps compute. Defaults to "
+            "2 (a modest bump over uvicorn's single-worker default that is safe "
+            "on the small default Apps compute); raise it to match larger compute "
+            "cores. Emitted to the app as the ``DAO_AI_APP_WORKERS`` env var and "
+            "forwarded to the backend as ``--workers``. Too many workers on a "
+            "small instance contends for CPU. Apps-target only (no effect on "
+            "Model Serving, which manages its own worker pool via workload_size)."
+        ),
+    )
     permissions: Optional[list[AppPermissionModel]] = Field(
         default_factory=list,
         description="Access control list for the serving endpoint.",

--- a/tests/dao_ai/test_bundle_app_workers.py
+++ b/tests/dao_ai/test_bundle_app_workers.py
@@ -1,0 +1,70 @@
+"""Bundle emission tests for ``AppModel.workers`` (uvicorn worker count).
+
+Locks in the contract that ``_build_app_block`` emits the ``DAO_AI_APP_WORKERS``
+env var, which ``start_app.py`` forwards to the backend as ``--workers``. The
+field defaults to 2 (a modest bump over uvicorn's single-worker default, safe on
+the small default Apps compute).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dao_ai.apps.bundle import _build_app_block
+from dao_ai.config import (
+    AgentModel,
+    AppConfig,
+    AppModel,
+    DeploymentTarget,
+    InferenceEndpointModel,
+)
+
+
+def _config(*, workers: int | None = None) -> AppConfig:
+    extra: dict = {}
+    if workers is not None:
+        extra["workers"] = workers
+    return AppConfig(
+        app=AppModel(
+            name="dao-ai-workers-test",
+            description="test agent",
+            deployment_target=DeploymentTarget.APPS,
+            enable_chat_proxy=False,
+            agents=[
+                AgentModel(
+                    name="greeter",
+                    description="test agent",
+                    model=InferenceEndpointModel(name="databricks-gpt-5-4-mini"),
+                )
+            ],
+            **extra,
+        ),
+    )
+
+
+def _workers_env(apps_block: dict) -> str | None:
+    (app_def,) = apps_block.values()
+    for e in app_def.get("config", {}).get("env", []):
+        if e.get("name") == "DAO_AI_APP_WORKERS":
+            return e.get("value")
+    return None
+
+
+@pytest.mark.unit
+class TestAppWorkersEmission:
+    def test_default_workers_is_two(self) -> None:
+        assert _config().app.workers == 2
+
+    def test_emits_default_workers_env(self) -> None:
+        _, _, apps_block = _build_app_block(_config(), "dao_ai.yaml")
+        assert _workers_env(apps_block) == "2"
+
+    def test_emits_explicit_workers_env(self) -> None:
+        _, _, apps_block = _build_app_block(_config(workers=4), "dao_ai.yaml")
+        assert _workers_env(apps_block) == "4"
+
+    def test_workers_must_be_positive(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            _config(workers=0)


### PR DESCRIPTION
## Summary

Adds `AppModel.workers` to control the number of uvicorn worker processes for the Databricks Apps backend server, raising the concurrent-request ceiling on multi-core Apps compute.

- **Default: 2** — a modest bump over mlflow `AgentServer`'s single-worker default, safe on the small default Apps compute. Override per-app for larger compute.
- Emitted by `write_bundle` as the `DAO_AI_APP_WORKERS` env var; `start_app.py` reads it and forwards `--workers N` to `python -m dao_ai.apps.server` (mlflow `AgentServer` already parses `--workers`; the app is a module-level var so multi-worker is safe).
- **Apps-target only** — no effect on Model Serving (which manages its own worker pool via `workload_size`).

## Motivation & honest scope

Surfaced while throughput-testing a single-agent app: one uvicorn worker saturated at ~4 concurrent / ~2 req/s (all requests succeeded; latency degraded gracefully under overload).

Measured impact of 2 workers on that app: modest — throughput improved at high concurrency (conc=8: 1.94 → 2.39 req/s) but was flat/noisy at low-mid concurrency. That app is **I/O-bound on a shared pay-per-token LLM endpoint**, so worker count is not the real throughput lever there (Provisioned Throughput on the model / more app instances are). The knob is nonetheless a correct, generally-useful control — CPU-bound dao-ai apps and higher-core Apps compute benefit directly, and it's the standard way to set ASGI concurrency.

## Verification
- Live on FEVM: bundle emits `DAO_AI_APP_WORKERS: '2'`; app logs show a uvicorn parent + 2 server processes started.
- Unit tests: field default (2), env emission (default + explicit), positive-int validation.
- `make schema` regenerated.

This pull request and its description were written by Isaac.