### PR TITLE
fix(deps): drop standalone pyspark so local model_serving deploy works (#211)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -58,6 +58,14 @@ dao-ai deploy -c config/my_config.yaml --development --profile fevm
 Target resolution: `--target` > `app.deployment_target` in the config >
 `model_serving`.
 
+No extra install is required: a plain `pip install dao-ai` is enough to deploy to
+either target. Model Serving logs the MLflow model in-process, which touches
+spark-connect — the core `databricks-connect` dependency supplies a
+protobuf-5-compatible pyspark for this, so do **not** add a standalone `pyspark`
+(pyspark 4.x needs protobuf ≥ 6.33 and collides with `databricks-ai-search`'s
+`protobuf < 6` cap; see issue #211). The Databricks runtime provides its own Spark,
+so this local stack never ships to the deployed endpoint.
+
 **When to use which:**
 
 - **`dao-ai deploy`** — quickest path to a running agent (Model Serving or Apps),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,8 +103,10 @@ test = [
     "pytest-xdist>=3.6.1",
 ]
 databricks = [
-    # databricks-vectorsearch moved to main dependencies (used unconditionally).
-    "pyspark>=3.5.0",
+    # databricks-connect bundles its own protobuf-5-compatible pyspark; a
+    # standalone pyspark>=3.5.0 resolves to 4.x, whose spark-connect gencode
+    # needs protobuf>=6.33 and collides with databricks-ai-search's protobuf<6
+    # cap (breaks local `dao-ai deploy --target model_serving`). See issue #211.
     "databricks-connect>=16.0.0",
 ]
 mcp = [
@@ -164,8 +166,10 @@ test = [
     "pytest-xdist>=3.6.1",
 ]
 databricks = [
-    # databricks-vectorsearch moved to main dependencies (used unconditionally).
-    "pyspark>=3.5.0",
+    # databricks-connect bundles its own protobuf-5-compatible pyspark; a
+    # standalone pyspark>=3.5.0 resolves to 4.x, whose spark-connect gencode
+    # needs protobuf>=6.33 and collides with databricks-ai-search's protobuf<6
+    # cap (breaks local `dao-ai deploy --target model_serving`). See issue #211.
     "databricks-connect>=16.0.0",
 ]
 mcp = [

--- a/tests/dao_ai/test_dependency_constraints.py
+++ b/tests/dao_ai/test_dependency_constraints.py
@@ -1,0 +1,113 @@
+"""Guard the local ``dao-ai deploy`` dependency set against the protobuf/pyspark
+regression tracked in issue #211.
+
+``dao-ai deploy --target model_serving`` logs the MLflow model in-process on the
+developer's machine. That path imports spark-connect (via MLflow schema inference
+and, for UC-function configs, ``DatabricksFunctionClient`` building a
+``DatabricksSession``). A *standalone* ``pyspark`` dependency resolves to 4.x, whose
+spark-connect proto gencode requires ``protobuf>=6.33`` — which collides with the
+always-installed ``databricks-ai-search``'s ``protobuf<6`` cap and crashes with a
+``VersionError``.
+
+``databricks-connect`` (already a core transitive dep via ``databricks-langchain``)
+bundles its own protobuf-5-compatible pyspark, so the fix is to never declare a
+standalone ``pyspark``. These tests assert that invariant in both ``pyproject.toml``
+and the resolved ``uv.lock`` so it can't silently regress.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+_REPO_ROOT: Path = Path(__file__).parents[2]
+_PYPROJECT: Path = _REPO_ROOT / "pyproject.toml"
+_UV_LOCK: Path = _REPO_ROOT / "uv.lock"
+
+
+def _pyproject() -> dict:
+    return tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+
+
+def _requirement_names(specs: list[str]) -> list[str]:
+    """Canonical (lowercased) distribution names from requirement strings."""
+    return [Requirement(s).name.lower() for s in specs]
+
+
+class TestPyprojectHasNoStandalonePyspark:
+    """Neither the ``databricks`` extra nor group may declare a bare ``pyspark``."""
+
+    def test_databricks_extra_has_no_pyspark(self) -> None:
+        extras = _pyproject()["project"]["optional-dependencies"]
+        assert "pyspark" not in _requirement_names(extras["databricks"])
+
+    def test_databricks_group_has_no_pyspark(self) -> None:
+        groups = _pyproject()["dependency-groups"]
+        assert "pyspark" not in _requirement_names(groups["databricks"])
+
+    def test_no_section_declares_standalone_pyspark(self) -> None:
+        """Sweep every extra + group: standalone pyspark must not reappear
+        anywhere (databricks-connect provides the pyspark namespace)."""
+        proj = _pyproject()
+        extras = proj["project"].get("optional-dependencies", {})
+        groups = proj.get("dependency-groups", {})
+        core = proj["project"].get("dependencies", [])
+
+        offenders: list[str] = []
+        for name, specs in [("dependencies", core)]:
+            if "pyspark" in _requirement_names(specs):
+                offenders.append(name)
+        for name, specs in extras.items():
+            if "pyspark" in _requirement_names(specs):
+                offenders.append(f"optional-dependencies.{name}")
+        for name, specs in groups.items():
+            # groups may contain include-group dicts; keep only str specs.
+            str_specs = [s for s in specs if isinstance(s, str)]
+            if "pyspark" in _requirement_names(str_specs):
+                offenders.append(f"dependency-groups.{name}")
+
+        assert not offenders, (
+            "standalone pyspark reintroduced in: "
+            + ", ".join(offenders)
+            + " — pyspark 4.x drags in protobuf>=6.33 and breaks local "
+            "`dao-ai deploy`; rely on databricks-connect's bundled pyspark "
+            "(see issue #211)."
+        )
+
+    def test_databricks_connect_still_declared(self) -> None:
+        """The fix keeps databricks-connect — it supplies the pyspark namespace."""
+        extras = _pyproject()["project"]["optional-dependencies"]
+        assert "databricks-connect" in _requirement_names(extras["databricks"])
+
+
+class TestUvLockIsProtobuf5Coherent:
+    """The resolved lock must not carry standalone pyspark 4.x or protobuf>=6."""
+
+    def _lock_packages(self) -> list[dict]:
+        return tomllib.loads(_UV_LOCK.read_text(encoding="utf-8"))["package"]
+
+    def test_no_standalone_pyspark_package(self) -> None:
+        names = {p["name"] for p in self._lock_packages()}
+        assert "pyspark" not in names, (
+            "uv.lock contains a top-level standalone pyspark package; it must "
+            "be provided only by databricks-connect's bundle (issue #211)."
+        )
+
+    def test_protobuf_resolves_below_6(self) -> None:
+        protobufs = [
+            p for p in self._lock_packages() if p["name"] == "protobuf"
+        ]
+        assert protobufs, "protobuf missing from uv.lock"
+        for p in protobufs:
+            assert Version(p["version"]) < Version("6"), (
+                f"protobuf resolved to {p['version']}; must stay <6 to satisfy "
+                "databricks-ai-search and databricks-connect's spark-connect "
+                "gencode (issue #211)."
+            )
+
+    def test_databricks_connect_present(self) -> None:
+        names = {p["name"] for p in self._lock_packages()}
+        assert "databricks-connect" in names

--- a/uv.lock
+++ b/uv.lock
@@ -988,7 +988,6 @@ all = [
 databricks = [
     { name = "databricks-connect", version = "16.1.7", source = { registry = "https://files.pythonhosted.org/simple/" }, marker = "python_full_version < '3.12'" },
     { name = "databricks-connect", version = "17.0.10", source = { registry = "https://files.pythonhosted.org/simple/" }, marker = "python_full_version >= '3.12'" },
-    { name = "pyspark" },
 ]
 deepagents = [
     { name = "deepagents" },
@@ -1049,7 +1048,6 @@ all = [
 databricks = [
     { name = "databricks-connect", version = "16.1.7", source = { registry = "https://files.pythonhosted.org/simple/" }, marker = "python_full_version < '3.12'" },
     { name = "databricks-connect", version = "17.0.10", source = { registry = "https://files.pythonhosted.org/simple/" }, marker = "python_full_version >= '3.12'" },
-    { name = "pyspark" },
 ]
 deepagents = [
     { name = "deepagents" },
@@ -1122,7 +1120,6 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.1" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.3.2" },
     { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "pyspark", marker = "extra == 'databricks'", specifier = ">=3.5.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.2" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=7.0.0" },
@@ -1156,10 +1153,7 @@ all = [
     { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "ruff", specifier = ">=0.14.9" },
 ]
-databricks = [
-    { name = "databricks-connect", specifier = ">=16.0.0" },
-    { name = "pyspark", specifier = ">=3.5.0" },
-]
+databricks = [{ name = "databricks-connect", specifier = ">=16.0.0" }]
 deepagents = [{ name = "deepagents", specifier = ">=0.5.7" }]
 dev = [
     { name = "mypy", specifier = ">=1.19.1" },
@@ -4898,16 +4892,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", upload-time = "2026-01-21T03:57:55.912Z" },
 ]
-
-[[package]]
-name = "pyspark"
-version = "4.1.2"
-source = { registry = "https://files.pythonhosted.org/simple/" }
-dependencies = [
-    { name = "py4j", version = "0.10.9.7", source = { registry = "https://files.pythonhosted.org/simple/" }, marker = "python_full_version < '3.12'" },
-    { name = "py4j", version = "0.10.9.9", source = { registry = "https://files.pythonhosted.org/simple/" }, marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/71/4dd20c69332a2a4bf7ece8a655c9da98e4bd9b6bcea235349c1a00399d57/pyspark-4.1.2.tar.gz", hash = "sha256:fa5d6159f700d0990a07f4f62df1b7449401dccee9cd7d5d6df8957530841602", upload-time = "2026-05-21T14:49:21.785Z" }
 
 [[package]]
 name = "pytest"


### PR DESCRIPTION
## Summary

Fixes #211. `dao-ai deploy --target model_serving` crashed on a developer's machine during `mlflow.pyfunc.log_model` with a protobuf gencode/runtime `VersionError` (`spark/connect/base.proto: gencode 6.33.0 runtime 5.29.6`).

`dao-ai deploy` is intentionally the quick, no-DAB, "just build the agent" path — it logs/registers/deploys in-process. That path imports spark-connect (MLflow schema inference via `_is_spark_df`, and for UC-function configs the `DatabricksFunctionClient` serverless `DatabricksSession`). The `databricks` extra/group each declared a **standalone `pyspark>=3.5.0`**, which resolves to pyspark 4.x — whose spark-connect proto gencode needs `protobuf>=6.33` and collides with the always-installed `databricks-ai-search`'s `protobuf<6` cap. Resolver pins protobuf 5.29.6, the connect import raises `VersionError`, and deploy dies.

`databricks-connect` (already a core transitive dep via `databricks-langchain[memory]`) bundles its own **protobuf-5-compatible** pyspark, so the fix is to stop declaring a standalone pyspark. A plain `pip install dao-ai` (no extra) then deploys to Model Serving cleanly. `--development` is unaffected (it only selects the shipped dao-ai artifact, never gated the crash).

## Changes

- **`pyproject.toml`** — remove standalone `pyspark` from both the `databricks` optional-dependency extra and the `databricks` dependency-group; keep `databricks-connect>=16.0.0`.
- **`uv.lock`** — relocked; only functional change is `pyspark 4.1.2` dropping out (protobuf stays 5.29.6, zero other version drift).
- **`tests/dao_ai/test_dependency_constraints.py`** (new) — 7 guards asserting no standalone pyspark in any extra/group or in `uv.lock`, protobuf<6, and databricks-connect present.
- **`docs/cli-reference.md`** — document that deploy needs no `[databricks]` extra.

No dao-ai runtime/core code changes. No effect on the deployed serving env — `get_installed_packages` never bakes pyspark/databricks-connect; the Databricks runtime supplies Spark.

## Validation (live on FEVM)

- `dao-ai deploy -c <minimal LLM config> --target model_serving --development -p fevm` → **exit 0, no VersionError**; `log_model` succeeded, inference-validated, model registered.
- Endpoint reached **READY**; live inference returned **HTTP 200** with a coherent response.
- MLflow **serving trace persisted** (`mlflow.databricks.modelServingEndpointName`) with the full 9-span agent hierarchy (`predict → dao_ai_apredict → LangGraph → router → verify_agent → model → ChatDatabricks`).
- Regression tests pass; `uv.lock` clean (`make check-lock`).

This pull request and its description were written by Isaac.