### PR TITLE
feat(deploy): auto-package a colocated src/ across all targets (prefix-free FQN)

### DIFF
--- a/src/dao_ai/_locking.py
+++ b/src/dao_ai/_locking.py
@@ -114,12 +114,20 @@ def render_portable_lock(pyproject_content: str, wheel_path: Path | None = None)
     with tempfile.TemporaryDirectory() as tmp:
         tmp_dir = Path(tmp)
         (tmp_dir / "pyproject.toml").write_text(pyproject_content)
-        # Stub package so uv can build the local project (packages = ["src/..."]).
+        # Stub package so uv can build the local project during locking. dao-ai
+        # templates use ``packages = ["src"]`` (auto-discover every package under
+        # ``src/``); older bundles used ``packages = ["src/<pkg>"]``. Either way
+        # hatch needs at least one package present under ``src/`` — create a stub.
         import re
 
-        match = re.search(r'packages\s*=\s*\["src/([^"]+)"\]', pyproject_content)
-        if match:
-            pkg_dir = tmp_dir / "src" / match.group(1)
+        legacy = re.search(r'packages\s*=\s*\["src/([^"]+)"\]', pyproject_content)
+        if legacy:
+            pkg_dir = tmp_dir / "src" / legacy.group(1)
+        elif re.search(r'packages\s*=\s*\["src"\]', pyproject_content):
+            pkg_dir = tmp_dir / "src" / "_daoai_lockstub"
+        else:
+            pkg_dir = None
+        if pkg_dir is not None:
             pkg_dir.mkdir(parents=True, exist_ok=True)
             (pkg_dir / "__init__.py").write_text("")
         if wheel_path is not None:

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -33,7 +33,7 @@ from dao_ai.apps.resources import (
     generate_app_resources,
     generate_user_api_scopes,
 )
-from dao_ai.code_paths import code_path_sync_globs
+from dao_ai.code_paths import _SRC_DIRNAME, code_path_sync_globs
 from dao_ai.config import AppConfig, value_of
 
 
