### PR TITLE
generate-workflow --development extras fix + 0.2.4 release test hardening

### DIFF
--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -2584,7 +2584,15 @@ def run_databricks_command(
                     "Development pipeline bundle has no staged dao-ai wheel "
                     f"under {staging_dir / 'dist'}."
                 )
-            dao_ai_dep = f"./dist/{staged_wheels[-1].name}{extras_suffix}"
+            # Bare wheel path — NO ``[extras]`` suffix. ``databricks bundle``
+            # treats a serverless-env dependency that looks like a local path as
+            # an artifact and *globs* it, so any ``[...]`` (extras) is parsed as
+            # a glob character class → "no files match pattern". The extras'
+            # backing packages are instead pinned as separate PyPI deps in the
+            # env spec (glob-safe) at bundle-generation time — same approach as
+            # the Model Serving dev path (``get_installed_packages``). See
+            # ``generate_pipeline_databricks_yaml``.
+            dao_ai_dep = f"./dist/{staged_wheels[-1].name}"
 
     # Use app-specific cloud target: {app_name}-{cloud}
     # This ensures each app has unique deployment identity while supporting cloud-specific settings

--- a/src/dao_ai/pipeline/bundle.py
+++ b/src/dao_ai/pipeline/bundle.py
@@ -102,11 +102,26 @@ def generate_pipeline_databricks_yaml(config: AppConfig, development: bool) -> s
     for glob in _asset_sync_globs(config):
         if glob not in sync_include:
             sync_include.append(glob)
+    # Development mode: the ``dao_ai_dep`` var is a BARE local wheel path (no
+    # ``[extras]`` — the bundle globs local-path deps, and ``[a2a]`` would be a
+    # glob char class). So the optional-feature extras the config needs can't
+    # ride on the wheel; pin their backing packages as separate, glob-safe PyPI
+    # deps instead — same approach as the Model Serving dev path. Published mode
+    # keeps extras on the ``dao-ai[extras]==ver`` spec (a PyPI spec is glob-safe).
+    extra_dep_pins: list[str] = []
     if development:
         # The bundle CLI excludes .whl by default; include the staged wheel so
         # the serverless environment can install it (../dist/<wheel> via the
         # ``dao_ai_dep`` variable).
         sync_include.append("dist/*.whl")
+
+        from dao_ai._extras import expand_all, resolve_required_extras_or_all
+        from dao_ai.utils import get_installed_packages
+
+        required_extras = expand_all(
+            resolve_required_extras_or_all(config, target="pipeline")
+        )
+        extra_dep_pins = get_installed_packages(required_extras)
 
     tasks: list[dict[str, Any]] = []
     for task_key, notebook, depends_on, extra_params in _PIPELINE_TASKS:
