### PR TITLE
feat(deploy): honor user pip_requirements on Apps/MCP/pipeline

### DIFF
--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -1642,7 +1642,7 @@
           "description": "Chat history summarization settings to manage long conversations."
         },
         "code_paths": {
-          "description": "Additional local Python modules/packages (paths relative to the config) shipped with the deployment \u2014 bundled into the Model Serving artifact and copied into generated Apps/MCP bundles.",
+          "description": "Additional Python file paths bundled with the Model Serving model artifact via ``log_model(code_paths=...)``. For Apps/MCP, put custom code in the generated bundle's ``src/<package>/`` instead \u2014 it is built and installed by ``uv sync`` at the app build phase.",
           "items": {
             "type": "string"
           },

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -1642,7 +1642,7 @@
           "description": "Chat history summarization settings to manage long conversations."
         },
         "code_paths": {
-          "description": "Additional Python file paths bundled with the model artifact.",
+          "description": "Additional local Python modules/packages (paths relative to the config) shipped with the deployment \u2014 bundled into the Model Serving artifact and copied into generated Apps/MCP bundles.",
           "items": {
             "type": "string"
           },
@@ -1650,7 +1650,7 @@
           "type": "array"
         },
         "pip_requirements": {
-          "description": "Extra pip packages installed in the serving environment.",
+          "description": "Extra pip packages for your custom code, installed alongside dao-ai in every deployment target (Model Serving conda env; Apps/MCP requirements.txt; pipeline job environment).",
           "items": {
             "type": "string"
           },

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -20,7 +20,7 @@ import shutil
 import subprocess
 from importlib.metadata import version as pkg_version
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 import yaml
 from loguru import logger
@@ -146,6 +146,7 @@ def _make_requirements_txt(
     development: bool,
     wheel_filename: Optional[str] = None,
     extras: str = "",
+    pip_requirements: Optional[Sequence[str]] = None,
 ) -> str:
     """Build the requirements.txt content for an app bundle.
 
@@ -167,14 +168,80 @@ def _make_requirements_txt(
         extras: Optional requirement-extras suffix (e.g. ``"[a2a,rerank]"``)
             appended to the ``dao-ai`` spec / dev wheel so the config's
             optional features install. Empty string installs the base package.
+        pip_requirements: User-declared extra pip packages
+            (``config.app.pip_requirements``) that the deployer's custom code
+            under ``src/<package>/`` needs. Appended verbatim, one per line,
+            after the dao-ai line so Apps' ``pip install -r requirements.txt``
+            installs them into the app environment.
     """
     if development:
         if not wheel_filename:
             raise ValueError(
                 "_make_requirements_txt: wheel_filename is required in development mode."
             )
-        return f"./dist/{wheel_filename}{extras}\n"
-    return f"dao-ai{extras}\n"
+        dao_ai_line = f"./dist/{wheel_filename}{extras}"
+    else:
+        dao_ai_line = f"dao-ai{extras}"
+
+    lines = [dao_ai_line, *(pip_requirements or [])]
+    return "\n".join(lines) + "\n"
+
+
+def _copy_code_paths_into_bundle(
+    config: AppConfig,
+    output_dir: Path,
+    *,
+    overwrite: bool,
+    written: list[str],
+    skipped: list[str],
+) -> None:
+    """Copy user-declared ``config.app.code_paths`` into a generated bundle.
+
+    Gives ``code_paths`` the same meaning on Apps/MCP as on Model Serving:
+    the custom modules/packages ship with the deployment. Each entry is copied
+    preserving its path relative to the config dir (the same anchor skills use),
+    so the ``add_code_paths_to_sys_path`` validator resolves it against the
+    bundle-root CWD at app startup. Absolute paths outside the config dir fall
+    back to copying under their basename at the bundle root.
+    """
+    if config.app is None or not config.app.code_paths:
+        return
+
+    from dao_ai.skills import _skill_base_dir
+
+    base: Path = _skill_base_dir(config)
+    for code_path_str in config.app.code_paths:
+        src: Path = Path(code_path_str)
+        if not src.is_absolute():
+            src = (base / src).resolve()
+        if not src.exists():
+            logger.warning(
+                "Declared code_path does not exist; skipping", code_path=code_path_str
+            )
+            continue
+        try:
+            rel: Path = src.relative_to(base)
+        except ValueError:
+            rel = Path(src.name)
+        dest: Path = output_dir / rel
+        if dest.exists() and not overwrite:
+            logger.info(
+                "Skipping code_path copy (exists; use --overwrite)", code_path=str(rel)
+            )
+            skipped.append(str(rel))
+            continue
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if dest.exists():
+            if dest.is_dir():
+                shutil.rmtree(dest)
+            else:
+                dest.unlink()
+        if src.is_dir():
+            shutil.copytree(src, dest)
+        else:
+            shutil.copy2(src, dest)
+        logger.info("Copied code_path into bundle", code_path=str(rel))
+        written.append(str(rel))
 
 
 def _get_dao_ai_version() -> str:
@@ -746,6 +813,13 @@ def write_bundle(
         resolve_required_extras_or_all(config, target="apps")
     )
 
+    # User-declared extra pip packages for their custom code under
+    # ``src/<package>/`` (the stub the generator scaffolds). These are appended
+    # to the generated requirements.txt so Apps installs them alongside dao-ai.
+    user_pip_requirements: list[str] = (
+        list(config.app.pip_requirements) if config.app else []
+    )
+
     # Warn loudly when the bundle is being built without `trace_location`:
     # Databricks Apps containers cannot reach the artifact-storage host the
     # default MLflow control-plane trace exporter PUTs spans to, so spans
@@ -858,6 +932,16 @@ def write_bundle(
         logger.info("Copied skill directory into bundle", skill=str(rel))
         written.append(str(rel))
 
+    # Copy user-declared ``code_paths`` (custom modules/packages) into the
+    # bundle so they deploy with the app — parity with Model Serving, which
+    # ships them via ``log_model(code_paths=...)``. They're preserved at their
+    # path relative to the config dir so the ``add_code_paths_to_sys_path``
+    # validator (which inserts ``Path(code_path).parent`` onto sys.path at
+    # config load) resolves them against the bundle-root CWD at app startup.
+    _copy_code_paths_into_bundle(
+        config, output_dir, overwrite=overwrite, written=written, skipped=skipped
+    )
+
     package_name = app_name.replace("-", "_")
 
     if development:
@@ -947,6 +1031,7 @@ def write_bundle(
                 development=True,
                 wheel_filename=wheel_path.name,
                 extras=extras_suffix,
+                pip_requirements=user_pip_requirements,
             ),
         )
 
@@ -975,7 +1060,11 @@ def write_bundle(
         # branch (kept in sync intentionally).
         _track(
             output_dir / "requirements.txt",
-            _make_requirements_txt(development=False, extras=extras_suffix),
+            _make_requirements_txt(
+                development=False,
+                extras=extras_suffix,
+                pip_requirements=user_pip_requirements,
+            ),
         )
 
         # Create stub package so the wheel builds and users can add custom code

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -187,63 +187,6 @@ def _make_requirements_txt(
     return "\n".join(lines) + "\n"
 
 
-def _copy_code_paths_into_bundle(
-    config: AppConfig,
-    output_dir: Path,
-    *,
-    overwrite: bool,
-    written: list[str],
-    skipped: list[str],
-) -> None:
-    """Copy user-declared ``config.app.code_paths`` into a generated bundle.
-
-    Gives ``code_paths`` the same meaning on Apps/MCP as on Model Serving:
-    the custom modules/packages ship with the deployment. Each entry is copied
-    preserving its path relative to the config dir (the same anchor skills use),
-    so the ``add_code_paths_to_sys_path`` validator resolves it against the
-    bundle-root CWD at app startup. Absolute paths outside the config dir fall
-    back to copying under their basename at the bundle root.
-    """
-    if config.app is None or not config.app.code_paths:
-        return
-
-    from dao_ai.skills import _skill_base_dir
-
-    base: Path = _skill_base_dir(config)
-    for code_path_str in config.app.code_paths:
-        src: Path = Path(code_path_str)
-        if not src.is_absolute():
-            src = (base / src).resolve()
-        if not src.exists():
-            logger.warning(
-                "Declared code_path does not exist; skipping", code_path=code_path_str
-            )
-            continue
-        try:
-            rel: Path = src.relative_to(base)
-        except ValueError:
-            rel = Path(src.name)
-        dest: Path = output_dir / rel
-        if dest.exists() and not overwrite:
-            logger.info(
-                "Skipping code_path copy (exists; use --overwrite)", code_path=str(rel)
-            )
-            skipped.append(str(rel))
-            continue
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        if dest.exists():
-            if dest.is_dir():
-                shutil.rmtree(dest)
-            else:
-                dest.unlink()
-        if src.is_dir():
-            shutil.copytree(src, dest)
-        else:
-            shutil.copy2(src, dest)
-        logger.info("Copied code_path into bundle", code_path=str(rel))
-        written.append(str(rel))
-
-
 def _get_dao_ai_version() -> str:
     """Return the currently installed dao-ai version for pinning in generated bundles."""
     try:
@@ -931,16 +874,6 @@ def write_bundle(
         shutil.copytree(src_dir, dest)
         logger.info("Copied skill directory into bundle", skill=str(rel))
         written.append(str(rel))
-
-    # Copy user-declared ``code_paths`` (custom modules/packages) into the
-    # bundle so they deploy with the app — parity with Model Serving, which
-    # ships them via ``log_model(code_paths=...)``. They're preserved at their
-    # path relative to the config dir so the ``add_code_paths_to_sys_path``
-    # validator (which inserts ``Path(code_path).parent`` onto sys.path at
-    # config load) resolves them against the bundle-root CWD at app startup.
-    _copy_code_paths_into_bundle(
-        config, output_dir, overwrite=overwrite, written=written, skipped=skipped
-    )
 
     package_name = app_name.replace("-", "_")
 

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -9436,11 +9436,15 @@ class AppModel(BaseModel):
     )
     code_paths: list[str] = Field(
         default_factory=list,
-        description="Additional Python file paths bundled with the model artifact.",
+        description="Additional local Python modules/packages (paths relative to "
+        "the config) shipped with the deployment — bundled into the Model Serving "
+        "artifact and copied into generated Apps/MCP bundles.",
     )
     pip_requirements: list[str] = Field(
         default_factory=list,
-        description="Extra pip packages installed in the serving environment.",
+        description="Extra pip packages for your custom code, installed alongside "
+        "dao-ai in every deployment target (Model Serving conda env; Apps/MCP "
+        "requirements.txt; pipeline job environment).",
     )
     python_version: Optional[str] = Field(
         default="3.12",

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -9436,9 +9436,10 @@ class AppModel(BaseModel):
     )
     code_paths: list[str] = Field(
         default_factory=list,
-        description="Additional local Python modules/packages (paths relative to "
-        "the config) shipped with the deployment — bundled into the Model Serving "
-        "artifact and copied into generated Apps/MCP bundles.",
+        description="Additional Python file paths bundled with the Model Serving "
+        "model artifact via ``log_model(code_paths=...)``. For Apps/MCP, put "
+        "custom code in the generated bundle's ``src/<package>/`` instead — it is "
+        "built and installed by ``uv sync`` at the app build phase.",
     )
     pip_requirements: list[str] = Field(
         default_factory=list,

--- a/src/dao_ai/mcp/generate.py
+++ b/src/dao_ai/mcp/generate.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+from collections.abc import Sequence
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
@@ -106,6 +107,12 @@ def write_mcp_bundle(
         sorted({"mcp", *expand_all(resolve_required_extras_or_all(config, target="mcp"))})
     )
 
+    # User-declared extra pip packages for custom code, appended to the MCP
+    # app's requirements.txt (parity with Model Serving / generate-agent).
+    user_pip_requirements: list[str] = (
+        list(config.app.pip_requirements) if config.app else []
+    )
+
     def _write(path: Path, content: str) -> None:
         if path.exists() and not overwrite:
             skipped.append(str(path.relative_to(output_dir)))
@@ -159,6 +166,7 @@ def write_mcp_bundle(
             development=development,
             wheel_filename=wheel_filename,
             extras=merged_extras,
+            pip_requirements=user_pip_requirements,
         ),
     )
     _write(
@@ -178,6 +186,15 @@ def write_mcp_bundle(
     _write(
         output_dir / "README.md",
         _render_readme(config, app_name=app_name, tool_name=tool_name),
+    )
+
+    # Ship user-declared code_paths (custom modules) with the MCP bundle —
+    # parity with Model Serving / generate-agent. Reuses the apps-bundle helper
+    # so the copy layout + sys.path resolution behave identically.
+    from dao_ai.apps.bundle import _copy_code_paths_into_bundle
+
+    _copy_code_paths_into_bundle(
+        config, output_dir, overwrite=overwrite, written=written, skipped=skipped
     )
 
     print(f"\nMCP bundle generated in {output_dir}/\n")
@@ -235,6 +252,7 @@ def _make_requirements_txt(
     development: bool,
     wheel_filename: str | None = None,
     extras: str = "mcp",
+    pip_requirements: Sequence[str] | None = None,
 ) -> str:
     """Build the requirements.txt content for an MCP app bundle.
 
@@ -248,14 +266,21 @@ def _make_requirements_txt(
         development: Whether to reference a bundled dev wheel vs the PyPI pin.
         wheel_filename: The dev wheel filename (required in development mode).
         extras: Comma-joined extras list (no brackets), e.g. ``"mcp,a2a"``.
+        pip_requirements: User-declared extra pip packages
+            (``config.app.pip_requirements``) for custom code, appended after
+            the dao-ai line so the MCP app installs them too.
     """
     if development:
         if not wheel_filename:
             raise ValueError(
                 "_make_requirements_txt: wheel_filename is required in development mode."
             )
-        return f"./dist/{wheel_filename}[{extras}]\n"
-    return f"dao-ai[{extras}]\n"
+        dao_ai_line = f"./dist/{wheel_filename}[{extras}]"
+    else:
+        dao_ai_line = f"dao-ai[{extras}]"
+
+    lines = [dao_ai_line, *(pip_requirements or [])]
+    return "\n".join(lines) + "\n"
 
 
 def _bundle_local_wheel(output_dir: Path, *, written: list[str]) -> str:

--- a/src/dao_ai/mcp/generate.py
+++ b/src/dao_ai/mcp/generate.py
@@ -188,15 +188,6 @@ def write_mcp_bundle(
         _render_readme(config, app_name=app_name, tool_name=tool_name),
     )
 
-    # Ship user-declared code_paths (custom modules) with the MCP bundle —
-    # parity with Model Serving / generate-agent. Reuses the apps-bundle helper
-    # so the copy layout + sys.path resolution behave identically.
-    from dao_ai.apps.bundle import _copy_code_paths_into_bundle
-
-    _copy_code_paths_into_bundle(
-        config, output_dir, overwrite=overwrite, written=written, skipped=skipped
-    )
-
     print(f"\nMCP bundle generated in {output_dir}/\n")
     for name in written:
         print(f"  {name:<32s} (created)")

--- a/src/dao_ai/pipeline/bundle.py
+++ b/src/dao_ai/pipeline/bundle.py
@@ -163,8 +163,17 @@ def generate_pipeline_databricks_yaml(config: AppConfig, development: bool) -> s
                             "environment_key": "dao-ai-env",
                             "spec": {
                                 "environment_version": "5",
+                                # dao-ai (+ resolved extras) via the var, then
+                                # any user-declared extra pip packages so the
+                                # provisioning notebooks' custom code has its
+                                # deps (parity with Model Serving / Apps).
                                 "dependencies": [
-                                    "${var.dao_ai_dep}"
+                                    "${var.dao_ai_dep}",
+                                    *(
+                                        list(config.app.pip_requirements)
+                                        if config.app
+                                        else []
+                                    ),
                                 ],
                             },
                         }

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -1688,6 +1688,12 @@ class DatabricksProvider(ServiceProvider):
         extras_suffix: str = format_extras_suffix(
             resolve_required_extras_or_all(config, target="apps")
         )
+        # User-declared extra pip packages for their custom app code — appended
+        # to the uploaded requirements.txt so Apps installs them (parity with
+        # Model Serving, which bakes them into the model's conda_env).
+        user_pip_requirements: list[str] = (
+            list(config.app.pip_requirements) if config.app else []
+        )
 
         # Use convention-based workspace path: /Workspace/Users/{user}/apps/{app_name}
         current_user: User = self.w.current_user.me()
@@ -1846,7 +1852,9 @@ class DatabricksProvider(ServiceProvider):
             # ``--index-url https://pypi.org/simple/`` override + unbounded
             # dao-ai pin. See ``_make_requirements_txt`` for the reasoning.
             requirements_content = _make_requirements_txt(
-                development=False, extras=extras_suffix
+                development=False,
+                extras=extras_suffix,
+                pip_requirements=user_pip_requirements,
             )
             self.w.workspace.upload(
                 path=f"{source_path}/requirements.txt",
@@ -1956,6 +1964,7 @@ class DatabricksProvider(ServiceProvider):
                 development=True,
                 wheel_filename=wheel_path.name,
                 extras=extras_suffix,
+                pip_requirements=user_pip_requirements,
             )
             self.w.workspace.upload(
                 path=f"{source_path}/requirements.txt",

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -36,6 +36,14 @@ def _stamp_extras_resolvable(mock_config: MagicMock) -> MagicMock:
     # app.a2a disabled + no orchestration → resolver adds no extras by default.
     mock_config.app.a2a = MagicMock(enabled=False)
     mock_config.app.orchestration = None
+    # Custom-dep passthrough surfaces read by the Apps/MS deploy paths. Only
+    # default them when the test hasn't set a real list — never clobber a
+    # test's own pip_requirements/code_paths values. ``getattr`` tolerates
+    # both plain and spec-restricted mocks.
+    if not isinstance(getattr(mock_config.app, "pip_requirements", None), list):
+        mock_config.app.pip_requirements = []
+    if not isinstance(getattr(mock_config.app, "code_paths", None), list):
+        mock_config.app.code_paths = []
     return mock_config
 from dao_ai.providers.databricks import DatabricksProvider
 

--- a/tests/dao_ai/test_extras_deploy_paths.py
+++ b/tests/dao_ai/test_extras_deploy_paths.py
@@ -38,6 +38,35 @@ def test_apps_dev_requires_wheel_filename() -> None:
         apps_reqs(development=True)
 
 
+@pytest.mark.unit
+def test_apps_appends_user_pip_requirements_published() -> None:
+    # User custom deps (config.app.pip_requirements) append after dao-ai, so
+    # Apps' `pip install -r requirements.txt` installs the deployer's code deps.
+    out = apps_reqs(
+        development=False,
+        extras="[a2a]",
+        pip_requirements=["cowsay==6.1", "my-internal-lib>=1.0"],
+    )
+    assert out == "dao-ai[a2a]\ncowsay==6.1\nmy-internal-lib>=1.0\n"
+
+
+@pytest.mark.unit
+def test_apps_appends_user_pip_requirements_dev() -> None:
+    out = apps_reqs(
+        development=True,
+        wheel_filename="dao_ai-0.2.0.whl",
+        pip_requirements=["cowsay==6.1"],
+    )
+    assert out == "./dist/dao_ai-0.2.0.whl\ncowsay==6.1\n"
+
+
+@pytest.mark.unit
+def test_apps_no_user_pip_requirements_unchanged() -> None:
+    # Empty/None user deps must not alter the single dao-ai line.
+    assert apps_reqs(development=False, pip_requirements=[]) == "dao-ai\n"
+    assert apps_reqs(development=False, pip_requirements=None) == "dao-ai\n"
+
+
 # ---------------------------------------------------------------------------
 # MCP bundle requirements — always carries the mcp extra, merges features
 # ---------------------------------------------------------------------------
@@ -55,6 +84,14 @@ def test_mcp_published_merged_extras() -> None:
 def test_mcp_dev_merged_extras() -> None:
     out = mcp_reqs(development=True, wheel_filename="w.whl", extras="mcp,rerank")
     assert out == "./dist/w.whl[mcp,rerank]\n"
+
+
+@pytest.mark.unit
+def test_mcp_appends_user_pip_requirements() -> None:
+    out = mcp_reqs(
+        development=False, extras="mcp", pip_requirements=["cowsay==6.1"]
+    )
+    assert out == "dao-ai[mcp]\ncowsay==6.1\n"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

User-declared custom-code pip dependencies (`config.app.pip_requirements`) were only wired into **Model Serving**; the Apps, MCP, and pipeline deploy paths **silently dropped** them. A deployer whose custom agent code (the `src/<package>/` stub that `generate-agent`/`generate-mcp` scaffold) needed an extra pip package got a broken install on those targets. This PR makes `pip_requirements` honored across **every** deployment target.

(Follow-up to #205. This is a pre-existing gap — not caused by #205.)

### `pip_requirements` — appended after the `dao-ai[extras]` line
- `apps/bundle.py` `write_bundle` (dev + published) and `providers/databricks.py` `deploy_apps_agent` (dev + published) → uploaded `requirements.txt`.
- `mcp/generate.py` `write_mcp_bundle` → MCP `requirements.txt`.
- `pipeline/bundle.py` → serverless job environment `dependencies` list.

### Scope note — `code_paths` stays Model-Serving-only (intentional)
Custom **code** does not need `code_paths` on Apps/MCP: the generated bundle's own `src/<package>/` is built and installed by `uv sync` at the app build phase, so tools referenced by fully-qualified name are importable. `code_paths` remains what it always was — a Model Serving mechanism (files shipped into the model artifact via `log_model(code_paths=...)`, where there is no `src/` build step). The `code_paths` field description was reworded to point Apps/MCP users at `src/<package>/`.

## Testing
- Unit tests: `pip_requirements` append (with extras, dev/published, empty/None no-op) for both Apps and MCP helpers.
- Codegen: `generate-agent` and `generate-mcp` emit `dao-ai[extras]` + the user's pip packages.
- **Live on FEVM**: an Apps deploy with `pip_requirements: [cowsay==6.1]` built, installed the dependency, reached RUNNING, and served inference (HTTP 200). Uploaded `requirements.txt` confirmed to carry the custom dep.
- `test_databricks` failure set unchanged vs baseline (12 pre-existing Mock/harness failures; zero net-new).

This pull request and its description were written by Isaac.