@@ -119,7 +119,9 @@ dependencies = [
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/{package_name}"]
+# ``packages = ["src"]`` auto-discovers every top-level package under ``src/``
+# (the ``src/`` convention), so ``src/foo/bar.py`` installs as ``foo.bar``.
+packages = ["src"]
 sources = ["src"]
 """
 
@@ -142,7 +144,9 @@ dependencies = [
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/{package_name}"]
+# ``packages = ["src"]`` auto-discovers every top-level package under ``src/``
+# (the ``src/`` convention), so ``src/foo/bar.py`` installs as ``foo.bar``.
+packages = ["src"]
 sources = ["src"]
 
 [tool.uv.sources]
@@ -848,10 +852,29 @@ def write_bundle(
     # This is the uniform declaration shared with Model Serving and the direct
     # Apps/pipeline deploys; the manual ``src/<package>`` wheel route still works
     # for users who prefer to hand-package their code.
-    from dao_ai.code_paths import iter_code_path_stagings, walk_code_path_files
+    from dao_ai.code_paths import (
+        discover_src_packages,
+        iter_code_path_stagings,
+        walk_code_path_files,
+    )
 
     for src, code_dest in iter_code_path_stagings(config):
         for file_src, file_dest in walk_code_path_files(src, code_dest):
+            out = output_dir / file_dest
+            if out.exists() and not overwrite:
+                skipped.append(file_dest)
+                continue
+            out.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(file_src, out)
+            written.append(file_dest)
+
+    # Convention: copy any colocated ``src/<pkg>`` packages into the bundle's
+    # ``src/`` so hatch (``packages=["src"]``) builds them into the app wheel —
+    # ``src/foo/bar.py`` installs as ``foo.bar``. No config declaration needed.
+    for pkg_dir in discover_src_packages(config):
+        for file_src, file_dest in walk_code_path_files(
+            pkg_dir, f"{_SRC_DIRNAME}/{pkg_dir.name}"
+        ):
             out = output_dir / file_dest
             if out.exists() and not overwrite:
                 skipped.append(file_dest)

--- a/src/dao_ai/code_paths.py
+++ b/src/dao_ai/code_paths.py
@@ -44,6 +44,12 @@ if TYPE_CHECKING:
 # ``skills/<basename>`` fallback used for skill bundling.
 _CODE_FALLBACK_PREFIX = "code"
 
+# Convention: a ``src/`` directory colocated with the config auto-ships every
+# top-level package under it as custom code (no ``code_paths`` declaration
+# needed). The import FQN drops the ``src`` prefix — ``src/foo/bar.py`` imports
+# as ``foo.bar`` — in every target (see the module docstring / the deploy code).
+_SRC_DIRNAME = "src"
+
 # Directory entries whose contents dao-ai never needs to ship.
 _SKIP_DIR_NAMES = {"__pycache__"}
 
@@ -143,6 +149,79 @@ def prepend_code_paths_to_sys_path(config: "AppConfig") -> None:
         if parent not in sys.path:
             sys.path.insert(0, parent)
             logger.debug("Prepended resolved code_path parent to sys.path", path=parent)
+
+
+def _src_dir(config: "AppConfig") -> Path:
+    """The ``src/`` directory colocated with the config (may not exist)."""
+    return _code_paths_base_dir(config) / _SRC_DIRNAME
+
+
+def discover_src_packages(config: "AppConfig") -> list[Path]:
+    """Top-level package directories under the config's colocated ``src/``.
+
+    The ``src/`` convention auto-ships custom code with NO ``code_paths``
+    declaration: any top-level directory under ``<config_dir>/src`` is a
+    package (namespace packages allowed — ``__init__.py`` is not required).
+    Loose files directly under ``src/`` are ignored (``src/`` holds packages,
+    not modules); ``__pycache__`` and ``*.egg-info`` are skipped.
+
+    Callers ship these so ``src/foo/bar.py`` imports as ``foo.bar`` (never
+    ``src.foo``): Model Serving passes each dir to ``log_model(code_paths=...)``
+    (MLflow copies it to ``code/foo/``); the wheel path lets hatch
+    (``packages=["src"]``) discover it; local validation puts ``src/`` itself on
+    ``sys.path`` (see :func:`prepend_src_to_sys_path`). Sorted, deduped; ``[]``
+    when ``src/`` is absent or empty.
+    """
+    src_dir = _src_dir(config)
+    if not src_dir.is_dir():
+        return []
+
+    packages: list[Path] = []
+    for child in sorted(src_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        if child.name in _SKIP_DIR_NAMES or child.name.endswith(".egg-info"):
+            continue
+        packages.append(child.resolve())
+    return packages
+
+
+def prepend_src_to_sys_path(config: "AppConfig") -> None:
+    """Put ``<config_dir>/src`` on ``sys.path`` so ``src/`` packages import.
+
+    Best-effort, idempotent. Makes ``import foo`` resolve during in-process
+    ``log_model`` validation (and any config load), matching the Model Serving
+    ``code/foo/`` layout and the Apps wheel — all three yield ``foo.bar``.
+    No-op when ``src/`` is absent.
+    """
+    import sys
+
+    src_dir = _src_dir(config)
+    if not src_dir.is_dir():
+        return
+    src_path = str(src_dir.resolve())
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
+        logger.debug("Prepended src/ to sys.path", path=src_path)
+
+
+def collect_serving_code_paths(config: "AppConfig") -> list[str]:
+    """Model Serving ``code_paths``: explicit ``code_paths`` + ``src/`` packages.
+
+    The deduped (by resolved posix path) union of :func:`collect_code_paths`
+    (explicit, out-of-tree, fail-loud on missing) and :func:`discover_src_packages`
+    (the colocated ``src/`` convention). Passing each ``src/`` package dir makes
+    MLflow copy it to ``code/<pkg>`` → import ``<pkg>.mod``. Deduping prevents a
+    double-ship when a ``code_paths`` entry points into ``src/``.
+    """
+    resolved: list[str] = list(collect_code_paths(config))
+    seen: set[str] = set(resolved)
+    for pkg in discover_src_packages(config):
+        as_str = pkg.as_posix()
+        if as_str not in seen:
+            seen.add(as_str)
+            resolved.append(as_str)
+    return resolved
 
 
 def iter_code_path_stagings(config: "AppConfig") -> list[tuple[Path, str]]:

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -31,6 +31,7 @@ import yaml
 
 if TYPE_CHECKING:
     from a2a.types import SecurityScheme
+
     from dao_ai.audit import LakebaseAuditSink
     from dao_ai.genie.cache.context_aware.optimization import (
         ContextAwareCacheEvalDataset,
@@ -38,6 +39,8 @@ if TYPE_CHECKING:
     )
     from dao_ai.state import Context
 
+from databricks.ai_search.client import VectorSearchClient
+from databricks.ai_search.index import VectorSearchIndex
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.credentials_provider import (
     CredentialsStrategy,
@@ -48,8 +51,6 @@ from databricks.sdk.service.apps import App
 from databricks.sdk.service.catalog import FunctionInfo, TableInfo
 from databricks.sdk.service.dashboards import GenieListSpacesResponse, GenieSpace
 from databricks.sdk.service.sql import GetWarehouseResponse
-from databricks.ai_search.client import VectorSearchClient
-from databricks.ai_search.index import VectorSearchIndex
 from databricks_langchain import (
     ChatDatabricks,
     DatabricksEmbeddings,
@@ -9254,9 +9255,8 @@ class A2AModel(BaseModel):
         from dao_ai._extras import require_extra
 
         require_extra("a2a", feature="A2A security schemes")
-        from pydantic import TypeAdapter
-
         from a2a.types import SecurityScheme
+        from pydantic import TypeAdapter
 
         # TypeAdapter validates both raw dicts and already-constructed
         # SecurityScheme instances against the discriminated union.
@@ -10888,9 +10888,16 @@ class AppConfig(BaseModel):
         # consumer that loads a config from a file — the deploy notebook's
         # ``display_graph``/``create_agent``, the Apps runtime, and any tool
         # resolution via ``load_function`` — regardless of the process CWD.
-        from dao_ai.code_paths import prepend_code_paths_to_sys_path
+        from dao_ai.code_paths import (
+            prepend_code_paths_to_sys_path,
+            prepend_src_to_sys_path,
+        )
 
         prepend_code_paths_to_sys_path(config)
+        # Convention: a colocated ``src/`` dir auto-ships its packages; put it on
+        # sys.path so ``src/foo/bar.py`` imports as ``foo.bar`` for every consumer
+        # (deploy notebook display_graph/create_agent, Apps runtime, load_function).
+        prepend_src_to_sys_path(config)
         # Stash the pre-substitution dict so tooling can recover which
         # YAML fields were backed by ``${var.X}`` references.
         config._raw_yaml_dict = raw_dict

--- a/src/dao_ai/mcp/generate.py
+++ b/src/dao_ai/mcp/generate.py
@@ -199,10 +199,28 @@ def write_mcp_bundle(
     # Copy the config's custom code (app.code_paths) next to the config so it is
     # importable at runtime (bundle root is the app CWD; add_code_paths_to_sys_path
     # inserts each entry's parent onto sys.path). Shared with generate-agent.
-    from dao_ai.code_paths import iter_code_path_stagings, walk_code_path_files
+    from dao_ai.code_paths import (
+        _SRC_DIRNAME,
+        discover_src_packages,
+        iter_code_path_stagings,
+        walk_code_path_files,
+    )
 
     for src, code_dest in iter_code_path_stagings(config):
         for file_src, file_dest in walk_code_path_files(src, code_dest):
+            out = output_dir / file_dest
+            if out.exists():
+                continue
+            out.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(file_src, out)
+            written.append(file_dest)
+
+    # Convention: copy colocated ``src/<pkg>`` packages into the bundle's ``src/``
+    # so hatch (``packages=["src"]``) builds them prefix-free (``foo.bar``).
+    for pkg_dir in discover_src_packages(config):
+        for file_src, file_dest in walk_code_path_files(
+            pkg_dir, f"{_SRC_DIRNAME}/{pkg_dir.name}"
+        ):
             out = output_dir / file_dest
             if out.exists():
                 continue
@@ -396,7 +414,10 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/{package_name}"]
+# ``packages = ["src"]`` + ``sources = ["src"]`` auto-discovers every top-level
+# package under ``src/`` and installs it prefix-free (``src/foo`` -> ``foo``).
+packages = ["src"]
+sources = ["src"]
 """
 
 _PYPROJECT_DEV_TEMPLATE = """\
@@ -415,7 +436,8 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/{package_name}"]
+packages = ["src"]
+sources = ["src"]
 
 [tool.uv.sources]
 dao-ai = {{ path = "dist/{wheel_filename}" }}

--- a/src/dao_ai/pipeline/bundle.py
+++ b/src/dao_ai/pipeline/bundle.py
@@ -376,6 +376,46 @@ def _stage_code_paths(
     return copied
 
 
+def _stage_src_packages(
+    config: AppConfig,
+    output_dir: Path,
+    overwrite: bool,
+) -> list[str]:
+    """Copy colocated ``src/<pkg>`` packages into the staged bundle under ``config/src``.
+
+    The ``src/`` convention: packages stage under ``config/src/<pkg>`` (next to
+    the staged config), so when ``06_deploy_agent.py`` reloads the staged config
+    its ``src/`` anchor is ``config/src`` — ``collect_serving_code_paths`` passes
+    each ``config/src/<pkg>`` to ``log_model`` (MLflow -> ``code/<pkg>``) and
+    ``prepend_src_to_sys_path`` puts ``config/src`` on ``sys.path``, both yielding
+    ``<pkg>.mod``. Returns bundle-relative labels copied.
+    """
+    from dao_ai.code_paths import (
+        _SRC_DIRNAME,
+        discover_src_packages,
+        walk_code_path_files,
+    )
+
+    dest_anchor = (output_dir / "config").resolve()
+    copied: list[str] = []
+    for pkg_dir in discover_src_packages(config):
+        for file_src, file_dest in walk_code_path_files(
+            pkg_dir, f"{_SRC_DIRNAME}/{pkg_dir.name}"
+        ):
+            file_out = (dest_anchor / file_dest).resolve()
+            if file_src == file_out:
+                continue
+            if file_out.exists() and not overwrite:
+                continue
+            file_out.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(file_src, file_out)
+            try:
+                copied.append(str(file_out.relative_to(output_dir)))
+            except ValueError:
+                copied.append(str(file_out))
+    return copied
+
+
 def write_pipeline_bundle(
     config: AppConfig,
     output_dir: Path,
@@ -522,6 +562,7 @@ def write_pipeline_bundle(
     # 6b. Custom code (app.code_paths) staged next to the config so the deploy
     # notebook's create_agent/deploy_agent find it (Model Serving + Apps).
     written.extend(_stage_code_paths(config, output_dir, overwrite))
+    written.extend(_stage_src_packages(config, output_dir, overwrite))
 
     print(f"\nPipeline bundle staged in {output_dir}/\n")
     for name in sorted(written):

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -11,6 +11,8 @@ import sqlparse
 import yaml
 from databricks import agents
 from databricks.agents import PermissionLevel, set_permissions
+from databricks.ai_search.client import VectorSearchClient
+from databricks.ai_search.index import VectorSearchIndex
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors.platform import (
     BadRequest,
@@ -32,8 +34,6 @@ from databricks.sdk.service.catalog import (
 from databricks.sdk.service.iam import User
 from databricks.sdk.service.serving import EndpointStateConfigUpdate
 from databricks.sdk.service.workspace import GetSecretResponse, ImportFormat
-from databricks.ai_search.client import VectorSearchClient
-from databricks.ai_search.index import VectorSearchIndex
 from loguru import logger
 from mlflow import MlflowClient
 from mlflow.entities import Experiment
@@ -1133,15 +1133,15 @@ class DatabricksProvider(ServiceProvider):
             user_api_scopes=list(auth_policy.user_auth_policy.api_scopes),
         )
 
-        # Resolve config.app.code_paths against the config directory (with a
-        # legacy CWD fallback), fail-loud on a missing entry. Shared with the
-        # Apps/pipeline/generate-* paths via dao_ai.code_paths. ``from_file``
-        # already put resolved code_paths on ``sys.path`` (best-effort); this is
-        # the deploy-time guard that fails loud if any entry is missing before
-        # log_model ships an unimportable model.
-        from dao_ai.code_paths import collect_code_paths
+        # Resolve the model's custom code: explicit ``config.app.code_paths``
+        # (out-of-tree, fail-loud on a missing entry) UNION the colocated ``src/``
+        # packages (the zero-config convention), deduped. Each is passed to
+        # ``log_model(code_paths=...)`` so MLflow copies it to ``code/<pkg>`` and
+        # it imports prefix-free (``src/foo`` -> ``foo.bar``). ``from_file`` already
+        # put these on ``sys.path`` (best-effort) for the in-process validation load.
+        from dao_ai.code_paths import collect_serving_code_paths
 
-        code_paths: list[str] = collect_code_paths(config)
+        code_paths: list[str] = collect_serving_code_paths(config)
 
         model_root_path: Path = Path(dao_ai.__file__).parent
         model_path: Path = model_root_path / "apps" / "model_serving.py"
@@ -1647,12 +1647,7 @@ class DatabricksProvider(ServiceProvider):
         runtime. Directories are walked file-by-file (``workspace.upload`` has no
         recursive form); parent workspace dirs are created as needed.
         """
-        import io
-
-        from dao_ai.code_paths import (
-            iter_code_path_stagings,
-            walk_code_path_files,
-        )
+        from dao_ai.code_paths import iter_code_path_stagings
 
         stagings = iter_code_path_stagings(config)
         if not stagings:
@@ -1660,26 +1655,65 @@ class DatabricksProvider(ServiceProvider):
 
         uploaded = 0
         for src, dest in stagings:
-            for file_src, file_dest in walk_code_path_files(src, dest):
-                ws_path = f"{source_path}/{file_dest}"
-                parent = ws_path.rsplit("/", 1)[0]
-                try:
-                    self.w.workspace.mkdirs(parent)
-                except Exception as e:  # noqa: BLE001
-                    logger.debug(f"code_paths parent dir may exist: {e}")
-                with open(file_src, "rb") as f:
-                    self.w.workspace.upload(
-                        path=ws_path,
-                        content=io.BytesIO(f.read()),
-                        format=ImportFormat.AUTO,
-                        overwrite=True,
-                    )
-                uploaded += 1
+            uploaded += self._upload_dir_files(src, dest, source_path)
         logger.info(
             "Uploaded custom code (app.code_paths) to app source",
             file_count=uploaded,
             source_path=source_path,
         )
+
+    def _upload_src_packages(self, config: AppConfig, source_path: str) -> None:
+        """Upload colocated ``src/<pkg>`` packages under ``<source_path>/src``.
+
+        The ``src/`` convention: every top-level package under the config's
+        ``src/`` is uploaded so the app's ``uv sync`` (with the generated
+        ``packages=["src"]`` pyproject) builds it into the app wheel — importing
+        prefix-free (``src/foo`` -> ``foo.bar``). No config declaration needed.
+        """
+        from dao_ai.code_paths import _SRC_DIRNAME, discover_src_packages
+
+        uploaded = 0
+        for pkg_dir in discover_src_packages(config):
+            uploaded += self._upload_dir_files(
+                pkg_dir, f"{_SRC_DIRNAME}/{pkg_dir.name}", source_path
+            )
+        if uploaded:
+            logger.info(
+                "Uploaded src/ packages to app source",
+                file_count=uploaded,
+                source_path=source_path,
+            )
+
+    def _upload_dir_files(
+        self, src: "Path", dest: str, source_path: str
+    ) -> int:
+        """Upload one staging pair's files under ``source_path`` (workspace).
+
+        ``workspace.upload`` has no recursive form, so directories are walked
+        file-by-file with parent workspace dirs created as needed. Returns the
+        number of files uploaded.
+        """
+        import io
+
+        from dao_ai.code_paths import walk_code_path_files
+
+        count = 0
+        for file_src, file_dest in walk_code_path_files(src, dest):
+            ws_path = f"{source_path}/{file_dest}"
+            parent = ws_path.rsplit("/", 1)[0]
+            try:
+                self.w.workspace.mkdirs(parent)
+            except Exception as e:  # noqa: BLE001
+                logger.debug(f"workspace parent dir may exist: {e}")
+            with open(file_src, "rb") as f:
+                self.w.workspace.upload(
+                    path=ws_path,
+                    content=io.BytesIO(f.read()),
+                    format=ImportFormat.AUTO,
+                    overwrite=True,
+                )
+            count += 1
+        return count
 
     def deploy_apps_agent(
         self, config: AppConfig, development: bool | None = None
@@ -1855,6 +1889,10 @@ class DatabricksProvider(ServiceProvider):
         # entry's parent onto sys.path. Same declaration used by Model Serving
         # (log_model code_paths) and the bundle generators.
         self._upload_code_paths(config, source_path)
+
+        # Upload colocated src/<pkg> packages (the zero-config convention) so the
+        # app's uv sync (packages=["src"]) builds them into the app wheel.
+        self._upload_src_packages(config, source_path)
 
         # Determine install command based on dev vs published mode.
         # Respect config.app.enable_chat_proxy (default True) so the deployed

--- a/tests/dao_ai/test_bundle_code_paths.py
+++ b/tests/dao_ai/test_bundle_code_paths.py
@@ -134,3 +134,101 @@ class TestDeployAppsUploadsCodePaths:
 
         provider._upload_code_paths(config, "/Workspace/Users/u/apps/x")
         provider.w.workspace.upload.assert_not_called()
+
+
+_SRC_CONFIG = textwrap.dedent(
+    """
+    resources:
+      models:
+        default_llm: &default_llm
+          name: databricks-claude-sonnet-5
+    agents:
+      greeter: &greeter
+        name: greeter
+        description: A friendly assistant.
+        model: *default_llm
+        prompt: You are concise.
+    app:
+      name: src_bundle_app
+      registered_model:
+        schema:
+          catalog_name: cat
+          schema_name: sch
+        name: src_bundle_model
+      agents:
+        - *greeter
+    """
+)
+
+
+@pytest.mark.unit
+class TestPyprojectTemplatesUseSrcConvention:
+    def test_apps_templates_package_src_prefix_free(self) -> None:
+        from dao_ai.apps.bundle import _PYPROJECT_DEV_TEMPLATE, _PYPROJECT_TEMPLATE
+
+        pub = _PYPROJECT_TEMPLATE.format(
+            name="x", package_name="x", dao_ai_version="0.2.4", extras="", extra_deps=""
+        )
+        dev = _PYPROJECT_DEV_TEMPLATE.format(
+            name="x", package_name="x", wheel_filename="w.whl", extras="", extra_deps=""
+        )
+        for rendered in (pub, dev):
+            assert 'packages = ["src"]' in rendered
+            assert 'sources = ["src"]' in rendered
+
+    def test_mcp_templates_package_src_prefix_free(self) -> None:
+        from dao_ai.mcp.generate import _PYPROJECT_DEV_TEMPLATE, _PYPROJECT_TEMPLATE
+
+        pub = _PYPROJECT_TEMPLATE.format(
+            name="x",
+            package_name="x",
+            dao_ai_version="0.2.4",
+            extras="mcp",
+            extra_deps="",
+        )
+        dev = _PYPROJECT_DEV_TEMPLATE.format(
+            name="x",
+            package_name="x",
+            wheel_filename="w.whl",
+            extras="mcp",
+            extra_deps="",
+        )
+        for rendered in (pub, dev):
+            assert 'packages = ["src"]' in rendered
+            # sources=["src"] was MISSING from MCP templates before the convention;
+            # required for prefix-free (foo.bar, not src.foo.bar) imports.
+            assert 'sources = ["src"]' in rendered
+
+
+@pytest.mark.unit
+class TestBundleShipsSrcPackages:
+    def _config(self, tmp_path: Path) -> AppConfig:
+        (tmp_path / "src" / "foo").mkdir(parents=True)
+        (tmp_path / "src" / "foo" / "bar.py").write_text("def t():\n    return 'x'\n")
+        cfg_path = tmp_path / "dao_ai.yaml"
+        cfg_path.write_text(_SRC_CONFIG)
+        return AppConfig.from_file(str(cfg_path))
+
+    def test_src_package_copied_into_bundle(self, tmp_path: Path) -> None:
+        config = self._config(tmp_path)
+        out = tmp_path / "bundle_out"
+        write_bundle(config, out, overwrite=True)
+
+        # Copied under the bundle's src/ so hatch (packages=["src"]) builds it.
+        assert (out / "src" / "foo" / "bar.py").exists()
+
+    def test_upload_src_planner_uploads_under_src(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock
+
+        from dao_ai.providers.databricks import DatabricksProvider
+
+        config = self._config(tmp_path)
+        provider = DatabricksProvider(w=MagicMock())
+        source_path = "/Workspace/Users/u/apps/src-bundle-app"
+
+        provider._upload_src_packages(config, source_path)
+
+        upload_paths = [
+            c.kwargs["path"] for c in provider.w.workspace.upload.call_args_list
+        ]
+        assert upload_paths == [f"{source_path}/src/foo/bar.py"]

--- a/tests/dao_ai/test_bundle_dependency_lock.py
+++ b/tests/dao_ai/test_bundle_dependency_lock.py
@@ -93,6 +93,33 @@ class TestGenerateBundleLock:
 
         return _run
 
+    def test_render_portable_lock_stubs_src_package(self, monkeypatch) -> None:
+        """``render_portable_lock`` must create a stub package under ``src/`` so
+        hatch can build the local project during locking. The template now uses
+        ``packages = ["src"]`` (not ``src/<pkg>``); a stub must still appear."""
+        from dao_ai import _locking
+
+        seen: dict[str, bool] = {}
+
+        def _run(cmd, cwd=None, capture_output=None, text=None, check=None):
+            seen["stub"] = (Path(cwd) / "src" / "_daoai_lockstub" / "__init__.py").exists()
+            (Path(cwd) / "uv.lock").write_text("# stub lock\n")
+
+            class _R:
+                returncode = 0
+                stderr = ""
+
+            return _R()
+
+        monkeypatch.setattr(_locking.subprocess, "run", _run)
+        pyproject = (
+            '[project]\nname = "x"\n'
+            '[tool.hatch.build.targets.wheel]\n'
+            'packages = ["src"]\nsources = ["src"]\n'
+        )
+        _locking.render_portable_lock(pyproject)
+        assert seen.get("stub") is True
+
     def test_rewrites_mirror_host_to_public_cdn(self, tmp_path, monkeypatch) -> None:
         from dao_ai import _locking
 

--- a/tests/dao_ai/test_code_paths.py
+++ b/tests/dao_ai/test_code_paths.py
@@ -53,6 +53,37 @@ def _write_config(tmp_path: Path, code_paths: list[str]) -> AppConfig:
     return AppConfig.from_file(str(tmp_path / "cfg.yaml"))
 
 
+_CONFIG_NO_CODE_PATHS = textwrap.dedent(
+    """
+    schemas:
+      s: &s
+        catalog_name: cat
+        schema_name: sch
+    resources:
+      models:
+        m: &m
+          name: databricks-claude-sonnet-5
+    agents:
+      a: &a
+        name: agent_one
+        model: *m
+        prompt: hi
+    app:
+      name: test_app
+      registered_model:
+        schema: *s
+        name: test_model
+      agents:
+      - *a
+    """
+)
+
+
+def _write_config_no_code_paths(tmp_path: Path) -> AppConfig:
+    (tmp_path / "cfg.yaml").write_text(_CONFIG_NO_CODE_PATHS)
+    return AppConfig.from_file(str(tmp_path / "cfg.yaml"))
+
+
 class TestResolveCodePath:
     def test_config_relative_resolves_against_config_dir(self, tmp_path: Path) -> None:
         (tmp_path / "tools").mkdir()
@@ -223,3 +254,82 @@ class TestCodePathSyncGlobs:
         abs_file.write_text("x = 1\n")
         config = _write_config(tmp_path, [str(abs_file)])
         assert cp.code_path_sync_globs(config) == ["code/**"]
+
+
+class TestDiscoverSrcPackages:
+    def test_discovers_top_level_packages(self, tmp_path: Path) -> None:
+        (tmp_path / "src" / "foo").mkdir(parents=True)
+        (tmp_path / "src" / "baz").mkdir()
+        (tmp_path / "src" / "foo" / "bar.py").write_text("x = 1\n")  # namespace pkg
+        (tmp_path / "src" / "baz" / "__init__.py").write_text("")   # regular pkg
+        config = _write_config_no_code_paths(tmp_path)
+
+        names = [p.name for p in cp.discover_src_packages(config)]
+        assert names == ["baz", "foo"]  # sorted
+
+    def test_absent_src_returns_empty(self, tmp_path: Path) -> None:
+        config = _write_config_no_code_paths(tmp_path)
+        assert cp.discover_src_packages(config) == []
+
+    def test_empty_src_returns_empty(self, tmp_path: Path) -> None:
+        (tmp_path / "src").mkdir()
+        config = _write_config_no_code_paths(tmp_path)
+        assert cp.discover_src_packages(config) == []
+
+    def test_skips_loose_files_pycache_egginfo(self, tmp_path: Path) -> None:
+        (tmp_path / "src" / "foo").mkdir(parents=True)
+        (tmp_path / "src" / "foo" / "__init__.py").write_text("")
+        (tmp_path / "src" / "loose.py").write_text("x = 1\n")  # loose file → ignored
+        (tmp_path / "src" / "__pycache__").mkdir()
+        (tmp_path / "src" / "pkg.egg-info").mkdir()
+        config = _write_config_no_code_paths(tmp_path)
+
+        assert [p.name for p in cp.discover_src_packages(config)] == ["foo"]
+
+
+class TestCollectServingCodePaths:
+    def test_unions_code_paths_and_src(self, tmp_path: Path) -> None:
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "t.py").write_text("x = 1\n")
+        (tmp_path / "src" / "foo").mkdir(parents=True)
+        (tmp_path / "src" / "foo" / "bar.py").write_text("x = 1\n")
+        config = _write_config(tmp_path, ["tools/t.py"])
+
+        names = sorted(Path(p).name for p in cp.collect_serving_code_paths(config))
+        assert names == ["foo", "t.py"]
+
+    def test_dedupes_code_path_pointing_into_src(self, tmp_path: Path) -> None:
+        # A code_paths entry that IS a src package must not be shipped twice.
+        (tmp_path / "src" / "foo").mkdir(parents=True)
+        (tmp_path / "src" / "foo" / "bar.py").write_text("x = 1\n")
+        config = _write_config(tmp_path, ["src/foo"])
+
+        resolved = cp.collect_serving_code_paths(config)
+        assert len(resolved) == 1
+        assert Path(resolved[0]).name == "foo"
+
+
+class TestPrependSrcToSysPath:
+    def test_puts_src_on_path_import_prefix_free(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "src" / "cpkg").mkdir(parents=True)
+        (tmp_path / "src" / "cpkg" / "mod.py").write_text("VALUE = 'src-ok'\n")
+        config = _write_config_no_code_paths(tmp_path)
+
+        other = tmp_path / "elsewhere"
+        other.mkdir()
+        monkeypatch.chdir(other)
+
+        import importlib
+        import sys as _sys
+
+        _sys.modules.pop("cpkg", None)
+        _sys.modules.pop("cpkg.mod", None)
+        cp.prepend_src_to_sys_path(config)
+        # FQN is prefix-free: cpkg.mod, NOT src.cpkg.mod
+        assert importlib.import_module("cpkg.mod").VALUE == "src-ok"
+
+    def test_noop_when_src_absent(self, tmp_path: Path) -> None:
+        config = _write_config_no_code_paths(tmp_path)
+        cp.prepend_src_to_sys_path(config)  # must not raise

--- a/tests/dao_ai/test_pipeline_bundle.py
+++ b/tests/dao_ai/test_pipeline_bundle.py
@@ -387,6 +387,19 @@ class TestWritePipelineBundle:
         doc = yaml.safe_load((out / "databricks.yaml").read_text())
         assert "config/**" in doc["sync"]["include"]
 
+    def test_stages_src_packages_under_config_src(self, tmp_path: Path) -> None:
+        # The src/ convention: a colocated src/<pkg> stages under config/src/<pkg>
+        # so the deploy notebook's src anchor (config/src) yields foo.bar.
+        (tmp_path / "src" / "foo").mkdir(parents=True)
+        (tmp_path / "src" / "foo" / "bar.py").write_text(
+            "def my_tool():\n    return 'src-custom'\n"
+        )
+        config = self._load(tmp_path, _MINIMAL_CONFIG)
+        out = tmp_path / "bundle"
+        write_pipeline_bundle(config, out)
+
+        assert (out / "config" / "src" / "foo" / "bar.py").exists()
+
     def test_sibling_use_case_assets_stage_and_get_sync_glob(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
> **Stacked on #215** (base branch = `feature/unified-code-paths`). Merge #215 first; this diff shows only the `src/` convention changes.

## Summary

Adds a **zero-config convention** on top of `app.code_paths` (#215): if a `src/` directory sits next to the config, **every top-level package under it is auto-shipped** as custom code — for all deploy strategies (`generate-agent`, `generate-mcp`, `generate-workflow`, `dao-ai deploy`) and both targets (apps + model_serving), with **no config declaration**. `code_paths` remains the explicit escape hatch for code *outside* the config dir; the two compose (deduped).

**Prefix-free FQN invariant:** `src/foo/bar.py` imports as **`foo.bar`** (never `src.foo.bar`) identically in every target:
- **Apps/wheel:** template `packages = ["src"]` + `sources = ["src"]` auto-discovers all top-level packages under `src/` and installs them prefix-free.
- **Model Serving:** each `src/<pkg>` dir is passed to `log_model(code_paths=...)` → MLflow copies it to `code/<pkg>` → `foo.bar`. (Passing `src/` itself would give `src.foo`, so we enumerate the package dirs.)
- **Local validation / deploy notebook:** `<config_dir>/src` is prepended to `sys.path`.

## Changes
- **`code_paths.py`** — `discover_src_packages`, `prepend_src_to_sys_path`, `collect_serving_code_paths` (deduped union of `code_paths` + `src/` packages, used by `create_agent`).
- **`config.py`** — `from_file` calls `prepend_src_to_sys_path` so `src/` modules import for every consumer regardless of CWD.
- **`apps/bundle.py` / `mcp/generate.py`** — templates → `packages = ["src"]`; **added the missing `sources = ["src"]` to the MCP templates** (without it MCP wheels would import as `src.foo`); copy the user's `src/` into the bundle.
- **`providers/databricks.py`** — `create_agent` ships the union; `deploy_apps_agent` uploads `src/` via `_upload_src_packages`.
- **`pipeline/bundle.py`** — `_stage_src_packages` stages `src/` under `config/src/` (found by the existing `config/**` sync).
- **`_locking.py`** — stub regex now also handles `packages = ["src"]` (published-mode lock generation must still build the local project).

The empty-`src/` default (app-name stub) still builds as a harmless no-op. Backward compatible — existing `src/<app_name>/` scaffolds are discovered by `packages = ["src"]`. No config field (convention, not config) → no schema change; `uv.lock` untouched.

## Validation
- **Unit:** `discover_src_packages` (namespace + regular pkgs, skips loose files/`__pycache__`/`.egg-info`), `collect_serving_code_paths` dedup, `prepend_src_to_sys_path` prefix-free import, apps+mcp template assertions, bundle/pipeline src copy, `_locking` stub for `packages=["src"]`. 76 relevant tests green.
- **Live FEVM 4-way matrix:** a colocated `src/mytools/tools.py` tool referenced as `mytools.tools.src_magic_tool` (**no `code_paths`**) loads + returns its value via `deploy` and `generate-workflow` × model_serving + apps. Plus a backward-compat regression on the existing single-package scaffold.

This pull request and its description were written by Isaac.