@@ -164,12 +179,14 @@ def generate_pipeline_databricks_yaml(config: AppConfig, development: bool) -> s
                             "environment_key": "dao-ai-env",
                             "spec": {
                                 "environment_version": "5",
-                                # dao-ai (+ resolved extras) via the var, then
-                                # any user-declared extra pip packages so the
-                                # provisioning notebooks' custom code has its
-                                # deps (parity with Model Serving / Apps).
+                                # dao-ai via the var (published: dao-ai[extras]==ver;
+                                # development: bare local wheel), then the dev-mode
+                                # extra-feature package pins (glob-safe PyPI specs,
+                                # empty in published mode), then any user-declared
+                                # extra pip packages. Parity with Model Serving / Apps.
                                 "dependencies": [
                                     "${var.dao_ai_dep}",
+                                    *extra_dep_pins,
                                     *(
                                         list(config.app.pip_requirements)
                                         if config.app

--- a/tests/dao_ai/genie/test_prompt_history.py
+++ b/tests/dao_ai/genie/test_prompt_history.py
@@ -1,9 +1,16 @@
 """Unit and integration tests for prompt history tracking in context-aware cache."""
 
+import os
 from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
+
+# The live Genie space this test exercises. Overridable via env so the test
+# isn't brittle to workspace drift (the default may be deleted/rotated in FEVM).
+GENIE_SPACE_ID: str = os.getenv(
+    "DAO_AI_TEST_GENIE_SPACE_ID", "01f0c482e842191587af6a40ad4044d8"
+)
 
 from dao_ai.config import (
     DatabaseModel,
@@ -401,8 +408,9 @@ class TestPromptHistoryIntegration:
 
         from dao_ai.genie.core import GenieService
 
-        # Use provided Genie space ID for testing
-        genie_space_id = "01f0c482e842191587af6a40ad4044d8"
+        # Genie space ID — overridable via DAO_AI_TEST_GENIE_SPACE_ID so the
+        # test survives workspace drift (the default may be rotated in FEVM).
+        genie_space_id = GENIE_SPACE_ID
 
         # Use unique table names for this test run to avoid permission issues
         import uuid
@@ -419,7 +427,15 @@ class TestPromptHistoryIntegration:
             embedding_model="databricks-gte-large-en",
         )
 
-        genie = Genie(space_id=genie_space_id)
+        from databricks.sdk.errors.platform import NotFound
+
+        try:
+            genie = Genie(space_id=genie_space_id)
+        except NotFound:
+            pytest.skip(
+                f"Genie space {genie_space_id} not found in this workspace; set "
+                "DAO_AI_TEST_GENIE_SPACE_ID to a live space to run this test."
+            )
         genie_service = GenieService(genie)
 
         cache_service = PostgresContextAwareGenieService(

--- a/tests/dao_ai/test_extras.py
+++ b/tests/dao_ai/test_extras.py
@@ -301,3 +301,106 @@ def test_non_notebook_returns_precise(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("dao_ai.utils.is_in_notebook", lambda: False)
     cfg = _config(app=_app(a2a=A2AModel(enabled=True)))
     assert _extras.resolve_required_extras_or_all(cfg, target="apps") == {"a2a"}
+
+
+@pytest.mark.unit
+def test_import_dao_ai_tools_does_not_eagerly_import_optional_packages() -> None:
+    """Guard the lazy-import contract: ``import dao_ai.tools`` must succeed
+    without pulling in the optional-extra packages (flashrank/langmem/a2a/ddgs/
+    deepagents). They are imported lazily inside factory functions behind
+    ``require_extra`` guards, so a base install (no extras) can import the
+    package tree. Run in a subprocess for a clean module table."""
+    import subprocess
+    import sys
+
+    code = (
+        "import sys, dao_ai.tools; "
+        "opt=['flashrank','langmem','a2a','ddgs','deepagents']; "
+        "leaked=[m for m in opt if m in sys.modules]; "
+        "print('LEAKED:'+','.join(leaked))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    )
+    leaked_line = [
+        ln for ln in result.stdout.splitlines() if ln.startswith("LEAKED:")
+    ]
+    assert leaked_line, f"probe produced no LEAKED line; stdout={result.stdout!r}"
+    leaked = leaked_line[0].removeprefix("LEAKED:").strip()
+    assert leaked == "", (
+        f"import dao_ai.tools eagerly imported optional packages: {leaked}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Permutation matrix — feature combinations resolved across ALL deploy targets.
+# Complements the single-feature tests above: verifies unioning + the one
+# target-dependent rule (default A2A routes count on apps/mcp/pipeline, never
+# on model_serving).
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestExtrasPermutationMatrix:
+    _ALL_TARGETS = ("apps", "mcp", "pipeline", "model_serving")
+
+    def _search_tool(self):
+        return {"web": ToolModel(name="web", function=SearchToolModel(type="search"))}
+
+    def _reranking_retriever_tool(self):
+        return {
+            "vs": ToolModel(
+                name="vs",
+                function=AiSearchToolModel(
+                    type="vector_search",
+                    retriever=_ai_search_retriever(
+                        rerank=RerankParametersModel(model="ms-marco-MiniLM-L-6-v2")
+                    ),
+                ),
+            )
+        }
+
+    def test_empty_config_no_extras_all_targets(self) -> None:
+        cfg = _config(app=_app(a2a=A2AModel(enabled=False)))
+        for t in self._ALL_TARGETS:
+            assert _extras.resolve_required_extras(cfg, target=t) == set(), t
+
+    def test_default_a2a_routes_target_dependent(self) -> None:
+        # AppModel.a2a defaults enabled → routes pull a2a on route-bearing
+        # targets, never on model_serving.
+        cfg = _config(app=_app())  # a2a defaults enabled
+        for t in ("apps", "mcp", "pipeline"):
+            assert "a2a" in _extras.resolve_required_extras(cfg, target=t), t
+        assert "a2a" not in _extras.resolve_required_extras(
+            cfg, target="model_serving"
+        )
+
+    def test_search_plus_rerank_union_all_targets(self) -> None:
+        tools = {**self._search_tool(), **self._reranking_retriever_tool()}
+        cfg = _config(tools=tools, app=_app(a2a=A2AModel(enabled=False)))
+        for t in self._ALL_TARGETS:
+            got = _extras.resolve_required_extras(cfg, target=t)
+            assert got == {"search", "rerank"}, (t, got)
+
+    def test_excel_dataset_plus_default_a2a(self) -> None:
+        cfg = _config(
+            datasets=[DatasetModel(table=None, ddl=None, data=None, format="excel")],
+            app=_app(),  # a2a enabled
+        )
+        assert _extras.resolve_required_extras(cfg, target="apps") == {"excel", "a2a"}
+        assert _extras.resolve_required_extras(cfg, target="model_serving") == {"excel"}
+
+    def test_kitchen_sink_unions_everything_apps(self) -> None:
+        tools = {**self._search_tool(), **self._reranking_retriever_tool()}
+        cfg = _config(
+            tools=tools,
+            memory=MemoryModel(store=StoreModel(name="s")),
+            datasets=[DatasetModel(table=None, ddl=None, data=None, format="excel")],
+            app=_app(
+                a2a=A2AModel(enabled=True),
+                orchestration=OrchestrationModel(deep_agent=DeepAgentModel(name="da")),
+            ),
+        )
+        got = _extras.resolve_required_extras(cfg, target="apps")
+        assert got == {"search", "rerank", "memory", "excel", "a2a", "deepagents"}, got
+        # model_serving drops only the route-driven a2a (no explicit a2a tool).
+        got_ms = _extras.resolve_required_extras(cfg, target="model_serving")
+        assert got_ms == {"search", "rerank", "memory", "excel", "deepagents"}, got_ms

--- a/tests/dao_ai/test_inference_endpoint_alias.py
+++ b/tests/dao_ai/test_inference_endpoint_alias.py
@@ -163,3 +163,64 @@ class TestAppConfigEndToEnd:
             }
         )
         assert cfg_models.resources.models == cfg_llms.resources.models
+
+
+@pytest.mark.unit
+class TestNullableSamplingDefaults:
+    """0.2.x: ``temperature`` / ``max_tokens`` default to ``None`` and, when
+    unset, are omitted from the outbound request so the serving endpoint uses
+    its own default (unblocks reasoning-mode endpoints that reject any
+    ``temperature``). Set values pass through unchanged."""
+
+    def test_defaults_are_none(self) -> None:
+        m = InferenceEndpointModel(name="databricks-claude-sonnet-4-5")
+        assert m.temperature is None
+        assert m.max_tokens is None
+
+    def test_unset_fields_omitted_from_request_payload(self) -> None:
+        from langchain_core.messages import HumanMessage
+
+        chat = InferenceEndpointModel(
+            name="databricks-claude-sonnet-4-5"
+        ).as_chat_model()
+        # as_chat_model may wrap in fallbacks/best_of_n; unwrap to the base client.
+        base = getattr(chat, "runnable", chat)
+        inputs = base._prepare_inputs([HumanMessage("hi")])
+        assert "temperature" not in inputs, (
+            f"unset temperature must be omitted from the payload; got {inputs.keys()}"
+        )
+        assert "max_tokens" not in inputs, (
+            f"unset max_tokens must be omitted from the payload; got {inputs.keys()}"
+        )
+
+    def test_set_fields_present_in_request_payload(self) -> None:
+        from langchain_core.messages import HumanMessage
+
+        chat = InferenceEndpointModel(
+            name="databricks-claude-sonnet-4-5", temperature=0.7, max_tokens=128
+        ).as_chat_model()
+        base = getattr(chat, "runnable", chat)
+        inputs = base._prepare_inputs([HumanMessage("hi")])
+        assert inputs.get("temperature") == 0.7
+        assert inputs.get("max_tokens") == 128
+
+
+@pytest.mark.unit
+class TestPromptModelInlineTemplate:
+    """0.2.x removed the MLflow prompt registry: ``PromptModel`` carries its
+    template inline via ``template`` (required) and rejects the old
+    registry-era ``default_template`` field (``extra="forbid"``)."""
+
+    def test_template_is_required_and_inline(self) -> None:
+        from dao_ai.config import PromptModel
+
+        p = PromptModel(name="greeting", template="You are helpful.")
+        assert p.template == "You are helpful."
+
+    def test_legacy_default_template_field_rejected(self) -> None:
+        from pydantic import ValidationError
+
+        from dao_ai.config import PromptModel
+
+        with pytest.raises(ValidationError):
+            PromptModel(name="greeting", default_template="You are helpful.")

--- a/tests/dao_ai/test_pipeline_bundle.py
+++ b/tests/dao_ai/test_pipeline_bundle.py
@@ -87,25 +87,41 @@ class TestPackagedAssets:
 # ---------------------------------------------------------------------------
 
 
+class _A2AStub:
+    """Stand-in for AppModel.a2a — the extras resolver reads ``.enabled``."""
+
+    enabled = False
+
+
 class _AppStub:
-    """Minimal stand-in — the generator reads ``config.app.name`` and
-    ``config.app.pip_requirements`` (extra deps folded into the job env)."""
+    """Minimal stand-in — the generator reads ``config.app.name``,
+    ``config.app.pip_requirements``, and (in dev mode, via the extras resolver)
+    ``config.app.a2a`` / ``config.app.orchestration``."""
 
     def __init__(
         self, name: str, pip_requirements: list[str] | None = None
     ) -> None:
         self.name = name
         self.pip_requirements = pip_requirements or []
+        # Resolver-touched attributes (dev-mode extras resolution).
+        self.a2a = _A2AStub()
+        self.orchestration = None
 
 
 @pytest.mark.unit
 class TestGeneratePipelineDatabricksYaml:
     @staticmethod
     def _config() -> AppConfig:
+        # ``model_construct`` bypasses validation; set the collections the
+        # extras resolver iterates so dev-mode resolution finds them empty.
         return AppConfig.model_construct(
             app=_AppStub("pipeline_test_app"),
             datasets=[],
             unity_catalog_functions=[],
+            tools={},
+            retrievers={},
+            middleware={},
+            memory=None,
         )
 
     def _doc(self, development: bool) -> dict:
@@ -155,6 +171,28 @@ class TestGeneratePipelineDatabricksYaml:
         # The serverless environment installs exactly the dao_ai_dep dependency.
         env = doc["resources"]["jobs"]["deploy_job"]["environments"][0]
         assert env["spec"]["dependencies"] == ["${var.dao_ai_dep}"]
+
+    def test_dev_env_deps_are_glob_safe_no_extras_on_wheel(self) -> None:
+        # Regression guard: databricks bundle globs local-path env deps, so the
+        # dev-mode wheel dep must NOT carry an ``[extras]`` suffix (a glob char
+        # class → "no files match pattern"). Extras' backing packages are pinned
+        # as separate glob-safe PyPI deps instead.
+        env = self._doc(development=True)["resources"]["jobs"]["deploy_job"][
+            "environments"
+        ][0]
+        deps = env["spec"]["dependencies"]
+        # First dep is the wheel var; no dependency entry may contain "[" (extras
+        # bracket) on a local path.
+        for dep in deps:
+            if dep.endswith(".whl") or "dist/" in dep or dep == "${var.dao_ai_dep}":
+                assert "[" not in dep, f"wheel dep must be glob-safe (no extras): {dep!r}"
+        # In development, the extra-feature package pins are present (glob-safe
+        # PyPI specs like "a2a-sdk==..."). The stub config exercises no optional
+        # features, so at minimum the core pins (e.g. mlflow) appear.
+        joined = " ".join(deps)
+        assert "mlflow" in joined or "databricks-agents" in joined, (
+            f"dev env deps should include glob-safe PyPI pins; got {deps}"
+        )
 
     def test_no_artifacts_block(self) -> None:
         # The dao-ai wheel is never built at bundle-deploy time.


### PR DESCRIPTION
## Summary

Two things, from the 0.1.115 → 0.2.4 feature-validation pass:

### 1. Fix: `generate-workflow --development` dependency regression
Dev-mode workflow deploys were **completely broken**: `dao_ai_dep` was set to `./dist/<wheel>[a2a]`, and `databricks bundle deploy` globs local-path serverless-env dependencies, so `[a2a]` was parsed as a glob character class → `Error: no files match pattern`. Introduced by `a44e533` (the extras split). Published mode was unaffected (`dao-ai[a2a]==ver` is a glob-safe PyPI spec).

**Fix:** in dev mode `dao_ai_dep` is the **bare wheel path** (glob-safe), and the config's optional-feature extras are pinned as **separate glob-safe PyPI deps** in the env spec — mirroring how the Model Serving dev path already handles this (`get_installed_packages`). Files: `src/dao_ai/cli.py`, `src/dao_ai/pipeline/bundle.py`.

### 2. Test hardening for the 0.1.115 → 0.2.4 feature delta
- **Nullable sampling defaults**: `temperature`/`max_tokens` are omitted from the request payload when unset, present when set.
- **Prompt registry removal**: `PromptModel` carries an inline `template`; legacy `default_template` is rejected.
- **Lazy-import contract**: `import dao_ai.tools` doesn't eagerly import optional packages (flashrank/langmem/a2a/ddgs/deepagents).
- **Extras permutation matrix**: correct extras resolution across all deploy targets (a2a routes on apps/mcp/pipeline but not model_serving; search+rerank+memory+excel+deepagents unioning).
- **Workflow dev deps glob-safe**: regression guard for the fix above.
- **Genie integration test**: space id overridable via `DAO_AI_TEST_GENIE_SPACE_ID`, self-skips on `NotFound` (was hardcoded to a since-deleted space).

## Validation

- **Live on FEVM (all 4 generate paths / dao-ai deploy):**
  - `generate-agent` → Apps: deployed via `uv sync --locked` (uv.lock, no requirements.txt), RUNNING, live inference 200, trace persisted to UC (only benign LangGraph `ParentCommand` handoff spans).
  - `generate-mcp` → Apps: agent-as-tool, `isError:false`, structured `AgentInvocationResult`, **OBO passthrough** (`obo_present:true`), full `_meta.databricks` block, clean trace.
  - `generate-workflow` → Job: **full 8-task provisioning DAG ran green** (ingest / VS / lakebase / UC fns / genie / deploy-agents / eval-data / run-evaluation all SUCCESS) — validates this PR's dev-extras fix end-to-end.
  - Model Serving: blocked locally by the pre-existing protobuf/pyspark dependency knot (#211), not a 0.2.4 regression.
- **Unit suite:** 1779 passed, 1 xfailed, 1 pre-existing pyspark-env flake (`test_converts_struct_columns_via_json`, fails identically on `main`).
- `make schema` in sync; `make dist` builds; committed `uv.lock` clean.

## Notes for reviewers
- The only runtime behavior change is the dev-mode workflow `dao_ai_dep` construction; the rest is tests.
- Related findings surfaced during validation: `inventory.sql` uses `CREATE OR REPLACE TABLE` (vs `products.sql`'s idempotent `CREATE TABLE IF NOT EXISTS` — minor, not a VS source); the VS index self-heal / source-GUID stale detection (`_index_is_stale`) is present and working (verified live: `products_index` healthy, 38,291 rows, non-stale pipeline). See #211 for the protobuf/pyspark knot.

This pull request and its description were written by Isaac.