### PR TITLE
feat(cli): shell tab-completion for dao-ai via argcomplete

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,5 +1,27 @@
 # CLI Reference
 
+## Shell Completion
+
+`dao-ai` supports tab-completion of subcommands and flags via
+[argcomplete](https://kislyuk.github.io/argcomplete/) (a core dependency —
+nothing extra to install). Enable it once in your shell:
+
+**bash** — add to `~/.bashrc`:
+
+```bash
+eval "$(register-python-argcomplete dao-ai)"
+```
+
+**zsh** — add to `~/.zshrc`:
+
+```zsh
+autoload -U bashcompinit && bashcompinit
+eval "$(register-python-argcomplete dao-ai)"
+```
+
+Restart the shell (or `source` the rc file), then `dao-ai <TAB>` completes
+subcommands and `dao-ai deploy --<TAB>` completes flags.
+
 ## Validate Configuration
 
 Check your configuration for errors:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,11 @@ classifiers = [
     "Topic :: System :: Distributed Computing",
 ]
 dependencies = [
+    # Shell tab-completion for the ``dao-ai`` CLI (argparse + argcomplete).
+    # Zero runtime deps and ~240 KB, so it's a core dep — completion just works
+    # once enabled in the shell (see docs/cli-reference.md). The autocomplete()
+    # hook in cli.py is still guarded, so a stripped env without it is harmless.
+    "argcomplete>=3.0.0",
     "databricks-agents>=1.11.0",
     "databricks-langchain[memory]>=0.20.0",
     "databricks-mcp>=0.9.0",

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -1,3 +1,4 @@
+# PYTHON_ARGCOMPLETE_OK
 import argparse
 import getpass
 import json
@@ -1190,6 +1191,17 @@ Examples:
         vars_parser,
     ):
         _add_profile_argument(sub)
+
+    # Shell completion via argcomplete (a core dep; enable in your shell — see
+    # docs/cli-reference.md). Still guarded so a stripped env without argcomplete
+    # is harmless. The ``# PYTHON_ARGCOMPLETE_OK`` marker at the top of this file
+    # lets ``register-python-argcomplete dao-ai`` discover the entry point.
+    try:
+        import argcomplete
+
+        argcomplete.autocomplete(parser)
+    except ImportError:
+        pass
 
     options = parser.parse_args(args)
 

--- a/tests/dao_ai/test_cli_completion.py
+++ b/tests/dao_ai/test_cli_completion.py
@@ -1,0 +1,28 @@
+"""The CLI opts into argcomplete shell completion.
+
+argcomplete discovers ``dao-ai`` via the ``# PYTHON_ARGCOMPLETE_OK`` marker and
+the ``argcomplete.autocomplete(parser)`` hook in ``parse_args``. The hook is
+guarded so a normal parse still works whether or not argcomplete is installed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import dao_ai.cli as cli
+
+
+@pytest.mark.unit
+def test_argcomplete_marker_present() -> None:
+    # Must be within argcomplete's first-1KB scan window (it's line 1 here).
+    head = Path(cli.__file__).read_text(encoding="utf-8")[:1024]
+    assert "# PYTHON_ARGCOMPLETE_OK" in head
+
+
+@pytest.mark.unit
+def test_parse_args_still_works_normally() -> None:
+    # The guarded autocomplete() call must not interfere with a real parse.
+    opts = cli.parse_args(["version"])
+    assert opts.command == "version"

--- a/uv.lock
+++ b/uv.lock
@@ -241,6 +241,15 @@ wheels = [
 ]
 
 [[package]]
+name = "argcomplete"
+version = "3.7.0"
+source = { registry = "https://files.pythonhosted.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/c0/c8e94135e66fabf89a120d9b4b123fe6993506beca6c1938a74c24cfa5fd/argcomplete-3.7.0.tar.gz", hash = "sha256:afde224f753f874807b1dc1414e883ab8fe0cda9c04807b6047dcb8e1ac23913", upload-time = "2026-06-30T22:28:22.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/f6/5b8ec087cd9cfa9449491ec83f76fb6b7006b4dff57d2ba8aaab330fe8e4/argcomplete-3.7.0-py3-none-any.whl", hash = "sha256:d8f0f22d2a8a7caa383be1e22b6caf1ecaf0ebd10d8f83cc125e36540c95830c", upload-time = "2026-06-30T22:28:20.547Z" },
+]
+
+[[package]]
 name = "ast-serialize"
 version = "0.5.0"
 source = { registry = "https://files.pythonhosted.org/simple/" }
@@ -949,6 +958,7 @@ name = "dao-ai"
 version = "0.2.4"
 source = { editable = "." }
 dependencies = [
+    { name = "argcomplete" },
     { name = "databricks-agents" },
     { name = "databricks-ai-search" },
     { name = "databricks-langchain", extra = ["memory"] },
@@ -1091,6 +1101,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "a2a-sdk", marker = "extra == 'a2a'", specifier = ">=0.3.0,<1.0.0" },
+    { name = "argcomplete", specifier = ">=3.0.0" },
     { name = "dao-ai", extras = ["a2a", "rerank", "deepagents", "memory", "search", "excel"], marker = "extra == 'all'" },
     { name = "databricks-agents", specifier = ">=1.11.0" },
     { name = "databricks-ai-search", specifier = ">=0.75" },


### PR DESCRIPTION
## Summary

Adds tab-completion of subcommands and flags for the argparse-based `dao-ai` CLI using [argcomplete](https://kislyuk.github.io/argcomplete/).

- `# PYTHON_ARGCOMPLETE_OK` marker at the top of `cli.py` so `register-python-argcomplete dao-ai` discovers the entry point.
- `argcomplete.autocomplete(parser)` in `parse_args` (before `parse_args(args)`), guarded by `try/except ImportError` so a stripped env is harmless.
- **argcomplete is a core dependency** — it has zero runtime deps and is ~240 KB, so completion works after a one-time shell enable with nothing extra to install.
- `docs/cli-reference.md` documents the bash/zsh enable steps.

## Enable (once, in your shell)

zsh (`~/.zshrc`):
```zsh
autoload -U bashcompinit && bashcompinit
eval "$(register-python-argcomplete dao-ai)"
```
bash (`~/.bashrc`):
```bash
eval "$(register-python-argcomplete dao-ai)"
```

Then `dao-ai <TAB>` completes subcommands and `dao-ai deploy --<TAB>` completes flags. Completion follows whatever `dao-ai` is on `PATH` at TAB time (the registration binds the *name*, and re-invokes it to compute completions).

## Validation

- Unit tests (`test_cli_completion.py`): the marker is within argcomplete's first-1KB scan window; `parse_args` still works normally with the guarded hook.
- End-to-end: simulated a shell completion request — `dao-ai <TAB>` returns all subcommands (`deploy`, `generate-agent/mcp/workflow`, `validate`, `chat`, …); `dao-ai deploy --<TAB>` returns `--config/--target/--profile/--development/--var/…`.
- `uv.lock` diff is just the argcomplete addition (no version drift); `make check-lock` clean.

This pull request and its description were written by Isaac.