### PR TITLE
refactor(bundle): typed _rendered_yaml access + fix pre-existing E501

### DIFF
--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -155,7 +155,7 @@ dao-ai = {{ path = "dist/{wheel_filename}" }}
 
 
 def _get_dao_ai_version() -> str:
-    """Return the currently installed dao-ai version for pinning in generated bundles."""
+    """Return the installed dao-ai version for pinning in generated bundles."""
     try:
         return pkg_version("dao-ai")
     except Exception:
@@ -339,7 +339,8 @@ def _convert_to_bundle_resources(
         result.append(converted)
 
     logger.info(
-        f"Converted {len(result)} bundle resources (from {len(app_resources)} app resources)"
+        f"Converted {len(result)} bundle resources "
+        f"(from {len(app_resources)} app resources)"
     )
     return result
 
@@ -805,7 +806,7 @@ def write_bundle(
             # and the parameters: declaration block stripped) so the deployed
             # app does not need the original CLI --var arguments. Fall back to
             # a plain copy if the config wasn't loaded via from_file.
-            rendered: str | None = getattr(config, "_rendered_yaml", None)
+            rendered: str | None = config._rendered_yaml
             if rendered is not None:
                 dest.write_text(_strip_parameters_block(rendered))
                 logger.info(

--- a/src/dao_ai/mcp/generate.py
+++ b/src/dao_ai/mcp/generate.py
@@ -147,7 +147,9 @@ def write_mcp_bundle(
     from dao_ai._extras import expand_all, resolve_required_extras_or_all
 
     merged_extras: str = ",".join(
-        sorted({"mcp", *expand_all(resolve_required_extras_or_all(config, target="mcp"))})
+        sorted(
+            {"mcp", *expand_all(resolve_required_extras_or_all(config, target="mcp"))}
+        )
     )
 
     # User-declared extra pip packages (config.app.pip_requirements) folded
@@ -198,7 +200,7 @@ def write_mcp_bundle(
         # their parameters: block). Belt-and-suspenders behind the CLI guard.
         preserved.append(config_filename)
     else:
-        rendered: str | None = getattr(config, "_rendered_yaml", None)
+        rendered: str | None = config._rendered_yaml
         if rendered is not None:
             _write(config_dest, _strip_parameters_block(rendered))
         elif source_config_path is not None:


### PR DESCRIPTION
## Summary

Small follow-up to the generate-* safety work. Switches the two remaining `getattr(config, "_rendered_yaml", None)` reads (`apps/bundle.py`, `mcp/generate.py`) to direct typed attribute access — `_rendered_yaml` is a declared `str | None` on `AppConfig`, so `config._rendered_yaml` is correct and matches the rest of the generate-* code (which already accesses `_source_config_path`/`_rendered_yaml` directly).

Also wraps three pre-existing over-length lines in the two touched files so both are lint-clean (`ruff check` → all checks passed).

No behavior change; relevant generate/bundle tests green.

This pull request and its description were written by Isaac.