### PR TITLE
feat(deploy): unify custom-code (app.code_paths) shipping across all deploy paths + targets

### DIFF
--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -1642,7 +1642,7 @@
           "description": "Chat history summarization settings to manage long conversations."
         },
         "code_paths": {
-          "description": "Additional Python file paths bundled with the Model Serving model artifact via ``log_model(code_paths=...)``. For Apps/MCP, put custom code in the generated bundle's ``src/<package>/`` instead \u2014 it is built and installed by ``uv sync`` at the app build phase.",
+          "description": "Additional Python files/directories (relative to the config file's directory; absolute paths pass through) shipped with EVERY deployment target: Model Serving via ``log_model(code_paths=...)``, Databricks Apps by uploading them next to the config (importable via ``sys.path``), and the generate-workflow job by staging them into the bundle. Use for custom ``type: python`` tool modules or agent code. (Apps bundles also still support hand-packaged code under ``src/<package>/``.)",
           "items": {
             "type": "string"
           },

--- a/src/dao_ai/_locking.py
+++ b/src/dao_ai/_locking.py
@@ -114,12 +114,20 @@ def render_portable_lock(pyproject_content: str, wheel_path: Path | None = None)
     with tempfile.TemporaryDirectory() as tmp:
         tmp_dir = Path(tmp)
         (tmp_dir / "pyproject.toml").write_text(pyproject_content)
-        # Stub package so uv can build the local project (packages = ["src/..."]).
+        # Stub package so uv can build the local project during locking. dao-ai
+        # templates use ``packages = ["src"]`` (auto-discover every package under
+        # ``src/``); older bundles used ``packages = ["src/<pkg>"]``. Either way
+        # hatch needs at least one package present under ``src/`` — create a stub.
         import re
 
-        match = re.search(r'packages\s*=\s*\["src/([^"]+)"\]', pyproject_content)
-        if match:
-            pkg_dir = tmp_dir / "src" / match.group(1)
+        legacy = re.search(r'packages\s*=\s*\["src/([^"]+)"\]', pyproject_content)
+        if legacy:
+            pkg_dir = tmp_dir / "src" / legacy.group(1)
+        elif re.search(r'packages\s*=\s*\["src"\]', pyproject_content):
+            pkg_dir = tmp_dir / "src" / "_daoai_lockstub"
+        else:
+            pkg_dir = None
+        if pkg_dir is not None:
             pkg_dir.mkdir(parents=True, exist_ok=True)
             (pkg_dir / "__init__.py").write_text("")
         if wheel_path is not None:

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -33,6 +33,7 @@ from dao_ai.apps.resources import (
     generate_app_resources,
     generate_user_api_scopes,
 )
+from dao_ai.code_paths import code_path_sync_globs
 from dao_ai.config import AppConfig, value_of
 
 
@@ -607,6 +608,13 @@ def generate_databricks_yaml(
         "uv.lock",
         ".python-version",
     ]
+    # Custom code (app.code_paths) is copied into the bundle at config-relative
+    # paths (e.g. ``tools/**``); force-include those top-level dirs so they sync
+    # from a gitignored staging dir. Entries at the bundle root that aren't dirs
+    # are already covered by the globs above.
+    for glob in code_path_sync_globs(config):
+        if glob not in sync_include:
+            sync_include.append(glob)
 
     bundle: dict[str, Any] = {
         "bundle": {
@@ -834,6 +842,24 @@ def write_bundle(
         logger.info("Copied skill directory into bundle", skill=str(rel))
         written.append(str(rel))
 
+    # Copy the config's custom code (app.code_paths) into the bundle next to the
+    # config so it is importable at runtime: the bundle root is the app CWD and
+    # ``add_code_paths_to_sys_path`` inserts each entry's parent onto sys.path.
+    # This is the uniform declaration shared with Model Serving and the direct
+    # Apps/pipeline deploys; the manual ``src/<package>`` wheel route still works
+    # for users who prefer to hand-package their code.
+    from dao_ai.code_paths import iter_code_path_stagings, walk_code_path_files
+
+    for src, code_dest in iter_code_path_stagings(config):
+        for file_src, file_dest in walk_code_path_files(src, code_dest):
+            out = output_dir / file_dest
+            if out.exists() and not overwrite:
+                skipped.append(file_dest)
+                continue
+            out.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(file_src, out)
+            written.append(file_dest)
+
     package_name = app_name.replace("-", "_")
 
     # Optional-feature extras this config exercises, threaded into the dao-ai
@@ -847,10 +873,9 @@ def write_bundle(
     # User-declared extra pip packages (config.app.pip_requirements) — folded
     # into the generated pyproject dependencies so `uv lock` captures them for
     # the deployer's custom code (parity with Model Serving / pipeline).
-    # NOTE: config.app.code_paths is intentionally NOT copied here — for
-    # Apps/MCP the deployer's custom modules live under the bundle's ``src/``
-    # (built into the app by hatch); code_paths applies to Model Serving only
-    # (shipped via ``log_model(code_paths=...)``).
+    # config.app.code_paths files are copied into the bundle above (next to the
+    # config) so they import at runtime via ``add_code_paths_to_sys_path``; the
+    # manual ``src/<package>`` hatch-wheel route still works for hand-packaged code.
     user_pip_requirements: list[str] = (
         list(config.app.pip_requirements) if config.app else []
     )

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -33,7 +33,7 @@ from dao_ai.apps.resources import (
     generate_app_resources,
     generate_user_api_scopes,
 )
-from dao_ai.code_paths import code_path_sync_globs
+from dao_ai.code_paths import _SRC_DIRNAME, code_path_sync_globs
 from dao_ai.config import AppConfig, value_of
 
 
@@ -119,7 +119,9 @@ dependencies = [
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/{package_name}"]
+# ``packages = ["src"]`` auto-discovers every top-level package under ``src/``
+# (the ``src/`` convention), so ``src/foo/bar.py`` installs as ``foo.bar``.
+packages = ["src"]
 sources = ["src"]
 """
 
@@ -142,7 +144,9 @@ dependencies = [
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/{package_name}"]
+# ``packages = ["src"]`` auto-discovers every top-level package under ``src/``
+# (the ``src/`` convention), so ``src/foo/bar.py`` installs as ``foo.bar``.
+packages = ["src"]
 sources = ["src"]
 
 [tool.uv.sources]
@@ -848,10 +852,29 @@ def write_bundle(
     # This is the uniform declaration shared with Model Serving and the direct
     # Apps/pipeline deploys; the manual ``src/<package>`` wheel route still works
     # for users who prefer to hand-package their code.
-    from dao_ai.code_paths import iter_code_path_stagings, walk_code_path_files
+    from dao_ai.code_paths import (
+        discover_src_packages,
+        iter_code_path_stagings,
+        walk_code_path_files,
+    )
 
     for src, code_dest in iter_code_path_stagings(config):
         for file_src, file_dest in walk_code_path_files(src, code_dest):
+            out = output_dir / file_dest
+            if out.exists() and not overwrite:
+                skipped.append(file_dest)
+                continue
+            out.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(file_src, out)
+            written.append(file_dest)
+
+    # Convention: copy any colocated ``src/<pkg>`` packages into the bundle's
+    # ``src/`` so hatch (``packages=["src"]``) builds them into the app wheel —
+    # ``src/foo/bar.py`` installs as ``foo.bar``. No config declaration needed.
+    for pkg_dir in discover_src_packages(config):
+        for file_src, file_dest in walk_code_path_files(
+            pkg_dir, f"{_SRC_DIRNAME}/{pkg_dir.name}"
+        ):
             out = output_dir / file_dest
             if out.exists() and not overwrite:
                 skipped.append(file_dest)

--- a/src/dao_ai/code_paths.py
+++ b/src/dao_ai/code_paths.py
@@ -1,0 +1,244 @@
+"""Helpers for shipping a config's custom code (``app.code_paths``) to every
+deployment target.
+
+``config.app.code_paths`` lists extra Python files/directories a config needs at
+runtime — e.g. a ``type: python`` tool whose ``function.name`` is
+``my_module.my_func``, or a custom agent module. These are declared once and must
+reach all deployment targets:
+
+* **Model Serving (MLflow)** — :func:`collect_code_paths` feeds
+  ``mlflow.pyfunc.log_model(code_paths=...)``, which copies each entry into
+  ``<model_dir>/code/<basename>/`` and prepends ``<model_dir>/code`` to
+  ``sys.path`` at load time.
+
+* **Databricks Apps** — the deployer uploads each entry next to the config in the
+  app source directory (via :func:`iter_code_path_stagings`). At runtime the app
+  CWD is that directory and ``AppConfig.add_code_paths_to_sys_path`` (a config
+  validator) inserts each entry's parent onto ``sys.path``, so the module imports.
+
+* **generate-workflow / generate-agent / generate-mcp bundles** — the bundle
+  generators stage each entry next to the staged config using the same
+  :func:`iter_code_path_stagings` plan, so the job/app finds them.
+
+Path contract: relative ``code_paths`` resolve against the **config file's own
+directory** (identical to ``ddl``/``data`` assets and skills), with a legacy
+fallback to the process CWD so pre-existing Model Serving configs keep working.
+Absolute paths pass through unchanged.
+"""
+
+from __future__ import annotations
+
+import posixpath
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from dao_ai.skills import _skill_base_dir
+
+if TYPE_CHECKING:
+    from dao_ai.config import AppConfig
+
+# Bundle-relative dest for entries that cannot be placed next to the config
+# (absolute paths, or relative paths that climb out with ``../``). Mirrors the
+# ``skills/<basename>`` fallback used for skill bundling.
+_CODE_FALLBACK_PREFIX = "code"
+
+# Directory entries whose contents dao-ai never needs to ship.
+_SKIP_DIR_NAMES = {"__pycache__"}
+
+
+def _code_paths_base_dir(config: "AppConfig") -> Path:
+    """Directory that relative ``code_paths`` resolve against at bundle time.
+
+    Custom code is colocated with the config (like ``ddl``/``data`` assets and
+    ``skills/``), so the anchor is the config file's own directory. Reuses
+    :func:`dao_ai.skills._skill_base_dir`, which falls back to the project root
+    for a programmatically built config with no source path.
+    """
+    return _skill_base_dir(config)
+
+
+def resolve_code_path(entry: str, config: "AppConfig") -> Path | None:
+    """Resolve one ``code_paths`` entry to an absolute path, or ``None`` if missing.
+
+    Absolute entries pass through verbatim. Relative entries resolve against the
+    config directory (:func:`_code_paths_base_dir`); if that does not exist, a
+    legacy fallback tries the process CWD (preserving pre-existing Model Serving
+    deploys that ran with CWD-relative paths). Returns ``None`` when neither
+    anchor locates the entry.
+    """
+    path = Path(entry)
+    if path.is_absolute():
+        return path if path.exists() else None
+
+    config_relative = (_code_paths_base_dir(config) / path).resolve()
+    if config_relative.exists():
+        return config_relative
+
+    cwd_relative = (Path.cwd() / path).resolve()
+    if cwd_relative.exists():
+        logger.debug(
+            "Resolved code_path against CWD (legacy); prefer config-relative paths",
+            entry=entry,
+            resolved=str(cwd_relative),
+        )
+        return cwd_relative
+
+    return None
+
+
+def collect_code_paths(config: "AppConfig") -> list[str]:
+    """Resolved absolute ``code_paths`` for ``mlflow.pyfunc.log_model(code_paths=...)``.
+
+    Sibling of :func:`dao_ai.skills.collect_skills_code_paths`. Order-preserving
+    and deduplicated. Raises ``FileNotFoundError`` for an entry that resolves
+    nowhere, preserving the fail-loud contract the Model Serving deploy has always
+    enforced.
+    """
+    app = config.app
+    if app is None or not app.code_paths:
+        return []
+
+    resolved: list[str] = []
+    seen: set[str] = set()
+    for entry in app.code_paths:
+        path = resolve_code_path(entry, config)
+        if path is None:
+            raise FileNotFoundError(f"Code path does not exist: {entry}")
+        as_str = path.as_posix()
+        if as_str not in seen:
+            seen.add(as_str)
+            resolved.append(as_str)
+    return resolved
+
+
+def prepend_code_paths_to_sys_path(config: "AppConfig") -> None:
+    """Put resolved ``code_paths`` parents on ``sys.path`` for in-process import.
+
+    ``AppConfig.add_code_paths_to_sys_path`` runs at config construction, before
+    ``from_file`` stamps ``_source_config_path``, so it can only anchor relative
+    entries at the process CWD. At deploy time (``mlflow.pyfunc.log_model``
+    validation loads the model in-process) the CWD is the developer's project
+    root, not the config directory, so a config-relative custom module would not
+    import. Resolving against the config directory here and inserting each
+    entry's parent makes the validation load succeed. Idempotent.
+
+    Best-effort: unlike :func:`collect_code_paths` (which fails loud so a deploy
+    never ships a missing module), this skips entries that don't resolve — it is
+    called from ``AppConfig.from_file`` for every consumer (validate, schema,
+    graph display), where a not-yet-present path must not block loading.
+    """
+    import sys
+
+    app = config.app
+    if app is None or not app.code_paths:
+        return
+
+    for entry in app.code_paths:
+        resolved = resolve_code_path(entry, config)
+        if resolved is None:
+            continue
+        parent = str(resolved.parent)
+        if parent not in sys.path:
+            sys.path.insert(0, parent)
+            logger.debug("Prepended resolved code_path parent to sys.path", path=parent)
+
+
+def iter_code_path_stagings(config: "AppConfig") -> list[tuple[Path, str]]:
+    """Plan how each ``code_paths`` entry is staged/uploaded next to the config.
+
+    Returns ``(source_abs, bundle_relative_dest)`` pairs shared by every bundle
+    generator and the Apps direct-deploy upload. ``bundle_relative_dest``
+    preserves the config-relative layout so the file lands next to the
+    staged/uploaded ``dao_ai.yaml`` (entry ``tools/x.py`` → dest ``tools/x.py``),
+    which is exactly where ``add_code_paths_to_sys_path`` looks at runtime.
+
+    Entries that are absolute or climb out of the config directory with ``../``
+    cannot sit next to the config; they fall back to ``code/<basename>`` and a
+    warning is logged (their runtime resolution then depends on the deployed
+    config carrying a matching relative path). Directories are returned as a
+    single pair; callers walk them (see :func:`walk_code_path_files`).
+    """
+    app = config.app
+    if app is None or not app.code_paths:
+        return []
+
+    base_dir = _code_paths_base_dir(config)
+    stagings: list[tuple[Path, str]] = []
+    for entry in app.code_paths:
+        source = resolve_code_path(entry, config)
+        if source is None:
+            logger.warning(
+                "code_paths entry not found; skipping staging",
+                entry=entry,
+            )
+            continue
+
+        dest = _bundle_relative_dest(entry, source, base_dir)
+        stagings.append((source, dest))
+    return stagings
+
+
+def _bundle_relative_dest(entry: str, source: Path, base_dir: Path) -> str:
+    """Config-relative dest for a staged entry, or a ``code/<name>`` fallback.
+
+    A relative entry that stays within the config directory keeps its declared
+    layout. An absolute entry, or a relative one that climbs out with ``../``,
+    cannot sit next to the config, so it lands under ``code/<basename>``.
+    """
+    raw = Path(entry)
+    if not raw.is_absolute():
+        normalized = posixpath.normpath(raw.as_posix())
+        if not normalized.startswith("../") and normalized != "..":
+            return normalized
+
+    name = source.name
+    logger.warning(
+        "code_paths entry is absolute or climbs outside the config directory; "
+        "staging under 'code/' — prefer paths colocated with the config",
+        entry=entry,
+        dest=f"{_CODE_FALLBACK_PREFIX}/{name}",
+    )
+    return f"{_CODE_FALLBACK_PREFIX}/{name}"
+
+
+def walk_code_path_files(source: Path, dest: str) -> list[tuple[Path, str]]:
+    """Expand one staging pair into ``(file_abs, file_relative_dest)`` per file.
+
+    A file staging yields itself. A directory staging yields every contained
+    file (recursively), skipping ``__pycache__`` and compiled ``.pyc``, with each
+    file's dest computed relative to ``dest``.
+    """
+    if source.is_file():
+        return [(source, dest)]
+
+    files: list[tuple[Path, str]] = []
+    for path in sorted(source.rglob("*")):
+        if not path.is_file():
+            continue
+        if any(part in _SKIP_DIR_NAMES for part in path.relative_to(source).parts):
+            continue
+        if path.suffix == ".pyc":
+            continue
+        rel = path.relative_to(source).as_posix()
+        files.append((path, posixpath.join(dest, rel)))
+    return files
+
+
+def code_path_sync_globs(config: "AppConfig") -> list[str]:
+    """Bundle-root-relative ``<top>/**`` globs for staged code_paths.
+
+    Mirrors :func:`dao_ai.pipeline.bundle._asset_sync_globs`. The pipeline bundle
+    stages code under ``config/<rel>`` (already covered by ``config/**``), but an
+    entry that lands under the ``code/`` fallback needs its own glob so
+    ``databricks bundle sync`` uploads it from a gitignored staging dir. Returns
+    the extra globs (deduped); entries under ``config/`` contribute nothing.
+    """
+    globs: list[str] = []
+    for _source, dest in iter_code_path_stagings(config):
+        top = dest.split("/", 1)[0]
+        glob = f"{top}/**"
+        if top not in {"", "config"} and glob not in globs:
+            globs.append(glob)
+    return globs

--- a/src/dao_ai/code_paths.py
+++ b/src/dao_ai/code_paths.py
@@ -44,6 +44,12 @@ if TYPE_CHECKING:
 # ``skills/<basename>`` fallback used for skill bundling.
 _CODE_FALLBACK_PREFIX = "code"
 
+# Convention: a ``src/`` directory colocated with the config auto-ships every
+# top-level package under it as custom code (no ``code_paths`` declaration
+# needed). The import FQN drops the ``src`` prefix — ``src/foo/bar.py`` imports
+# as ``foo.bar`` — in every target (see the module docstring / the deploy code).
+_SRC_DIRNAME = "src"
+
 # Directory entries whose contents dao-ai never needs to ship.
 _SKIP_DIR_NAMES = {"__pycache__"}
 
@@ -143,6 +149,79 @@ def prepend_code_paths_to_sys_path(config: "AppConfig") -> None:
         if parent not in sys.path:
             sys.path.insert(0, parent)
             logger.debug("Prepended resolved code_path parent to sys.path", path=parent)
+
+
+def _src_dir(config: "AppConfig") -> Path:
+    """The ``src/`` directory colocated with the config (may not exist)."""
+    return _code_paths_base_dir(config) / _SRC_DIRNAME
+
+
+def discover_src_packages(config: "AppConfig") -> list[Path]:
+    """Top-level package directories under the config's colocated ``src/``.
+
+    The ``src/`` convention auto-ships custom code with NO ``code_paths``
+    declaration: any top-level directory under ``<config_dir>/src`` is a
+    package (namespace packages allowed — ``__init__.py`` is not required).
+    Loose files directly under ``src/`` are ignored (``src/`` holds packages,
+    not modules); ``__pycache__`` and ``*.egg-info`` are skipped.
+
+    Callers ship these so ``src/foo/bar.py`` imports as ``foo.bar`` (never
+    ``src.foo``): Model Serving passes each dir to ``log_model(code_paths=...)``
+    (MLflow copies it to ``code/foo/``); the wheel path lets hatch
+    (``packages=["src"]``) discover it; local validation puts ``src/`` itself on
+    ``sys.path`` (see :func:`prepend_src_to_sys_path`). Sorted, deduped; ``[]``
+    when ``src/`` is absent or empty.
+    """
+    src_dir = _src_dir(config)
+    if not src_dir.is_dir():
+        return []
+
+    packages: list[Path] = []
+    for child in sorted(src_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        if child.name in _SKIP_DIR_NAMES or child.name.endswith(".egg-info"):
+            continue
+        packages.append(child.resolve())
+    return packages
+
+
+def prepend_src_to_sys_path(config: "AppConfig") -> None:
+    """Put ``<config_dir>/src`` on ``sys.path`` so ``src/`` packages import.
+
+    Best-effort, idempotent. Makes ``import foo`` resolve during in-process
+    ``log_model`` validation (and any config load), matching the Model Serving
+    ``code/foo/`` layout and the Apps wheel — all three yield ``foo.bar``.
+    No-op when ``src/`` is absent.
+    """
+    import sys
+
+    src_dir = _src_dir(config)
+    if not src_dir.is_dir():
+        return
+    src_path = str(src_dir.resolve())
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
+        logger.debug("Prepended src/ to sys.path", path=src_path)
+
+
+def collect_serving_code_paths(config: "AppConfig") -> list[str]:
+    """Model Serving ``code_paths``: explicit ``code_paths`` + ``src/`` packages.
+
+    The deduped (by resolved posix path) union of :func:`collect_code_paths`
+    (explicit, out-of-tree, fail-loud on missing) and :func:`discover_src_packages`
+    (the colocated ``src/`` convention). Passing each ``src/`` package dir makes
+    MLflow copy it to ``code/<pkg>`` → import ``<pkg>.mod``. Deduping prevents a
+    double-ship when a ``code_paths`` entry points into ``src/``.
+    """
+    resolved: list[str] = list(collect_code_paths(config))
+    seen: set[str] = set(resolved)
+    for pkg in discover_src_packages(config):
+        as_str = pkg.as_posix()
+        if as_str not in seen:
+            seen.add(as_str)
+            resolved.append(as_str)
+    return resolved
 
 
 def iter_code_path_stagings(config: "AppConfig") -> list[tuple[Path, str]]:

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -9436,10 +9436,13 @@ class AppModel(BaseModel):
     )
     code_paths: list[str] = Field(
         default_factory=list,
-        description="Additional Python file paths bundled with the Model Serving "
-        "model artifact via ``log_model(code_paths=...)``. For Apps/MCP, put "
-        "custom code in the generated bundle's ``src/<package>/`` instead — it is "
-        "built and installed by ``uv sync`` at the app build phase.",
+        description="Additional Python files/directories (relative to the config "
+        "file's directory; absolute paths pass through) shipped with EVERY "
+        "deployment target: Model Serving via ``log_model(code_paths=...)``, "
+        "Databricks Apps by uploading them next to the config (importable via "
+        "``sys.path``), and the generate-workflow job by staging them into the "
+        "bundle. Use for custom ``type: python`` tool modules or agent code. "
+        "(Apps bundles also still support hand-packaged code under ``src/<package>/``.)",
     )
     pip_requirements: list[str] = Field(
         default_factory=list,
@@ -10876,6 +10879,18 @@ class AppConfig(BaseModel):
             dataset._base_path = base_path
         for fn in config.unity_catalog_functions or []:
             fn._base_path = base_path
+
+        # Put custom code (``app.code_paths``) on ``sys.path`` now that the
+        # config directory is known, resolving each entry against it. The
+        # ``add_code_paths_to_sys_path`` validator ran at construction (before
+        # ``_source_config_path`` was set) and could only anchor at the process
+        # CWD; this makes config-relative custom modules importable for every
+        # consumer that loads a config from a file — the deploy notebook's
+        # ``display_graph``/``create_agent``, the Apps runtime, and any tool
+        # resolution via ``load_function`` — regardless of the process CWD.
+        from dao_ai.code_paths import prepend_code_paths_to_sys_path
+
+        prepend_code_paths_to_sys_path(config)
         # Stash the pre-substitution dict so tooling can recover which
         # YAML fields were backed by ``${var.X}`` references.
         config._raw_yaml_dict = raw_dict

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -31,6 +31,7 @@ import yaml
 
 if TYPE_CHECKING:
     from a2a.types import SecurityScheme
+
     from dao_ai.audit import LakebaseAuditSink
     from dao_ai.genie.cache.context_aware.optimization import (
         ContextAwareCacheEvalDataset,
@@ -38,6 +39,8 @@ if TYPE_CHECKING:
     )
     from dao_ai.state import Context
 
+from databricks.ai_search.client import VectorSearchClient
+from databricks.ai_search.index import VectorSearchIndex
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.credentials_provider import (
     CredentialsStrategy,
@@ -48,8 +51,6 @@ from databricks.sdk.service.apps import App
 from databricks.sdk.service.catalog import FunctionInfo, TableInfo
 from databricks.sdk.service.dashboards import GenieListSpacesResponse, GenieSpace
 from databricks.sdk.service.sql import GetWarehouseResponse
-from databricks.ai_search.client import VectorSearchClient
-from databricks.ai_search.index import VectorSearchIndex
 from databricks_langchain import (
     ChatDatabricks,
     DatabricksEmbeddings,
@@ -9254,9 +9255,8 @@ class A2AModel(BaseModel):
         from dao_ai._extras import require_extra
 
         require_extra("a2a", feature="A2A security schemes")
-        from pydantic import TypeAdapter
-
         from a2a.types import SecurityScheme
+        from pydantic import TypeAdapter
 
         # TypeAdapter validates both raw dicts and already-constructed
         # SecurityScheme instances against the discriminated union.
@@ -10888,9 +10888,16 @@ class AppConfig(BaseModel):
         # consumer that loads a config from a file — the deploy notebook's
         # ``display_graph``/``create_agent``, the Apps runtime, and any tool
         # resolution via ``load_function`` — regardless of the process CWD.
-        from dao_ai.code_paths import prepend_code_paths_to_sys_path
+        from dao_ai.code_paths import (
+            prepend_code_paths_to_sys_path,
+            prepend_src_to_sys_path,
+        )
 
         prepend_code_paths_to_sys_path(config)
+        # Convention: a colocated ``src/`` dir auto-ships its packages; put it on
+        # sys.path so ``src/foo/bar.py`` imports as ``foo.bar`` for every consumer
+        # (deploy notebook display_graph/create_agent, Apps runtime, load_function).
+        prepend_src_to_sys_path(config)
         # Stash the pre-substitution dict so tooling can recover which
         # YAML fields were backed by ``${var.X}`` references.
         config._raw_yaml_dict = raw_dict

--- a/src/dao_ai/mcp/generate.py
+++ b/src/dao_ai/mcp/generate.py
@@ -150,8 +150,9 @@ def write_mcp_bundle(
 
     # User-declared extra pip packages (config.app.pip_requirements) folded
     # into the pyproject deps so uv.lock captures them. config.app.code_paths
-    # is NOT copied — for Apps/MCP custom modules live under the bundle's
-    # ``src/``; code_paths applies to Model Serving only.
+    # files are copied into the bundle below (next to the config) so they import
+    # at runtime via ``add_code_paths_to_sys_path``; the manual ``src/<package>``
+    # hatch-wheel route still works for hand-packaged code.
     from dao_ai.apps.bundle import _format_extra_deps
 
     user_pip_requirements: list[str] = (
@@ -194,6 +195,20 @@ def write_mcp_bundle(
         _write(output_dir / config_filename, Path(source_config_path).read_text())
     else:
         logger.warning("mcp.generate.no_source_config — skipping config copy")
+
+    # Copy the config's custom code (app.code_paths) next to the config so it is
+    # importable at runtime (bundle root is the app CWD; add_code_paths_to_sys_path
+    # inserts each entry's parent onto sys.path). Shared with generate-agent.
+    from dao_ai.code_paths import iter_code_path_stagings, walk_code_path_files
+
+    for src, code_dest in iter_code_path_stagings(config):
+        for file_src, file_dest in walk_code_path_files(src, code_dest):
+            out = output_dir / file_dest
+            if out.exists():
+                continue
+            out.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(file_src, out)
+            written.append(file_dest)
 
     _write(
         output_dir / "README.md",

--- a/src/dao_ai/mcp/generate.py
+++ b/src/dao_ai/mcp/generate.py
@@ -199,10 +199,28 @@ def write_mcp_bundle(
     # Copy the config's custom code (app.code_paths) next to the config so it is
     # importable at runtime (bundle root is the app CWD; add_code_paths_to_sys_path
     # inserts each entry's parent onto sys.path). Shared with generate-agent.
-    from dao_ai.code_paths import iter_code_path_stagings, walk_code_path_files
+    from dao_ai.code_paths import (
+        _SRC_DIRNAME,
+        discover_src_packages,
+        iter_code_path_stagings,
+        walk_code_path_files,
+    )
 
     for src, code_dest in iter_code_path_stagings(config):
         for file_src, file_dest in walk_code_path_files(src, code_dest):
+            out = output_dir / file_dest
+            if out.exists():
+                continue
+            out.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(file_src, out)
+            written.append(file_dest)
+
+    # Convention: copy colocated ``src/<pkg>`` packages into the bundle's ``src/``
+    # so hatch (``packages=["src"]``) builds them prefix-free (``foo.bar``).
+    for pkg_dir in discover_src_packages(config):
+        for file_src, file_dest in walk_code_path_files(
+            pkg_dir, f"{_SRC_DIRNAME}/{pkg_dir.name}"
+        ):
             out = output_dir / file_dest
             if out.exists():
                 continue
@@ -396,7 +414,10 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/{package_name}"]
+# ``packages = ["src"]`` + ``sources = ["src"]`` auto-discovers every top-level
+# package under ``src/`` and installs it prefix-free (``src/foo`` -> ``foo``).
+packages = ["src"]
+sources = ["src"]
 """
 
 _PYPROJECT_DEV_TEMPLATE = """\
@@ -415,7 +436,8 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/{package_name}"]
+packages = ["src"]
+sources = ["src"]
 
 [tool.uv.sources]
 dao-ai = {{ path = "dist/{wheel_filename}" }}

--- a/src/dao_ai/pipeline/bundle.py
+++ b/src/dao_ai/pipeline/bundle.py
@@ -99,6 +99,9 @@ def generate_pipeline_databricks_yaml(config: AppConfig, development: bool) -> s
     # that references a sibling use case's shared assets via ``../`` stages them
     # outside ``config/`` at the bundle root; add explicit globs so those upload
     # too (the staging dir is gitignored, so nothing syncs implicitly).
+    # ``app.code_paths`` files also stage under ``config/`` (see
+    # ``_stage_code_paths``), so ``config/**`` already covers them — no extra
+    # code_paths globs are needed here.
     for glob in _asset_sync_globs(config):
         if glob not in sync_include:
             sync_include.append(glob)
@@ -341,6 +344,38 @@ def _stage_assets(
     return copied, missing
 
 
+def _stage_code_paths(
+    config: AppConfig,
+    output_dir: Path,
+    overwrite: bool,
+) -> list[str]:
+    """Copy ``config.app.code_paths`` files into the staged bundle under ``config/``.
+
+    Custom code stages next to the staged config (``config/<dest>``) so that when
+    ``06_deploy_agent.py`` reloads the staged config, ``add_code_paths_to_sys_path``
+    inserts the staged parent and ``create_agent``'s ``collect_code_paths`` resolves
+    against the staged config directory. Returns bundle-relative labels copied.
+    """
+    from dao_ai.code_paths import iter_code_path_stagings, walk_code_path_files
+
+    dest_anchor = (output_dir / "config").resolve()
+    copied: list[str] = []
+    for src, dest in iter_code_path_stagings(config):
+        for file_src, file_dest in walk_code_path_files(src, dest):
+            file_out = (dest_anchor / file_dest).resolve()
+            if file_src == file_out:
+                continue
+            if file_out.exists() and not overwrite:
+                continue
+            file_out.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(file_src, file_out)
+            try:
+                copied.append(str(file_out.relative_to(output_dir)))
+            except ValueError:
+                copied.append(str(file_out))
+    return copied
+
+
 def write_pipeline_bundle(
     config: AppConfig,
     output_dir: Path,
@@ -483,6 +518,10 @@ def write_pipeline_bundle(
     # 6. Config-referenced data/functions asset files.
     copied, missing = _stage_assets(config, output_dir, overwrite)
     written.extend(copied)
+
+    # 6b. Custom code (app.code_paths) staged next to the config so the deploy
+    # notebook's create_agent/deploy_agent find it (Model Serving + Apps).
+    written.extend(_stage_code_paths(config, output_dir, overwrite))
 
     print(f"\nPipeline bundle staged in {output_dir}/\n")
     for name in sorted(written):

--- a/src/dao_ai/pipeline/bundle.py
+++ b/src/dao_ai/pipeline/bundle.py
@@ -376,6 +376,46 @@ def _stage_code_paths(
     return copied
 
 
+def _stage_src_packages(
+    config: AppConfig,
+    output_dir: Path,
+    overwrite: bool,
+) -> list[str]:
+    """Copy colocated ``src/<pkg>`` packages into the staged bundle under ``config/src``.
+
+    The ``src/`` convention: packages stage under ``config/src/<pkg>`` (next to
+    the staged config), so when ``06_deploy_agent.py`` reloads the staged config
+    its ``src/`` anchor is ``config/src`` — ``collect_serving_code_paths`` passes
+    each ``config/src/<pkg>`` to ``log_model`` (MLflow -> ``code/<pkg>``) and
+    ``prepend_src_to_sys_path`` puts ``config/src`` on ``sys.path``, both yielding
+    ``<pkg>.mod``. Returns bundle-relative labels copied.
+    """
+    from dao_ai.code_paths import (
+        _SRC_DIRNAME,
+        discover_src_packages,
+        walk_code_path_files,
+    )
+
+    dest_anchor = (output_dir / "config").resolve()
+    copied: list[str] = []
+    for pkg_dir in discover_src_packages(config):
+        for file_src, file_dest in walk_code_path_files(
+            pkg_dir, f"{_SRC_DIRNAME}/{pkg_dir.name}"
+        ):
+            file_out = (dest_anchor / file_dest).resolve()
+            if file_src == file_out:
+                continue
+            if file_out.exists() and not overwrite:
+                continue
+            file_out.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(file_src, file_out)
+            try:
+                copied.append(str(file_out.relative_to(output_dir)))
+            except ValueError:
+                copied.append(str(file_out))
+    return copied
+
+
 def write_pipeline_bundle(
     config: AppConfig,
     output_dir: Path,
@@ -522,6 +562,7 @@ def write_pipeline_bundle(
     # 6b. Custom code (app.code_paths) staged next to the config so the deploy
     # notebook's create_agent/deploy_agent find it (Model Serving + Apps).
     written.extend(_stage_code_paths(config, output_dir, overwrite))
+    written.extend(_stage_src_packages(config, output_dir, overwrite))
 
     print(f"\nPipeline bundle staged in {output_dir}/\n")
     for name in sorted(written):

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -11,6 +11,8 @@ import sqlparse
 import yaml
 from databricks import agents
 from databricks.agents import PermissionLevel, set_permissions
+from databricks.ai_search.client import VectorSearchClient
+from databricks.ai_search.index import VectorSearchIndex
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors.platform import (
     BadRequest,
@@ -32,8 +34,6 @@ from databricks.sdk.service.catalog import (
 from databricks.sdk.service.iam import User
 from databricks.sdk.service.serving import EndpointStateConfigUpdate
 from databricks.sdk.service.workspace import GetSecretResponse, ImportFormat
-from databricks.ai_search.client import VectorSearchClient
-from databricks.ai_search.index import VectorSearchIndex
 from loguru import logger
 from mlflow import MlflowClient
 from mlflow.entities import Experiment
@@ -1133,15 +1133,15 @@ class DatabricksProvider(ServiceProvider):
             user_api_scopes=list(auth_policy.user_auth_policy.api_scopes),
         )
 
-        # Resolve config.app.code_paths against the config directory (with a
-        # legacy CWD fallback), fail-loud on a missing entry. Shared with the
-        # Apps/pipeline/generate-* paths via dao_ai.code_paths. ``from_file``
-        # already put resolved code_paths on ``sys.path`` (best-effort); this is
-        # the deploy-time guard that fails loud if any entry is missing before
-        # log_model ships an unimportable model.
-        from dao_ai.code_paths import collect_code_paths
+        # Resolve the model's custom code: explicit ``config.app.code_paths``
+        # (out-of-tree, fail-loud on a missing entry) UNION the colocated ``src/``
+        # packages (the zero-config convention), deduped. Each is passed to
+        # ``log_model(code_paths=...)`` so MLflow copies it to ``code/<pkg>`` and
+        # it imports prefix-free (``src/foo`` -> ``foo.bar``). ``from_file`` already
+        # put these on ``sys.path`` (best-effort) for the in-process validation load.
+        from dao_ai.code_paths import collect_serving_code_paths
 
-        code_paths: list[str] = collect_code_paths(config)
+        code_paths: list[str] = collect_serving_code_paths(config)
 
         model_root_path: Path = Path(dao_ai.__file__).parent
         model_path: Path = model_root_path / "apps" / "model_serving.py"
@@ -1647,12 +1647,7 @@ class DatabricksProvider(ServiceProvider):
         runtime. Directories are walked file-by-file (``workspace.upload`` has no
         recursive form); parent workspace dirs are created as needed.
         """
-        import io
-
-        from dao_ai.code_paths import (
-            iter_code_path_stagings,
-            walk_code_path_files,
-        )
+        from dao_ai.code_paths import iter_code_path_stagings
 
         stagings = iter_code_path_stagings(config)
         if not stagings:
@@ -1660,26 +1655,65 @@ class DatabricksProvider(ServiceProvider):
 
         uploaded = 0
         for src, dest in stagings:
-            for file_src, file_dest in walk_code_path_files(src, dest):
-                ws_path = f"{source_path}/{file_dest}"
-                parent = ws_path.rsplit("/", 1)[0]
-                try:
-                    self.w.workspace.mkdirs(parent)
-                except Exception as e:  # noqa: BLE001
-                    logger.debug(f"code_paths parent dir may exist: {e}")
-                with open(file_src, "rb") as f:
-                    self.w.workspace.upload(
-                        path=ws_path,
-                        content=io.BytesIO(f.read()),
-                        format=ImportFormat.AUTO,
-                        overwrite=True,
-                    )
-                uploaded += 1
+            uploaded += self._upload_dir_files(src, dest, source_path)
         logger.info(
             "Uploaded custom code (app.code_paths) to app source",
             file_count=uploaded,
             source_path=source_path,
         )
+
+    def _upload_src_packages(self, config: AppConfig, source_path: str) -> None:
+        """Upload colocated ``src/<pkg>`` packages under ``<source_path>/src``.
+
+        The ``src/`` convention: every top-level package under the config's
+        ``src/`` is uploaded so the app's ``uv sync`` (with the generated
+        ``packages=["src"]`` pyproject) builds it into the app wheel — importing
+        prefix-free (``src/foo`` -> ``foo.bar``). No config declaration needed.
+        """
+        from dao_ai.code_paths import _SRC_DIRNAME, discover_src_packages
+
+        uploaded = 0
+        for pkg_dir in discover_src_packages(config):
+            uploaded += self._upload_dir_files(
+                pkg_dir, f"{_SRC_DIRNAME}/{pkg_dir.name}", source_path
+            )
+        if uploaded:
+            logger.info(
+                "Uploaded src/ packages to app source",
+                file_count=uploaded,
+                source_path=source_path,
+            )
+
+    def _upload_dir_files(
+        self, src: "Path", dest: str, source_path: str
+    ) -> int:
+        """Upload one staging pair's files under ``source_path`` (workspace).
+
+        ``workspace.upload`` has no recursive form, so directories are walked
+        file-by-file with parent workspace dirs created as needed. Returns the
+        number of files uploaded.
+        """
+        import io
+
+        from dao_ai.code_paths import walk_code_path_files
+
+        count = 0
+        for file_src, file_dest in walk_code_path_files(src, dest):
+            ws_path = f"{source_path}/{file_dest}"
+            parent = ws_path.rsplit("/", 1)[0]
+            try:
+                self.w.workspace.mkdirs(parent)
+            except Exception as e:  # noqa: BLE001
+                logger.debug(f"workspace parent dir may exist: {e}")
+            with open(file_src, "rb") as f:
+                self.w.workspace.upload(
+                    path=ws_path,
+                    content=io.BytesIO(f.read()),
+                    format=ImportFormat.AUTO,
+                    overwrite=True,
+                )
+            count += 1
+        return count
 
     def deploy_apps_agent(
         self, config: AppConfig, development: bool | None = None
@@ -1855,6 +1889,10 @@ class DatabricksProvider(ServiceProvider):
         # entry's parent onto sys.path. Same declaration used by Model Serving
         # (log_model code_paths) and the bundle generators.
         self._upload_code_paths(config, source_path)
+
+        # Upload colocated src/<pkg> packages (the zero-config convention) so the
+        # app's uv sync (packages=["src"]) builds them into the app wheel.
+        self._upload_src_packages(config, source_path)
 
         # Determine install command based on dev vs published mode.
         # Respect config.app.enable_chat_proxy (default True) so the deployed

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -1133,11 +1133,15 @@ class DatabricksProvider(ServiceProvider):
             user_api_scopes=list(auth_policy.user_auth_policy.api_scopes),
         )
 
-        code_paths: list[str] = config.app.code_paths
-        for path in code_paths:
-            path = Path(path)
-            if not path.exists():
-                raise FileNotFoundError(f"Code path does not exist: {path}")
+        # Resolve config.app.code_paths against the config directory (with a
+        # legacy CWD fallback), fail-loud on a missing entry. Shared with the
+        # Apps/pipeline/generate-* paths via dao_ai.code_paths. ``from_file``
+        # already put resolved code_paths on ``sys.path`` (best-effort); this is
+        # the deploy-time guard that fails loud if any entry is missing before
+        # log_model ships an unimportable model.
+        from dao_ai.code_paths import collect_code_paths
+
+        code_paths: list[str] = collect_code_paths(config)
 
         model_root_path: Path = Path(dao_ai.__file__).parent
         model_path: Path = model_root_path / "apps" / "model_serving.py"
@@ -1634,6 +1638,49 @@ class DatabricksProvider(ServiceProvider):
                 scorer_count=len(registered_scorers),
             )
 
+    def _upload_code_paths(self, config: AppConfig, source_path: str) -> None:
+        """Upload ``config.app.code_paths`` files under the app ``source_path``.
+
+        Each entry is placed preserving its config-relative layout (or under
+        ``code/`` for absolute / ``../``-climbing entries), so the app's
+        ``add_code_paths_to_sys_path`` validator finds it on ``sys.path`` at
+        runtime. Directories are walked file-by-file (``workspace.upload`` has no
+        recursive form); parent workspace dirs are created as needed.
+        """
+        import io
+
+        from dao_ai.code_paths import (
+            iter_code_path_stagings,
+            walk_code_path_files,
+        )
+
+        stagings = iter_code_path_stagings(config)
+        if not stagings:
+            return
+
+        uploaded = 0
+        for src, dest in stagings:
+            for file_src, file_dest in walk_code_path_files(src, dest):
+                ws_path = f"{source_path}/{file_dest}"
+                parent = ws_path.rsplit("/", 1)[0]
+                try:
+                    self.w.workspace.mkdirs(parent)
+                except Exception as e:  # noqa: BLE001
+                    logger.debug(f"code_paths parent dir may exist: {e}")
+                with open(file_src, "rb") as f:
+                    self.w.workspace.upload(
+                        path=ws_path,
+                        content=io.BytesIO(f.read()),
+                        format=ImportFormat.AUTO,
+                        overwrite=True,
+                    )
+                uploaded += 1
+        logger.info(
+            "Uploaded custom code (app.code_paths) to app source",
+            file_count=uploaded,
+            source_path=source_path,
+        )
+
     def deploy_apps_agent(
         self, config: AppConfig, development: bool | None = None
     ) -> None:
@@ -1801,6 +1848,13 @@ class DatabricksProvider(ServiceProvider):
             overwrite=True,
         )
         logger.info("Config file uploaded", path=workspace_config_path)
+
+        # Upload the config's custom code (app.code_paths) next to the config so
+        # it is importable in the app container: the app CWD is source_path and
+        # AppConfig.from_file's add_code_paths_to_sys_path validator inserts each
+        # entry's parent onto sys.path. Same declaration used by Model Serving
+        # (log_model code_paths) and the bundle generators.
+        self._upload_code_paths(config, source_path)
 
         # Determine install command based on dev vs published mode.
         # Respect config.app.enable_chat_proxy (default True) so the deployed

--- a/tests/dao_ai/test_bundle_code_paths.py
+++ b/tests/dao_ai/test_bundle_code_paths.py
@@ -1,0 +1,136 @@
+"""``write_bundle`` (generate-agent) copies ``app.code_paths`` into the bundle.
+
+Custom code declared via ``app.code_paths`` must be copied next to the config in
+the generated Apps bundle so it imports at runtime (bundle root is the app CWD;
+``add_code_paths_to_sys_path`` puts each entry's parent on ``sys.path``). This is
+additive to the manual ``src/<package>`` wheel route, which still works.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from dao_ai.apps.bundle import write_bundle
+from dao_ai.config import AppConfig
+
+_CONFIG = textwrap.dedent(
+    """
+    resources:
+      models:
+        default_llm: &default_llm
+          name: databricks-claude-sonnet-5
+    agents:
+      greeter: &greeter
+        name: greeter
+        description: A friendly assistant.
+        model: *default_llm
+        prompt: You are concise.
+    app:
+      name: cp_bundle_app
+      code_paths:
+        - tools/custom_tool.py
+      registered_model:
+        schema:
+          catalog_name: cat
+          schema_name: sch
+        name: cp_bundle_model
+      agents:
+        - *greeter
+    """
+)
+
+
+@pytest.fixture(autouse=True)
+def _stub_bundle_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Avoid a real ``uv lock`` (needs network / published dao-ai)."""
+
+    def _fake_lock(bundle_dir: Path) -> None:
+        (bundle_dir / "uv.lock").write_text("# stub lock for tests\n")
+
+    monkeypatch.setattr("dao_ai.apps.bundle.generate_bundle_lock", _fake_lock)
+
+
+@pytest.mark.unit
+class TestBundleShipsCodePaths:
+    def _config(self, tmp_path: Path) -> AppConfig:
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "custom_tool.py").write_text(
+            "def my_tool():\n    return 'custom'\n"
+        )
+        cfg_path = tmp_path / "dao_ai.yaml"
+        cfg_path.write_text(_CONFIG)
+        return AppConfig.from_file(str(cfg_path))
+
+    def test_code_path_copied_next_to_config(self, tmp_path: Path) -> None:
+        config = self._config(tmp_path)
+        out = tmp_path / "bundle_out"
+        write_bundle(config, out, overwrite=True)
+
+        # Custom code lands at its config-relative layout under the bundle root
+        # (the app CWD at runtime), alongside the copied dao_ai.yaml.
+        assert (out / "tools" / "custom_tool.py").exists()
+        assert (out / "dao_ai.yaml").exists()
+
+    def test_databricks_yaml_syncs_code_path_dir(self, tmp_path: Path) -> None:
+        import yaml
+
+        config = self._config(tmp_path)
+        out = tmp_path / "bundle_out"
+        write_bundle(config, out, overwrite=True)
+
+        doc = yaml.safe_load((out / "databricks.yaml").read_text())
+        assert "tools/**" in doc["sync"]["include"]
+
+
+@pytest.mark.unit
+class TestDeployAppsUploadsCodePaths:
+    """The Apps direct-deploy uploads code_paths per-file under the source path."""
+
+    def _config(self, tmp_path: Path) -> AppConfig:
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "custom_tool.py").write_text(
+            "def my_tool():\n    return 'custom'\n"
+        )
+        cfg_path = tmp_path / "dao_ai.yaml"
+        cfg_path.write_text(_CONFIG)
+        return AppConfig.from_file(str(cfg_path))
+
+    def test_upload_planner_walks_and_uploads_each_file(
+        self, tmp_path: Path
+    ) -> None:
+        from unittest.mock import MagicMock
+
+        from dao_ai.providers.databricks import DatabricksProvider
+
+        config = self._config(tmp_path)
+        provider = DatabricksProvider(w=MagicMock())
+        source_path = "/Workspace/Users/u/apps/cp-bundle-app"
+
+        provider._upload_code_paths(config, source_path)
+
+        upload_paths = [
+            c.kwargs["path"]
+            for c in provider.w.workspace.upload.call_args_list
+        ]
+        assert upload_paths == [f"{source_path}/tools/custom_tool.py"]
+        # Parent dir created before upload.
+        mkdir_args = [
+            c.args[0] if c.args else c.kwargs.get("path")
+            for c in provider.w.workspace.mkdirs.call_args_list
+        ]
+        assert f"{source_path}/tools" in mkdir_args
+
+    def test_no_uploads_when_no_code_paths(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock
+
+        from dao_ai.providers.databricks import DatabricksProvider
+
+        config = self._config(tmp_path)
+        config.app.code_paths = []
+        provider = DatabricksProvider(w=MagicMock())
+
+        provider._upload_code_paths(config, "/Workspace/Users/u/apps/x")
+        provider.w.workspace.upload.assert_not_called()

--- a/tests/dao_ai/test_bundle_code_paths.py
+++ b/tests/dao_ai/test_bundle_code_paths.py
@@ -134,3 +134,101 @@ class TestDeployAppsUploadsCodePaths:
 
         provider._upload_code_paths(config, "/Workspace/Users/u/apps/x")
         provider.w.workspace.upload.assert_not_called()
+
+
+_SRC_CONFIG = textwrap.dedent(
+    """
+    resources:
+      models:
+        default_llm: &default_llm
+          name: databricks-claude-sonnet-5
+    agents:
+      greeter: &greeter
+        name: greeter
+        description: A friendly assistant.
+        model: *default_llm
+        prompt: You are concise.
+    app:
+      name: src_bundle_app
+      registered_model:
+        schema:
+          catalog_name: cat
+          schema_name: sch
+        name: src_bundle_model
+      agents:
+        - *greeter
+    """
+)
+
+
+@pytest.mark.unit
+class TestPyprojectTemplatesUseSrcConvention:
+    def test_apps_templates_package_src_prefix_free(self) -> None:
+        from dao_ai.apps.bundle import _PYPROJECT_DEV_TEMPLATE, _PYPROJECT_TEMPLATE
+
+        pub = _PYPROJECT_TEMPLATE.format(
+            name="x", package_name="x", dao_ai_version="0.2.4", extras="", extra_deps=""
+        )
+        dev = _PYPROJECT_DEV_TEMPLATE.format(
+            name="x", package_name="x", wheel_filename="w.whl", extras="", extra_deps=""
+        )
+        for rendered in (pub, dev):
+            assert 'packages = ["src"]' in rendered
+            assert 'sources = ["src"]' in rendered
+
+    def test_mcp_templates_package_src_prefix_free(self) -> None:
+        from dao_ai.mcp.generate import _PYPROJECT_DEV_TEMPLATE, _PYPROJECT_TEMPLATE
+
+        pub = _PYPROJECT_TEMPLATE.format(
+            name="x",
+            package_name="x",
+            dao_ai_version="0.2.4",
+            extras="mcp",
+            extra_deps="",
+        )
+        dev = _PYPROJECT_DEV_TEMPLATE.format(
+            name="x",
+            package_name="x",
+            wheel_filename="w.whl",
+            extras="mcp",
+            extra_deps="",
+        )
+        for rendered in (pub, dev):
+            assert 'packages = ["src"]' in rendered
+            # sources=["src"] was MISSING from MCP templates before the convention;
+            # required for prefix-free (foo.bar, not src.foo.bar) imports.
+            assert 'sources = ["src"]' in rendered
+
+
+@pytest.mark.unit
+class TestBundleShipsSrcPackages:
+    def _config(self, tmp_path: Path) -> AppConfig:
+        (tmp_path / "src" / "foo").mkdir(parents=True)
+        (tmp_path / "src" / "foo" / "bar.py").write_text("def t():\n    return 'x'\n")
+        cfg_path = tmp_path / "dao_ai.yaml"
+        cfg_path.write_text(_SRC_CONFIG)
+        return AppConfig.from_file(str(cfg_path))
+
+    def test_src_package_copied_into_bundle(self, tmp_path: Path) -> None:
+        config = self._config(tmp_path)
+        out = tmp_path / "bundle_out"
+        write_bundle(config, out, overwrite=True)
+
+        # Copied under the bundle's src/ so hatch (packages=["src"]) builds it.
+        assert (out / "src" / "foo" / "bar.py").exists()
+
+    def test_upload_src_planner_uploads_under_src(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock
+
+        from dao_ai.providers.databricks import DatabricksProvider
+
+        config = self._config(tmp_path)
+        provider = DatabricksProvider(w=MagicMock())
+        source_path = "/Workspace/Users/u/apps/src-bundle-app"
+
+        provider._upload_src_packages(config, source_path)
+
+        upload_paths = [
+            c.kwargs["path"] for c in provider.w.workspace.upload.call_args_list
+        ]
+        assert upload_paths == [f"{source_path}/src/foo/bar.py"]

--- a/tests/dao_ai/test_bundle_dependency_lock.py
+++ b/tests/dao_ai/test_bundle_dependency_lock.py
@@ -19,9 +19,12 @@ from pathlib import Path
 
 import pytest
 
-from dao_ai.apps.bundle import _PYPROJECT_DEV_TEMPLATE, _PYPROJECT_TEMPLATE
+from dao_ai.apps.bundle import (
+    _PYPROJECT_DEV_TEMPLATE,
+    _PYPROJECT_TEMPLATE,
+    _format_extra_deps,
+)
 from dao_ai.utils import dev_local_version
-
 
 # ---------------------------------------------------------------------------
 # pyproject templates — dev redirects dao-ai to the bundled wheel
@@ -35,6 +38,7 @@ class TestPyprojectTemplates:
             package_name="foo_bar",
             wheel_filename="dao_ai-0.2.0-py3-none-any.whl",
             extras="[a2a]",
+            extra_deps="",
         )
         assert "[tool.uv.sources]" in rendered
         assert 'dao-ai = { path = "dist/dao_ai-0.2.0-py3-none-any.whl" }' in rendered
@@ -47,11 +51,25 @@ class TestPyprojectTemplates:
             package_name="foo_bar",
             dao_ai_version="0.2.0",
             extras="[a2a,rerank]",
+            extra_deps="",
         )
         # Exact pin (==) for reproducible redeploys, extras threaded through.
         assert "dao-ai[a2a,rerank]==0.2.0" in rendered
         # No local wheel source in published mode.
         assert "tool.uv.sources" not in rendered
+
+    def test_published_template_threads_user_pip_requirements(self) -> None:
+        # config.app.pip_requirements flow through the {extra_deps} slot so the
+        # generated pyproject's dependency array captures the deployer's own
+        # packages alongside dao-ai.
+        rendered: str = _PYPROJECT_TEMPLATE.format(
+            name="foo-bar",
+            package_name="foo_bar",
+            dao_ai_version="0.2.0",
+            extras="",
+            extra_deps=_format_extra_deps(["httpx>=0.27"]),
+        )
+        assert '"httpx>=0.27",' in rendered
 
 
 # ---------------------------------------------------------------------------

--- a/tests/dao_ai/test_bundle_dependency_lock.py
+++ b/tests/dao_ai/test_bundle_dependency_lock.py
@@ -93,6 +93,33 @@ class TestGenerateBundleLock:
 
         return _run
 
+    def test_render_portable_lock_stubs_src_package(self, monkeypatch) -> None:
+        """``render_portable_lock`` must create a stub package under ``src/`` so
+        hatch can build the local project during locking. The template now uses
+        ``packages = ["src"]`` (not ``src/<pkg>``); a stub must still appear."""
+        from dao_ai import _locking
+
+        seen: dict[str, bool] = {}
+
+        def _run(cmd, cwd=None, capture_output=None, text=None, check=None):
+            seen["stub"] = (Path(cwd) / "src" / "_daoai_lockstub" / "__init__.py").exists()
+            (Path(cwd) / "uv.lock").write_text("# stub lock\n")
+
+            class _R:
+                returncode = 0
+                stderr = ""
+
+            return _R()
+
+        monkeypatch.setattr(_locking.subprocess, "run", _run)
+        pyproject = (
+            '[project]\nname = "x"\n'
+            '[tool.hatch.build.targets.wheel]\n'
+            'packages = ["src"]\nsources = ["src"]\n'
+        )
+        _locking.render_portable_lock(pyproject)
+        assert seen.get("stub") is True
+
     def test_rewrites_mirror_host_to_public_cdn(self, tmp_path, monkeypatch) -> None:
         from dao_ai import _locking
 

--- a/tests/dao_ai/test_code_paths.py
+++ b/tests/dao_ai/test_code_paths.py
@@ -53,6 +53,37 @@ def _write_config(tmp_path: Path, code_paths: list[str]) -> AppConfig:
     return AppConfig.from_file(str(tmp_path / "cfg.yaml"))
 
 
+_CONFIG_NO_CODE_PATHS = textwrap.dedent(
+    """
+    schemas:
+      s: &s
+        catalog_name: cat
+        schema_name: sch
+    resources:
+      models:
+        m: &m
+          name: databricks-claude-sonnet-5
+    agents:
+      a: &a
+        name: agent_one
+        model: *m
+        prompt: hi
+    app:
+      name: test_app
+      registered_model:
+        schema: *s
+        name: test_model
+      agents:
+      - *a
+    """
+)
+
+
+def _write_config_no_code_paths(tmp_path: Path) -> AppConfig:
+    (tmp_path / "cfg.yaml").write_text(_CONFIG_NO_CODE_PATHS)
+    return AppConfig.from_file(str(tmp_path / "cfg.yaml"))
+
+
 class TestResolveCodePath:
     def test_config_relative_resolves_against_config_dir(self, tmp_path: Path) -> None:
         (tmp_path / "tools").mkdir()
@@ -223,3 +254,82 @@ class TestCodePathSyncGlobs:
         abs_file.write_text("x = 1\n")
         config = _write_config(tmp_path, [str(abs_file)])
         assert cp.code_path_sync_globs(config) == ["code/**"]
+
+
+class TestDiscoverSrcPackages:
+    def test_discovers_top_level_packages(self, tmp_path: Path) -> None:
+        (tmp_path / "src" / "foo").mkdir(parents=True)
+        (tmp_path / "src" / "baz").mkdir()
+        (tmp_path / "src" / "foo" / "bar.py").write_text("x = 1\n")  # namespace pkg
+        (tmp_path / "src" / "baz" / "__init__.py").write_text("")   # regular pkg
+        config = _write_config_no_code_paths(tmp_path)
+
+        names = [p.name for p in cp.discover_src_packages(config)]
+        assert names == ["baz", "foo"]  # sorted
+
+    def test_absent_src_returns_empty(self, tmp_path: Path) -> None:
+        config = _write_config_no_code_paths(tmp_path)
+        assert cp.discover_src_packages(config) == []
+
+    def test_empty_src_returns_empty(self, tmp_path: Path) -> None:
+        (tmp_path / "src").mkdir()
+        config = _write_config_no_code_paths(tmp_path)
+        assert cp.discover_src_packages(config) == []
+
+    def test_skips_loose_files_pycache_egginfo(self, tmp_path: Path) -> None:
+        (tmp_path / "src" / "foo").mkdir(parents=True)
+        (tmp_path / "src" / "foo" / "__init__.py").write_text("")
+        (tmp_path / "src" / "loose.py").write_text("x = 1\n")  # loose file → ignored
+        (tmp_path / "src" / "__pycache__").mkdir()
+        (tmp_path / "src" / "pkg.egg-info").mkdir()
+        config = _write_config_no_code_paths(tmp_path)
+
+        assert [p.name for p in cp.discover_src_packages(config)] == ["foo"]
+
+
+class TestCollectServingCodePaths:
+    def test_unions_code_paths_and_src(self, tmp_path: Path) -> None:
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "t.py").write_text("x = 1\n")
+        (tmp_path / "src" / "foo").mkdir(parents=True)
+        (tmp_path / "src" / "foo" / "bar.py").write_text("x = 1\n")
+        config = _write_config(tmp_path, ["tools/t.py"])
+
+        names = sorted(Path(p).name for p in cp.collect_serving_code_paths(config))
+        assert names == ["foo", "t.py"]
+
+    def test_dedupes_code_path_pointing_into_src(self, tmp_path: Path) -> None:
+        # A code_paths entry that IS a src package must not be shipped twice.
+        (tmp_path / "src" / "foo").mkdir(parents=True)
+        (tmp_path / "src" / "foo" / "bar.py").write_text("x = 1\n")
+        config = _write_config(tmp_path, ["src/foo"])
+
+        resolved = cp.collect_serving_code_paths(config)
+        assert len(resolved) == 1
+        assert Path(resolved[0]).name == "foo"
+
+
+class TestPrependSrcToSysPath:
+    def test_puts_src_on_path_import_prefix_free(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "src" / "cpkg").mkdir(parents=True)
+        (tmp_path / "src" / "cpkg" / "mod.py").write_text("VALUE = 'src-ok'\n")
+        config = _write_config_no_code_paths(tmp_path)
+
+        other = tmp_path / "elsewhere"
+        other.mkdir()
+        monkeypatch.chdir(other)
+
+        import importlib
+        import sys as _sys
+
+        _sys.modules.pop("cpkg", None)
+        _sys.modules.pop("cpkg.mod", None)
+        cp.prepend_src_to_sys_path(config)
+        # FQN is prefix-free: cpkg.mod, NOT src.cpkg.mod
+        assert importlib.import_module("cpkg.mod").VALUE == "src-ok"
+
+    def test_noop_when_src_absent(self, tmp_path: Path) -> None:
+        config = _write_config_no_code_paths(tmp_path)
+        cp.prepend_src_to_sys_path(config)  # must not raise

--- a/tests/dao_ai/test_code_paths.py
+++ b/tests/dao_ai/test_code_paths.py
@@ -1,0 +1,225 @@
+"""Unit tests for the shared ``code_paths`` helpers.
+
+These cover the resolver, the Model Serving collector, the shared staging
+planner (used by both bundle generators and the Apps upload), and the sync-glob
+helper. Path-semantics contract: relative entries resolve against the config
+file's directory, with a legacy CWD fallback; absolute / ``../``-climbing entries
+fall back to a ``code/<basename>`` bundle dest.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from dao_ai import code_paths as cp
+from dao_ai.config import AppConfig
+
+_CONFIG_TEMPLATE = textwrap.dedent(
+    """
+    schemas:
+      s: &s
+        catalog_name: cat
+        schema_name: sch
+    resources:
+      models:
+        m: &m
+          name: databricks-claude-sonnet-5
+    agents:
+      a: &a
+        name: agent_one
+        model: *m
+        prompt: hi
+    app:
+      name: test_app
+      code_paths:
+    {code_paths_block}
+      registered_model:
+        schema: *s
+        name: test_model
+      agents:
+      - *a
+    """
+)
+
+
+def _write_config(tmp_path: Path, code_paths: list[str]) -> AppConfig:
+    block = "\n".join(f"    - {p}" for p in code_paths)
+    (tmp_path / "cfg.yaml").write_text(
+        _CONFIG_TEMPLATE.format(code_paths_block=block)
+    )
+    return AppConfig.from_file(str(tmp_path / "cfg.yaml"))
+
+
+class TestResolveCodePath:
+    def test_config_relative_resolves_against_config_dir(self, tmp_path: Path) -> None:
+        (tmp_path / "tools").mkdir()
+        target = tmp_path / "tools" / "custom_tool.py"
+        target.write_text("def my_tool():\n    return 'x'\n")
+        config = _write_config(tmp_path, ["tools/custom_tool.py"])
+
+        resolved = cp.resolve_code_path("tools/custom_tool.py", config)
+        assert resolved == target.resolve()
+
+    def test_absolute_passes_through(self, tmp_path: Path) -> None:
+        target = tmp_path / "abs_tool.py"
+        target.write_text("x = 1\n")
+        config = _write_config(tmp_path, ["tools/placeholder.py"])
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "placeholder.py").write_text("x = 1\n")
+
+        resolved = cp.resolve_code_path(str(target), config)
+        assert resolved == target
+
+    def test_cwd_fallback_for_legacy_relative(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Config lives in one dir; the code file only exists relative to CWD —
+        # the legacy Model Serving behavior. The fallback must still find it.
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "placeholder.py").write_text("x = 1\n")
+        config = _write_config(tmp_path, ["tools/placeholder.py"])
+
+        cwd = tmp_path / "elsewhere"
+        (cwd / "legacy").mkdir(parents=True)
+        (cwd / "legacy" / "mod.py").write_text("x = 1\n")
+        monkeypatch.chdir(cwd)
+
+        resolved = cp.resolve_code_path("legacy/mod.py", config)
+        assert resolved == (cwd / "legacy" / "mod.py").resolve()
+
+    def test_missing_returns_none(self, tmp_path: Path) -> None:
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "placeholder.py").write_text("x = 1\n")
+        config = _write_config(tmp_path, ["tools/placeholder.py"])
+        assert cp.resolve_code_path("tools/nope.py", config) is None
+
+
+class TestCollectCodePaths:
+    def test_dedupes_and_preserves_order(self, tmp_path: Path) -> None:
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "a.py").write_text("x = 1\n")
+        (tmp_path / "tools" / "b.py").write_text("x = 1\n")
+        config = _write_config(
+            tmp_path, ["tools/a.py", "tools/b.py", "tools/a.py"]
+        )
+
+        collected = cp.collect_code_paths(config)
+        assert [Path(p).name for p in collected] == ["a.py", "b.py"]
+
+    def test_raises_on_missing(self, tmp_path: Path) -> None:
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "placeholder.py").write_text("x = 1\n")
+        config = _write_config(tmp_path, ["tools/placeholder.py"])
+        config.app.code_paths = ["tools/missing.py"]
+
+        with pytest.raises(FileNotFoundError, match="missing.py"):
+            cp.collect_code_paths(config)
+
+    def test_empty_when_no_code_paths(self, tmp_path: Path) -> None:
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "placeholder.py").write_text("x = 1\n")
+        config = _write_config(tmp_path, ["tools/placeholder.py"])
+        config.app.code_paths = []
+        assert cp.collect_code_paths(config) == []
+
+
+class TestIterCodePathStagings:
+    def test_file_entry_preserves_layout(self, tmp_path: Path) -> None:
+        (tmp_path / "tools").mkdir()
+        target = tmp_path / "tools" / "custom_tool.py"
+        target.write_text("x = 1\n")
+        config = _write_config(tmp_path, ["tools/custom_tool.py"])
+
+        stagings = cp.iter_code_path_stagings(config)
+        assert stagings == [(target.resolve(), "tools/custom_tool.py")]
+
+    def test_directory_entry_single_pair(self, tmp_path: Path) -> None:
+        pkg = tmp_path / "mypkg"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        (pkg / "mod.py").write_text("x = 1\n")
+        config = _write_config(tmp_path, ["mypkg"])
+
+        stagings = cp.iter_code_path_stagings(config)
+        assert stagings == [(pkg.resolve(), "mypkg")]
+
+    def test_absolute_entry_falls_back_to_code_prefix(self, tmp_path: Path) -> None:
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "placeholder.py").write_text("x = 1\n")
+        abs_file = tmp_path / "outside.py"
+        abs_file.write_text("x = 1\n")
+        config = _write_config(tmp_path, [str(abs_file)])
+
+        stagings = cp.iter_code_path_stagings(config)
+        assert stagings == [(abs_file, "code/outside.py")]
+
+
+class TestWalkCodePathFiles:
+    def test_file_yields_itself(self, tmp_path: Path) -> None:
+        f = tmp_path / "a.py"
+        f.write_text("x = 1\n")
+        assert cp.walk_code_path_files(f, "tools/a.py") == [(f, "tools/a.py")]
+
+    def test_directory_walks_and_skips_pycache(self, tmp_path: Path) -> None:
+        pkg = tmp_path / "pkg"
+        (pkg / "__pycache__").mkdir(parents=True)
+        (pkg / "__pycache__" / "x.pyc").write_text("junk")
+        (pkg / "__init__.py").write_text("")
+        (pkg / "mod.py").write_text("x = 1\n")
+
+        walked = cp.walk_code_path_files(pkg, "pkg")
+        dests = sorted(d for _s, d in walked)
+        assert dests == ["pkg/__init__.py", "pkg/mod.py"]
+
+
+class TestPrependCodePathsToSysPath:
+    def test_makes_config_relative_module_importable_from_other_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Custom module colocated with the config; process CWD is elsewhere
+        # (mimics deploy-time log_model validation running from the repo root).
+        (tmp_path / "custom_pkg").mkdir()
+        (tmp_path / "custom_pkg" / "mod.py").write_text("VALUE = 'cp-ok'\n")
+        config = _write_config(tmp_path, ["custom_pkg"])
+
+        other = tmp_path / "elsewhere"
+        other.mkdir()
+        monkeypatch.chdir(other)
+
+        import sys as _sys
+
+        _sys.modules.pop("custom_pkg", None)
+        _sys.modules.pop("custom_pkg.mod", None)
+        cp.prepend_code_paths_to_sys_path(config)
+        import importlib
+
+        mod = importlib.import_module("custom_pkg.mod")
+        assert mod.VALUE == "cp-ok"
+
+    def test_noop_when_no_code_paths(self, tmp_path: Path) -> None:
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "placeholder.py").write_text("x = 1\n")
+        config = _write_config(tmp_path, ["tools/placeholder.py"])
+        config.app.code_paths = []
+        # Should not raise.
+        cp.prepend_code_paths_to_sys_path(config)
+
+
+class TestCodePathSyncGlobs:
+    def test_config_relative_entries_contribute_nothing(self, tmp_path: Path) -> None:
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "a.py").write_text("x = 1\n")
+        config = _write_config(tmp_path, ["tools/a.py"])
+        # 'tools' is a top-level dir next to the config, not 'config'
+        assert cp.code_path_sync_globs(config) == ["tools/**"]
+
+    def test_absolute_entry_yields_code_glob(self, tmp_path: Path) -> None:
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "placeholder.py").write_text("x = 1\n")
+        abs_file = tmp_path / "outside.py"
+        abs_file.write_text("x = 1\n")
+        config = _write_config(tmp_path, [str(abs_file)])
+        assert cp.code_path_sync_globs(config) == ["code/**"]

--- a/tests/dao_ai/test_pipeline_bundle.py
+++ b/tests/dao_ai/test_pipeline_bundle.py
@@ -387,6 +387,19 @@ class TestWritePipelineBundle:
         doc = yaml.safe_load((out / "databricks.yaml").read_text())
         assert "config/**" in doc["sync"]["include"]
 
+    def test_stages_src_packages_under_config_src(self, tmp_path: Path) -> None:
+        # The src/ convention: a colocated src/<pkg> stages under config/src/<pkg>
+        # so the deploy notebook's src anchor (config/src) yields foo.bar.
+        (tmp_path / "src" / "foo").mkdir(parents=True)
+        (tmp_path / "src" / "foo" / "bar.py").write_text(
+            "def my_tool():\n    return 'src-custom'\n"
+        )
+        config = self._load(tmp_path, _MINIMAL_CONFIG)
+        out = tmp_path / "bundle"
+        write_pipeline_bundle(config, out)
+
+        assert (out / "config" / "src" / "foo" / "bar.py").exists()
+
     def test_sibling_use_case_assets_stage_and_get_sync_glob(
         self, tmp_path: Path
     ) -> None:

--- a/tests/dao_ai/test_pipeline_bundle.py
+++ b/tests/dao_ai/test_pipeline_bundle.py
@@ -349,6 +349,44 @@ class TestWritePipelineBundle:
         assert (out / "config" / "data" / "seed.sql").exists()
         assert (out / "config" / "functions" / "fn.sql").exists()
 
+    _CODE_PATHS_CONFIG = (
+        "resources:\n"
+        "  models:\n"
+        "    default_llm: &default_llm\n"
+        "      name: databricks-gpt-5-4-mini\n"
+        "agents:\n"
+        "  greeter: &greeter\n"
+        "    name: greeter\n"
+        "    description: A friendly assistant.\n"
+        "    model: *default_llm\n"
+        "    prompt: You are a concise assistant.\n"
+        "app:\n"
+        "  name: cp_app\n"
+        "  deployment_target: apps\n"
+        "  code_paths:\n"
+        "    - tools/custom_tool.py\n"
+        "  agents:\n"
+        "    - *greeter\n"
+    )
+
+    def test_stages_code_paths_next_to_config(self, tmp_path: Path) -> None:
+        # Custom code colocated with the config stages under config/ so the
+        # deploy notebook resolves it against the staged config directory.
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "custom_tool.py").write_text(
+            "def my_tool():\n    return 'custom'\n"
+        )
+        config = self._load(tmp_path, self._CODE_PATHS_CONFIG)
+        out = tmp_path / "bundle"
+        write_pipeline_bundle(config, out)
+
+        assert (out / "config" / "tools" / "custom_tool.py").exists()
+        # config/** already covers it; no extra sync glob needed.
+        import yaml
+
+        doc = yaml.safe_load((out / "databricks.yaml").read_text())
+        assert "config/**" in doc["sync"]["include"]
+
     def test_sibling_use_case_assets_stage_and_get_sync_glob(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary

`app.code_paths` — custom user code (e.g. a `type: python` tool's module) — now ships to **both** deployment targets across **all** deploy paths. Previously it was handled inconsistently, and was silently dropped in two paths.

### Gaps closed

| Path × Target | Before | After |
|---|---|---|
| `deploy` → model_serving | ✅ `log_model(code_paths=...)` | ✅ (now via shared resolver) |
| `deploy` → **apps** | ❌ only an empty `src/<pkg>` stub uploaded | ✅ files uploaded next to the config |
| `generate-workflow` → model_serving | ❌ files not staged → deploy job `FileNotFoundError` | ✅ staged under `config/` |
| `generate-workflow` → apps | ❌ same gap | ✅ (rides the apps upload) |
| `generate-agent` / `generate-mcp` → apps | ⚠️ manual `src/<pkg>` only | ✅ auto-copied (manual route still works) |

## Design

- **Path contract:** `code_paths` resolve relative to the config file's directory (like `ddl`/`data` assets and skills); absolute paths pass through.
- **New shared module `dao_ai/code_paths.py`** centralizes all logic: `resolve_code_path`, `collect_code_paths` (fail-loud; replaces the inline loop in `create_agent`), `iter_code_path_stagings` + `walk_code_path_files` (the DRY staging/upload planner shared by bundle generators and the Apps upload), `code_path_sync_globs`, `prepend_code_paths_to_sys_path`.
- **`AppConfig.from_file`** now prepends resolved `code_paths` onto `sys.path` once the config dir is known. The `add_code_paths_to_sys_path` validator runs at construction — before `_source_config_path` is set — so it could only anchor at CWD; the fix makes config-relative modules importable for every consumer (deploy notebook `display_graph`/`create_agent`, Apps runtime, `load_function` tool resolution) regardless of process CWD. Best-effort on load; `create_agent` still fails loud at deploy time.
- **Apps upload** (`_upload_code_paths`) walks directories and uploads each file next to the config; the runtime `sys.path` validator makes them importable (no wheel build). The manual `src/<package>` hatch-wheel route is unchanged.

## Also

Fixes 2 pre-existing stale tests in `test_bundle_dependency_lock.py` that called the pyproject templates without the `extra_deps` kwarg (`KeyError`, failing on `main` today).

## Validation

- **Unit:** new `test_code_paths.py` (resolver/collector/planner/sys.path), `test_bundle_code_paths.py` (apps bundle copy + upload planner with mocked workspace), extended `test_pipeline_bundle.py` (workflow staging). 62 relevant tests green.
- **Live FEVM 4-way matrix:** a config with a colocated custom `type: python` tool deployed via `deploy` and `generate-workflow`, to `model_serving` and `apps`. In every case a request exercising the tool returns its distinctive output (proves import + execution), and MLflow traces capture the tool run. Two CWD-vs-config-dir bugs surfaced during live testing and were fixed centrally in `from_file`.

No dependency changes (`uv.lock` untouched). `make schema` regenerated for the `code_paths` field description update.

This pull request and its description were written by Isaac.