### PR TITLE
Release 0.2.4: version-pin generated bundles + release validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 2026-07-21
+## [0.2.4] - 2026-07-23
+
+### Fixed
+
+- **Generated deploy bundles now pin the exact dao-ai version in published mode.** `dao-ai generate-agent` / `generate-mcp` previously wrote an *unbounded* `dao-ai` (and a `>=` floor in `pyproject.toml`) into the App bundle's `requirements.txt`, so a redeploy months later silently resolved whatever was newest on PyPI — non-reproducible, and an unintended upgrade on every rebuild. Published mode now emits `dao-ai[extras]==<version>` in both `requirements.txt` and `pyproject.toml`, matching the Model Serving deploy path (`create_agent` already pinned `==`). `generate-workflow`'s `dao_ai_dep` bundle variable is likewise pinned (CLI override and the `databricks.yaml` default). `--development` is unchanged — it references the bundled local wheel (`./dist/<wheel>`) by path.
 
 ### Removed
 
@@ -22,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CLI: unified the three DAB generators into a consistent `generate-*` family.** All three now generate a Databricks Asset Bundle and share `--deploy`/`--run`/`--destroy`/`--dry-run` action flags, a common deploy driver, and a common bundle-staging namespace.
   - **BREAKING — renamed `dao-ai generate-bundle` → `dao-ai generate-agent`** (emits the agent's Databricks App bundle) and **`dao-ai pipeline` → `dao-ai generate-workflow`** (emits the provisioning multi-task Job / Workflow — not a Lakeflow Declarative Pipeline). The old names are **removed** — invoking `generate-bundle` or `pipeline` now exits with an `invalid choice` error. Update scripts to the new verbs. Sibling `generate-mcp` is unchanged.
   - **`generate-agent` / `generate-mcp` gained `--deploy`/`--run`/`--destroy`.** They previously only wrote a bundle. When `--deploy` is passed the shared driver runs `databricks bundle deploy`, then — when `app.trace_location` is set — **automatically links the MLflow experiment trace destination and grants the App SP** the experiment + UC OTEL table privileges (the steps previously documented as manual follow-ups; silent trace loss otherwise), then `--run` starts the app. No action flags → generate-only, as before.
-  - **`generate-workflow` is wheel-only** and stages a self-contained bundle: step notebooks + pinned `requirements.txt` ship as package data; `databricks.yaml` is built programmatically (shared `dump_bundle_yaml`) — no source checkout and no repo-root template. Step notebooks install dao-ai from the bundled wheel (`--development`) or PyPI.
+  - **`generate-workflow` is wheel-only** and stages a self-contained bundle: step notebooks ship as package data; `databricks.yaml` is built programmatically (shared `dump_bundle_yaml`) — no source checkout and no repo-root template. There is no pinned `requirements.txt`: dao-ai (+ its transitive deps) installs via the serverless job environment's `dao_ai_dep` dependency — the bundled wheel (`--development`) or the `dao-ai` PyPI package.
   - **Unified bundle location** `./.dao-ai/bundle/{workflow,agent,mcp}/<app-name>` (per-app, so deploying multiple configs never collides on DAB state). Override the base dir with the `DAO_AI_BUNDLE_DIR` env var (the `{kind}/<app>` structure is appended underneath — e.g. `DAO_AI_BUNDLE_DIR=~/.dao-ai/bundle` for a central location), or a specific bundle dir with `-o/--output-dir` (highest precedence). New `--overwrite` on `generate-workflow`.
     - Each generated `databricks.yaml` carries an explicit `sync.include` for its own source. Databricks bundle sync honors `.gitignore`, and the default `.dao-ai/` base is gitignored — without the include the deployed App would fail with "no files found".
   - **Post-deploy links.** All four deploy paths now print a link on success: `generate-agent`/`generate-mcp` and `dao-ai deploy -t apps` print the **App URL**; `generate-workflow --deploy` prints the **Job URL**; `dao-ai deploy` (Model Serving) prints the **serving-endpoint URL**. Best-effort — a lookup failure never fails the deploy.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DAO: Declarative Agent Orchestration
 
-[![Version](https://img.shields.io/badge/version-0.1.2-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.2.4-blue.svg)](CHANGELOG.md)
 [![Python](https://img.shields.io/badge/python-3.11+-green.svg)](https://www.python.org/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
@@ -456,10 +456,8 @@ dao-ai generate-workflow --deploy --run -c config/my_config.yaml
 dao-ai generate-workflow --deploy -c config/my_config.yaml --profile aws-field-eng
 dao-ai generate-workflow --deploy -c config/my_config.yaml --profile azure-retail
 
-# Generate a deployable Databricks Apps bundle
-dao-ai generate-agent -c config/my_config.yaml -o ./my-bundle
-# Then `cd` in and run `uv sync` to produce uv.lock — see "Deploying to
-# Databricks Apps" below for the full two-step workflow.
+# Generate + deploy + start a Databricks Apps bundle in one step
+dao-ai generate-agent -c config/my_config.yaml --deploy --run -p <profile>
 
 # Interactive chat with agent
 dao-ai chat -c config/my_config.yaml
@@ -470,33 +468,26 @@ dao-ai parameters list -c config/my_config.yaml --param catalog=nfleming
 
 ### Deploying to Databricks Apps
 
-`dao-ai generate-agent` produces a bundle skeleton (`pyproject.toml` + app/resource YAML + your config), but it deliberately does **not** generate `uv.lock`. The lock encodes URLs and pins specific to your environment, so you own it.
+`dao-ai generate-agent` produces a deploy-ready Databricks Apps bundle: `databricks.yaml`, the app resource YAML (with the agent's UC resource wiring), a `requirements.txt`, a `pyproject.toml`, and a copy of your config. The Apps build phase installs dependencies by running `pip install -r requirements.txt`, so no `uv.lock` is generated or needed.
 
-**External users** (default index = public PyPI):
+The simplest path is the one-step deploy (generate + `bundle deploy` + trace-link/grant + `bundle run`):
+
+```bash
+dao-ai generate-agent -c config/my_config.yaml --deploy --run -p <profile>
+```
+
+Or generate first and drive the bundle by hand:
 
 ```bash
 dao-ai generate-agent -c config/my_config.yaml -o ./my-bundle
 cd ./my-bundle
-uv sync                                # produces uv.lock from public PyPI
 databricks bundle deploy -t dev -p <profile>
 databricks bundle run <app-name> -t dev -p <profile>
 ```
 
-**Databricks-internal users** (local `uv` config defaults to the internal `pypi-proxy.dev.databricks.com` mirror): you need one extra step. The mirror is not reachable from Apps containers, so the lock URLs must be rewritten to public PyPI before deploy. The mirror is transparent, so hashes match — only the URLs need to change:
+The generated `requirements.txt` pins `dao-ai==<version>` (published mode) so the deploy is reproducible, or references the bundled local wheel (`./dist/<wheel>`) under `--development`. The app runtime command is bare `python -m dao_ai.apps.start_app` (chat-proxy variant) or `python -m dao_ai.apps.server` (no chat UI).
 
-```bash
-dao-ai generate-agent -c config/my_config.yaml -o ./my-bundle
-cd ./my-bundle
-uv sync                                # produces uv.lock with internal-proxy URLs
-sed -i '' \
-  -e 's|pypi-proxy\.dev\.databricks\.com/packages/|files.pythonhosted.org/packages/|g' \
-  -e 's|pypi-proxy\.dev\.databricks\.com/simple/|pypi.org/simple/|g' \
-  uv.lock
-databricks bundle deploy -t dev -p <profile>
-databricks bundle run <app-name> -t dev -p <profile>
-```
-
-Apps' native uv support (announced 2026) activates automatically when `pyproject.toml` + `uv.lock` are present and `requirements.txt` is absent. The BUILD phase runs `uv sync --locked --no-dev`; the runtime command is bare `python -m dao_ai.apps.start_app` (chat-proxy variant) or `python -m dao_ai.apps.server` (no chat UI). No `uv run` wrapper needed.
+> **Note:** A future release plans to move Apps deploys to `pyproject.toml` + a portable `uv.lock` (`uv sync --locked`); that work is not in this version, which uses `requirements.txt` + `pip`.
 
 #### Trace persistence on Apps
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -168,25 +168,11 @@ The command creates a self-contained bundle directory with everything needed to 
 | `.python-version` | Python version pin (3.11) |
 | `src/<package>/` | Stub package for custom code |
 
-### Lock file: user-owned
+### Dependency install: `requirements.txt` + pip
 
-`dao-ai generate-agent` does **not** create `uv.lock`. The lock encodes URLs and version pins that depend on the index your environment uses, so the user owns it. After `generate-agent`, run:
+`dao-ai generate-agent` writes a `requirements.txt` to the bundle. The Databricks Apps build phase installs dependencies by running `pip install -r requirements.txt` — no `uv.lock` is generated or required. Published mode (`--no-development`) pins `dao-ai==<version>` for reproducible redeploys; `--development` references the bundled local wheel (`./dist/<wheel>`) instead of PyPI.
 
-```bash
-cd ./my-bundle
-uv sync           # produces uv.lock from pyproject.toml against your default index
-```
-
-Apps' native uv support activates when both `pyproject.toml` and `uv.lock` are present and `requirements.txt` is absent — the BUILD phase runs `uv sync --locked --no-dev` for you.
-
-> **Databricks-internal users**: if your local `uv` config defaults to the internal `pypi-proxy.dev.databricks.com` mirror, your generated lock will contain URLs that Apps containers cannot reach. Rewrite them before deploy (hashes don't change — proxy is a transparent mirror):
->
-> ```bash
-> sed -i '' \
->   -e 's|pypi-proxy\.dev\.databricks\.com/packages/|files.pythonhosted.org/packages/|g' \
->   -e 's|pypi-proxy\.dev\.databricks\.com/simple/|pypi.org/simple/|g' \
->   uv.lock
-> ```
+> **Future direction:** an unmerged branch moves Apps deploys to `pyproject.toml` + a portable `uv.lock` (`uv sync --locked --no-dev`, with internal-mirror URLs rewritten to public PyPI). That is not part of this release — today's generated bundles use `requirements.txt` + pip.
 
 When `app.enable_chat_proxy` is `true` (the default), the deployed app automatically clones and builds the Databricks [e2e-chatbot-app-next](https://github.com/databricks/app-templates/tree/main/e2e-chatbot-app-next) chat UI at startup. The Apps runtime has Node.js pre-installed, so no Node.js is needed on your development machine. Set `enable_chat_proxy: false` to deploy without the chat UI.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dao-ai"
-version = "0.2.0"
+version = "0.2.4"
 description = "DAO AI: A modular, multi-agent orchestration framework for complex AI workflows. Supports agent handoff, tool integration, and dynamic configuration via YAML."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -112,7 +112,7 @@ version = "0.1.0"
 description = "DAO AI Agent: {name}"
 requires-python = ">=3.11"
 dependencies = [
-    "dao-ai{extras}>={dao_ai_version}",
+    "dao-ai{extras}=={dao_ai_version}",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -150,13 +150,15 @@ def _make_requirements_txt(
 ) -> str:
     """Build the requirements.txt content for an app bundle.
 
-    The published pin is left *unbounded* (``dao-ai``) rather than
-    floor-pinned to the locally-installed version. ``_get_dao_ai_version()``
-    reflects whatever is checked out in the developer's tree, which may
-    be an unreleased pre-publish build. Baking that floor into
-    requirements.txt would cause Apps to fail with ``Could not find a
-    version that satisfies …``. Users who need reproducibility can
-    tighten the pin by hand.
+    Published mode pins the exact installed version (``dao-ai==<version>``)
+    so a redeploy months later resolves the same release rather than
+    silently pulling whatever is newest — the deploy is reproducible. This
+    matches the Model Serving path (``create_agent`` pins
+    ``dao-ai=={dao_ai_version()}``). When generating a published bundle from
+    an unreleased local checkout the pin would name a version not yet on
+    PyPI — that is exactly what ``--development`` (bundle the local wheel) is
+    for, so ``--no-development`` legitimately assumes the version is (or will
+    be) published.
 
     Development mode: reference the bundled wheel via a relative path
     (``./dist/<wheel>``). Pip installs the wheel and resolves transitive
@@ -181,7 +183,7 @@ def _make_requirements_txt(
             )
         dao_ai_line = f"./dist/{wheel_filename}{extras}"
     else:
-        dao_ai_line = f"dao-ai{extras}"
+        dao_ai_line = f"dao-ai{extras}=={_get_dao_ai_version()}"
 
     lines = [dao_ai_line, *(pip_requirements or [])]
     return "\n".join(lines) + "\n"

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -2542,17 +2542,20 @@ def run_databricks_command(
             resolve_required_extras_or_all,
         )
         from dao_ai.pipeline.bundle import write_pipeline_bundle
-        from dao_ai.utils import resolve_use_local_source
+        from dao_ai.utils import dao_ai_version, resolve_use_local_source
 
         use_local_source: bool = resolve_use_local_source(development)
 
         # The provisioning job's serverless env installs dao-ai with exactly
         # the optional-feature extras this config exercises, so provisioning
         # notebooks (ingest, vector-search, deploy) can import feature paths.
+        # Published mode pins the exact version for reproducible re-runs
+        # (parity with Model Serving + the Apps requirements.txt); the local
+        # wheel path (set below when use_local_source) overrides this.
         extras_suffix: str = format_extras_suffix(
             resolve_required_extras_or_all(app_config, target="pipeline")
         )
-        dao_ai_dep = f"dao-ai{extras_suffix}"
+        dao_ai_dep = f"dao-ai{extras_suffix}=={dao_ai_version()}"
 
         # Regenerate the owned default dir cleanly so stale dev artifacts
         # (e.g. dist/ wheels) don't linger across dev/published switches.

--- a/src/dao_ai/mcp/generate.py
+++ b/src/dao_ai/mcp/generate.py
@@ -247,8 +247,9 @@ def _make_requirements_txt(
 ) -> str:
     """Build the requirements.txt content for an MCP app bundle.
 
-    The published pin is intentionally *unbounded* (``dao-ai[...]``) — see
-    ``dao_ai.apps.bundle._make_requirements_txt`` for the reasoning. The
+    Published mode pins the exact installed version (``dao-ai[...]==<version>``)
+    for reproducible redeploys — see ``dao_ai.apps.bundle._make_requirements_txt``
+    for the reasoning (parity with generate-agent + Model Serving). The
     ``mcp`` extra is always present (the server module needs fastmcp, uvicorn,
     etc.); any config-derived feature extras (a2a, rerank, ...) are merged in
     via ``extras``.
@@ -268,7 +269,7 @@ def _make_requirements_txt(
             )
         dao_ai_line = f"./dist/{wheel_filename}[{extras}]"
     else:
-        dao_ai_line = f"dao-ai[{extras}]"
+        dao_ai_line = f"dao-ai[{extras}]=={_get_dao_ai_version()}"
 
     lines = [dao_ai_line, *(pip_requirements or [])]
     return "\n".join(lines) + "\n"
@@ -392,7 +393,7 @@ requires-python = ">=3.11,<3.12"
 # Runtime deps live in requirements.txt (installed by Apps' build phase).
 # Kept declared here too so local `uv sync` works for iterative dev.
 dependencies = [
-    "dao-ai[{extras}]>={dao_ai_version}",
+    "dao-ai[{extras}]=={dao_ai_version}",
 ]
 
 [build-system]

--- a/src/dao_ai/pipeline/bundle.py
+++ b/src/dao_ai/pipeline/bundle.py
@@ -43,7 +43,7 @@ from dao_ai.apps.bundle import (
     dump_bundle_yaml,
 )
 from dao_ai.config import AppConfig
-from dao_ai.utils import normalize_name
+from dao_ai.utils import dao_ai_version, normalize_name
 
 # Package location of the step notebooks shipped in the wheel.
 _NOTEBOOKS_PKG = "dao_ai.pipeline.notebooks"
@@ -145,12 +145,13 @@ def generate_pipeline_databricks_yaml(config: AppConfig, development: bool) -> s
                 "description": (
                     "dao-ai dependency for the serverless environment - the "
                     "bundled './dist/<wheel>' in development mode, or the "
-                    "'dao-ai' PyPI spec otherwise, each carrying the optional-"
-                    "feature extras the config uses (e.g. 'dao-ai[a2a,rerank]'). "
-                    "Installed by the job's serverless environment before each "
-                    "task's notebook runs."
+                    "version-pinned PyPI spec otherwise, each carrying the "
+                    "optional-feature extras the config uses (e.g. "
+                    "'dao-ai[a2a,rerank]==X.Y.Z'). The CLI overrides this per "
+                    "deploy; the default pins the generating version so a raw "
+                    "``databricks bundle deploy`` stays reproducible."
                 ),
-                "default": "dao-ai",
+                "default": f"dao-ai=={dao_ai_version()}",
             },
         },
         "resources": {

--- a/tests/dao_ai/mcp/test_mcp_generate.py
+++ b/tests/dao_ai/mcp/test_mcp_generate.py
@@ -60,16 +60,17 @@ def test_write_mcp_bundle_emits_expected_files(tmp_path: Path) -> None:
     )
 
     requirements = (out / "requirements.txt").read_text().strip()
-    # The version pin must be unbounded: the locally-installed dao-ai
-    # (`_get_dao_ai_version()`) may be an unreleased pre-publish build,
-    # so floor-pinning would cause Apps to fail with ``Could not find a
-    # version that satisfies …`` at build time. The ``mcp`` extra must always
-    # be present; other extras depend on what the config exercises.
+    # Published mode pins the exact installed version for reproducible
+    # redeploys (fixed in 0.2.4; parity with generate-agent + Model Serving).
+    # The ``mcp`` extra must always be present; other extras depend on what
+    # the config exercises.
+    from dao_ai.mcp.generate import _get_dao_ai_version
+
     assert requirements.startswith("dao-ai[") and "mcp" in requirements, (
-        f"requirements.txt must install unbounded dao-ai[mcp,...]; got:\n{requirements}"
+        f"requirements.txt must install dao-ai[mcp,...]; got:\n{requirements}"
     )
-    assert "==" not in requirements, (
-        f"requirements.txt dao-ai pin must stay unbounded; got:\n{requirements}"
+    assert requirements.endswith(f"=={_get_dao_ai_version()}"), (
+        f"requirements.txt dao-ai pin must be exact-version; got:\n{requirements}"
     )
 
     databricks = (out / "databricks.yaml").read_text()

--- a/tests/dao_ai/test_autolog_config.py
+++ b/tests/dao_ai/test_autolog_config.py
@@ -21,9 +21,7 @@ Two layers:
 from __future__ import annotations
 
 import asyncio
-import importlib
-import sys
-from unittest.mock import patch
+from pathlib import Path
 
 import mlflow
 import pytest
@@ -42,27 +40,43 @@ class TestAutologCallSite:
         ["dao_ai.apps.handlers", "dao_ai.apps.model_serving"],
     )
     def test_autolog_called_with_run_tracer_inline_true(self, module_name: str) -> None:
-        sys.modules.pop(module_name, None)
-        with (
-            patch("mlflow.langchain.autolog") as mock_autolog,
-            patch("mlflow.set_registry_uri"),
-            patch("mlflow.set_tracking_uri"),
-            patch("mlflow.tracing.set_destination"),
-        ):
-            try:
-                importlib.import_module(module_name)
-            except Exception:
-                # Entry-point modules execute heavy setup at import time
-                # (AppConfig.from_file, etc.). We only need to observe the
-                # autolog kwarg, which fires before that work runs.
-                pass
-        assert mock_autolog.called, (
+        # These entry-point modules build their AppConfig at import time
+        # (``AppConfig.from_file`` in handlers; ``ModelConfig()`` +
+        # ``AppConfig(**...)`` in model_serving) *before* the autolog call, so
+        # importing them here to observe the call would require a live config +
+        # workspace auth. Assert the call-site statically instead — an AST walk
+        # over the module source pins the ``mlflow.langchain.autolog`` call and
+        # its ``run_tracer_inline=True`` kwarg without executing import-time
+        # side effects (and without leaking patches across the suite).
+        import ast
+        import importlib.util
+
+        spec = importlib.util.find_spec(module_name)
+        assert spec and spec.origin, f"cannot locate source for {module_name}"
+        tree = ast.parse(Path(spec.origin).read_text())
+
+        autolog_calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "autolog"
+            and isinstance(node.func.value, ast.Attribute)
+            and node.func.value.attr == "langchain"
+        ]
+        assert autolog_calls, (
             f"{module_name} did not call mlflow.langchain.autolog"
         )
-        _, kwargs = mock_autolog.call_args
-        assert kwargs.get("run_tracer_inline") is True, (
-            f"{module_name} must call autolog(run_tracer_inline=True); "
-            f"got kwargs={kwargs}"
+        inline_kwargs = [
+            kw
+            for call in autolog_calls
+            for kw in call.keywords
+            if kw.arg == "run_tracer_inline"
+            and isinstance(kw.value, ast.Constant)
+            and kw.value.value is True
+        ]
+        assert inline_kwargs, (
+            f"{module_name} must call autolog(run_tracer_inline=True)"
         )
 
 

--- a/tests/dao_ai/test_bundle_requirements_txt.py
+++ b/tests/dao_ai/test_bundle_requirements_txt.py
@@ -20,6 +20,7 @@ import pytest
 
 from dao_ai.apps.bundle import (
     _PYPROJECT_DEV_TEMPLATE,
+    _get_dao_ai_version,
     _make_requirements_txt,
 )
 from dao_ai.utils import dev_local_version
@@ -30,14 +31,18 @@ from dao_ai.utils import dev_local_version
 
 
 class TestMakeRequirementsTxt:
-    def test_published_installs_dao_ai_unbounded(self) -> None:
-        """The published pin is intentionally unbounded — the locally-installed
-        version may be an unreleased pre-publish build, so floor-pinning to
-        it would cause Apps to fail with ``Could not find a version``."""
+    def test_published_pins_exact_version(self) -> None:
+        """Published mode pins the exact installed version so a redeploy
+        resolves the same release rather than silently pulling whatever is
+        newest — parity with the Model Serving pin and reproducible deploys."""
         content: str = _make_requirements_txt(development=False)
-        assert content.strip() == "dao-ai", (
-            f"Published requirements.txt must install unbounded dao-ai; got: {content!r}"
+        assert content.strip() == f"dao-ai=={_get_dao_ai_version()}", (
+            f"Published requirements.txt must pin the exact version; got: {content!r}"
         )
+
+    def test_published_pins_exact_version_with_extras(self) -> None:
+        content: str = _make_requirements_txt(development=False, extras="[a2a]")
+        assert content.strip() == f"dao-ai[a2a]=={_get_dao_ai_version()}"
 
     def test_published_does_not_reference_local_wheel(self) -> None:
         content: str = _make_requirements_txt(development=False)

--- a/tests/dao_ai/test_config_vars.py
+++ b/tests/dao_ai/test_config_vars.py
@@ -1674,6 +1674,9 @@ def test_cli_run_databricks_command_forwards_vars_to_databricks_cli(
         ["bundle", "deploy"],
         config=str(parameterised_config_path),
         config_vars={"module_id": "09", "catalog": "nfleming"},
+        # Published mode: the stubbed bundle-write stages no wheel, and this
+        # test only asserts --var forwarding, not local-wheel staging.
+        development=False,
     )
 
     cmd = captured["cmd"]

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -44,6 +44,25 @@ def _stamp_extras_resolvable(mock_config: MagicMock) -> MagicMock:
         mock_config.app.pip_requirements = []
     if not isinstance(getattr(mock_config.app, "code_paths", None), list):
         mock_config.app.code_paths = []
+    # Trace-permission fields the deploy paths read at grant time. Default to
+    # the real model defaults (manage_permissions=True, experiment=None) unless
+    # a test set concrete values. ``getattr`` tolerates spec-restricted mocks.
+    if not isinstance(getattr(mock_config.app, "manage_permissions", None), bool):
+        mock_config.app.manage_permissions = True
+    if getattr(mock_config.app, "experiment", None) is None or isinstance(
+        getattr(mock_config.app, "experiment", None), MagicMock
+    ):
+        mock_config.app.experiment = None
+    # The Model-Serving grant path fires only when a service principal is
+    # declared (``manage_permissions and service_principal is not None``).
+    # Default it off so deploy tests don't spin up a real WorkspaceClient for
+    # grants they aren't asserting; tests exercising the grant path set a
+    # concrete SP themselves. ``spec``-restricted mocks block the attribute
+    # entirely (getattr returns the default and never materializes it), so set
+    # it explicitly unless a test already assigned a concrete model instance.
+    sp = getattr(mock_config.app, "service_principal", None)
+    if sp is None or isinstance(sp, MagicMock):
+        mock_config.app.service_principal = None
     return mock_config
 from dao_ai.providers.databricks import DatabricksProvider
 
@@ -709,6 +728,11 @@ def test_deploy_agent_sets_endpoint_tag():
                         # Create provider and call deploy_agent
                         provider = DatabricksProvider()
                         _stamp_extras_resolvable(mock_config)
+                        # Keep the deploy hermetic: experiment resolution would
+                        # otherwise build a live WorkspaceClient.
+                        provider.get_or_create_experiment = MagicMock(
+                            return_value=MagicMock(experiment_id="exp1")
+                        )
                         provider.deploy_agent(config=mock_config)
 
                         # Verify deploy was called with the dao_ai tag
@@ -746,6 +770,7 @@ def test_deploy_model_serving_omits_tags_when_serving_endpoint_exists():
     mock_app.monitoring = None
     mock_config.app = mock_app
     mock_config.resources = None
+    _stamp_extras_resolvable(mock_config)
 
     with patch.object(
         DatabricksProvider, "_serving_endpoint_exists", return_value=True
@@ -767,6 +792,11 @@ def test_deploy_model_serving_omits_tags_when_serving_endpoint_exists():
                             ):
                                 provider = DatabricksProvider()
                                 provider.w = MagicMock()
+                                # Keep hermetic: experiment resolution would
+                                # otherwise build a live WorkspaceClient.
+                                provider.get_or_create_experiment = MagicMock(
+                                    return_value=MagicMock(experiment_id="exp1")
+                                )
                                 provider.deploy_model_serving_agent(mock_config)
 
                                 mock_deploy.assert_called_once()
@@ -868,7 +898,7 @@ def test_deploy_agent_routes_to_apps_when_specified():
             _stamp_extras_resolvable(mock_config)
             provider.deploy_agent(config=mock_config, target=DeploymentTarget.APPS)
 
-            mock_apps.assert_called_once_with(mock_config)
+            mock_apps.assert_called_once_with(mock_config, development=None)
             mock_model_serving.assert_not_called()
 
 
@@ -2007,6 +2037,14 @@ def test_vector_store_obo_skips_client_args():
             clear=False,
         ),
         patch("dao_ai.tools.vector_search.mlflow"),
+        # Tool creation/invocation triggers column auto-discovery and a VS
+        # refresh, both of which would build a live client (DNS) against the
+        # fake host. Stub the column probe and the refresh VS client.
+        patch(
+            "dao_ai.tools.vector_search._fetch_index_columns",
+            return_value=[("col1", None, None)],
+        ),
+        patch("dao_ai.tools.vector_search.VectorSearchClient"),
     ):
         mock_dvs_instance = MagicMock()
         mock_dvs_instance.similarity_search.return_value = []
@@ -2484,6 +2522,7 @@ def test_deploy_model_serving_links_experiment_and_grants_permissions():
 
     mock_config.app = mock_app
     mock_config.resources = None
+    _stamp_extras_resolvable(mock_config)
 
     mock_experiment = MagicMock()
     mock_experiment.experiment_id = "exp123"
@@ -2609,11 +2648,12 @@ def test_deploy_apps_agent_uploads_pyproject_with_dao_ai_version_pin(tmp_path):
     requirements_text = (
         requirements_uploads[0].kwargs["content"].getvalue().decode("utf-8")
     )
-    # The published pin is intentionally unbounded — the locally-installed
-    # version may be an unreleased pre-publish build, so floor-pinning
-    # would cause Apps to fail with ``Could not find a version``.
-    assert requirements_text.strip() == "dao-ai", (
-        f"requirements.txt must install unbounded dao-ai; got: {requirements_text!r}"
+    # Published mode pins the exact installed version so a redeploy resolves
+    # the same release rather than silently pulling whatever is newest —
+    # reproducible deploys, parity with the Model Serving pin.
+    assert requirements_text.strip() == f"dao-ai=={dao_ai_version()}", (
+        f"requirements.txt must pin the exact dao-ai version; "
+        f"got: {requirements_text!r}"
     )
 
     # pyproject.toml is also uploaded with the local version pin (for
@@ -2627,7 +2667,7 @@ def test_deploy_apps_agent_uploads_pyproject_with_dao_ai_version_pin(tmp_path):
     ]
     assert pyproject_uploads
     pyproject_text = pyproject_uploads[0].kwargs["content"].getvalue().decode("utf-8")
-    assert f"dao-ai>={dao_ai_version()}" in pyproject_text
+    assert f"dao-ai=={dao_ai_version()}" in pyproject_text
 
     # app.yaml's command must be a bare ``python -m ...`` (no runtime pip
     # install) so Apps' build-phase install is the sole installer.

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -180,7 +180,12 @@ class TestPipelineEmitsDevelopmentVar:
         exec_mock = patch.object(cli, "_exec_bundle_command").start()
 
         run_databricks_command(
-            None, config=str(cfg), output_dir=str(tmp_path / "out")
+            None,
+            config=str(cfg),
+            output_dir=str(tmp_path / "out"),
+            # Published mode: the stubbed bundle-write stages no wheel; this
+            # test asserts staging + no-exec, not local-wheel resolution.
+            development=False,
         )
         patch.stopall()
 

--- a/tests/dao_ai/test_extras_deploy_paths.py
+++ b/tests/dao_ai/test_extras_deploy_paths.py
@@ -8,9 +8,14 @@ requested.
 
 import pytest
 
+from dao_ai.apps.bundle import _get_dao_ai_version
 from dao_ai.apps.bundle import _make_requirements_txt as apps_reqs
 from dao_ai.mcp.generate import _make_requirements_txt as mcp_reqs
 from dao_ai.utils import get_installed_packages
+
+# Published-mode bundles pin the exact installed version for reproducible
+# redeploys (was previously unbounded; fixed in 0.2.4).
+VER = _get_dao_ai_version()
 
 
 # ---------------------------------------------------------------------------
@@ -18,12 +23,15 @@ from dao_ai.utils import get_installed_packages
 # ---------------------------------------------------------------------------
 @pytest.mark.unit
 def test_apps_published_no_extras() -> None:
-    assert apps_reqs(development=False) == "dao-ai\n"
+    assert apps_reqs(development=False) == f"dao-ai=={VER}\n"
 
 
 @pytest.mark.unit
 def test_apps_published_with_extras() -> None:
-    assert apps_reqs(development=False, extras="[a2a,rerank]") == "dao-ai[a2a,rerank]\n"
+    assert (
+        apps_reqs(development=False, extras="[a2a,rerank]")
+        == f"dao-ai[a2a,rerank]=={VER}\n"
+    )
 
 
 @pytest.mark.unit
@@ -47,7 +55,7 @@ def test_apps_appends_user_pip_requirements_published() -> None:
         extras="[a2a]",
         pip_requirements=["cowsay==6.1", "my-internal-lib>=1.0"],
     )
-    assert out == "dao-ai[a2a]\ncowsay==6.1\nmy-internal-lib>=1.0\n"
+    assert out == f"dao-ai[a2a]=={VER}\ncowsay==6.1\nmy-internal-lib>=1.0\n"
 
 
 @pytest.mark.unit
@@ -63,8 +71,8 @@ def test_apps_appends_user_pip_requirements_dev() -> None:
 @pytest.mark.unit
 def test_apps_no_user_pip_requirements_unchanged() -> None:
     # Empty/None user deps must not alter the single dao-ai line.
-    assert apps_reqs(development=False, pip_requirements=[]) == "dao-ai\n"
-    assert apps_reqs(development=False, pip_requirements=None) == "dao-ai\n"
+    assert apps_reqs(development=False, pip_requirements=[]) == f"dao-ai=={VER}\n"
+    assert apps_reqs(development=False, pip_requirements=None) == f"dao-ai=={VER}\n"
 
 
 # ---------------------------------------------------------------------------
@@ -72,12 +80,12 @@ def test_apps_no_user_pip_requirements_unchanged() -> None:
 # ---------------------------------------------------------------------------
 @pytest.mark.unit
 def test_mcp_published_default_mcp_extra() -> None:
-    assert mcp_reqs(development=False) == "dao-ai[mcp]\n"
+    assert mcp_reqs(development=False) == f"dao-ai[mcp]=={VER}\n"
 
 
 @pytest.mark.unit
 def test_mcp_published_merged_extras() -> None:
-    assert mcp_reqs(development=False, extras="mcp,a2a") == "dao-ai[mcp,a2a]\n"
+    assert mcp_reqs(development=False, extras="mcp,a2a") == f"dao-ai[mcp,a2a]=={VER}\n"
 
 
 @pytest.mark.unit
@@ -91,7 +99,7 @@ def test_mcp_appends_user_pip_requirements() -> None:
     out = mcp_reqs(
         development=False, extras="mcp", pip_requirements=["cowsay==6.1"]
     )
-    assert out == "dao-ai[mcp]\ncowsay==6.1\n"
+    assert out == f"dao-ai[mcp]=={VER}\ncowsay==6.1\n"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/dao_ai/test_grant_trace_permissions.py
+++ b/tests/dao_ai/test_grant_trace_permissions.py
@@ -1,4 +1,4 @@
-"""Tests for ``_grant_trace_permissions_to_principal``.
+"""Tests for ``_grant_uc_trace_table_permissions_to_principal``.
 
 The helper must issue the exact set of UC grants the Databricks docs
 prescribe for MLflow trace persistence:
@@ -25,12 +25,14 @@ import pytest
 
 @pytest.mark.unit
 def test_helper_grants_all_documented_privileges() -> None:
-    from dao_ai.providers.databricks import _grant_trace_permissions_to_principal
+    from dao_ai.providers.databricks import (
+        _grant_uc_trace_table_permissions_to_principal,
+    )
 
     with patch("databricks.sdk.WorkspaceClient") as mock_wc:
         mock_client = MagicMock()
         mock_wc.return_value = mock_client
-        _grant_trace_permissions_to_principal(
+        _grant_uc_trace_table_permissions_to_principal(
             principal="sp-uuid",
             catalog_name="cat",
             schema_name="sch",
@@ -68,7 +70,9 @@ def test_helper_grants_all_documented_privileges() -> None:
 
 @pytest.mark.unit
 def test_helper_survives_individual_grant_failures() -> None:
-    from dao_ai.providers.databricks import _grant_trace_permissions_to_principal
+    from dao_ai.providers.databricks import (
+        _grant_uc_trace_table_permissions_to_principal,
+    )
 
     call_count = 0
 
@@ -82,7 +86,7 @@ def test_helper_survives_individual_grant_failures() -> None:
         mock_client = MagicMock()
         mock_client.api_client.do.side_effect = flaky_do
         mock_wc.return_value = mock_client
-        _grant_trace_permissions_to_principal(
+        _grant_uc_trace_table_permissions_to_principal(
             principal="sp-uuid",
             catalog_name="cat",
             schema_name="sch",

--- a/tests/dao_ai/test_link_trace_destination_cli.py
+++ b/tests/dao_ai/test_link_trace_destination_cli.py
@@ -187,11 +187,16 @@ class TestHandleCommand:
             patch(
                 "dao_ai.providers.databricks._link_experiment_trace_location"
             ) as link,
+            patch("dao_ai.cli._grant_trace_writes_to_app_sp"),
         ):
             ac.from_file.return_value = cfg
             handle_link_trace_destination_command(
                 Namespace(
-                    config="cfg.yaml", profile=None, experiment_id=None, var=None
+                    config="cfg.yaml",
+                    profile=None,
+                    experiment_id=None,
+                    var=None,
+                    app_sp=None,
                 )
             )
         link.assert_called_once_with(cfg, "exp42")

--- a/tests/dao_ai/test_pipeline_bundle.py
+++ b/tests/dao_ai/test_pipeline_bundle.py
@@ -33,6 +33,7 @@ from dao_ai.pipeline.bundle import (
     generate_pipeline_databricks_yaml,
     write_pipeline_bundle,
 )
+from dao_ai.utils import dao_ai_version
 
 _MINIMAL_CONFIG = """\
 resources:
@@ -87,10 +88,14 @@ class TestPackagedAssets:
 
 
 class _AppStub:
-    """Minimal stand-in — the generator only reads ``config.app.name``."""
+    """Minimal stand-in — the generator reads ``config.app.name`` and
+    ``config.app.pip_requirements`` (extra deps folded into the job env)."""
 
-    def __init__(self, name: str) -> None:
+    def __init__(
+        self, name: str, pip_requirements: list[str] | None = None
+    ) -> None:
         self.name = name
+        self.pip_requirements = pip_requirements or []
 
 
 @pytest.mark.unit
@@ -144,8 +149,9 @@ class TestGeneratePipelineDatabricksYaml:
 
     def test_env_spec_installs_dao_ai_via_bundle_var(self) -> None:
         doc = self._doc(development=False)
-        # The dao_ai_dep variable exists (defaults to the PyPI spec).
-        assert doc["variables"]["dao_ai_dep"]["default"] == "dao-ai"
+        # The dao_ai_dep variable exists and defaults to the version-pinned
+        # PyPI spec so a raw ``bundle deploy`` (no CLI override) is reproducible.
+        assert doc["variables"]["dao_ai_dep"]["default"] == f"dao-ai=={dao_ai_version()}"
         # The serverless environment installs exactly the dao_ai_dep dependency.
         env = doc["resources"]["jobs"]["deploy_job"]["environments"][0]
         assert env["spec"]["dependencies"] == ["${var.dao_ai_dep}"]

--- a/tests/dao_ai/test_reranking.py
+++ b/tests/dao_ai/test_reranking.py
@@ -112,8 +112,14 @@ class TestRetrieverModelWithReranker:
 class TestVectorSearchToolCreation:
     """Unit tests for vector search tool creation using @tool decorator pattern."""
 
+    @patch(
+        "dao_ai.tools.vector_search._fetch_index_columns",
+        return_value=[("text", None, None)],
+    )
     @patch("dao_ai.tools.vector_search.DatabricksVectorSearch")
-    def test_creates_tool_without_reranker(self, mock_vector_search: MagicMock) -> None:
+    def test_creates_tool_without_reranker(
+        self, mock_vector_search: MagicMock, mock_fetch_cols: MagicMock
+    ) -> None:
         """Test that tool is created without reranker when not configured."""
         # Create mock retriever config without reranking
         retriever_config = Mock(spec=AiSearchRetrieverModel)
@@ -147,12 +153,17 @@ class TestVectorSearchToolCreation:
         # Description includes filter columns when columns are specified
         assert tool.description.startswith("Test description")
 
+    @patch(
+        "dao_ai.tools.vector_search._fetch_index_columns",
+        return_value=[("text", None, None), ("metadata", None, None)],
+    )
     @patch("dao_ai.providers.databricks.DatabricksProvider")
     @patch("dao_ai.tools.vector_search.DatabricksVectorSearch")
     def test_creates_tool_from_vector_store_directly(
         self,
         mock_vector_search: MagicMock,
         mock_provider_class: MagicMock,
+        mock_fetch_cols: MagicMock,
     ) -> None:
         """Test that tool can be created from VectorStoreModel directly with defaults."""
         # Mock the provider to avoid actual Databricks calls
@@ -186,9 +197,12 @@ class TestVectorSearchToolCreation:
         # Verify tool was created
         assert hasattr(tool, "invoke")
         assert tool.name == "test_tool"
-        # Description includes filter columns when columns are specified
+        # Description includes filter columns when columns are specified.
+        # 0.2.0 renders the upstream-databricks-langchain bullet format.
         assert tool.description.startswith("Test description")
-        assert "Available filter columns: text, metadata" in tool.description
+        assert "Available columns for filtering:" in tool.description
+        assert "- text" in tool.description
+        assert "- metadata" in tool.description
 
         # DatabricksVectorSearch uses lazy initialization - it's only created when
         # the tool is invoked. Verify the tool structure is correct without invoking.
@@ -218,8 +232,14 @@ class TestVectorSearchToolCreation:
                 retriever=retriever_config, vector_store=vector_store_config
             )
 
+    @patch(
+        "dao_ai.tools.vector_search._fetch_index_columns",
+        return_value=[("text", None, None)],
+    )
     @patch("dao_ai.tools.vector_search.DatabricksVectorSearch")
-    def test_creates_tool_with_reranker(self, mock_vector_search: MagicMock) -> None:
+    def test_creates_tool_with_reranker(
+        self, mock_vector_search: MagicMock, mock_fetch_cols: MagicMock
+    ) -> None:
         """Test that tool is created with reranker when configured."""
         # Create mock retriever config with reranking
         reranker_config = RerankParametersModel(
@@ -309,10 +329,17 @@ class TestRerankingE2E:
         assert reranker2.top_n == 5
         assert reranker2.cache_dir == "/tmp/test"
 
+    @patch(
+        "dao_ai.tools.vector_search._fetch_index_columns",
+        return_value=[("text", None, None)],
+    )
     @patch("dao_ai.tools.vector_search.DatabricksVectorSearch")
     @patch("mlflow.models.set_retriever_schema")
     def test_tool_creation_flow(
-        self, mock_set_schema: MagicMock, mock_vector_search: MagicMock
+        self,
+        mock_set_schema: MagicMock,
+        mock_vector_search: MagicMock,
+        mock_fetch_cols: MagicMock,
     ) -> None:
         """Test that create_vector_search_tool returns a callable tool."""
         # Create mock retriever config

--- a/tests/dao_ai/test_resource_protocol.py
+++ b/tests/dao_ai/test_resource_protocol.py
@@ -79,10 +79,12 @@ class TestPolymorphicIteration:
 
         all_models = [schema, room, vs, warehouse, table]
         provisionable = [m for m in all_models if isinstance(m, Provisionable)]
+        # ``VectorStoreModel`` is an alias for ``AiSearchVectorStoreModel``
+        # after the Vector Search → AI Search rebrand.
         assert {type(m).__name__ for m in provisionable} == {
             "SchemaModel",
             "GenieRoomModel",
-            "VectorStoreModel",
+            "AiSearchVectorStoreModel",
         }
 
     def test_filter_refreshable_from_mixed_list(self):
@@ -93,7 +95,7 @@ class TestPolymorphicIteration:
         refreshable = [m for m in (schema, room, vs) if isinstance(m, Refreshable)]
         assert {type(m).__name__ for m in refreshable} == {
             "GenieRoomModel",
-            "VectorStoreModel",
+            "AiSearchVectorStoreModel",
         }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -946,7 +946,7 @@ wheels = [
 
 [[package]]
 name = "dao-ai"
-version = "0.2.0"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "databricks-agents" },


### PR DESCRIPTION
## Summary

Validation pass for the **0.2.4** release plus a customer-reported fix. Version bumped `0.2.0` → `0.2.4` (the `v0.2.0`–`v0.2.3` tags are already taken by an unrelated orphaned history, so this avoids any tag/PyPI collision).

### 1. Fix: generated deploy bundles now pin `dao-ai==<version>` (published mode)
A customer noticed generated bundles didn't pin the dao-ai version. In published (`--no-development`) mode, `generate-agent` / `generate-mcp` / `generate-workflow` wrote an **unbounded** `dao-ai` (and a `>=` floor in `pyproject.toml`), so a redeploy months later silently pulled whatever was newest on PyPI — non-reproducible.

Now all generators emit `dao-ai[extras]==<version>` in `requirements.txt` and `pyproject.toml`, matching the Model Serving path (`create_agent` already pinned `==`). `generate-mcp` had its own duplicate templates that also needed fixing. `--development` is unchanged — it references the bundled local wheel by path.

### 2. Release validation
- **Fixed ~13 stale unit tests** that encoded 0.2.0's own renames/migrations as expected behavior (grant-fn rename, new `app.pip_requirements` / `manage_permissions` / `experiment` fields, `deploy_apps_agent(development=)` kwarg, `VectorStoreModel`→`AiSearchVectorStoreModel` alias, reranker description wording, and `_fetch_index_columns`/`VectorSearchClient` network calls leaking into unit tests). Replaced a leaky `__new__` patch in `test_autolog_config` with a static AST assertion of the autolog call-site.
- **Docs:** corrected README + `cli-reference.md` — they claimed Apps deploy uses uv (`uv sync --locked`), but this release installs via `requirements.txt` + `pip`. (The uv.lock deploy path is a separate unmerged branch, noted as future direction.) Also fixed a stale CHANGELOG `requirements.txt` note for `generate-workflow`.
- **CHANGELOG:** `[0.2.0]` → `[0.2.4]` (2026-07-23) with a new `### Fixed` entry for the pin.

### Verification
- Unit suite: **1781 passed, 0 failed, 1 xfailed** (run with `MLFLOW_ALLOW_FILE_STORE=true`, `--timeout-method=signal`, `fevm` profile — see notes below).
- Config schema in sync (`make schema` clean); wheel + sdist build.
- **Live on FEVM (`--development`):** Model Serving (v23, real tool-backed inference + 18 trace spans persisted to UC), `generate-agent` Apps (deployed + RUNNING), `generate-mcp` Apps (agent-as-tool exposed, RUNNING). All net-new resources torn down. `generate-workflow` pin change is unit-covered.

### Notes for reviewers
- No functional runtime behavior changed beyond the dependency pin string; the rest is tests + docs + version.
- Local unit runs need `MLFLOW_ALLOW_FILE_STORE=true` (newer MLflow refuses the `./mlruns` file store) and a valid Databricks profile; these are environmental, not shipped-code issues.

This pull request and its description were written by Isaac.