### PR TITLE
Idempotent DDL for AI Search index source tables

### DIFF
--- a/examples/15_complete_applications/hardware_store/data/inventory.sql
+++ b/examples/15_complete_applications/hardware_store/data/inventory.sql
@@ -1,6 +1,6 @@
 USE IDENTIFIER(:database);
 
-CREATE OR REPLACE TABLE inventory (
+CREATE TABLE IF NOT EXISTS inventory (
   inventory_id BIGINT COMMENT 'Unique identifier for each inventory record' NOT NULL PRIMARY KEY
   ,product_id BIGINT COMMENT 'Foreign key reference to the product table identifying the specific product' NOT NULL 
   ,store STRING COMMENT 'Store identifier where inventory is located' NOT NULL

--- a/examples/15_complete_applications/quick_serve_restaurant/data/items_description.sql
+++ b/examples/15_complete_applications/quick_serve_restaurant/data/items_description.sql
@@ -1,6 +1,6 @@
 USE IDENTIFIER(:database);
 
-CREATE OR REPLACE TABLE items_description (
+CREATE TABLE IF NOT EXISTS items_description (
   item_name STRING,
   item_review STRING)
 USING delta


### PR DESCRIPTION
## Summary

Audited every example config with a configured `source_table` and validated that the DDL creating each **AI Search index source table** is idempotent. Vector Search Delta-Sync indexes key their checkpoint on the source table's **Delta GUID** — a `CREATE OR REPLACE TABLE` on a source table changes that GUID on every provisioning run, forcing dao-ai's stale-checkpoint self-heal (`_index_is_stale` → drop + recreate + full re-embed) each time. Idempotent `CREATE TABLE IF NOT EXISTS` keeps the GUID (and the index checkpoint) stable.

## Changes
- **`quick_serve_restaurant/data/items_description.sql`** — `items_description` **is** the QSR VS index source; was `CREATE OR REPLACE TABLE` → now `CREATE TABLE IF NOT EXISTS`. **This is the real fix** (only VS-source DDL that wasn't idempotent).
- **`hardware_store/data/inventory.sql`** — normalized to `IF NOT EXISTS` for consistency. (`inventory` is a UC-function table there, not a VS source, so no checkpoint impact — consistency only.)

## Validation
Programmatically cross-referenced all `source_table` declarations in `examples/**/*.yaml` against their seed DDL. After this change: **zero non-idempotent VS-source DDLs remain**. All other VS sources (`products`, `dim_stores`, `faqs`, `policies`, `offer_catalog`, ...) were already `CREATE TABLE IF NOT EXISTS`.

The VS stale-checkpoint self-heal itself (`_index_is_stale` — failed-state + source-GUID-drift detection → drop/recreate) is present and verified working; this change reduces how often it needs to fire.

This pull request and its description were written by Isaac.