### PR TITLE
feat(cli): add -p/--profile to doctor + report auth status

### DIFF
--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -403,6 +403,7 @@ Examples:
         help="Show the resolved Databricks environment and connection details",
         description="Resolve and display the Databricks host, profile, and auth type. May make network calls or fail when no credentials are configured.",
     )
+    _add_profile_argument(_doctor_parser)
 
     # Schema command
     _: ArgumentParser = subparsers.add_parser(
@@ -2356,23 +2357,38 @@ def handle_doctor_command(options: Namespace) -> None:
     Unlike ``version``, this command resolves Databricks auth and may make
     network calls, prompt, or fail when no credentials are configured.
     """
-    host = os.environ.get("DATABRICKS_HOST")
-    profile = os.environ.get("DATABRICKS_CONFIG_PROFILE")
-    print("Databricks environment:")
-    if profile:
-        print(f"  Databricks Profile: {profile}")
-    if host:
-        print(f"  Databricks Host:    {host}")
-    else:
-        try:
-            from databricks.sdk import WorkspaceClient
+    _apply_profile_context(options.profile)
 
-            w = WorkspaceClient()
-            print(f"  Databricks Host:    {w.config.host}")
-            if w.config.auth_type:
-                print(f"  Auth Type:          {w.config.auth_type}")
-        except Exception as e:
-            print(f"  Databricks Host:    unresolved ({type(e).__name__})")
+    from databricks.sdk import WorkspaceClient
+
+    print("Databricks environment:")
+    if options.profile:
+        print(f"  Requested Profile:  {options.profile}")
+
+    # Resolve the config (host/profile/auth type) first, then actively
+    # authenticate so we report whether the credentials actually work — not
+    # just what was configured. A resolved host with an expired token is the
+    # most common failure and looks "fine" until an SDK call is made.
+    try:
+        w = WorkspaceClient()
+        print(f"  Databricks Host:    {w.config.host}")
+        if w.config.profile:
+            print(f"  Databricks Profile: {w.config.profile}")
+        if w.config.auth_type:
+            print(f"  Auth Type:          {w.config.auth_type}")
+    except Exception as e:
+        print("  Authenticated:      no")
+        print(f"  Reason:             could not resolve config ({type(e).__name__})")
+        print(f"  Detail:             {e}")
+        return
+
+    try:
+        w.config.authenticate()
+        print("  Authenticated:      yes")
+    except Exception as e:
+        print("  Authenticated:      no")
+        print(f"  Reason:             {type(e).__name__}")
+        print(f"  Detail:             {e}")
 
 
 def setup_logging(verbosity: int) -> None:


### PR DESCRIPTION
## What

`dao-ai doctor` now:

1. **Accepts `-p/--profile`** (via the shared `_add_profile_argument` helper, identical to every other subcommand) and applies it through `_apply_profile_context`. No more needing to export `DATABRICKS_*` env vars just to point `doctor` at a workspace.
2. **Reports a clear auth verdict.** It resolves config *and* actively calls `authenticate()`, then prints `Authenticated: yes/no` with the underlying reason + detail — instead of swallowing the SDK error behind `unresolved (ValueError)`.

## Why

`doctor` is the diagnostic counterpart to `version`, but in practice it (a) offered no way to select a profile without env vars, and (b) hid the one thing it exists to report. A resolved host with an expired token looked "fine" and a broken `DEFAULT` profile printed only `(ValueError)` with no indication of which host it tried or how to fix it.

## Verification

```
$ dao-ai doctor -p fevm
Databricks environment:
  Requested Profile:  fevm
  Databricks Host:    https://fevm-nfleming-stable-aws.cloud.databricks.com
  Auth Type:          pat
  Authenticated:      yes

$ dao-ai doctor            # bare shell, expired DEFAULT profile
Databricks environment:
  Authenticated:      no
  Reason:             could not resolve config (ValueError)
  Detail:             ...refresh token is invalid. To reauthenticate, run:
                      $ databricks auth login --profile DEFAULT ...
```

`--help` lists the flag. No config schema change (no `make schema` needed). Changed lines are ruff-clean.

This pull request and its description were written by Isaac.