### PR TITLE
feat(cli)!: deploy-model redesign — two axes (noun × --mode), up verb, trace/monitor regroup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,3 +289,6 @@ deploy/
 # Chat UI build artifacts (cloned/built by dao-ai when enable_chat_proxy is true)
 e2e-chatbot-app-next/
 chat-ui.tar.gz
+
+# Isaac local tool state
+.isaac/

--- a/.isaac/config.json
+++ b/.isaac/config.json
@@ -1,0 +1,3 @@
+{
+  "sync_reminder_last_shown": "2026-07-24"
+}

--- a/.isaac/config.json
+++ b/.isaac/config.json
@@ -1,3 +1,0 @@
-{
-  "sync_reminder_last_shown": "2026-07-24"
-}

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ DAO AI Builder generates valid YAML configurations that work seamlessly with thi
 - **[Configuration Reference](docs/configuration-reference.md)** - Complete YAML configuration guide
 - **[Examples](docs/examples.md)** - Ready-to-use example configurations
 - **[A2A Protocol](docs/a2a_protocol.md)** - Google Agent2Agent endpoints on every Apps deployment
-- **[MCP Server](docs/mcp_server.md)** - Expose a dao-ai agent as a single MCP tool via `dao-ai generate-mcp` — for integrating dao-ai into external agent frameworks (Claude Desktop, Cursor, MAS, ADK, etc.)
+- **[MCP Server](docs/mcp_server.md)** - Expose a dao-ai agent as a single MCP tool via `dao-ai mcp generate` — for integrating dao-ai into external agent frameworks (Claude Desktop, Cursor, MAS, ADK, etc.)
 - **[Background Agents](docs/background_agents.md)** - kickoff/poll/cancel for multi-minute graph runs
 - **[Auditable Tool Invocations](docs/audit.md)** - Tamper-evident approval receipts + agent-driven audit-trail queries (SOX / SOC2 / HIPAA-ready)
 
@@ -287,7 +287,7 @@ config.deploy_agent()
 **Option B: Using the CLI** (one command)
 
 ```bash
-dao-ai generate-workflow --deploy --run -c config/my_agent.yaml
+dao-ai workflow generate --deploy --run -c config/my_agent.yaml
 ```
 
 This single command:
@@ -300,11 +300,18 @@ This single command:
 
 ```bash
 # Deploy to AWS workspace
-dao-ai generate-workflow --deploy --run -c config/my_agent.yaml --profile aws-field-eng
+dao-ai workflow generate --deploy --run -c config/my_agent.yaml --profile aws-field-eng
 
 # Deploy to Azure workspace
-dao-ai generate-workflow --deploy --run -c config/my_agent.yaml --profile azure-retail
+dao-ai workflow generate --deploy --run -c config/my_agent.yaml --profile azure-retail
 ```
+
+> The bundle generators are **verb-under-noun** commands —
+> `dao-ai <agent|mcp|workflow> <generate|deploy|run|destroy>`. `generate` stages
+> the bundle (and can one-shot `--deploy`/`--run`); `deploy`/`run`/`destroy` act
+> on the already-staged bundle without regenerating. The flat `generate-agent`,
+> `generate-mcp`, and `generate-workflow` commands remain as back-compat aliases
+> for `<noun> generate`.
 
 **Step 5: Interact with your agent**
 
@@ -450,14 +457,17 @@ dao-ai schema > schemas/model_config_schema.json
 dao-ai graph -c config/my_config.yaml -o workflow.png
 
 # Deploy with Databricks Asset Bundles
-dao-ai generate-workflow --deploy --run -c config/my_config.yaml
+dao-ai workflow generate --deploy --run -c config/my_config.yaml
 
 # Deploy to a specific workspace (multi-cloud support)
-dao-ai generate-workflow --deploy -c config/my_config.yaml --profile aws-field-eng
-dao-ai generate-workflow --deploy -c config/my_config.yaml --profile azure-retail
+dao-ai workflow generate --deploy -c config/my_config.yaml --profile aws-field-eng
+dao-ai workflow generate --deploy -c config/my_config.yaml --profile azure-retail
 
 # Generate + deploy + start a Databricks Apps bundle in one step
-dao-ai generate-agent -c config/my_config.yaml --deploy --run -p <profile>
+dao-ai agent generate -c config/my_config.yaml --deploy --run -p <profile>
+
+# Re-deploy the already-staged bundle without regenerating (retry a transient failure)
+dao-ai agent deploy -c config/my_config.yaml -p <profile>
 
 # Interactive chat with agent
 dao-ai chat -c config/my_config.yaml
@@ -468,18 +478,22 @@ dao-ai parameters list -c config/my_config.yaml --param catalog=nfleming
 
 ### Deploying to Databricks Apps
 
-`dao-ai generate-agent` produces a deploy-ready Databricks Apps bundle: `databricks.yaml`, the app resource YAML (with the agent's UC resource wiring), a `pyproject.toml`, a portable `uv.lock`, and a copy of your config. The Apps build phase installs dependencies by running `uv sync --locked --no-dev` from the pyproject + lock (no `requirements.txt` — it would take precedence and force the slower pip path). The lock's internal-mirror URLs are rewritten to the public CDN so it resolves from Apps containers.
+`dao-ai agent generate` produces a deploy-ready Databricks Apps bundle: `databricks.yaml`, the app resource YAML (with the agent's UC resource wiring), a `pyproject.toml`, a portable `uv.lock`, and a copy of your config. The Apps build phase installs dependencies by running `uv sync --locked --no-dev` from the pyproject + lock (no `requirements.txt` — it would take precedence and force the slower pip path). The lock's internal-mirror URLs are rewritten to the public CDN so it resolves from Apps containers.
 
 The simplest path is the one-step deploy (generate + `bundle deploy` + trace-link/grant + `bundle run`):
 
 ```bash
-dao-ai generate-agent -c config/my_config.yaml --deploy --run -p <profile>
+dao-ai agent generate -c config/my_config.yaml --deploy --run -p <profile>
 ```
 
-Or generate first and drive the bundle by hand:
+Or generate first, optionally hand-edit the staged files, then ship exactly what's on disk with the strict `deploy` verb (no regeneration):
 
 ```bash
-dao-ai generate-agent -c config/my_config.yaml -o ./my-bundle
+dao-ai agent generate -c config/my_config.yaml -o ./my-bundle
+# (optionally hand-edit ./my-bundle)
+dao-ai agent deploy --run -c config/my_config.yaml -o ./my-bundle -p <profile>
+
+# ...or drive the bundle by hand
 cd ./my-bundle
 databricks bundle deploy -t dev -p <profile>
 databricks bundle run <app-name> -t dev -p <profile>
@@ -502,7 +516,7 @@ app:
     warehouse: "your-warehouse-id"           # or a *warehouse anchor
 ```
 
-When `trace_location` is set, `generate-agent` automatically attaches the SQL warehouse as an App resource (with `CAN_USE` for the App SP) and adds `MLFLOW_TRACING_SQL_WAREHOUSE_ID` to the App's env. The OTEL trace tables themselves are auto-created by MLflow at first trace write — dao-ai does not emit per-table grants because the tables don't exist at deploy time and the Apps platform would reject the bundle. After deploy, grant the App SP schema-level privileges so MLflow can create + write to the OTEL tables (one-time setup):
+When `trace_location` is set, `agent generate` automatically attaches the SQL warehouse as an App resource (with `CAN_USE` for the App SP) and adds `MLFLOW_TRACING_SQL_WAREHOUSE_ID` to the App's env. The OTEL trace tables themselves are auto-created by MLflow at first trace write — dao-ai does not emit per-table grants because the tables don't exist at deploy time and the Apps platform would reject the bundle. After deploy, grant the App SP schema-level privileges so MLflow can create + write to the OTEL tables (one-time setup):
 
 ```bash
 SP=$(databricks apps get <app-name> -p <profile> --output json | jq -r .service_principal_client_id)
@@ -512,9 +526,9 @@ databricks grants update schema <catalog>.<schema> -p <profile> \
   --json "{\"changes\":[{\"principal\":\"$SP\",\"add\":[\"USE_SCHEMA\",\"CREATE_TABLE\",\"MODIFY\",\"SELECT\"]}]}"
 ```
 
-**Run `dao-ai link-trace-destination` between `bundle deploy` and `bundle run`** so the UC linkage is established from your machine on a fresh (0-traces) experiment — the app's own runtime link attempt is rejected on re-deploys with `already contains traces`, which causes silent trace loss. `generate-agent` prints a one-line reminder in its "Next steps" when `trace_location` is set. See [`docs/cli-reference.md#link-trace-destination`](docs/cli-reference.md#link-trace-destination) for details, including the migration playbook (Databricks does not allow un-linking or changing a UC destination once set — moving traces to a different `catalog` / `schema` / `table_prefix` requires a fresh experiment).
+**Run `dao-ai link-trace-destination` between `bundle deploy` and `bundle run`** so the UC linkage is established from your machine on a fresh (0-traces) experiment — the app's own runtime link attempt is rejected on re-deploys with `already contains traces`, which causes silent trace loss. `agent generate` prints a one-line reminder in its "Next steps" when `trace_location` is set. See [`docs/cli-reference.md#link-trace-destination`](docs/cli-reference.md#link-trace-destination) for details, including the migration playbook (Databricks does not allow un-linking or changing a UC destination once set — moving traces to a different `catalog` / `schema` / `table_prefix` requires a fresh experiment).
 
-When `trace_location` is unset, `generate-agent` emits a loud warning. Local notebook/CLI runs and Model Serving deploys are unaffected and continue to use the default control-plane path. See `examples/01_getting_started/ai_gateway.yaml` for a commented example.
+When `trace_location` is unset, `agent generate` emits a loud warning. Local notebook/CLI runs and Model Serving deploys are unaffected and continue to use the default control-plane path. See `examples/01_getting_started/ai_gateway.yaml` for a commented example.
 
 ### Multi-Cloud Deployment
 
@@ -522,13 +536,13 @@ DAO AI supports deploying to Azure, AWS, and GCP workspaces with automatic cloud
 
 ```bash
 # Deploy to AWS workspace
-dao-ai generate-workflow --deploy -c config/my_config.yaml --profile aws-prod
+dao-ai workflow generate --deploy -c config/my_config.yaml --profile aws-prod
 
 # Deploy to Azure workspace
-dao-ai generate-workflow --deploy -c config/my_config.yaml --profile azure-prod
+dao-ai workflow generate --deploy -c config/my_config.yaml --profile azure-prod
 
 # Deploy to GCP workspace
-dao-ai generate-workflow --deploy -c config/my_config.yaml --profile gcp-prod
+dao-ai workflow generate --deploy -c config/my_config.yaml --profile gcp-prod
 ```
 
 The CLI automatically:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ DAO AI Builder generates valid YAML configurations that work seamlessly with thi
 - **[Configuration Reference](docs/configuration-reference.md)** - Complete YAML configuration guide
 - **[Examples](docs/examples.md)** - Ready-to-use example configurations
 - **[A2A Protocol](docs/a2a_protocol.md)** - Google Agent2Agent endpoints on every Apps deployment
-- **[MCP Server](docs/mcp_server.md)** - Expose a dao-ai agent as a single MCP tool via `dao-ai mcp generate` — for integrating dao-ai into external agent frameworks (Claude Desktop, Cursor, MAS, ADK, etc.)
+- **[MCP Server](docs/mcp_server.md)** - Expose a dao-ai agent as a single MCP tool via `dao-ai agent generate --mode mcp` — for integrating dao-ai into external agent frameworks (Claude Desktop, Cursor, MAS, ADK, etc.)
 - **[Background Agents](docs/background_agents.md)** - kickoff/poll/cancel for multi-minute graph runs
 - **[Auditable Tool Invocations](docs/audit.md)** - Tamper-evident approval receipts + agent-driven audit-trail queries (SOX / SOC2 / HIPAA-ready)
 
@@ -307,11 +307,12 @@ dao-ai workflow generate --deploy --run -c config/my_agent.yaml --profile azure-
 ```
 
 > The bundle generators are **verb-under-noun** commands —
-> `dao-ai <agent|mcp|workflow> <generate|deploy|run|destroy>`. `generate` stages
+> `dao-ai <agent|workflow> <generate|deploy|run|destroy>`. `generate` stages
 > the bundle (and can one-shot `--deploy`/`--run`); `deploy`/`run`/`destroy` act
-> on the already-staged bundle without regenerating. The flat `generate-agent`,
-> `generate-mcp`, and `generate-workflow` commands remain as back-compat aliases
-> for `<noun> generate`.
+> on the already-staged bundle without regenerating. Use `--mode mcp` on the
+> `agent` noun to generate/deploy the MCP-server App instead. The old flat
+> `generate-agent`, `generate-mcp`, `generate-workflow`, and `dao-ai mcp` commands
+> have been removed — see the [migration table](docs/cli-reference.md#migration-from-pre-v2-cli).
 
 **Step 5: Interact with your agent**
 
@@ -526,7 +527,7 @@ databricks grants update schema <catalog>.<schema> -p <profile> \
   --json "{\"changes\":[{\"principal\":\"$SP\",\"add\":[\"USE_SCHEMA\",\"CREATE_TABLE\",\"MODIFY\",\"SELECT\"]}]}"
 ```
 
-**Run `dao-ai link-trace-destination` between `bundle deploy` and `bundle run`** so the UC linkage is established from your machine on a fresh (0-traces) experiment — the app's own runtime link attempt is rejected on re-deploys with `already contains traces`, which causes silent trace loss. `agent generate` prints a one-line reminder in its "Next steps" when `trace_location` is set. See [`docs/cli-reference.md#link-trace-destination`](docs/cli-reference.md#link-trace-destination) for details, including the migration playbook (Databricks does not allow un-linking or changing a UC destination once set — moving traces to a different `catalog` / `schema` / `table_prefix` requires a fresh experiment).
+**Run `dao-ai trace link` between `bundle deploy` and `bundle run`** so the UC linkage is established from your machine on a fresh (0-traces) experiment — the app's own runtime link attempt is rejected on re-deploys with `already contains traces`, which causes silent trace loss. `agent generate` prints a one-line reminder in its "Next steps" when `trace_location` is set. See [`docs/cli-reference.md#trace-commands`](docs/cli-reference.md#trace-commands) for details, including the migration playbook (Databricks does not allow un-linking or changing a UC destination once set — moving traces to a different `catalog` / `schema` / `table_prefix` requires a fresh experiment).
 
 When `trace_location` is unset, `agent generate` emits a loud warning. Local notebook/CLI runs and Model Serving deploys are unaffected and continue to use the default control-plane path. See `examples/01_getting_started/ai_gateway.yaml` for a commented example.
 

--- a/docs/a2a_protocol.md
+++ b/docs/a2a_protocol.md
@@ -36,7 +36,7 @@ governed by the Linux Foundation. Once an agent speaks A2A, it can:
 
 ## What you get out of the box
 
-When you set `app.deployment_target: apps` and deploy, your agent's
+When you deploy to Databricks Apps (the default — or pass `--mode apps`), your agent's
 Agent Card automatically advertises:
 
 - **`name`** — `app.name`.
@@ -66,7 +66,7 @@ everything):
 app:
   name: my_agent
   description: My helpful assistant.
-  deployment_target: apps
+  # deploy with: dao-ai agent deploy --mode apps
   agents:
     - *my_agent
 ```
@@ -79,7 +79,7 @@ To customise:
 app:
   name: my_agent
   description: My helpful assistant.
-  deployment_target: apps
+  # deploy with: dao-ai agent deploy --mode apps
   a2a:
     enabled: true                        # default; set false to skip mounting
     server_url: null                     # default: derive from $DATABRICKS_APP_URL
@@ -250,7 +250,7 @@ agents:
 
 app:
   name: my-app
-  deployment_target: apps
+  # deploy with: dao-ai agent deploy --mode apps
   agents: [...]
   # No a2a block — Agent Card auto-emits oauth2 + bearer
 ```

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -523,7 +523,7 @@ Databricks Apps forwards user identity on `X-Forwarded-User` /
 picks these up automatically. Deployment flow:
 
 ```bash
-uv run dao-ai generate-agent --overwrite --development -c my_config.yaml
+uv run dao-ai agent generate --overwrite --development -c my_config.yaml
 databricks bundle deploy -p <profile>
 # Critical: link the trace destination BEFORE bundle run.
 uv run dao-ai link-trace-destination -c my_config.yaml -p <profile>

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -526,11 +526,11 @@ picks these up automatically. Deployment flow:
 uv run dao-ai agent generate --overwrite --development -c my_config.yaml
 databricks bundle deploy -p <profile>
 # Critical: link the trace destination BEFORE bundle run.
-uv run dao-ai link-trace-destination -c my_config.yaml -p <profile>
+uv run dao-ai trace link -c my_config.yaml -p <profile>
 databricks bundle run <app_name> -p <profile>
 ```
 
-The `link-trace-destination` step provisions the OTEL span tables in
+The `dao-ai trace link` step provisions the OTEL span tables in
 the configured `trace_location` schema and links the experiment to
 them. Without it, span attributes still emit but the OTEL tables are
 missing on cold-start and traces do not surface in the Databricks Trace

--- a/docs/background_agents.md
+++ b/docs/background_agents.md
@@ -579,7 +579,7 @@ connection-check failed. If you're seeing this in production:
 
 The dao-ai CLI's start-before-deploy step can't reconcile this state. The
 workaround is to invoke `databricks apps deploy <app>` directly — once
-the app is back in `RUNNING`, subsequent `dao-ai deploy -t apps` calls
+the app is back in `RUNNING`, subsequent `dao-ai agent deploy --mode apps` calls
 work normally.
 
 ## Best practices

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -20,7 +20,7 @@ eval "$(register-python-argcomplete dao-ai)"
 ```
 
 Restart the shell (or `source` the rc file), then `dao-ai <TAB>` completes
-subcommands and `dao-ai deploy --<TAB>` completes flags.
+subcommands and `dao-ai agent deploy --<TAB>` completes flags.
 
 ## Validate Configuration
 
@@ -52,36 +52,39 @@ dao-ai graph -c config/my_config.yaml -o workflow.png
 dao-ai graph -c config/my_config.yaml -o workflow.png --param catalog=main
 ```
 
-## Deploy (direct)
+## Deploy
 
-`dao-ai deploy` deploys the agent **directly** from your machine — no Databricks
-Asset Bundle, no job. It calls `AppConfig.create_agent()` + `deploy_agent()`
-in-process: for Model Serving it registers the MLflow model and creates the
-serving endpoint (`agents.deploy`); for Apps it uploads the config + source and
-drives the Apps REST API. It works from a pip-installed `dao-ai` (no repo
-checkout), auto-links the UC trace destination, and auto-grants the runtime
-service principal the trace-write permissions (gated on `app.manage_permissions`).
-On success it prints a link to the endpoint or app.
+`dao-ai agent deploy` deploys the agent using its staged bundle (the default path).
+Pass `--mode model_serving` to deploy directly to Databricks Model Serving (no
+bundle), or `--direct` to deploy Apps/MCP via the SDK without writing a bundle to
+disk. All paths call `AppConfig.create_agent()` + `deploy_agent()` in-process:
+for Model Serving it registers the MLflow model and creates the serving endpoint
+(`agents.deploy`); for Apps it uploads the config + source and drives the Apps
+REST API. Auto-links the UC trace destination and auto-grants the runtime service
+principal the trace-write permissions (gated on `app.manage_permissions`).
 
 ```bash
-# Deploy to Model Serving (default when no target is set)
-dao-ai deploy -c config/my_config.yaml --target model_serving --profile fevm
+# Deploy to Model Serving (SDK path, no bundle)
+dao-ai agent deploy -c config/my_config.yaml --mode model_serving --profile fevm
 
-# Deploy as a Databricks App
-dao-ai deploy -c config/my_config.yaml --target apps --profile fevm
+# Deploy as a Databricks App (bundle path, default)
+dao-ai agent deploy -c config/my_config.yaml --mode apps --profile fevm
 
-# Both surfaces
-dao-ai deploy -c config/my_config.yaml --target both --profile fevm
+# Deploy as Apps via SDK directly (no bundle on disk — fast iteration)
+dao-ai agent deploy -c config/my_config.yaml --mode apps --direct --profile fevm
+
+# Deploy MCP server App
+dao-ai agent deploy -c config/my_config.yaml --mode mcp --profile fevm
 
 # Ship the local dao-ai wheel instead of the published PyPI package
-dao-ai deploy -c config/my_config.yaml --development --profile fevm
+dao-ai agent generate -c config/my_config.yaml --development --profile fevm
+dao-ai agent deploy   -c config/my_config.yaml --profile fevm
 ```
 
-Target resolution: `--target` > `app.deployment_target` in the config >
-`model_serving`.
+Mode resolution: `--mode` flag wins; default is `apps`.
 
 No extra install is required: a plain `pip install dao-ai` is enough to deploy to
-either target. Model Serving logs the MLflow model in-process, which touches
+any mode. Model Serving logs the MLflow model in-process, which touches
 spark-connect — the core `databricks-connect` dependency supplies a
 protobuf-5-compatible pyspark for this, so do **not** add a standalone `pyspark`
 (pyspark 4.x needs protobuf ≥ 6.33 and collides with `databricks-ai-search`'s
@@ -90,31 +93,28 @@ so this local stack never ships to the deployed endpoint.
 
 **When to use which:**
 
-- **`dao-ai deploy`** — quickest path to a running agent (Model Serving or Apps),
-  no bundle artifact. Best for iterating.
-- **`dao-ai agent` / `dao-ai mcp`** — emit an inspectable/committable
-  Databricks App bundle you can deploy from CI or hand-tune (Apps only).
+- **`dao-ai agent deploy --mode model_serving`** — deploy to Model Serving (SDK, no bundle). Best for iterating on the serving endpoint.
+- **`dao-ai agent deploy --mode apps` / `--mode mcp`** — deploy Apps or MCP bundle. Generates on first run if unstaged; ships staged bundle if already generated.
+- **`dao-ai agent deploy --direct`** — deploy Apps/MCP via SDK without writing a bundle (fast iteration when you don't need an auditable bundle artifact).
 - **`dao-ai workflow`** — provision the full backing infra (schemas,
   Vector Search, Lakebase, Genie, UC functions) *and* deploy the agent, as a
   multi-task Databricks Job. The job's deploy step runs the same
-  `create_agent`/`deploy_agent` code `dao-ai deploy` runs directly.
+  `create_agent`/`deploy_agent` code as the direct deploy paths.
 
-## Bundle Generators: `agent`, `mcp`, `workflow`
+## Bundle Generators: `agent`, `workflow`
 
-The three bundle generators are **verb-under-noun** commands — pick a noun for
+The bundle generators are **verb-under-noun** commands — pick a noun for
 what you're shipping, then a verb for the lifecycle step:
 
 | Noun | What it ships |
 |------|---------------|
-| `dao-ai agent` | A Databricks App running the agent graph. |
-| `dao-ai mcp` | A Databricks App exposing the agent as an MCP server. |
+| `dao-ai agent` | A Databricks App running the agent graph (default: `--mode apps`). Use `--mode mcp` to emit the MCP-server App instead, or `--mode model_serving` on `deploy` to go SDK-direct. |
 | `dao-ai workflow` | A multi-task Databricks Job that provisions the backing infra (schemas, Vector Search, Lakebase, Genie, UC functions) *and* deploys the agent. |
 
 Each noun takes the same four verbs:
 
 ```bash
 dao-ai agent    generate|deploy|run|destroy  -c <cfg> [-p <profile>]
-dao-ai mcp      generate|deploy|run|destroy  -c <cfg> [-p <profile>]
 dao-ai workflow generate|deploy|run|destroy  -c <cfg> [-p <profile>]
 ```
 
@@ -144,9 +144,10 @@ marker file's mtime), unless you pass `--overwrite`. The error points you at
 `--overwrite` and `--development` are only on `generate`, not on
 `deploy`/`run`/`destroy`.
 
-> **Back-compat:** the flat commands `generate-agent`, `generate-mcp`, and
-> `generate-workflow` still work — they are aliases for `<noun> generate` with
-> identical flags. Existing scripts and examples remain valid.
+> **Migration:** the flat commands `generate-agent`, `generate-mcp`, and
+> `generate-workflow` have been removed. Use `dao-ai agent generate`,
+> `dao-ai agent generate --mode mcp`, and `dao-ai workflow generate` instead.
+> See [Migration reference](#migration-from-pre-v2-cli) below.
 
 ## Workflow: Provision and Deploy
 
@@ -235,7 +236,7 @@ dao-ai agent deploy -c config/retail.yaml -p fevm
 dao-ai agent deploy --run -c config/retail.yaml -p fevm
 ```
 
-The same verbs apply to `dao-ai mcp` (MCP server App). Use `dao-ai agent run` / `dao-ai mcp run` to `databricks bundle run <app>` an already-deployed bundle, and `dao-ai agent destroy` to tear it down. See [Bundle Generators](#bundle-generators-agent-mcp-workflow) for the full lifecycle and the flat `generate-agent` / `generate-mcp` back-compat aliases.
+MCP server bundles use `dao-ai agent generate --mode mcp` (not a separate noun). Use `dao-ai agent run` to `databricks bundle run <app>` an already-deployed bundle, and `dao-ai agent destroy` to tear it down. See [Bundle Generators](#bundle-generators-agent-workflow) for the full lifecycle.
 
 ### Output location
 
@@ -310,7 +311,7 @@ When `trace_location` is unset, `agent generate` emits a `⚠` warning to alert 
 
 See `examples/01_getting_started/ai_gateway.yaml` for a drop-in example.
 
-#### Linking the UC trace destination — run `dao-ai link-trace-destination` between deploy and run
+#### Linking the UC trace destination — run `dao-ai trace link` between deploy and run
 
 MLflow requires the UC trace-destination link to be established on an experiment **before** that experiment receives any traces. On a re-deploy (or after a `trace_location` change), the experiment already has traces from prior runs, so the app's runtime attempt to link is rejected with `already contains traces` and every subsequent trace silently drops with `TABLE_DOES_NOT_EXIST`.
 
@@ -318,7 +319,7 @@ The fix is a standalone CLI verb that links from **your** machine (operator cred
 
 ```bash
 databricks bundle deploy --target dev -p <profile>
-dao-ai link-trace-destination -c my_config.yaml -p <profile>
+dao-ai trace link -c my_config.yaml -p <profile>
 databricks bundle run <app-name> --target dev -p <profile>
 # then restart to pick up the freshly-linked destination:
 databricks apps restart <app-name> -p <profile>
@@ -326,11 +327,11 @@ databricks apps restart <app-name> -p <profile>
 
 The verb is idempotent — safe on every deploy — but load-bearing on re-deploys and after `trace_location` changes. `agent generate` prints a one-line reminder in its "Next steps" when `trace_location` is configured.
 
-See [Link Trace Destination](#link-trace-destination) for full flag reference and the migration playbook for moving traces between destinations.
+See [Trace Commands](#trace-commands) for full flag reference and the migration playbook for moving traces between destinations.
 
 #### Runtime trace-destination sync (`apply_runtime_trace_destination`)
 
-`link-trace-destination` writes the trace-destination tag on the experiment record so that future traces route to the configured UC schema. That works when MLflow's runtime picks up the linkage from the experiment — but if the app also has `MLFLOW_TRACING_DESTINATION` env set (dao-ai's `agent generate` sets it as `catalog.schema` for warehouse routing), MLflow parses that env value as the deprecated `UCSchemaLocation` and populates the `_MLFLOW_TRACE_USER_DESTINATION` ContextVar accordingly. The ContextVar SHADOWS MLflow's auto-resolver from experiment tags, so the exporter targets `mlflow_experiment_trace_otel_spans` (the un-prefixed default) which doesn't exist on the prefixed schema — and every span export fails with `TABLE_DOES_NOT_EXIST`.
+`dao-ai trace link` writes the trace-destination tag on the experiment record so that future traces route to the configured UC schema. That works when MLflow's runtime picks up the linkage from the experiment — but if the app also has `MLFLOW_TRACING_DESTINATION` env set (dao-ai's `agent generate` sets it as `catalog.schema` for warehouse routing), MLflow parses that env value as the deprecated `UCSchemaLocation` and populates the `_MLFLOW_TRACE_USER_DESTINATION` ContextVar accordingly. The ContextVar SHADOWS MLflow's auto-resolver from experiment tags, so the exporter targets `mlflow_experiment_trace_otel_spans` (the un-prefixed default) which doesn't exist on the prefixed schema — and every span export fails with `TABLE_DOES_NOT_EXIST`.
 
 To close that gap, the App startup path (`apps/handlers.py`) and the MCP-server startup path (`mcp/server.py`) both call `apply_runtime_trace_destination(config)` from `dao_ai.providers.databricks` right after `link_experiment_trace_location`. The helper:
 
@@ -345,7 +346,7 @@ The helper is only invoked from the two container entrypoints that HAVE ambient 
 Once an experiment has been linked to a UC trace destination with a specific `table_prefix`, MLflow rejects any attempt to change it — you'll see `already contains traces` on the re-link. To change catalog / schema / table_prefix, provision a fresh experiment:
 
 ```bash
-dao-ai create-experiment --name /Shared/my-app/dao-ai-fresh -p <profile>
+dao-ai trace create --name /Shared/my-app/dao-ai-fresh -p <profile>
 # Then reference the new experiment id under `app.experiment.id` in the config,
 # or rev `app.name` so the auto-declared experiment path is distinct.
 ```
@@ -398,15 +399,17 @@ databricks bundle deploy --target dev
 databricks bundle run <app-name> --target dev
 ```
 
-## Link Trace Destination
+## Trace Commands
 
-`dao-ai link-trace-destination` attaches an MLflow experiment to its Unity Catalog trace destination declared under `app.trace_location`. Run it as an explicit step **between** `databricks bundle deploy` and `databricks bundle run` — see the [background above](#linking-the-uc-trace-destination--run-dao-ai-link-trace-destination-between-deploy-and-run) for why the app's runtime attempt is unreliable.
+The `dao-ai trace` group manages MLflow experiments and UC trace destinations.
 
-### Basic usage
+### `dao-ai trace link`
+
+`dao-ai trace link` attaches an MLflow experiment to its Unity Catalog trace destination declared under `app.trace_location`. Run it as an explicit step **between** `databricks bundle deploy` and `databricks bundle run` — see the [background above](#linking-the-uc-trace-destination--run-dao-ai-trace-link-between-deploy-and-run) for why the app's runtime attempt is unreliable.
 
 ```bash
 databricks bundle deploy --target dev -p <profile>
-dao-ai link-trace-destination -c my_config.yaml -p <profile>
+dao-ai trace link -c my_config.yaml -p <profile>
 databricks bundle run <app-name> --target dev -p <profile>
 databricks apps restart <app-name> -p <profile>    # required — see below
 ```
@@ -432,7 +435,7 @@ If none of the above resolves, the CLI prints the candidates and exits 1.
 
 ### Two things that surprise operators
 
-**1. You must restart the app after linking.** MLflow's OTEL exporter binds the trace destination at **process startup**. Running `link-trace-destination` while the app is up does not retroactively route in-flight traces to the new location — the running exporter is already bound to whatever destination was in effect when it started. Trigger `databricks apps restart <name>` (or any bundle re-deploy) so the app picks up the fresh linkage.
+**1. You must restart the app after linking.** MLflow's OTEL exporter binds the trace destination at **process startup**. Running `dao-ai trace link` while the app is up does not retroactively route in-flight traces to the new location — the running exporter is already bound to whatever destination was in effect when it started. Trigger `databricks apps restart <name>` (or any bundle re-deploy) so the app picks up the fresh linkage.
 
 **2. A UC-linked experiment is permanently bound to that destination on Databricks.** Verified against a live Databricks workspace (MLflow 3.11):
 
@@ -477,7 +480,7 @@ app:
 dao-ai agent generate -c my_config.yaml -o ./bundle --overwrite
 cd ./bundle
 databricks bundle deploy --target dev -p <profile>
-dao-ai link-trace-destination -c ../my_config.yaml -p <profile>
+dao-ai trace link -c ../my_config.yaml -p <profile>
 databricks bundle run <new-app-name> --target dev -p <profile>
 databricks apps restart <new-app-name> -p <profile>
 ```
@@ -499,15 +502,17 @@ dao-ai chat -c config/my_config.yaml --param catalog=nfleming --param module_id=
 
 Discover and inspect tools available from MCP (Model Context Protocol) servers configured in your application.
 
+Use `dao-ai tools` (formerly `dao-ai list-mcp-tools`).
+
 ### Basic Usage
 
 List all MCP tools with full descriptions and schemas:
 
 ```bash
-dao-ai list-mcp-tools -c config/my_config.yaml
+dao-ai tools -c config/my_config.yaml
 
 # With parameter overrides
-dao-ai list-mcp-tools -c config/my_config.yaml --param catalog=main
+dao-ai tools -c config/my_config.yaml --param catalog=main
 ```
 
 ### Show Only Filtered Tools
@@ -515,7 +520,7 @@ dao-ai list-mcp-tools -c config/my_config.yaml --param catalog=main
 Use `--apply-filters` to see only the tools that will actually be loaded (respecting `include_tools` and `exclude_tools` configuration):
 
 ```bash
-dao-ai list-mcp-tools -c config/my_config.yaml --apply-filters
+dao-ai tools -c config/my_config.yaml --apply-filters
 ```
 
 ### What It Shows
@@ -690,7 +695,7 @@ dao-ai workflow destroy  -c config/my_config.yaml [OPTIONS]
 | `--param KEY=VALUE` / `--var KEY=VALUE` | Config parameter overrides (repeatable) | all |
 | `--cloud {azure,aws,gcp}` | Cloud provider (auto-detected if not specified) | all |
 | `-t, --target NAME` | Bundle target name (auto-generated if not specified) | all |
-| `--deployment-target` | Deployment target selector | all |
+| `--mode {apps,mcp}` | Serving mode selector (`generate`); also `model_serving` for `deploy` | all |
 | `--dry-run` | Preview commands without executing | all |
 | `-d, --deploy` | After generating, deploy the workflow bundle to Databricks | `generate` |
 | `-r, --run` | Run the `deploy_job` after deploying | `generate` |
@@ -701,23 +706,21 @@ dao-ai workflow destroy  -c config/my_config.yaml [OPTIONS]
 
 With no action flag (`--deploy`/`--run`/`--destroy`), `workflow generate`
 stages the bundle only, for inspection or manual `databricks bundle deploy`.
-The flat `generate-workflow` command remains as a back-compat alias for
-`workflow generate`.
+The flat `generate-workflow` command has been removed — use `dao-ai workflow generate`.
 
-### Agent / MCP Options (`dao-ai agent|mcp generate|deploy|run|destroy`)
+### Agent Options (`dao-ai agent generate|deploy|run|destroy`)
 
 ```bash
 dao-ai agent generate -c config/my_config.yaml [OPTIONS]
 dao-ai agent deploy   -c config/my_config.yaml [OPTIONS]
 dao-ai agent run      -c config/my_config.yaml [OPTIONS]
 dao-ai agent destroy  -c config/my_config.yaml [OPTIONS]
-# dao-ai mcp <verb> ... — identical, emits an MCP-server App instead
+# Use --mode mcp to generate/deploy the MCP-server bundle instead of the chat-agent bundle
 ```
 
-Both nouns emit a Databricks App bundle and share the same options. `generate`
-stages the bundle (and can one-shot `--deploy`/`--run`); `deploy`/`run`/`destroy`
+`generate` stages the bundle (and can one-shot `--deploy`/`--run`); `deploy`/`run`/`destroy`
 drive `databricks bundle` from the already-staged dir without regenerating. For
-`agent`/`mcp`, `run` is `databricks bundle run <app>`.
+`agent`, `run` is `databricks bundle run <app>`.
 
 | Option | Description | Verbs |
 |--------|-------------|-------|
@@ -725,6 +728,8 @@ drive `databricks bundle` from the already-staged dir without regenerating. For
 | `-o, --output-dir DIR` | Output dir (default: `$DAO_AI_BUNDLE_DIR/<kind>/<app>` or `./.dao-ai/bundle/<kind>/<app>`, where `<kind>` is `agent` or `mcp`) | all |
 | `-p, --profile NAME` | Databricks profile for config loading and deploy | all |
 | `--param KEY=VALUE` / `--var KEY=VALUE` | Config parameter overrides (repeatable) | all |
+| `--mode {apps,mcp}` | Serving mode for `generate`; also `model_serving` for `deploy` (default: `apps`) | all |
+| `--direct` | Deploy via SDK directly, no bundle on disk (apps/mcp; `deploy` only) | `deploy` |
 | `--dry-run` | Preview commands without executing | all |
 | `-d, --deploy` | After generating, run `databricks bundle deploy` (auto-links traces + grants SP when `app.trace_location` is set) | `generate` |
 | `-r, --run` | Start the app via `databricks bundle run <app>` | `generate` |
@@ -733,8 +738,7 @@ drive `databricks bundle` from the already-staged dir without regenerating. For
 | `--development` / `--no-development` | Bundle a local dao-ai wheel vs pin PyPI (default: auto-detect) | `generate` |
 | `--run` | Start the app after deploying the staged bundle | `deploy` |
 
-The flat `generate-agent` / `generate-mcp` commands remain as back-compat
-aliases for `agent generate` / `mcp generate`.
+The flat `generate-agent` and `generate-mcp` commands have been removed — use `dao-ai agent generate` and `dao-ai agent generate --mode mcp`.
 
 ### Chat Options
 
@@ -747,7 +751,7 @@ Starts an interactive REPL session where you can chat with your agent locally.
 ### List MCP Tools Options
 
 ```bash
-dao-ai list-mcp-tools -c config/my_config.yaml [OPTIONS]
+dao-ai tools -c config/my_config.yaml [OPTIONS]
 ```
 
 | Option | Description |
@@ -841,6 +845,29 @@ dao-ai graph -c config/my_app.yaml -o workflow.png
 # Generate and deploy and run
 dao-ai workflow generate --deploy --run -c config/my_app.yaml --profile aws-field-eng
 ```
+
+---
+
+## Migration from pre-v2 CLI
+
+The deploy-model v2 release removed several commands and renamed others. Use this table to update scripts and docs.
+
+| Old command (removed) | New command |
+|---|---|
+| `dao-ai deploy -c ... --target model_serving` | `dao-ai agent deploy -c ... --mode model_serving` |
+| `dao-ai deploy -c ... --target apps` | `dao-ai agent deploy -c ... --mode apps` |
+| `dao-ai deploy -c ... --target both` | Run `dao-ai agent deploy --mode model_serving` then `dao-ai agent deploy --mode apps` |
+| `dao-ai generate-agent ...` | `dao-ai agent generate ...` |
+| `dao-ai generate-mcp ...` | `dao-ai agent generate --mode mcp ...` |
+| `dao-ai generate-workflow ...` | `dao-ai workflow generate ...` |
+| `dao-ai mcp generate\|deploy\|run\|destroy` | `dao-ai agent generate\|deploy\|run\|destroy --mode mcp` |
+| `dao-ai create-experiment ...` | `dao-ai trace create ...` |
+| `dao-ai link-trace-destination ...` | `dao-ai trace link ...` |
+| `dao-ai grant-trace-permissions ...` | `dao-ai trace grant ...` |
+| `dao-ai list-mcp-tools ...` | `dao-ai tools ...` |
+| `--deployment-target <mode>` flag | `--mode <mode>` flag |
+| `app.deployment_target:` config field | Removed — serving mode is chosen at deploy time via `--mode` (default `apps`) |
+| `DeploymentTarget.BOTH` | Removed — deploy each mode separately |
 
 ---
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -92,25 +92,77 @@ so this local stack never ships to the deployed endpoint.
 
 - **`dao-ai deploy`** — quickest path to a running agent (Model Serving or Apps),
   no bundle artifact. Best for iterating.
-- **`dao-ai generate-agent` / `generate-mcp`** — emit an inspectable/committable
+- **`dao-ai agent` / `dao-ai mcp`** — emit an inspectable/committable
   Databricks App bundle you can deploy from CI or hand-tune (Apps only).
-- **`dao-ai generate-workflow`** — provision the full backing infra (schemas,
+- **`dao-ai workflow`** — provision the full backing infra (schemas,
   Vector Search, Lakebase, Genie, UC functions) *and* deploy the agent, as a
   multi-task Databricks Job. The job's deploy step runs the same
   `create_agent`/`deploy_agent` code `dao-ai deploy` runs directly.
 
-## Pipeline: Deploy and Run
+## Bundle Generators: `agent`, `mcp`, `workflow`
 
-The `dao-ai generate-workflow` subcommand deploys your agent to Databricks (under the hood it drives a Databricks Asset Bundle) and supports multi-cloud deployments with automatic cloud detection.
+The three bundle generators are **verb-under-noun** commands — pick a noun for
+what you're shipping, then a verb for the lifecycle step:
+
+| Noun | What it ships |
+|------|---------------|
+| `dao-ai agent` | A Databricks App running the agent graph. |
+| `dao-ai mcp` | A Databricks App exposing the agent as an MCP server. |
+| `dao-ai workflow` | A multi-task Databricks Job that provisions the backing infra (schemas, Vector Search, Lakebase, Genie, UC functions) *and* deploys the agent. |
+
+Each noun takes the same four verbs:
+
+```bash
+dao-ai agent    generate|deploy|run|destroy  -c <cfg> [-p <profile>]
+dao-ai mcp      generate|deploy|run|destroy  -c <cfg> [-p <profile>]
+dao-ai workflow generate|deploy|run|destroy  -c <cfg> [-p <profile>]
+```
+
+**The lifecycle — `generate → deploy → run → destroy`:**
+
+- **`generate`** stages a bundle to disk (`<base>/<noun>/<app>`, where `<base>`
+  is `$DAO_AI_BUNDLE_DIR` or `./.dao-ai/bundle`, or `-o <dir>`). It can one-shot
+  continue with `--deploy` and/or `--run` — e.g.
+  `dao-ai agent generate --deploy --run -p fevm`.
+- **`deploy` / `run` / `destroy`** act on the **already-staged** bundle
+  **without regenerating it**. Generate once, optionally hand-edit the staged
+  files, then `dao-ai agent deploy -c <cfg> -p fevm` ships exactly what's on
+  disk. `dao-ai agent deploy --run` deploys then runs. For `agent`/`mcp`,
+  `run` is `databricks bundle run <app>`; for `workflow`, `run` is
+  `databricks bundle run deploy_job` (the provisioning job).
+- The verbs are **strict** — `deploy`/`run` never auto-generate. If nothing is
+  staged they error and point you at `<noun> generate`. `run` on a
+  staged-but-undeployed app errors and points at `<noun> deploy --run`.
+
+This is the payoff: a deploy that failed on a transient error can be retried
+with just `dao-ai agent deploy -c <cfg> -p fevm` — no regeneration.
+
+**Edit safety.** Re-running `generate` into the **default** staging dir refuses
+to wipe it once it has local hand-edits (detected via the `.dao-ai-generated`
+marker file's mtime), unless you pass `--overwrite`. The error points you at
+`<noun> deploy` to ship the edits instead. A `-o <dir>` is never auto-wiped.
+`--overwrite` and `--development` are only on `generate`, not on
+`deploy`/`run`/`destroy`.
+
+> **Back-compat:** the flat commands `generate-agent`, `generate-mcp`, and
+> `generate-workflow` still work — they are aliases for `<noun> generate` with
+> identical flags. Existing scripts and examples remain valid.
+
+## Workflow: Provision and Deploy
+
+The `dao-ai workflow` command deploys your agent to Databricks (under the hood it drives a Databricks Asset Bundle) and supports multi-cloud deployments with automatic cloud detection.
 
 ### Basic Deployment
 
 ```bash
-# Deploy using default profile or environment
-dao-ai generate-workflow --deploy -c config/my_config.yaml
+# Generate + deploy using default profile or environment
+dao-ai workflow generate --deploy -c config/my_config.yaml
 
 # Deploy with parameter overrides
-dao-ai generate-workflow --deploy -c config/my_config.yaml --param catalog=prod_catalog --param schema=prod_schema
+dao-ai workflow generate --deploy -c config/my_config.yaml --param catalog=prod_catalog --param schema=prod_schema
+
+# Re-deploy the already-staged bundle without regenerating (e.g. retry a transient failure)
+dao-ai workflow deploy -c config/my_config.yaml
 ```
 
 `--param` (and the `--var` alias) flags are forwarded to the underlying `databricks bundle ...` invocation as `--var`, so Databricks Asset Bundles' own `${var.NAME}` substitution sees the same values when the names overlap.
@@ -121,20 +173,26 @@ The CLI automatically detects the cloud provider from your Databricks workspace 
 
 ```bash
 # Deploy to AWS workspace
-dao-ai generate-workflow --deploy -c config/my_config.yaml --profile aws-field-eng
+dao-ai workflow generate --deploy -c config/my_config.yaml --profile aws-field-eng
 
 # Deploy to Azure workspace
-dao-ai generate-workflow --deploy -c config/my_config.yaml --profile azure-retail
+dao-ai workflow generate --deploy -c config/my_config.yaml --profile azure-retail
 
 # Deploy to GCP workspace
-dao-ai generate-workflow --deploy -c config/my_config.yaml --profile gcp-analytics
+dao-ai workflow generate --deploy -c config/my_config.yaml --profile gcp-analytics
 ```
 
 ### Deploy and Run
 
 ```bash
-# Deploy and immediately run the job
-dao-ai generate-workflow --deploy --run -c config/my_config.yaml --profile aws-field-eng
+# Generate, deploy, and immediately run the deploy_job
+dao-ai workflow generate --deploy --run -c config/my_config.yaml --profile aws-field-eng
+
+# Run the deploy_job on an already-deployed bundle (databricks bundle run deploy_job)
+dao-ai workflow run -c config/my_config.yaml --profile aws-field-eng
+
+# Deploy the staged bundle then run it, no regeneration
+dao-ai workflow deploy --run -c config/my_config.yaml --profile aws-field-eng
 ```
 
 ### Explicit Cloud Override
@@ -142,7 +200,7 @@ dao-ai generate-workflow --deploy --run -c config/my_config.yaml --profile aws-f
 If cloud auto-detection doesn't work, you can specify the cloud explicitly:
 
 ```bash
-dao-ai generate-workflow --deploy -c config/my_config.yaml --cloud aws
+dao-ai workflow generate --deploy -c config/my_config.yaml --cloud aws
 ```
 
 ### Dry Run
@@ -150,27 +208,38 @@ dao-ai generate-workflow --deploy -c config/my_config.yaml --cloud aws
 Preview commands without executing:
 
 ```bash
-dao-ai generate-workflow --deploy -c config/my_config.yaml --profile aws-field-eng --dry-run
+dao-ai workflow generate --deploy -c config/my_config.yaml --profile aws-field-eng --dry-run
 ```
 
-## Generate Bundle
+## Agent / MCP Bundle
 
-Generate a complete, deployable Databricks Apps bundle directory from a dao-ai config file. This is distinct from the `bundle` command -- while `bundle` wraps `databricks bundle deploy/run/destroy`, `generate-agent` **creates** the bundle project itself.
+Generate a complete, deployable Databricks Apps bundle directory from a dao-ai config file. This is distinct from the `bundle` command -- while `bundle` wraps `databricks bundle deploy/run/destroy`, `dao-ai agent generate` **creates** the bundle project itself.
 
 When the source config uses `${param.NAME}` / `${var.NAME}` parameters or `${workspace.*}` references, the generated bundle writes the **resolved** config (all references substituted to literal values, `parameters:` block dropped) so the deployed app does not need the original `--param` flags or a runtime workspace lookup.
 
 ### Basic Usage
 
 ```bash
-dao-ai generate-agent -c config/retail.yaml -o ./my-bundle
+dao-ai agent generate -c config/retail.yaml -o ./my-bundle
 
 # With parameter overrides baked into the generated bundle
-dao-ai generate-agent -c config/retail.yaml -o ./my-bundle --param catalog=prod_catalog
+dao-ai agent generate -c config/retail.yaml -o ./my-bundle --param catalog=prod_catalog
+
+# Generate, deploy, and start the app in one shot
+dao-ai agent generate --deploy --run -c config/retail.yaml -p fevm
+
+# Ship the already-staged bundle without regenerating (e.g. after hand-editing, or retrying a transient deploy failure)
+dao-ai agent deploy -c config/retail.yaml -p fevm
+
+# Deploy the staged bundle then start it
+dao-ai agent deploy --run -c config/retail.yaml -p fevm
 ```
+
+The same verbs apply to `dao-ai mcp` (MCP server App). Use `dao-ai agent run` / `dao-ai mcp run` to `databricks bundle run <app>` an already-deployed bundle, and `dao-ai agent destroy` to tear it down. See [Bundle Generators](#bundle-generators-agent-mcp-workflow) for the full lifecycle and the flat `generate-agent` / `generate-mcp` back-compat aliases.
 
 ### Output location
 
-All three generators (`generate-agent`, `generate-mcp`, `generate-workflow`)
+All three generators (`agent`, `mcp`, `workflow`)
 resolve where to write the bundle in this order:
 
 1. `-o/--output-dir <dir>` — used verbatim.
@@ -200,7 +269,7 @@ The command creates a self-contained bundle directory with everything needed to 
 
 ### Dependency install: `pyproject.toml` + portable `uv.lock`
 
-`dao-ai generate-agent` writes a `pyproject.toml` and a portable `uv.lock` to the bundle (no `requirements.txt` — its presence would take precedence and force the pip path). The Databricks Apps build phase runs `uv sync --locked --no-dev` from them. Published mode (`--no-development`) pins `dao-ai[<extras>]==<version>` for reproducible redeploys; `--development` redirects dao-ai to the bundled local wheel via `[tool.uv.sources]`. `uv lock` records the full closure, and any internal-mirror host (`pypi-proxy.dev.databricks.com`) is rewritten to the public CDN so the lock resolves from Apps containers.
+`dao-ai agent generate` writes a `pyproject.toml` and a portable `uv.lock` to the bundle (no `requirements.txt` — its presence would take precedence and force the pip path). The Databricks Apps build phase runs `uv sync --locked --no-dev` from them. Published mode (`--no-development`) pins `dao-ai[<extras>]==<version>` for reproducible redeploys; `--development` redirects dao-ai to the bundled local wheel via `[tool.uv.sources]`. `uv lock` records the full closure, and any internal-mirror host (`pypi-proxy.dev.databricks.com`) is rewritten to the public CDN so the lock resolves from Apps containers.
 
 > **Pre-publish note:** published-mode lock generation resolves `dao-ai==<version>` from PyPI, so it fails with an actionable error until that version is published (release-time / CI). For local/pre-release iteration, generate with `--development` (locks against the bundled wheel — works anytime).
 
@@ -227,7 +296,7 @@ app:
     warehouse: "your-warehouse-id"           # or a *warehouse anchor reference
 ```
 
-When `trace_location` is set, `generate-agent` wires up the SQL warehouse as an App resource (CAN_USE for the App SP) and adds `MLFLOW_TRACING_SQL_WAREHOUSE_ID` to the App's `env`. The OTEL trace tables themselves are auto-created by MLflow at first trace write — dao-ai does not emit per-table grants because the tables don't exist at deploy time. After deploy, grant the App SP schema-level privileges (one-time):
+When `trace_location` is set, `agent generate` wires up the SQL warehouse as an App resource (CAN_USE for the App SP) and adds `MLFLOW_TRACING_SQL_WAREHOUSE_ID` to the App's `env`. The OTEL trace tables themselves are auto-created by MLflow at first trace write — dao-ai does not emit per-table grants because the tables don't exist at deploy time. After deploy, grant the App SP schema-level privileges (one-time):
 
 ```bash
 SP=$(databricks apps get <app-name> -p <profile> --output json | jq -r .service_principal_client_id)
@@ -237,7 +306,7 @@ databricks grants update schema <catalog>.<schema> -p <profile> \
   --json "{\"changes\":[{\"principal\":\"$SP\",\"add\":[\"USE_SCHEMA\",\"CREATE_TABLE\",\"MODIFY\",\"SELECT\"]}]}"
 ```
 
-When `trace_location` is unset, `generate-agent` emits a `⚠` warning to alert you. Local notebook/CLI runs and Model Serving deploys are unaffected.
+When `trace_location` is unset, `agent generate` emits a `⚠` warning to alert you. Local notebook/CLI runs and Model Serving deploys are unaffected.
 
 See `examples/01_getting_started/ai_gateway.yaml` for a drop-in example.
 
@@ -255,13 +324,13 @@ databricks bundle run <app-name> --target dev -p <profile>
 databricks apps restart <app-name> -p <profile>
 ```
 
-The verb is idempotent — safe on every deploy — but load-bearing on re-deploys and after `trace_location` changes. `generate-agent` prints a one-line reminder in its "Next steps" when `trace_location` is configured.
+The verb is idempotent — safe on every deploy — but load-bearing on re-deploys and after `trace_location` changes. `agent generate` prints a one-line reminder in its "Next steps" when `trace_location` is configured.
 
 See [Link Trace Destination](#link-trace-destination) for full flag reference and the migration playbook for moving traces between destinations.
 
 #### Runtime trace-destination sync (`apply_runtime_trace_destination`)
 
-`link-trace-destination` writes the trace-destination tag on the experiment record so that future traces route to the configured UC schema. That works when MLflow's runtime picks up the linkage from the experiment — but if the app also has `MLFLOW_TRACING_DESTINATION` env set (dao-ai's `generate-agent` sets it as `catalog.schema` for warehouse routing), MLflow parses that env value as the deprecated `UCSchemaLocation` and populates the `_MLFLOW_TRACE_USER_DESTINATION` ContextVar accordingly. The ContextVar SHADOWS MLflow's auto-resolver from experiment tags, so the exporter targets `mlflow_experiment_trace_otel_spans` (the un-prefixed default) which doesn't exist on the prefixed schema — and every span export fails with `TABLE_DOES_NOT_EXIST`.
+`link-trace-destination` writes the trace-destination tag on the experiment record so that future traces route to the configured UC schema. That works when MLflow's runtime picks up the linkage from the experiment — but if the app also has `MLFLOW_TRACING_DESTINATION` env set (dao-ai's `agent generate` sets it as `catalog.schema` for warehouse routing), MLflow parses that env value as the deprecated `UCSchemaLocation` and populates the `_MLFLOW_TRACE_USER_DESTINATION` ContextVar accordingly. The ContextVar SHADOWS MLflow's auto-resolver from experiment tags, so the exporter targets `mlflow_experiment_trace_otel_spans` (the un-prefixed default) which doesn't exist on the prefixed schema — and every span export fails with `TABLE_DOES_NOT_EXIST`.
 
 To close that gap, the App startup path (`apps/handlers.py`) and the MCP-server startup path (`mcp/server.py`) both call `apply_runtime_trace_destination(config)` from `dao_ai.providers.databricks` right after `link_experiment_trace_location`. The helper:
 
@@ -286,15 +355,17 @@ dao-ai create-experiment --name /Shared/my-app/dao-ai-fresh -p <profile>
 If the output directory already contains generated files, they are skipped by default. Use `--overwrite` to overwrite:
 
 ```bash
-dao-ai generate-agent -c config/retail.yaml -o ./my-bundle --overwrite
+dao-ai agent generate -c config/retail.yaml -o ./my-bundle --overwrite
 ```
+
+Re-running `generate` into the **default** staging dir (no `-o`) refuses to wipe it once it has local hand-edits (detected via the `.dao-ai-generated` marker's mtime) unless you pass `--overwrite`; the error points you at `dao-ai agent deploy` to ship the edits as-is. A `-o <dir>` is never auto-wiped. `--overwrite` is only valid on `generate`.
 
 ### Using a Databricks Profile
 
 If your config references workspace resources (Genie rooms, warehouses, etc.), specify a profile so they can be resolved during generation:
 
 ```bash
-dao-ai generate-agent -c config/retail.yaml -o ./my-bundle --profile my-workspace
+dao-ai agent generate -c config/retail.yaml -o ./my-bundle --profile my-workspace
 ```
 
 ### Development Mode
@@ -302,7 +373,7 @@ dao-ai generate-agent -c config/retail.yaml -o ./my-bundle --profile my-workspac
 Use `--development` to bundle a local build of dao-ai instead of pulling from PyPI. This is useful when testing unreleased dao-ai changes in a deployed app.
 
 ```bash
-dao-ai generate-agent -c config/retail.yaml -o ./my-bundle --development
+dao-ai agent generate -c config/retail.yaml -o ./my-bundle --development
 ```
 
 Development mode changes the generated bundle in several ways:
@@ -314,9 +385,13 @@ Development mode changes the generated bundle in several ways:
 
 ### Next Steps
 
-After generating the bundle, the command prints the next steps:
+After generating the bundle, the command prints the next steps. You can either drive Databricks directly, or use the strict `deploy`/`run` verbs (which act on the staged dir without regenerating):
 
 ```bash
+# Option A — dao-ai verbs (no regeneration; deploy --run to do both)
+dao-ai agent deploy --run -c config/retail.yaml -p <profile>
+
+# Option B — drive databricks bundle directly
 cd ./my-bundle
 uv sync
 databricks bundle deploy --target dev
@@ -399,7 +474,7 @@ app:
 
 ```bash
 # 3. Deploy → link → run → restart.
-dao-ai generate-agent -c my_config.yaml -o ./bundle --overwrite
+dao-ai agent generate -c my_config.yaml -o ./bundle --overwrite
 cd ./bundle
 databricks bundle deploy --target dev -p <profile>
 dao-ai link-trace-destination -c ../my_config.yaml -p <profile>
@@ -596,51 +671,70 @@ dao-ai graph -c config/my_config.yaml -o output.png [OPTIONS]
 |--------|-------------|
 | `-o, --output FILE` | Output file path (supports .png, .pdf, .svg) |
 
-### Generate Workflow Options
+### Workflow Options (`dao-ai workflow generate|deploy|run|destroy`)
 
 ```bash
-dao-ai generate-workflow -c config/my_config.yaml [OPTIONS]
+dao-ai workflow generate -c config/my_config.yaml [OPTIONS]
+dao-ai workflow deploy   -c config/my_config.yaml [OPTIONS]
+dao-ai workflow run      -c config/my_config.yaml [OPTIONS]
+dao-ai workflow destroy  -c config/my_config.yaml [OPTIONS]
 ```
 
-| Option | Description |
-|--------|-------------|
-| `-c, --config FILE` | Path to the dao-ai configuration file (required) |
-| `-d, --deploy` | Deploy the workflow bundle to Databricks |
-| `-r, --run` | Run the `deploy_job` after deploying |
-| `--destroy` | Destroy the deployed workflow bundle |
-| `-o, --output-dir DIR` | Bundle staging dir (default: `$DAO_AI_BUNDLE_DIR/workflow/<app>` or `./.dao-ai/bundle/workflow/<app>`) |
-| `--overwrite` | Overwrite copied-in files in the staging dir |
-| `-p, --profile NAME` | Databricks CLI profile to use |
-| `--cloud {azure,aws,gcp}` | Cloud provider (auto-detected if not specified) |
-| `-t, --target NAME` | Bundle target name (auto-generated if not specified) |
-| `--development` / `--no-development` | Ship the local dao-ai wheel vs pin PyPI (default: auto-detect) |
-| `--dry-run` | Preview commands without executing |
+`generate` stages the bundle (and can one-shot `--deploy`/`--run`); `deploy`/`run`/`destroy` act on the already-staged bundle without regenerating. For `workflow`, `run` is `databricks bundle run deploy_job` (the provisioning job).
 
-With no action flag (`--deploy`/`--run`/`--destroy`), `generate-workflow`
+| Option | Description | Verbs |
+|--------|-------------|-------|
+| `-c, --config FILE` | Path to the dao-ai configuration file (required) | all |
+| `-o, --output-dir DIR` | Bundle staging dir (default: `$DAO_AI_BUNDLE_DIR/workflow/<app>` or `./.dao-ai/bundle/workflow/<app>`) | all |
+| `-p, --profile NAME` | Databricks CLI profile to use | all |
+| `--param KEY=VALUE` / `--var KEY=VALUE` | Config parameter overrides (repeatable) | all |
+| `--cloud {azure,aws,gcp}` | Cloud provider (auto-detected if not specified) | all |
+| `-t, --target NAME` | Bundle target name (auto-generated if not specified) | all |
+| `--deployment-target` | Deployment target selector | all |
+| `--dry-run` | Preview commands without executing | all |
+| `-d, --deploy` | After generating, deploy the workflow bundle to Databricks | `generate` |
+| `-r, --run` | Run the `deploy_job` after deploying | `generate` |
+| `--destroy` | Destroy the deployed workflow bundle after generating | `generate` |
+| `--overwrite` | Overwrite copied-in files in the staging dir | `generate` |
+| `--development` / `--no-development` | Ship the local dao-ai wheel vs pin PyPI (default: auto-detect) | `generate` |
+| `--run` | Run `deploy_job` after deploying the staged bundle | `deploy` |
+
+With no action flag (`--deploy`/`--run`/`--destroy`), `workflow generate`
 stages the bundle only, for inspection or manual `databricks bundle deploy`.
+The flat `generate-workflow` command remains as a back-compat alias for
+`workflow generate`.
 
-### Generate Agent / Generate MCP Options
+### Agent / MCP Options (`dao-ai agent|mcp generate|deploy|run|destroy`)
 
 ```bash
-dao-ai generate-agent -c config/my_config.yaml [OPTIONS]
-dao-ai generate-mcp   -c config/my_config.yaml [OPTIONS]
+dao-ai agent generate -c config/my_config.yaml [OPTIONS]
+dao-ai agent deploy   -c config/my_config.yaml [OPTIONS]
+dao-ai agent run      -c config/my_config.yaml [OPTIONS]
+dao-ai agent destroy  -c config/my_config.yaml [OPTIONS]
+# dao-ai mcp <verb> ... — identical, emits an MCP-server App instead
 ```
 
-Both emit a Databricks App bundle and share the same options. With no action
-flag they generate only; `--deploy`/`--run`/`--destroy` drive
-`databricks bundle` from the generated dir.
+Both nouns emit a Databricks App bundle and share the same options. `generate`
+stages the bundle (and can one-shot `--deploy`/`--run`); `deploy`/`run`/`destroy`
+drive `databricks bundle` from the already-staged dir without regenerating. For
+`agent`/`mcp`, `run` is `databricks bundle run <app>`.
 
-| Option | Description |
-|--------|-------------|
-| `-c, --config FILE` | Path to the dao-ai configuration file (required) |
-| `-o, --output-dir DIR` | Output dir (default: `$DAO_AI_BUNDLE_DIR/<kind>/<app>` or `./.dao-ai/bundle/<kind>/<app>`, where `<kind>` is `agent` or `mcp`) |
-| `--overwrite` | Overwrite existing files in the output directory |
-| `-d, --deploy` | After generating, run `databricks bundle deploy` (auto-links traces + grants SP when `app.trace_location` is set) |
-| `-r, --run` | Start the app via `databricks bundle run <app>` |
-| `--destroy` | Destroy the deployed app bundle |
-| `--development` / `--no-development` | Bundle a local dao-ai wheel vs pin PyPI (default: auto-detect) |
-| `--dry-run` | Preview commands without executing |
-| `-p, --profile NAME` | Databricks profile for config loading and deploy |
+| Option | Description | Verbs |
+|--------|-------------|-------|
+| `-c, --config FILE` | Path to the dao-ai configuration file (required) | all |
+| `-o, --output-dir DIR` | Output dir (default: `$DAO_AI_BUNDLE_DIR/<kind>/<app>` or `./.dao-ai/bundle/<kind>/<app>`, where `<kind>` is `agent` or `mcp`) | all |
+| `-p, --profile NAME` | Databricks profile for config loading and deploy | all |
+| `--param KEY=VALUE` / `--var KEY=VALUE` | Config parameter overrides (repeatable) | all |
+| `--dry-run` | Preview commands without executing | all |
+| `-d, --deploy` | After generating, run `databricks bundle deploy` (auto-links traces + grants SP when `app.trace_location` is set) | `generate` |
+| `-r, --run` | Start the app via `databricks bundle run <app>` | `generate` |
+| `--destroy` | Destroy the deployed app bundle after generating | `generate` |
+| `--overwrite` | Overwrite existing files in the output directory | `generate` |
+| `--development` / `--no-development` | Bundle a local dao-ai wheel vs pin PyPI (default: auto-detect) | `generate` |
+| `--run` | Start the app after deploying the staged bundle | `deploy` |
+
+The flat `generate-agent` / `generate-mcp` commands remain as back-compat
+aliases for `agent generate` / `mcp generate`.
 
 ### Chat Options
 
@@ -716,23 +810,23 @@ This allows you to deploy the same application to multiple workspaces without co
 
 ```bash
 # Deploy to AWS
-dao-ai generate-workflow --deploy -c config/hardware_store.yaml --profile aws-prod
+dao-ai workflow generate --deploy -c config/hardware_store.yaml --profile aws-prod
 
 # Deploy same app to Azure
-dao-ai generate-workflow --deploy -c config/hardware_store.yaml --profile azure-prod
+dao-ai workflow generate --deploy -c config/hardware_store.yaml --profile azure-prod
 
 # Deploy same app to GCP
-dao-ai generate-workflow --deploy -c config/hardware_store.yaml --profile gcp-prod
+dao-ai workflow generate --deploy -c config/hardware_store.yaml --profile gcp-prod
 ```
 
 ### Development vs Production
 
 ```bash
 # Deploy to development workspace
-dao-ai generate-workflow --deploy -c config/my_app.yaml --profile aws-dev
+dao-ai workflow generate --deploy -c config/my_app.yaml --profile aws-dev
 
 # Deploy to production workspace
-dao-ai generate-workflow --deploy -c config/my_app.yaml --profile aws-prod
+dao-ai workflow generate --deploy -c config/my_app.yaml --profile aws-prod
 ```
 
 ### Full Deployment Pipeline
@@ -744,8 +838,8 @@ dao-ai validate -c config/my_app.yaml
 # Generate workflow diagram
 dao-ai graph -c config/my_app.yaml -o workflow.png
 
-# Deploy and run
-dao-ai generate-workflow --deploy --run -c config/my_app.yaml --profile aws-field-eng
+# Generate and deploy and run
+dao-ai workflow generate --deploy --run -c config/my_app.yaml --profile aws-field-eng
 ```
 
 ---

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -782,7 +782,7 @@ Substitution does not recurse. If a substituted value happens to contain `${para
 
 ### Bundle behaviour
 
-When `dao-ai generate-agent` writes the deployable Apps bundle, the emitted config YAML has every reference (both `${param.*}` and `${workspace.*}`) substituted to a literal value and the `parameters:` block dropped. The deployed app does not need the original `--param` flags or runtime workspace lookups.
+When `dao-ai agent generate` writes the deployable Apps bundle, the emitted config YAML has every reference (both `${param.*}` and `${workspace.*}`) substituted to a literal value and the `parameters:` block dropped. The deployed app does not need the original `--param` flags or runtime workspace lookups.
 
 ---
 
@@ -899,7 +899,7 @@ At load time, `${var.secret_scope}` and `${var.client_id_secret_key}` are text-s
 Override at deploy time:
 
 ```bash
-dao-ai generate-workflow --deploy -c dao_ai.yaml --param secret_scope=prod_dao_ai --param client_id_secret_key=PROD_SP_CLIENT_ID
+dao-ai workflow generate --deploy -c dao_ai.yaml --param secret_scope=prod_dao_ai --param client_id_secret_key=PROD_SP_CLIENT_ID
 ```
 
 **What this does NOT do:** You cannot substitute a parameter for an _entire_ typed mapping - only for string fields inside one. This works:

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -400,7 +400,7 @@ app:
   scale_to_zero: bool              # default: true
   workload_size: Small | Medium | Large   # default: Small
   python_version: string           # default: "3.12"
-  deployment_target: model_serving | apps # default override; CLI --deployment-target wins
+  # deployment_target field removed — serving mode is chosen at deploy time via --mode (default apps)
   budget_policy_id: string         # Cost-attribution policy id
   code_paths: [string]             # Extra Python files bundled with the model artifact
   pip_requirements: [string]       # Extra pip packages installed in the serving env
@@ -417,8 +417,8 @@ app:
 
   # OTEL trace storage in Unity Catalog Delta tables.
   # Requires an explicit post-deploy link step:
-  #   `dao-ai link-trace-destination -c my_config.yaml -p <profile>`
-  # See `docs/cli-reference.md#link-trace-destination` for the flow and
+  #   `dao-ai trace link -c my_config.yaml -p <profile>`
+  # See `docs/cli-reference.md#trace-commands` for the flow and
   # for the migration playbook. IMPORTANT: once an experiment is linked
   # to a UC destination, Databricks does NOT allow un-linking or
   # changing the destination (verified live — the server rejects

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -87,7 +87,7 @@ dao-ai chat -c examples/02_tools/slack_integration.yaml
 
 ### Deploy to Databricks
 ```bash
-dao-ai generate-workflow --deploy --run -c examples/07_human_in_the_loop/human_in_the_loop.yaml
+dao-ai workflow generate --deploy --run -c examples/07_human_in_the_loop/human_in_the_loop.yaml
 ```
 
 ---
@@ -461,7 +461,7 @@ Each example is a starting point:
 2. **Modify** prompts, tools, and settings
 3. **Validate**: `dao-ai validate -c config/my_agent.yaml`
 4. **Test** locally: `dao-ai chat -c config/my_agent.yaml`
-5. **Deploy**: `dao-ai generate-workflow --deploy -c config/my_agent.yaml`
+5. **Deploy**: `dao-ai workflow generate --deploy -c config/my_agent.yaml`
 
 For detailed guidance, see the README.md in each category directory.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -135,10 +135,10 @@ Yes! Use different configuration files for each environment:
 
 ```bash
 # Development
-dao-ai generate-workflow --deploy -c config/dev.yaml --profile dev
+dao-ai workflow generate --deploy -c config/dev.yaml --profile dev
 
 # Production
-dao-ai generate-workflow --deploy -c config/prod.yaml --profile prod
+dao-ai workflow generate --deploy -c config/prod.yaml --profile prod
 ```
 
 **Learn more:** [`docs/cli-reference.md`](cli-reference.md) · [`docs/configuration-reference.md`](configuration-reference.md) (parameters + variables lifecycle)
@@ -171,7 +171,7 @@ variables:
 Simply redeploy with the updated configuration:
 
 ```bash
-dao-ai generate-workflow --deploy --run -c config/my_config.yaml
+dao-ai workflow generate --deploy --run -c config/my_config.yaml
 ```
 
 This will update the existing deployment.
@@ -194,16 +194,19 @@ print(f"Deployed app: {config.app.name}")
 
 `deploy_agent(target=APPS)` generates the Asset Bundle, uploads source + `requirements.txt`, deploys the app, waits for compute ACTIVE, and (if `app.trace_location:` is set) grants the App SP the OTEL-table permissions.  See [Lab 1 — Your First DAO-AI Agent](https://github.com/natefleming/dao-ai-workshop/tree/main/L100-foundations/lab-01-first-agent) for the shortest working example.
 
-**Path 2 — `dao-ai generate-agent` (Asset Bundle you can inspect / edit / check into Git):**
+**Path 2 — `dao-ai agent generate` (Asset Bundle you can inspect / edit / check into Git):**
 
 ```bash
-dao-ai generate-agent -c config/my_agent.yaml -o ./my-bundle
+dao-ai agent generate -c config/my_agent.yaml -o ./my-bundle
+# Optionally hand-edit ./my-bundle, then ship exactly what's on disk (no regeneration):
+dao-ai agent deploy --run -c config/my_agent.yaml -o ./my-bundle
+# ...or drive the bundle manually
 cd my-bundle
 databricks bundle deploy
 databricks bundle run <app-name>
 ```
 
-`generate-agent` writes a complete, deployable Databricks Apps bundle directory (`databricks.yaml`, `app.yaml`, `pyproject.toml`, scaffolding). Useful when you want the bundle under version control, need to hand-tune anything the generator produced, or want to deploy from CI outside of Python. Add `--development` to bundle local dao-ai source instead of the pinned PyPI wheel; add `--overwrite` to overwrite an existing output directory.
+`agent generate` writes a complete, deployable Databricks Apps bundle directory (`databricks.yaml`, `app.yaml`, `pyproject.toml`, scaffolding). Useful when you want the bundle under version control, need to hand-tune anything the generator produced, or want to deploy from CI outside of Python. Add `--development` to bundle local dao-ai source instead of the pinned PyPI wheel; add `--overwrite` to overwrite an existing output directory. The strict `deploy`/`run`/`destroy` verbs act on the already-staged bundle without regenerating. The flat `generate-agent` command remains as a back-compat alias.
 
 **Learn more:** [`docs/cli-reference.md`](cli-reference.md) · [`docs/python-api.md`](python-api.md)
 
@@ -758,7 +761,7 @@ app:
 **Deploy flow for Databricks Apps** (bundle path):
 
 ```bash
-dao-ai generate-agent -c my_config.yaml -o ./bundle
+dao-ai agent generate -c my_config.yaml -o ./bundle
 cd ./bundle
 databricks bundle deploy --target dev -p <profile>
 dao-ai link-trace-destination -c ../my_config.yaml -p <profile>   # explicit link step

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -206,7 +206,7 @@ databricks bundle deploy
 databricks bundle run <app-name>
 ```
 
-`agent generate` writes a complete, deployable Databricks Apps bundle directory (`databricks.yaml`, `app.yaml`, `pyproject.toml`, scaffolding). Useful when you want the bundle under version control, need to hand-tune anything the generator produced, or want to deploy from CI outside of Python. Add `--development` to bundle local dao-ai source instead of the pinned PyPI wheel; add `--overwrite` to overwrite an existing output directory. The strict `deploy`/`run`/`destroy` verbs act on the already-staged bundle without regenerating. The flat `generate-agent` command remains as a back-compat alias.
+`agent generate` writes a complete, deployable Databricks Apps bundle directory (`databricks.yaml`, `app.yaml`, `pyproject.toml`, scaffolding). Useful when you want the bundle under version control, need to hand-tune anything the generator produced, or want to deploy from CI outside of Python. Add `--development` to bundle local dao-ai source instead of the pinned PyPI wheel; add `--overwrite` to overwrite an existing output directory. The strict `deploy`/`run`/`destroy` verbs act on the already-staged bundle without regenerating. Use `--mode mcp` to generate an MCP-server App instead.
 
 **Learn more:** [`docs/cli-reference.md`](cli-reference.md) · [`docs/python-api.md`](python-api.md)
 
@@ -764,16 +764,16 @@ app:
 dao-ai agent generate -c my_config.yaml -o ./bundle
 cd ./bundle
 databricks bundle deploy --target dev -p <profile>
-dao-ai link-trace-destination -c ../my_config.yaml -p <profile>   # explicit link step
+dao-ai trace link -c ../my_config.yaml -p <profile>               # explicit link step
 databricks bundle run <app-name> --target dev -p <profile>
 databricks apps restart <app-name> -p <profile>                   # required
 ```
 
-The `link-trace-destination` step is idempotent — safe on every deploy — but load-bearing on re-deploys. It runs from your machine with your credentials, before the app boots. Skipping it (and relying on the app's own runtime link attempt in `dao_ai.apps.handlers`) causes silent trace loss on re-deploys because MLflow rejects re-linking with `already contains traces`.
+The `dao-ai trace link` step is idempotent — safe on every deploy — but load-bearing on re-deploys. It runs from your machine with your credentials, before the app boots. Skipping it (and relying on the app's own runtime link attempt in `dao_ai.apps.handlers`) causes silent trace loss on re-deploys because MLflow rejects re-linking with `already contains traces`.
 
 **Model Serving** deploys via `dao-ai deploy` link automatically inside `deploy_apps_agent` / `deploy_model_serving_agent` (same `link_experiment_trace_location` helper) — no manual step required.
 
-**Important once linked:** Databricks does NOT allow un-linking or changing a UC trace destination. `catalog` / `schema` / `table_prefix` are permanent for that experiment. To move traces to a different destination, create a fresh experiment (new name or id) and re-link it — see [`docs/cli-reference.md#link-trace-destination`](cli-reference.md#link-trace-destination) for the full migration playbook.
+**Important once linked:** Databricks does NOT allow un-linking or changing a UC trace destination. `catalog` / `schema` / `table_prefix` are permanent for that experiment. To move traces to a different destination, create a fresh experiment (new name or id) and re-link it — see [`docs/cli-reference.md#trace-commands`](cli-reference.md#trace-commands) for the full migration playbook.
 
 See [Lab 24 — UC OTEL Trace Tables](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-24-uc-trace-location) for the walkthrough. **Note:** in-process notebook usage of the same config additionally needs `mlflow.langchain.autolog(run_tracer_inline=True)` + `dao_ai.logging.suppress_autolog_context_warnings()` — the deploy runtime does both automatically at boot, but the notebook flow must do them explicitly.
 
@@ -789,7 +789,7 @@ dao-ai grants the required privileges automatically at deploy time (see `_grant_
 - `USE_SCHEMA` on the target schema
 - `SELECT` + `MODIFY` on each of the four OTEL tables
 
-**Gotcha:** the *deployer* (the person running `deploy_agent(...)` or `dao-ai generate-workflow --deploy`) must hold `MANAGE` on the target UC schema for those grants to succeed. If the deployer doesn't have `MANAGE`, ask a metastore admin to run once:
+**Gotcha:** the *deployer* (the person running `deploy_agent(...)` or `dao-ai workflow generate --deploy`) must hold `MANAGE` on the target UC schema for those grants to succeed. If the deployer doesn't have `MANAGE`, ask a metastore admin to run once:
 
 ```sql
 GRANT USE_CATALOG ON CATALOG <catalog> TO `<endpoint-sp-client-id>`;

--- a/docs/key-capabilities.md
+++ b/docs/key-capabilities.md
@@ -28,9 +28,9 @@ These are the powerful features that make DAO production-ready. Don't worry if s
 ```yaml
 app:
   name: my_agent
-  deployment_target: model_serving  # or 'apps'
+  # Serving mode is chosen at deploy time via --mode (default: apps)
   
-  # Model Serving specific options (only used when deployment_target: model_serving)
+  # Model Serving specific options (used when deploying with --mode model_serving)
   endpoint_name: my_agent_endpoint
   workload_size: Small
   scale_to_zero: true
@@ -41,15 +41,15 @@ app:
 
 **Deploy to Model Serving:**
 ```bash
-dao-ai deploy -c config.yaml --target model_serving
+dao-ai agent deploy -c config.yaml --mode model_serving
 ```
 
 **Deploy to Databricks Apps:**
 ```bash
-dao-ai deploy -c config.yaml --target apps
+dao-ai agent deploy -c config.yaml --mode apps
 ```
 
-**CLI override:** The `--target` flag always takes precedence over the YAML config, making it easy to deploy the same config to different environments.
+**CLI override:** The `--mode` flag selects the serving target at deploy time (default: `apps`).
 
 **Behind the scenes:**
 - Model Serving deployments create an MLflow model and serving endpoint
@@ -2090,8 +2090,7 @@ same LangGraph, same checkpointer, two protocols on one FastAPI app.
 - **Ecosystem interop.** Once your agent speaks A2A, any A2A-aware client
   (LangChain, AutoGen, Strands, OpenAI Agents SDK, custom Python clients)
   can discover and call it without bespoke glue.
-- **Zero config to enable.** A2A is on by default when
-  `app.deployment_target: apps`. Set `app.a2a.enabled: false` to opt out.
+- **Zero config to enable.** A2A is on by default on every Apps deployment. Set `app.a2a.enabled: false` to opt out.
 - **Same dao-ai capabilities, exposed on a different wire.** HITL, OBO,
   conversation history (`thread_id`↔`contextId`), custom inputs (via
   `DataPart`), and long-running task persistence (via Lakebase-backed
@@ -2112,7 +2111,6 @@ same LangGraph, same checkpointer, two protocols on one FastAPI app.
 app:
   name: my_agent
   description: My agent's job
-  deployment_target: apps
   agents: [*my_agent]
   # No app.a2a block required — A2A is on by default with sensible
   # defaults. To customise:

--- a/docs/lakebase.md
+++ b/docs/lakebase.md
@@ -168,7 +168,7 @@ docs = tool.invoke({"query": "How do I reset my password?"})
 
 ## Deploy-path notes
 
-- **App bundle** (`dao-ai generate-agent` + `databricks bundle deploy`) —
+- **App bundle** (`dao-ai agent generate` + `databricks bundle deploy`) —
   Lakebase entries under `resources.vector_stores` emit no
   `vector-search-index` resource (the App SP authenticates via
   `database.client_id` / `client_secret` at runtime).

--- a/docs/mcp_server.md
+++ b/docs/mcp_server.md
@@ -24,7 +24,7 @@ Search, UC functions) already have first-class Databricks MCP surfaces or
 UC exposure; publishing them a second time from a dao-ai MCP server is
 duplicative.
 
-`dao-ai mcp generate` bundles a Databricks App that runs the same graph
+`dao-ai agent generate --mode mcp` bundles a Databricks App that runs the same graph
 `dao-ai agent generate` deploys — but with an MCP entrypoint instead of an
 MLflow AgentServer HTTP entrypoint. OBO tokens from the caller flow
 through the graph unchanged: downstream Genie / Vector Search / UC
@@ -46,13 +46,14 @@ function calls run as the caller, not as the App's service principal.
 pip install 'dao-ai[mcp]'
 
 # 2. Generate a deploy-ready bundle from your dao-ai config
-dao-ai mcp generate \
+dao-ai agent generate \
+  --mode mcp \
   -c my_agent.yaml \
   -o ./my-agent-mcp \
   -p <profile>
 
 # 3. Deploy + run in one step (or drive databricks bundle by hand, below)
-dao-ai mcp deploy --run -c my_agent.yaml -o ./my-agent-mcp -p <profile>
+dao-ai agent deploy --mode mcp --run -c my_agent.yaml -o ./my-agent-mcp -p <profile>
 
 # 3b. ...or drive the bundle manually
 cd my-agent-mcp
@@ -74,11 +75,10 @@ Your dao-ai config needs:
 
 - `app.name` — Databricks App name **and** MCP tool name (slugified).
 - `app.description` — recommended; surfaced as the MCP tool description.
-- `app.deployment_target: apps` — the MCP server runs on Databricks Apps.
 - At least one agent (or an `orchestration.deep_agent` block) — the
   server calls `AppConfig.as_responses_agent()` at boot.
 - Any resources the agent needs (Genie rooms, Vector Search indexes,
-  Lakebase, warehouses, models) — same as `generate-agent`.
+  Lakebase, warehouses, models) — same as `dao-ai agent generate`.
 
 The MCP server prefers `mcp-`-prefixed app names because Databricks
 Multi-Agent Supervisor pattern-matches that prefix when auto-discovering
@@ -141,8 +141,8 @@ Every `tools/call` response is a `CallToolResult` with:
 
 ### Experiment provisioning
 
-`generate-mcp` emits an MLflow experiment resource in the DAB — parity
-with `generate-agent`. Behaviour:
+`dao-ai agent generate --mode mcp` emits an MLflow experiment resource in the DAB — parity
+with `dao-ai agent generate`. Behaviour:
 
 - If `config.app.experiment` is set → binds by literal experiment id
   (and if `manage_permissions: false`, requests `CAN_READ` only).
@@ -430,7 +430,7 @@ with **no code changes** in the agent config beyond the usual
 
 ## Deployment artifacts
 
-`dao-ai generate-mcp` emits:
+`dao-ai agent generate --mode mcp` emits:
 
 ```
 output/
@@ -460,12 +460,12 @@ launches the server via module invocation — no console script required.
 
 ### App resource bindings
 
-`generate-mcp` derives App resource bindings via
+`dao-ai agent generate --mode mcp` derives App resource bindings via
 `dao_ai.apps.resources.generate_app_resources` and converts them with
 `dao_ai.apps.bundle._convert_to_bundle_resources`. The resulting
 `databricks.yml` declares whatever bindings the agent needs — genie
 space, sql warehouse, postgres, uc securable, serving endpoint, secret —
-identical to what `generate-agent` emits.
+identical to what `dao-ai agent generate` emits.
 
 Lakebase `database_instances` are **not** auto-provisioned. The bundle
 assumes the Lakebase project already exists.
@@ -785,7 +785,7 @@ parent-graph and MCP-side conversation lineage stay aligned.
 - `dao_ai.mcp.agent_tool` — the single-tool registration surface.
 - `dao_ai.mcp.server` — FastAPI + FastMCP entrypoint.
 - `dao_ai.mcp.generate` — `write_mcp_bundle` bundle emission.
-- `dao_ai.apps.bundle.write_bundle` — the `dao-ai generate-agent` entry
+- `dao_ai.apps.bundle.write_bundle` — the `dao-ai agent generate` entry
   point for the standard AgentServer HTTP deployment. `write_mcp_bundle`
   mirrors its shape.
 - `dao_ai.apps.mcp` — **client** primitives for consuming external MCP

--- a/docs/mcp_server.md
+++ b/docs/mcp_server.md
@@ -24,8 +24,8 @@ Search, UC functions) already have first-class Databricks MCP surfaces or
 UC exposure; publishing them a second time from a dao-ai MCP server is
 duplicative.
 
-`dao-ai generate-mcp` bundles a Databricks App that runs the same graph
-`generate-agent` deploys — but with an MCP entrypoint instead of an
+`dao-ai mcp generate` bundles a Databricks App that runs the same graph
+`dao-ai agent generate` deploys — but with an MCP entrypoint instead of an
 MLflow AgentServer HTTP entrypoint. OBO tokens from the caller flow
 through the graph unchanged: downstream Genie / Vector Search / UC
 function calls run as the caller, not as the App's service principal.
@@ -46,12 +46,15 @@ function calls run as the caller, not as the App's service principal.
 pip install 'dao-ai[mcp]'
 
 # 2. Generate a deploy-ready bundle from your dao-ai config
-dao-ai generate-mcp \
+dao-ai mcp generate \
   -c my_agent.yaml \
   -o ./my-agent-mcp \
   -p <profile>
 
-# 3. Deploy to Databricks Apps
+# 3. Deploy + run in one step (or drive databricks bundle by hand, below)
+dao-ai mcp deploy --run -c my_agent.yaml -o ./my-agent-mcp -p <profile>
+
+# 3b. ...or drive the bundle manually
 cd my-agent-mcp
 uv sync
 databricks bundle deploy -t dev -p <profile>

--- a/docs/mlflow-tracing.md
+++ b/docs/mlflow-tracing.md
@@ -8,8 +8,8 @@ dao-ai supports three deploy targets and each drives MLflow tracing differently:
 
 | Target | Startup entrypoint | Trace destination binding |
 |---|---|---|
-| Databricks Apps (`generate-agent`) | `src/dao_ai/apps/handlers.py` | `link_experiment_trace_location` at import time + `apply_runtime_trace_destination` populates `_MLFLOW_TRACE_USER_DESTINATION` ContextVar so the OTEL exporter picks the correct UC table. |
-| MCP server on Apps (`generate-mcp`) | `src/dao_ai/mcp/server.py` | Same as Databricks Apps — imports `apply_runtime_trace_destination` after `mlflow.set_experiment`. |
+| Databricks Apps (`dao-ai agent generate`) | `src/dao_ai/apps/handlers.py` | `link_experiment_trace_location` at import time + `apply_runtime_trace_destination` populates `_MLFLOW_TRACE_USER_DESTINATION` ContextVar so the OTEL exporter picks the correct UC table. |
+| MCP server on Apps (`dao-ai agent generate --mode mcp`) | `src/dao_ai/mcp/server.py` | Same as Databricks Apps — imports `apply_runtime_trace_destination` after `mlflow.set_experiment`. |
 | Model Serving (`agents.deploy`) | `src/dao_ai/apps/model_serving.py` | **No** in-container MLflow calls. `agents.deploy()` sets `MLFLOW_EXPERIMENT_ID`, `MLFLOW_TRACING_DESTINATION`, and `MLFLOW_TRACING_SQL_WAREHOUSE_ID` on the endpoint; MLflow's `_get_span_processors` resolves the destination from those env vars. See the header comment in `model_serving.py` for the rationale (MS containers can't reliably call `mlflow.set_experiment` without OAuth-config crashes). |
 
 The Apps and MCP-server paths intentionally diverge from Model Serving: they call `mlflow.set_experiment(trace_location=UnityCatalog(...))` because their containers have ambient OAuth. Model Serving relies purely on env-driven routing so the container can boot even when the model wasn't logged with the experiment as a resource dependency.
@@ -34,34 +34,34 @@ Semantics:
 **`table_prefix` is permanent per experiment.** Once an experiment has been linked to a UC trace destination with a specific prefix, MLflow rejects any attempt to change catalog / schema / table_prefix ("already contains traces"). To change any of the three, provision a fresh experiment:
 
 ```bash
-dao-ai create-experiment --name /Shared/my-app/dao-ai-v2 -p <profile>
+dao-ai trace create --name /Shared/my-app/dao-ai-v2 -p <profile>
 # then reference the new experiment id under app.experiment.id in your config,
 # or rev app.name so the auto-declared experiment path is distinct.
 ```
 
-## The `dao-ai link-trace-destination` CLI
+## The `dao-ai trace link` CLI
 
 Between `bundle deploy` and `bundle run` you must run:
 
 ```bash
 databricks bundle deploy --target dev -p <profile>
-dao-ai link-trace-destination -c my_config.yaml -p <profile>
+dao-ai trace link -c my_config.yaml -p <profile>
 databricks bundle run <app-name> --target dev -p <profile>
 ```
 
 The verb is idempotent — safe on every deploy — but load-bearing on re-deploys and after `trace_location` changes because the app's own runtime linkage attempt is rejected once the experiment already has traces. Running the link from the operator machine (deterministic timing, full OAuth) avoids that race.
 
-`generate-agent` and `generate-mcp` both print a one-line reminder in their "Next steps" output when `trace_location` is configured.
+`dao-ai agent generate` prints a one-line reminder in its "Next steps" output when `trace_location` is configured.
 
 ## Runtime ContextVar sync — `apply_runtime_trace_destination`
 
-`link-trace-destination` writes the experiment ↔ trace_location tag on the tracking server. That's necessary but not sufficient — MLflow's OTEL span exporter reads a client-side ContextVar `mlflow.tracing.provider._MLFLOW_TRACE_USER_DESTINATION` to decide which table to write to. Three things can populate the ContextVar:
+`dao-ai trace link` writes the experiment ↔ trace_location tag on the tracking server. That's necessary but not sufficient — MLflow's OTEL span exporter reads a client-side ContextVar `mlflow.tracing.provider._MLFLOW_TRACE_USER_DESTINATION` to decide which table to write to. Three things can populate the ContextVar:
 
 1. `mlflow.set_experiment(..., trace_location=UnityCatalog(...))` — inside MLflow, this calls `_sync_trace_destination_and_provider` which writes the correct UnityCatalog into the ContextVar.
-2. `MLFLOW_TRACING_DESTINATION` env var — MLflow's env parser reads this as a 2-part `catalog.schema` string and populates the ContextVar with the **deprecated `UCSchemaLocation`** (whose `full_otel_spans_table_name` defaults to the hard-coded `mlflow_experiment_trace_otel_spans`). `dao-ai generate-agent` emits this env var whenever `trace_location` is set.
+2. `MLFLOW_TRACING_DESTINATION` env var — MLflow's env parser reads this as a 2-part `catalog.schema` string and populates the ContextVar with the **deprecated `UCSchemaLocation`** (whose `full_otel_spans_table_name` defaults to the hard-coded `mlflow_experiment_trace_otel_spans`). `dao-ai agent generate` emits this env var whenever `trace_location` is set.
 3. `mlflow.tracing.set_destination(...)` — the public API, which explicitly rejects the `UnityCatalog(table_prefix=...)` form.
 
-The problem: when `link-trace-destination` skips re-linking on the "already linked" path, MLflow never calls `_sync_trace_destination_and_provider`. So the ContextVar keeps whatever `MLFLOW_TRACING_DESTINATION` set — the deprecated UCSchemaLocation. The exporter then targets `mlflow_experiment_trace_otel_spans` (which doesn't exist on the prefixed schema) and every span export silently fails with `TABLE_DOES_NOT_EXIST`.
+The problem: when `dao-ai trace link` skips re-linking on the "already linked" path, MLflow never calls `_sync_trace_destination_and_provider`. So the ContextVar keeps whatever `MLFLOW_TRACING_DESTINATION` set — the deprecated UCSchemaLocation. The exporter then targets `mlflow_experiment_trace_otel_spans` (which doesn't exist on the prefixed schema) and every span export silently fails with `TABLE_DOES_NOT_EXIST`.
 
 `dao_ai.providers.databricks.apply_runtime_trace_destination(config)` closes that gap:
 
@@ -89,10 +89,10 @@ When traces are landing correctly you'll see the full agent flow — root `predi
 ## Diagnostic loop when traces don't land
 
 1. **App logs** — `databricks apps logs <app-name>` and grep for `mlflow.tracing.export` warnings. A `TABLE_DOES_NOT_EXIST: mlflow_experiment_trace_otel_spans` line means the exporter fell back to the deprecated UCSchemaLocation path — `apply_runtime_trace_destination` didn't run (or its provider reset didn't take effect).
-2. **`link-trace-destination` log** — the CLI reports either "Linked experiment to UC trace location" or "Experiment already linked to matching UC trace destination, skipping". The second is fine on re-deploys; only worrying if you're changing catalog / schema / table_prefix on an existing experiment (which is rejected — you need a fresh experiment).
+2. **`dao-ai trace link` log** — the CLI reports either "Linked experiment to UC trace location" or "Experiment already linked to matching UC trace destination, skipping". The second is fine on re-deploys; only worrying if you're changing catalog / schema / table_prefix on an existing experiment (which is rejected — you need a fresh experiment).
 3. **App startup log** — grep for `Set MLflow runtime trace destination`. Confirms `apply_runtime_trace_destination` ran. If absent, either `trace_location` is unset or the app crashed before reaching that line.
 4. **Experiment lifecycle** — check with `databricks api get /api/2.0/mlflow/experiments/get --json '{"experiment_id":"<id>"}'`. Trashed experiments accept trace metadata writes but silently drop OTEL spans. Restore with `databricks api post /api/2.0/mlflow/experiments/restore --json '{"experiment_id":"<id>"}'`.
-5. **App SP grants** — the app service principal needs `USE_CATALOG` + `USE_SCHEMA` + `CREATE_TABLE` + `MODIFY` + `SELECT` on the trace-location schema (one-time per app SP). `generate-agent`'s "Next steps" prints the grant commands.
+5. **App SP grants** — the app service principal needs `USE_CATALOG` + `USE_SCHEMA` + `CREATE_TABLE` + `MODIFY` + `SELECT` on the trace-location schema (one-time per app SP). `dao-ai agent generate`'s "Next steps" prints the grant commands.
 6. **Async flush** — MLflow batches OTEL exports. Allow 60–120 s between the inference call and querying the tables. Async logging can be disabled per-app with `MLFLOW_ENABLE_ASYNC_TRACE_LOGGING=false` in the app env.
 
 ## Distributed tracing across MCP (`_meta` propagation)

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -146,8 +146,8 @@ config.deploy_agent()
 # Deploy directly to Databricks Apps (no asset bundle needed)
 config.deploy_agent(target=DeploymentTarget.APPS)
 
-# Deploy to both Model Serving and Apps
-config.deploy_agent(target=DeploymentTarget.BOTH)
+# Deploy to MCP server (Apps with MCP entrypoint)
+config.deploy_agent(target=DeploymentTarget.MCP)
 ```
 
 ### Apps deployment and chat UI
@@ -161,7 +161,7 @@ additional tools are needed on your development machine.
 All three deploy flows converge on the same runtime behavior:
 
 - `config.deploy_agent(target=DeploymentTarget.APPS)` (programmatic)
-- `dao-ai workflow generate --deploy --run --deployment-target apps` (CLI, runs a notebook that calls `deploy_agent`)
+- `dao-ai workflow generate --deploy --run --mode apps` (CLI, runs a notebook that calls `deploy_agent`)
 - `dao-ai agent generate` + `databricks bundle deploy` (standalone bundle)
 
 Set `app.enable_chat_proxy: false` in your config to deploy without the chat

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -161,8 +161,8 @@ additional tools are needed on your development machine.
 All three deploy flows converge on the same runtime behavior:
 
 - `config.deploy_agent(target=DeploymentTarget.APPS)` (programmatic)
-- `dao-ai generate-workflow --deploy --run --deployment-target apps` (CLI, runs a notebook that calls `deploy_agent`)
-- `dao-ai generate-agent` + `databricks bundle deploy` (standalone bundle)
+- `dao-ai workflow generate --deploy --run --deployment-target apps` (CLI, runs a notebook that calls `deploy_agent`)
+- `dao-ai agent generate` + `databricks bundle deploy` (standalone bundle)
 
 Set `app.enable_chat_proxy: false` in your config to deploy without the chat
 UI (backend API only).

--- a/examples/02_mcp/mcp_meta_test.yaml
+++ b/examples/02_mcp/mcp_meta_test.yaml
@@ -74,7 +74,6 @@ app:
     name: dao_ai_mcp_meta_test
   agents:
   - *mcp_meta_test_agent
-  deployment_target: apps                              # Deploy as a Databricks App
   environment_vars:
     DAO_AI_WAREHOUSE_ID:                               # Forwarded to the deployed app env
       env: DAO_AI_WAREHOUSE_ID

--- a/examples/04_genie/genie_with_context_management.yaml
+++ b/examples/04_genie/genie_with_context_management.yaml
@@ -76,7 +76,6 @@ app:
   name: genie_context_managed
   description: "Sales & pricing analytics agent for sporting goods with summarization and context management"
   log_level: DEBUG
-  deployment_target: apps
   agents:
   - *genie_agent
 

--- a/examples/10_agent_integrations/a2a_agent.yaml
+++ b/examples/10_agent_integrations/a2a_agent.yaml
@@ -155,7 +155,6 @@ app:
     Single-agent system that delegates to a remote agent via the Google
     A2A (Agent-to-Agent) protocol.
   log_level: INFO
-  deployment_target: apps
   agents:
   - *a2a_delegate_agent
 

--- a/examples/10_agent_integrations/a2a_first_class.yaml
+++ b/examples/10_agent_integrations/a2a_first_class.yaml
@@ -84,7 +84,6 @@ app:
   description: >
     Minimal example of the first-class `type: a2a` tool shape.
   log_level: INFO
-  deployment_target: apps
   agents:
   - *delegate_agent
 

--- a/examples/10_agent_integrations/app_first_class.yaml
+++ b/examples/10_agent_integrations/app_first_class.yaml
@@ -73,7 +73,6 @@ app:
     Minimal example of the first-class `type: app` tool shape for
     calling a Databricks App as a tool.
   log_level: INFO
-  deployment_target: apps
   agents:
   - *orchestrator
 

--- a/examples/10_agent_integrations/genie_agent_model_obo.yaml
+++ b/examples/10_agent_integrations/genie_agent_model_obo.yaml
@@ -41,7 +41,6 @@ app:
   description: >
     Genie Agent model with forwarded-token OBO, deployed as a Databricks App.
   log_level: INFO
-  deployment_target: apps
   agents:
   - *genie_specialist
 

--- a/examples/10_agent_integrations/serving_endpoint_first_class.yaml
+++ b/examples/10_agent_integrations/serving_endpoint_first_class.yaml
@@ -84,7 +84,6 @@ app:
     Minimal example of the first-class `type: serving_endpoint` tool
     shape for calling Model Serving endpoints (FMAPI or UC agents).
   log_level: INFO
-  deployment_target: apps
   agents:
   - *orchestrator
 

--- a/examples/10_agent_integrations/vertex_agent_engine.yaml
+++ b/examples/10_agent_integrations/vertex_agent_engine.yaml
@@ -246,7 +246,6 @@ app:
     Two-agent system: Genie-powered retail analytics (sales + logistics) +
     Vertex AI Agent Engine customer service agent.
   log_level: INFO
-  deployment_target: apps
   agents:
   - *retail_analytics_agent
   - *customer_service_agent

--- a/examples/15_complete_applications/commerce/commerce_supervisor.yaml
+++ b/examples/15_complete_applications/commerce/commerce_supervisor.yaml
@@ -861,7 +861,6 @@ app:
   # Deploy to BOTH Databricks Apps (chat UI + agent server) AND Model Serving
   # (UC-registered model). The Apps surface is the primary user path; the
   # Model Serving registration enables run-evaluation against the UC model.
-  deployment_target: both
 
   registered_model:
     schema: *retail_schema

--- a/examples/15_complete_applications/commerce/commerce_swarm.yaml
+++ b/examples/15_complete_applications/commerce/commerce_swarm.yaml
@@ -880,7 +880,6 @@ app:
   # Deploy to BOTH Databricks Apps (chat UI + agent server) AND Model Serving
   # (UC-registered model). The Apps surface is the primary user path; the
   # Model Serving registration enables run-evaluation against the UC model.
-  deployment_target: both
 
   registered_model:
     schema: *retail_schema

--- a/examples/15_complete_applications/loyalty_offer_personalization/loyalty_offer_personalization.yaml
+++ b/examples/15_complete_applications/loyalty_offer_personalization/loyalty_offer_personalization.yaml
@@ -743,7 +743,6 @@ app:
   name: loyalty_offers_dao
   description: "Multi-agent operator companion for receipt-driven loyalty offer personalization. CRM marketers + merchandisers investigate, explain, and re-run LLM-ranked offer assignments."
   log_level: INFO
-  deployment_target: both
   registered_model:
     schema: *loyalty_schema
     name: loyalty_offers_dao

--- a/examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml
+++ b/examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml
@@ -138,7 +138,6 @@ app:
     Procurement officer agent that calls Acme Industrial Supply via
     A2A. Paired with supplier.yaml in this directory; see README.md.
   log_level: INFO
-  deployment_target: apps
   agents:
     - *procurement_agent
   # ``orchestration.memory`` is omitted — no HITL, no deep-agent state.

--- a/examples/15_complete_applications/procurement_supplier_a2a/supplier.yaml
+++ b/examples/15_complete_applications/procurement_supplier_a2a/supplier.yaml
@@ -78,7 +78,6 @@ app:
     with the procurement app in this directory; see README.md for
     deployment.
   log_level: INFO
-  deployment_target: apps
   agents:
     - *supplier_agent
   # ``orchestration.memory`` is omitted — this agent has no HITL, no

--- a/examples/16_test_scenarios/genie_provisioning_only.yaml
+++ b/examples/16_test_scenarios/genie_provisioning_only.yaml
@@ -95,7 +95,6 @@ agents:
 app:
   name: dao_ai_genie_provisioning_test
   log_level: INFO
-  deployment_target: model_serving
   registered_model:
     schema: *loyalty_schema
     name: dao_ai_genie_provisioning_test

--- a/examples/19_background_agents/deep_research.yaml
+++ b/examples/19_background_agents/deep_research.yaml
@@ -95,7 +95,6 @@ app:
   name: background_dao
   description: "Background deep-research agent (demo of background kickoff + poll)"
   log_level: INFO
-  deployment_target: both
 
   registered_model:
     schema: *retail_schema

--- a/examples/20_a2a_protocol/a2a_background.yaml
+++ b/examples/20_a2a_protocol/a2a_background.yaml
@@ -78,7 +78,6 @@ app:
   name: a2a-background
   description: dao-ai A2A demo with Lakebase-persisted Tasks + HITL + OBO.
   log_level: INFO
-  deployment_target: apps
   agents:
     - *hitl_obo_agent
   orchestration:

--- a/examples/20_a2a_protocol/a2a_hitl_obo.yaml
+++ b/examples/20_a2a_protocol/a2a_hitl_obo.yaml
@@ -88,7 +88,6 @@ app:
   name: a2a-hitl-obo
   description: dao-ai A2A demo with live HITL + OBO inference.
   log_level: INFO
-  deployment_target: apps
   agents:
     - *hitl_obo_agent
   orchestration:

--- a/examples/20_a2a_protocol/a2a_minimal.yaml
+++ b/examples/20_a2a_protocol/a2a_minimal.yaml
@@ -30,7 +30,6 @@ app:
   name: a2a-minimal
   description: Minimal dao-ai agent demonstrating Google A2A protocol support.
   log_level: INFO
-  deployment_target: apps
   agents:
     - *greeter
   # A2A is enabled by default on Databricks Apps deployments. The block below

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -1642,7 +1642,7 @@
           "description": "Chat history summarization settings to manage long conversations."
         },
         "code_paths": {
-          "description": "Additional Python files/directories (relative to the config file's directory; absolute paths pass through) shipped with EVERY deployment target: Model Serving via ``log_model(code_paths=...)``, Databricks Apps by uploading them next to the config (importable via ``sys.path``), and the generate-workflow job by staging them into the bundle. Use for custom ``type: python`` tool modules or agent code. (Apps bundles also still support hand-packaged code under ``src/<package>/``.)",
+          "description": "Additional Python files/directories (relative to the config file's directory; absolute paths pass through) shipped with EVERY deployment target: Model Serving via ``log_model(code_paths=...)``, Databricks Apps by uploading them next to the config (importable via ``sys.path``), and the ``workflow generate`` job by staging them into the bundle. Use for custom ``type: python`` tool modules or agent code. (Apps bundles also still support hand-packaged code under ``src/<package>/``.)",
           "items": {
             "type": "string"
           },
@@ -1692,7 +1692,7 @@
             }
           ],
           "default": null,
-          "description": "Server-side MCP capabilities exposed when dao-ai is deployed as an MCP server (``dao-ai generate-mcp``). Declares static resources, prompt templates, and whether progress + logging notifications are emitted from the agent tool. When None the server publishes only the single agent-as-tool surface with no notifications."
+          "description": "Server-side MCP capabilities exposed when dao-ai is deployed as an MCP server (``dao-ai agent generate --mode mcp``). Declares static resources, prompt templates, and whether progress + logging notifications are emitted from the agent tool. When None the server publishes only the single agent-as-tool surface with no notifications."
         },
         "experiment": {
           "anyOf": [

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -1497,8 +1497,8 @@
               "type": "null"
             }
           ],
-          "default": 2,
-          "description": "Number of uvicorn worker processes for the Databricks Apps backend server. Each worker is a separate process, raising the app's concurrent-request ceiling on multi-core Apps compute. Defaults to 2 (a modest bump over uvicorn's single-worker default that is safe on the small default Apps compute); raise it to match larger compute cores. Emitted to the app as the ``DAO_AI_APP_WORKERS`` env var and forwarded to the backend as ``--workers``. Too many workers on a small instance contends for CPU. Apps-target only (no effect on Model Serving, which manages its own worker pool via workload_size).",
+          "default": 1,
+          "description": "Number of uvicorn worker processes for the Databricks Apps backend server. Each worker is a SEPARATE PROCESS that re-imports the app and rebuilds the full agent graph, so its memory footprint is duplicated per worker (uvicorn spawns workers \u2014 there is no copy-on-write sharing). Defaults to 1: on the default MEDIUM Apps compute (2 vCPU / 6 GB) a second full graph OOM-kills the workers in a respawn loop. Because this agent is async and I/O-bound, a single worker's event loop already serves many concurrent requests, so 1 is the right default. Raise ONLY on larger Apps compute with headroom for N resident graphs. Emitted as the ``DAO_AI_APP_WORKERS`` env var and forwarded to the backend as ``--workers``. Apps-target only (no effect on Model Serving, which manages its own worker pool via workload_size).",
           "title": "Workers"
         },
         "permissions": {

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -1670,18 +1670,6 @@
           "description": "Python version for Model Serving deployment. Defaults to 3.12 which is supported by Databricks Model Serving. This allows deploying from environments with different Python versions (e.g., Databricks Apps with 3.11).",
           "title": "Python Version"
         },
-        "deployment_target": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/DeploymentTarget"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Default deployment target. If not specified, defaults to MODEL_SERVING. Can be overridden via CLI --target flag. Options: 'model_serving' or 'apps'."
-        },
         "trace_location": {
           "anyOf": [
             {
@@ -3729,16 +3717,6 @@
       },
       "title": "DeepAgentModel",
       "type": "object"
-    },
-    "DeploymentTarget": {
-      "description": "Target platform for agent deployment.",
-      "enum": [
-        "model_serving",
-        "apps",
-        "both"
-      ],
-      "title": "DeploymentTarget",
-      "type": "string"
     },
     "Entitlement": {
       "description": "Access control entitlements for serving endpoints and apps.",

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -572,11 +572,10 @@ def generate_databricks_yaml(
     dao-ai wheel is uploaded as a regular source file (not intercepted as
     an artifact).
 
-    Note on deployment_target:
+    Note on serving mode:
         The emitted bundle is always Databricks-Apps-shaped
         (``resources.apps.<name>`` with its ``resources`` list and optional
-        ``user_api_scopes``). This bundle works regardless of
-        ``app.deployment_target``:
+        ``user_api_scopes``). This bundle works regardless of serving mode:
 
         - ``apps``           → the App IS the deployment target.
         - ``model_serving``  → the App process registers the MLflow model
@@ -587,8 +586,8 @@ def generate_databricks_yaml(
                                ``dao-ai deploy-agent`` instead of
                                ``generate-agent`` + ``databricks bundle deploy``.
 
-        ``generate-agent`` therefore intentionally ignores
-        ``app.deployment_target``; the enum selects the runtime code path,
+        ``generate-agent`` therefore intentionally ignores the serving mode;
+        the ``--mode`` CLI flag selects the runtime code path,
         not the bundle layout.
     """
     app_name, _experiments_block, _apps_block = _build_app_block(

--- a/src/dao_ai/apps/resources.py
+++ b/src/dao_ai/apps/resources.py
@@ -1683,6 +1683,7 @@ def generate_app_yaml(
     config: AppConfig,
     command: str | list[str] | None = None,
     include_resources: bool = True,
+    include_chat_ui: bool | None = None,
 ) -> str:
     """
     Generate a complete app.yaml for Databricks Apps deployment.
@@ -1696,6 +1697,9 @@ def generate_app_yaml(
         config: The AppConfig containing deployment configuration
         command: Optional custom command. If not provided, uses default dao-ai app_server
         include_resources: Whether to include the resources section (default: True)
+        include_chat_ui: Whether to inject the chat-UI proxy env vars. None
+            (default) preserves the legacy behavior of deriving this from
+            config.app.enable_chat_proxy; True force-includes; False skips.
 
     Returns:
         A complete app.yaml as a string
@@ -1746,7 +1750,7 @@ def generate_app_yaml(
         if config.app and config.app.enable_chat_proxy is not None
         else True
     )
-    if enable_chat_proxy:
+    if enable_chat_proxy if include_chat_ui is None else include_chat_ui:
         from dao_ai.apps.chat_ui import chat_ui_env_vars
 
         env_vars.extend(chat_ui_env_vars())

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -594,7 +594,7 @@ Examples:
   dao-ai validate -c config/model_config.yaml            # Validate a specific configuration file
   dao-ai graph -o architecture.png -c my_config.yaml -v  # Generate visual graph with verbose output
   dao-ai chat -c config/retail.yaml --custom-input store_num=87887  # Start interactive chat session
-  dao-ai list-mcp-tools -c config/mcp_config.yaml --apply-filters  # List filtered MCP tools only
+  dao-ai tools -c config/mcp_config.yaml --apply-filters  # List filtered MCP tools only
   dao-ai validate                                        # Validate with detailed logging
   dao-ai generate-workflow -c my_config.yaml --deploy    # Provision infra + deploy the agent (Workflow Job)
   dao-ai generate-agent -c my_config.yaml --deploy --run # Generate + deploy + start the agent App
@@ -984,7 +984,7 @@ Examples:
 
     # List MCP tools command
     list_mcp_parser: ArgumentParser = subparsers.add_parser(
-        "list-mcp-tools",
+        "tools",
         help="List available MCP tools from configuration",
         description="""
 List all available MCP tools from the configured MCP servers.
@@ -1009,8 +1009,8 @@ Options:
 Note: Schemas are displayed in a concise, readable format instead of verbose JSON
         """,
         epilog="""Examples:
-  dao-ai list-mcp-tools -c config/model_config.yaml
-  dao-ai list-mcp-tools -c config/model_config.yaml --apply-filters
+  dao-ai tools -c config/model_config.yaml
+  dao-ai tools -c config/model_config.yaml --apply-filters
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -3385,7 +3385,7 @@ def main() -> None:
             handle_monitor_command(options)
         case "chat":
             handle_chat_command(options)
-        case "list-mcp-tools":
+        case "tools":
             handle_list_mcp_tools_command(options)
         case "parameters" | "vars":
             handle_vars_command(options)

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -370,6 +370,7 @@ def _add_mode_argument(parser: ArgumentParser, *, choices: list[str]) -> None:
     """Add the serving-mode flag. Choices are per-verb so an unusable value is
     rejected at parse time (never offered when it cannot succeed)."""
     parser.add_argument(
+        "-m",
         "--mode",
         choices=choices,
         default="apps",

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -335,8 +335,7 @@ def _add_workflow_target_args(parser: ArgumentParser) -> None:
 
     The workflow bundle's target is ``<app>-<cloud>`` (contrast the App
     bundle's fixed ``dev``), so deploy/run/destroy need cloud + optional target
-    overrides to address the right target; ``--deployment-target`` selects the
-    agent deploy surface passed to the provisioning notebook.
+    overrides to address the right target.
     """
     parser.add_argument(
         "-t",
@@ -349,15 +348,6 @@ def _add_workflow_target_args(parser: ArgumentParser) -> None:
         type=str,
         choices=["azure", "aws", "gcp"],
         help="Cloud provider (auto-detected from workspace URL if not specified)",
-    )
-    parser.add_argument(
-        "--deployment-target",
-        type=str,
-        choices=["model_serving", "apps", "both"],
-        default=None,
-        help="Agent deployment target: 'model_serving', 'apps', or 'both'. "
-        "If not specified, uses app.deployment_target from config file, "
-        "or defaults to 'model_serving'. Passed to the deploy notebook.",
     )
 
 
@@ -407,8 +397,8 @@ def _add_noun_verb_parsers(
     _add_bundle_source_args(generate_parser)
     if is_workflow:
         _add_workflow_target_args(generate_parser)
+        _add_mode_argument(generate_parser, choices=["apps", "mcp"])
     else:
-        # Workflow gets --mode in Task 8; agent/mcp get it here.
         _add_mode_argument(generate_parser, choices=["apps", "mcp"])
     _add_bundle_action_arguments(generate_parser)
 
@@ -426,12 +416,10 @@ def _add_noun_verb_parsers(
         _add_bundle_common_args(verb_parser, kind=noun)
         if is_workflow:
             _add_workflow_target_args(verb_parser)
+        if verb == "deploy":
+            _add_mode_argument(verb_parser, choices=["model_serving", "apps", "mcp"])
         else:
-            # Workflow gets --mode in Task 8; agent/mcp get it here.
-            if verb == "deploy":
-                _add_mode_argument(verb_parser, choices=["model_serving", "apps", "mcp"])
-            else:
-                _add_mode_argument(verb_parser, choices=["apps", "mcp"])
+            _add_mode_argument(verb_parser, choices=["apps", "mcp"])
         if verb == "deploy":
             # Forward chaining: `dao-ai <noun> deploy --run` deploys the staged
             # bundle then runs it (parity with `generate --deploy --run`).
@@ -2614,24 +2602,10 @@ def run_databricks_command(
     for key, value in (config_vars or {}).items():
         extra_vars.append(f'--var="{key}={value}"')
 
-    # Add deployment_target variable for notebooks (hybrid resolution)
-    # Priority: CLI arg > config file > default (model_serving)
-    resolved_deployment_target: str = "model_serving"
-    if deployment_target is not None:
-        resolved_deployment_target = deployment_target
-        logger.debug(
-            f"Using CLI-specified deployment target: {resolved_deployment_target}"
-        )
-    elif app_config and app_config.app and app_config.app.deployment_target:
-        # deployment_target is DeploymentTarget enum (str subclass) or string
-        # str() works for both since DeploymentTarget inherits from str
-        resolved_deployment_target = str(app_config.app.deployment_target)
-        logger.debug(
-            f"Using config file deployment target: {resolved_deployment_target}"
-        )
-    else:
-        logger.debug("Using default deployment target: model_serving")
-
+    # Add deployment_target variable for notebooks.
+    # Priority: CLI arg > default (model_serving)
+    resolved_deployment_target: str = deployment_target or "model_serving"
+    logger.debug(f"Using deployment target: {resolved_deployment_target}")
     extra_vars.append(f'--var="deployment_target={resolved_deployment_target}"')
 
     # Forward the development tri-state to the deploy notebook via a bundle var.
@@ -2887,7 +2861,7 @@ def _exec_workflow_verb(options: Namespace, command: list[str]) -> None:
         target=options.target,
         cloud=options.cloud,
         dry_run=options.dry_run,
-        deployment_target=options.deployment_target,
+        deployment_target=getattr(options, "mode", None),
         config_vars=_parse_var_args(options.var),
         output_dir=options.output_dir,
         stage=False,
@@ -2901,7 +2875,7 @@ def handle_generate_workflow_command(options: Namespace) -> None:
     target: Optional[str] = options.target
     cloud: Optional[str] = options.cloud
     dry_run: bool = options.dry_run
-    deployment_target: Optional[str] = options.deployment_target
+    deployment_target: Optional[str] = getattr(options, "mode", None)
     development: bool | None = getattr(options, "development", None)
     config_vars: dict[str, str] = _parse_var_args(options.var)
     output_dir: str | None = getattr(options, "output_dir", None)

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -233,11 +233,14 @@ def _add_profile_argument(parser: ArgumentParser) -> None:
 
 
 def _add_bundle_action_arguments(parser: ArgumentParser) -> None:
-    """Add the deploy/run/destroy/dry-run action flags to a generate-* subparser.
+    """Add the deploy/run/destroy continuation flags to a ``generate`` verb.
 
-    Shared by ``generate-agent`` and ``generate-mcp`` so the App bundles gain the
-    same lifecycle verbs as ``generate-workflow``. When none of these flags are
-    passed the command stays generate-only (writes the bundle and stops).
+    These let a single ``<noun> generate`` invocation continue into deploy/run/
+    destroy (the one-shot happy path, e.g. ``dao-ai agent generate --deploy
+    --run``). When none are passed the command stays generate-only (writes the
+    bundle and stops). ``--dry-run`` is added separately via
+    :func:`_add_bundle_common_args` so the standalone ``deploy``/``run``/
+    ``destroy`` verbs get it too.
     """
     parser.add_argument(
         "-d",
@@ -259,11 +262,164 @@ def _add_bundle_action_arguments(parser: ArgumentParser) -> None:
         action="store_true",
         help="Run `databricks bundle destroy` for the generated bundle.",
     )
+
+
+def _add_bundle_common_args(parser: ArgumentParser, *, kind: str) -> None:
+    """Add the flags every bundle verb shares: -c/-o/-p/--dry-run/--param.
+
+    Shared across ``generate``/``deploy``/``run``/``destroy`` for all three
+    nouns (agent/mcp/workflow) so the config path, staging dir, profile, and
+    dry-run switch are spelled identically everywhere. ``kind`` only customizes
+    the ``--output-dir`` help text (``<base>/<kind>/<app>``).
+    """
+    parser.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        required=True,
+        metavar="FILE",
+        help="Path to the dao-ai configuration file",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        type=str,
+        default=None,
+        metavar="DIR",
+        help=f"Directory for the bundle staging dir (default: <base>/{kind}/"
+        "<app-name>; <base> is $DAO_AI_BUNDLE_DIR or ./.dao-ai/bundle). deploy/"
+        "run/destroy act on this same dir without regenerating it.",
+    )
     parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print the databricks bundle commands without executing them.",
     )
+    _add_profile_argument(parser)
+    _add_var_argument(parser)
+
+
+def _add_bundle_source_args(parser: ArgumentParser) -> None:
+    """Add source-selection flags (--overwrite, --development tri-state).
+
+    Only meaningful on the ``generate`` verb — deploy/run/destroy never
+    re-stage, so these would be inert there.
+    """
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite existing files in the staging directory (and discard "
+        "local hand-edits in a default staging dir).",
+    )
+    parser.add_argument(
+        "--development",
+        dest="development",
+        default=None,
+        action="store_true",
+        help="Bundle local dao-ai source/wheel instead of pinning the published "
+        "PyPI package. Rebuild the wheel first with 'uv build --wheel'. "
+        "Defaults to auto-detect from the install type.",
+    )
+    parser.add_argument(
+        "--no-development",
+        dest="development",
+        action="store_false",
+        help="Force the published PyPI dao-ai package even from a local/editable "
+        "install.",
+    )
+
+
+def _add_workflow_target_args(parser: ArgumentParser) -> None:
+    """Add workflow-only target/cloud flags used to resolve the bundle target.
+
+    The workflow bundle's target is ``<app>-<cloud>`` (contrast the App
+    bundle's fixed ``dev``), so deploy/run/destroy need cloud + optional target
+    overrides to address the right target; ``--deployment-target`` selects the
+    agent deploy surface passed to the provisioning notebook.
+    """
+    parser.add_argument(
+        "-t",
+        "--target",
+        type=str,
+        help="Bundle target name (default: auto-generated from app name and cloud)",
+    )
+    parser.add_argument(
+        "--cloud",
+        type=str,
+        choices=["azure", "aws", "gcp"],
+        help="Cloud provider (auto-detected from workspace URL if not specified)",
+    )
+    parser.add_argument(
+        "--deployment-target",
+        type=str,
+        choices=["model_serving", "apps", "both"],
+        default=None,
+        help="Agent deployment target: 'model_serving', 'apps', or 'both'. "
+        "If not specified, uses app.deployment_target from config file, "
+        "or defaults to 'model_serving'. Passed to the deploy notebook.",
+    )
+
+
+def _add_noun_verb_parsers(
+    subparsers: "argparse._SubParsersAction",
+    *,
+    noun: str,
+    generate_description: str,
+    generate_epilog: str,
+) -> None:
+    """Register the generate/deploy/run/destroy verb parsers for one noun.
+
+    ``noun`` is ``"agent"``/``"mcp"``/``"workflow"``. The ``generate`` verb
+    carries the source flags (+ one-shot --deploy/--run/--destroy) and inherits
+    the noun's rich help; deploy/run/destroy carry only the common args. The
+    workflow noun additionally gets target/cloud flags on every verb.
+    """
+    is_workflow: bool = noun == "workflow"
+
+    parser: ArgumentParser = subparsers.add_parser(
+        noun,
+        help=f"Manage the {noun} bundle (generate | deploy | run | destroy)",
+        description=generate_description,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    verbs = parser.add_subparsers(dest="subcommand", required=True)
+
+    generate_parser: ArgumentParser = verbs.add_parser(
+        "generate",
+        help=f"Generate the {noun} bundle from a config",
+        description=generate_description,
+        epilog=generate_epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    _add_bundle_common_args(generate_parser, kind=noun)
+    _add_bundle_source_args(generate_parser)
+    if is_workflow:
+        _add_workflow_target_args(generate_parser)
+    _add_bundle_action_arguments(generate_parser)
+
+    for verb, verb_help in (
+        ("deploy", f"Deploy the already-staged {noun} bundle (no regenerate)"),
+        ("run", f"Run the deployed {noun} bundle"),
+        ("destroy", f"Destroy the deployed {noun} bundle"),
+    ):
+        verb_parser: ArgumentParser = verbs.add_parser(
+            verb,
+            help=verb_help,
+            description=f"{verb_help}. Acts on the staging dir written by "
+            f"`dao-ai {noun} generate` (or -o); errors if nothing is staged.",
+        )
+        _add_bundle_common_args(verb_parser, kind=noun)
+        if is_workflow:
+            _add_workflow_target_args(verb_parser)
+        if verb == "deploy":
+            # Forward chaining: `dao-ai <noun> deploy --run` deploys the staged
+            # bundle then runs it (parity with `generate --deploy --run`).
+            verb_parser.add_argument(
+                "-r",
+                "--run",
+                action="store_true",
+                help="After deploying, run `databricks bundle run <app>`.",
+            )
 
 
 def _validate_bundle_action_flags(options: Namespace) -> None:
@@ -289,6 +445,15 @@ def _validate_bundle_action_flags(options: Namespace) -> None:
 _BUNDLE_DIR_ENV_VAR = "DAO_AI_BUNDLE_DIR"
 _DEFAULT_BUNDLE_BASE = ".dao-ai/bundle"
 
+# Back-compat: flat `generate-<noun>` commands map to the nested `<noun>
+# generate` verb. main() rewrites options.command via this table before
+# dispatch, so the aliases share the exact generate code path.
+_ALIAS_TO_NOUN: dict[str, str] = {
+    "generate-agent": "agent",
+    "generate-mcp": "mcp",
+    "generate-workflow": "workflow",
+}
+
 
 def _default_bundle_base() -> Path:
     """Base dir for generated bundles: ``$DAO_AI_BUNDLE_DIR`` or ``.dao-ai/bundle``.
@@ -312,16 +477,60 @@ def _default_bundle_dir(kind: str, app_name: str) -> Path:
     return _default_bundle_base() / kind / normalize_name(app_name)
 
 
-def _clean_default_staging_dir(bundle_dir: Path, *, is_default: bool) -> None:
+# Marker file dao-ai drops in a default staging dir after each generate. Its
+# mtime is the "last generated" timestamp used to detect later hand-edits.
+_STAGING_MARKER = ".dao-ai-generated"
+
+
+def _write_staging_marker(bundle_dir: Path, *, is_default: bool) -> None:
+    """Stamp a default staging dir as freshly dao-ai-generated.
+
+    Only marks a dao-ai-owned default dir (never a user ``-o`` dir). Written
+    LAST, after the writer, so its mtime post-dates every generated file; a
+    later hand-edit then shows an mtime newer than the marker, which
+    :func:`_clean_default_staging_dir` uses to protect edits from a re-generate.
+    """
+    if not is_default or not bundle_dir.exists():
+        return
+    (bundle_dir / _STAGING_MARKER).write_text("")
+
+
+def _staging_dir_has_local_edits(bundle_dir: Path) -> bool:
+    """True if a marked staging dir looks hand-edited since its last generate.
+
+    Missing marker → treat as edited (a legacy or user-created dir we didn't
+    stamp). Otherwise any file with an mtime newer than the marker (an edit or a
+    newly-added stray file) counts as a local edit.
+    """
+    marker: Path = bundle_dir / _STAGING_MARKER
+    if not marker.exists():
+        return True
+    marker_mtime: float = marker.stat().st_mtime
+    for path in bundle_dir.rglob("*"):
+        if path == marker or path.is_dir():
+            continue
+        if path.stat().st_mtime > marker_mtime:
+            return True
+    return False
+
+
+def _clean_default_staging_dir(
+    bundle_dir: Path, *, is_default: bool, overwrite: bool, noun: str
+) -> None:
     """Clear a dao-ai-owned default staging dir before regenerating into it.
 
-    Only wipes when ``is_default`` (a path dao-ai chose under
-    :func:`_default_bundle_base`) — never a user-supplied ``-o`` dir, which may
+    Only touches an ``is_default`` path dao-ai chose under
+    :func:`_default_bundle_base` — never a user-supplied ``-o`` dir, which may
     hold hand-edits. Regenerating into a stale dir otherwise produces an
     internally-inconsistent bundle (e.g. a ``--development`` run leaves ``dist/``
     wheels + a dev ``pyproject.toml`` that a later ``--no-development`` run then
     mixes with a published layout). Guarded to only ever remove a path under the
     resolved default base.
+
+    Edit safety: if the dir carries local modifications since the last generate
+    (see :func:`_staging_dir_has_local_edits`), refuse to wipe unless
+    ``overwrite`` — pointing the user at ``<noun> deploy`` to ship what's on
+    disk. Untouched dao-ai output is wiped silently as before.
     """
     if not is_default or not bundle_dir.exists():
         return
@@ -330,6 +539,13 @@ def _clean_default_staging_dir(bundle_dir: Path, *, is_default: bool) -> None:
     # safety: only wipe paths strictly under the owned base dir
     if base not in resolved.parents:
         return
+    if not overwrite and _staging_dir_has_local_edits(bundle_dir):
+        logger.error(
+            f"Staging dir {bundle_dir} has local modifications. "
+            f"Ship it with `dao-ai {noun} deploy -c <config>`, "
+            f"or pass --overwrite to discard the edits and regenerate."
+        )
+        sys.exit(1)
     shutil.rmtree(bundle_dir)
 
 
@@ -706,244 +922,80 @@ Examples:
         help="Path to the model configuration file to visualize",
     )
 
-    generate_workflow_parser: ArgumentParser = subparsers.add_parser(
-        "generate-workflow",
-        help="Generate + deploy/run the provisioning Workflow (multi-task Job)",
-        description="""
-Generate and deploy/run the DAO AI provisioning Workflow — a multi-task
-Databricks Job (Lakeflow Workflow) that provisions the backing infra (schemas,
-Vector Search, Lakebase, Genie, UC functions), deploys the agent, and runs
-evaluation. Emits a self-contained Databricks Asset Bundle and wraps
-`databricks bundle deploy/run/destroy`. (This is a Job/Workflow, not a Lakeflow
-Declarative Pipeline.) Sibling of `generate-agent` / `generate-mcp`.
+    # --- Bundle nouns: `dao-ai <noun> <generate|deploy|run|destroy>` ----------
+    # Each noun owns the full generate → deploy → run → destroy lifecycle as
+    # discrete verbs. generate stages (and can one-shot --deploy/--run); deploy/
+    # run/destroy act on the already-staged dir without regenerating it.
+    _WORKFLOW_DESC = """
+Manage the DAO AI provisioning Workflow — a multi-task Databricks Job (Lakeflow
+Workflow) that provisions the backing infra (schemas, Vector Search, Lakebase,
+Genie, UC functions), deploys the agent, and runs evaluation. Emits a
+self-contained Databricks Asset Bundle and wraps `databricks bundle
+deploy/run/destroy`. (This is a Job/Workflow, not a Lakeflow Declarative
+Pipeline.) Sibling of `agent` / `mcp`.
+"""
+    _AGENT_DESC = """
+Manage the agent's Databricks Apps bundle. `generate` writes a complete,
+deployable bundle directory (databricks.yaml, app.yaml, pyproject.toml, and
+scaffolding) from a dao-ai config; `deploy`/`run`/`destroy` act on that staged
+bundle. Sibling of `mcp` (the MCP-server App bundle).
+"""
+    _MCP_DESC = """
+Manage the dao-ai MCP-server Databricks Apps bundle. `generate` writes a
+deploy-ready bundle that exposes the configured Genie cache + Vector Search
+retriever tools as MCP tools over Streamable HTTP; `deploy`/`run`/`destroy` act
+on that staged bundle. Mirrors `agent` but emits the MCP-only artifact.
+"""
+
+    _add_noun_verb_parsers(
+        subparsers,
+        noun="agent",
+        generate_description=_AGENT_DESC,
+        generate_epilog="""
+Examples:
+  dao-ai agent generate -c config/retail.yaml
+  dao-ai agent generate -c config/retail.yaml --deploy --run -p fevm
+  dao-ai agent deploy   -c config/retail.yaml -p fevm      # ship staged bundle
 """,
-        epilog="""
+    )
+    _add_noun_verb_parsers(
+        subparsers,
+        noun="mcp",
+        generate_description=_MCP_DESC,
+        generate_epilog="""
 Examples:
-    dao-ai generate-workflow -c config/retail.yaml --deploy
-    dao-ai generate-workflow -c config/retail.yaml --run
+  dao-ai mcp generate -c config/retail.yaml -o ./retail-mcp
+  dao-ai mcp deploy   -c config/retail.yaml -p fevm
+""",
+    )
+    _add_noun_verb_parsers(
+        subparsers,
+        noun="workflow",
+        generate_description=_WORKFLOW_DESC,
+        generate_epilog="""
+Examples:
+  dao-ai workflow generate -c config/retail.yaml --deploy
+  dao-ai workflow run      -c config/retail.yaml   # run staged provisioning job
 """,
     )
 
-    generate_workflow_parser.add_argument(
-        "-p",
-        "--profile",
-        type=str,
-        help="The Databricks profile to use for deployment",
-    )
-    generate_workflow_parser.add_argument(
-        "-c",
-        "--config",
-        type=str,
-        required=True,
-        metavar="FILE",
-        help="Path to the model configuration file for the bundle",
-    )
-    generate_workflow_parser.add_argument(
-        "-d",
-        "--deploy",
-        action="store_true",
-        help="Deploy the DAO AI asset bundle",
-    )
-    generate_workflow_parser.add_argument(
-        "--destroy",
-        action="store_true",
-        help="Destroy the DAO AI asset bundle",
-    )
-    generate_workflow_parser.add_argument(
-        "-r",
-        "--run",
-        action="store_true",
-        help="Run the DAO AI system with the current configuration",
-    )
-    generate_workflow_parser.add_argument(
-        "-t",
-        "--target",
-        type=str,
-        help="Bundle target name (default: auto-generated from app name and cloud)",
-    )
-    generate_workflow_parser.add_argument(
-        "--cloud",
-        type=str,
-        choices=["azure", "aws", "gcp"],
-        help="Cloud provider (auto-detected from workspace URL if not specified)",
-    )
-    generate_workflow_parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Perform a dry run without executing the deployment or run commands",
-    )
-    generate_workflow_parser.add_argument(
-        "--deployment-target",
-        type=str,
-        choices=["model_serving", "apps", "both"],
-        default=None,
-        help="Agent deployment target: 'model_serving', 'apps', or 'both'. "
-        "If not specified, uses app.deployment_target from config file, "
-        "or defaults to 'model_serving'. Passed to the deploy notebook.",
-    )
-    generate_workflow_parser.add_argument(
-        "--development",
-        dest="development",
-        default=None,
-        action="store_true",
-        help="Ship local dao-ai source/wheel instead of the published PyPI "
-        "package. Rebuild the wheel first with 'uv build --wheel'. "
-        "Defaults to auto-detect from the install type. Passed to the deploy "
-        "notebook.",
-    )
-    generate_workflow_parser.add_argument(
-        "--no-development",
-        dest="development",
-        action="store_false",
-        help="Force the published PyPI dao-ai package even from a local/editable "
-        "install. Passed to the deploy notebook.",
-    )
-    generate_workflow_parser.add_argument(
-        "-o",
-        "--output-dir",
-        type=str,
-        default=None,
-        metavar="DIR",
-        help="Directory to stage the workflow bundle into before deploying "
-        "(default: <base>/workflow/<app-name>, a per-app dir so deploying "
-        "multiple configs never collides; <base> is $DAO_AI_BUNDLE_DIR or "
-        "./.dao-ai/bundle). The bundle is self-contained — notebooks, "
-        "requirements.txt, and databricks.yaml are materialized from the "
-        "installed dao-ai wheel, so no source checkout is required.",
-    )
-    generate_workflow_parser.add_argument(
-        "--overwrite",
-        action="store_true",
-        help="Overwrite existing files in the staging output directory.",
-    )
-
-    # Generate agent-app bundle command.
-    generate_agent_parser: ArgumentParser = subparsers.add_parser(
-        "generate-agent",
-        help="Generate the agent's Databricks App bundle from a config",
-        description="""
-Generate a complete, deployable Databricks Apps bundle directory that serves the
-dao-ai agent, from a dao-ai config file. Creates databricks.yaml, app.yaml,
-pyproject.toml, and scaffolding files. Sibling of `generate-mcp` (which emits the
-MCP-server App bundle).
-        """,
-        epilog="""
-Examples:
-  dao-ai generate-agent -c config/retail.yaml -o ./my-bundle
-  dao-ai generate-agent -c config/retail.yaml -o ./my-bundle --overwrite
-        """,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    generate_agent_parser.add_argument(
-        "-c",
-        "--config",
-        type=str,
-        required=True,
-        metavar="FILE",
-        help="Path to the dao-ai configuration file",
-    )
-    generate_agent_parser.add_argument(
-        "-o",
-        "--output-dir",
-        type=str,
-        default=None,
-        metavar="DIR",
-        help="Directory to write the generated bundle files to "
-        "(default: <base>/agent/<app-name>; <base> is $DAO_AI_BUNDLE_DIR or "
-        "./.dao-ai/bundle).",
-    )
-    generate_agent_parser.add_argument(
-        "--overwrite",
-        action="store_true",
-        help="Overwrite existing files in the output directory",
-    )
-    generate_agent_parser.add_argument(
-        "--development",
-        dest="development",
-        default=None,
-        action="store_true",
-        help="Bundle local dao-ai source/wheel instead of pinning the published "
-        "PyPI package. Rebuild the wheel first with 'uv build --wheel'. "
-        "Defaults to auto-detect from the install type.",
-    )
-    generate_agent_parser.add_argument(
-        "--no-development",
-        dest="development",
-        action="store_false",
-        help="Force the published PyPI dao-ai package even from a local/editable "
-        "install.",
-    )
-    generate_agent_parser.add_argument(
-        "-p",
-        "--profile",
-        type=str,
-        help="The Databricks profile to use for config loading",
-    )
-    _add_bundle_action_arguments(generate_agent_parser)
-
-    # Generate MCP-server bundle command
-    generate_mcp_parser: ArgumentParser = subparsers.add_parser(
-        "generate-mcp",
-        help="Generate a Databricks Apps bundle that runs the dao-ai MCP server",
-        description="""
-Generate a deploy-ready Databricks Apps bundle from a dao-ai config that exposes
-the configured Genie cache + Vector Search retriever tools as MCP tools over
-Streamable HTTP. Mirrors `generate-agent` but emits the MCP-only artifact
-(databricks.yml, app.yaml, pyproject.toml, requirements.txt, README.md).
-        """,
-        epilog="""
-Examples:
-  dao-ai generate-mcp -c config/retail.yaml -o ./retail-mcp
-  dao-ai generate-mcp -c config/retail.yaml -o ./retail-mcp --overwrite
-        """,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    generate_mcp_parser.add_argument(
-        "-c",
-        "--config",
-        type=str,
-        required=True,
-        metavar="FILE",
-        help="Path to the dao-ai configuration file",
-    )
-    generate_mcp_parser.add_argument(
-        "-o",
-        "--output-dir",
-        type=str,
-        default=None,
-        metavar="DIR",
-        help="Directory to write the generated MCP bundle files to "
-        "(default: <base>/mcp/<app-name>; <base> is $DAO_AI_BUNDLE_DIR or "
-        "./.dao-ai/bundle).",
-    )
-    generate_mcp_parser.add_argument(
-        "--overwrite",
-        action="store_true",
-        help="Overwrite existing files in the output directory",
-    )
-    generate_mcp_parser.add_argument(
-        "--development",
-        dest="development",
-        default=None,
-        action="store_true",
-        help="Bundle local dao-ai source/wheel instead of pinning the published "
-        "PyPI package. Rebuild the wheel first with 'uv build --wheel'. "
-        "Defaults to auto-detect from the install type.",
-    )
-    generate_mcp_parser.add_argument(
-        "--no-development",
-        dest="development",
-        action="store_false",
-        help="Force the published PyPI dao-ai package even from a local/editable "
-        "install.",
-    )
-    generate_mcp_parser.add_argument(
-        "-p",
-        "--profile",
-        type=str,
-        help="The Databricks profile to use for config loading",
-    )
-    _add_bundle_action_arguments(generate_mcp_parser)
+    # --- Back-compat flat aliases: `generate-<noun>` == `<noun> generate` -----
+    # Register each as its own top-level parser reusing the same generate-verb
+    # flags (argparse can't alias a flat name onto a nested subcommand). main()
+    # normalizes options.command back to (noun, "generate") before dispatch.
+    for alias, noun in _ALIAS_TO_NOUN.items():
+        alias_parser: ArgumentParser = subparsers.add_parser(
+            alias,
+            help=f"Alias for `dao-ai {noun} generate` (back-compat).",
+            description=f"Deprecated alias for `dao-ai {noun} generate`. "
+            f"Generates the {noun} bundle; supports the same flags.",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+        )
+        _add_bundle_common_args(alias_parser, kind=noun)
+        _add_bundle_source_args(alias_parser)
+        if noun == "workflow":
+            _add_workflow_target_args(alias_parser)
+        _add_bundle_action_arguments(alias_parser)
 
     # Deploy command
     deploy_parser: ArgumentParser = subparsers.add_parser(
@@ -1165,12 +1217,12 @@ Examples:
         help="Path to the model configuration file to inspect.",
     )
 
+    # The bundle nouns (agent/mcp/workflow) and their generate-* aliases get
+    # --param/--var and -p/--profile from `_add_bundle_common_args`, so they are
+    # NOT listed here — only the non-bundle subcommands are.
     for sub in (
         validation_parser,
         graph_parser,
-        generate_workflow_parser,
-        generate_agent_parser,
-        generate_mcp_parser,
         deploy_parser,
         list_mcp_parser,
         monitor_parser,
@@ -1180,9 +1232,10 @@ Examples:
         _add_var_argument(sub)
 
     # Add -p/--profile to the subcommands that touch Databricks but don't
-    # already declare it inline (deploy/pipeline/generate-*/create-experiment/
-    # link-trace/grant-trace define their own). Without it a shell/.env
-    # DATABRICKS_* var silently wins — the hijack _apply_profile_context guards.
+    # already declare it inline (deploy/create-experiment/link-trace/grant-trace
+    # define their own; bundle nouns get it from _add_bundle_common_args).
+    # Without it a shell/.env DATABRICKS_* var silently wins — the hijack
+    # _apply_profile_context guards.
     for sub in (
         validation_parser,
         graph_parser,
@@ -2498,6 +2551,7 @@ def run_databricks_command(
     config_vars: Optional[dict[str, str]] = None,
     output_dir: Optional[str] = None,
     overwrite: bool = False,
+    stage: bool = True,
 ) -> None:
     """Execute a databricks CLI command with optional profile, target, and cloud.
 
@@ -2526,6 +2580,13 @@ def run_databricks_command(
         overwrite: Overwrite copied-in *content* (config, data/functions assets)
             in the staging dir. Derived artifacts (databricks.yaml,
             requirements.txt, notebooks) are always regenerated regardless.
+        stage: When True (default) write/refresh the bundle in the staging dir
+            before running ``command`` — the behavior of ``workflow generate``.
+            When False, skip staging entirely and run ``command`` against the
+            EXISTING staged dir (the standalone ``workflow deploy/run/destroy``
+            verbs); the bundle ``--var`` values are still re-derived from config
+            + the already-staged ``dist/`` so the bundle verb has what it needs.
+            Errors if nothing is staged there.
     """
     config_path = Path(config) if config else None
 
@@ -2600,16 +2661,31 @@ def run_databricks_command(
         )
         dao_ai_dep = f"dao-ai{extras_suffix}=={dao_ai_version()}"
 
-        # Regenerate the owned default dir cleanly so stale dev artifacts
-        # (e.g. dist/ wheels) don't linger across dev/published switches.
-        _clean_default_staging_dir(staging_dir, is_default=is_default_dir)
+        if stage:
+            # Regenerate the owned default dir cleanly so stale dev artifacts
+            # (e.g. dist/ wheels) don't linger across dev/published switches.
+            _clean_default_staging_dir(
+                staging_dir,
+                is_default=is_default_dir,
+                overwrite=overwrite,
+                noun="workflow",
+            )
+            write_pipeline_bundle(
+                app_config,
+                staging_dir,
+                overwrite=overwrite,
+                development=use_local_source,
+            )
+            _write_staging_marker(staging_dir, is_default=is_default_dir)
+        elif not (staging_dir / "databricks.yaml").exists():
+            # Standalone deploy/run/destroy on an unstaged dir: nothing to run.
+            logger.error(
+                f"No staged workflow bundle at {staging_dir}. "
+                f"Run `dao-ai workflow generate -c {config}"
+                f"{f' -o {output_dir}' if output_dir else ''}` first."
+            )
+            sys.exit(1)
 
-        write_pipeline_bundle(
-            app_config,
-            staging_dir,
-            overwrite=overwrite,
-            development=use_local_source,
-        )
         # The config is staged at <staging>/config/<name>; notebooks run with
         # CWD == <staging>/notebooks, so the config-path var is deterministic.
         config_filename: str = Path(config_path).name
@@ -2619,13 +2695,15 @@ def run_databricks_command(
         # bundle variable: the staged local wheel in development mode (the
         # notebooks run with CWD == <staging>/notebooks, so ``./dist`` resolves),
         # else the unbounded ``dao-ai`` PyPI spec. write_pipeline_bundle staged
-        # exactly one wheel under <staging>/dist in development mode.
+        # exactly one wheel under <staging>/dist in development mode — the
+        # no-stage path reads that same already-staged wheel.
         if use_local_source:
             staged_wheels = sorted((staging_dir / "dist").glob("dao_ai-*.whl"))
             if not staged_wheels:
                 raise RuntimeError(
                     "Development pipeline bundle has no staged dao-ai wheel "
-                    f"under {staging_dir / 'dist'}."
+                    f"under {staging_dir / 'dist'}. "
+                    "Run `dao-ai workflow generate --development` first."
                 )
             # Bare wheel path — NO ``[extras]`` suffix. ``databricks bundle``
             # treats a serverless-env dependency that looks like a local path as
@@ -2900,6 +2978,41 @@ def _print_endpoint_link(endpoint_name: str) -> None:
         logger.debug(f"Could not resolve endpoint URL for {endpoint_name}: {e}")
 
 
+def handle_workflow_command(options: Namespace) -> None:
+    """Dispatch `dao-ai workflow <generate|deploy|run|destroy>`.
+
+    ``generate`` stages the provisioning-job bundle (and may one-shot
+    ``--deploy``/``--run``/``--destroy``). The standalone verbs run the
+    corresponding ``databricks bundle`` command against the ALREADY-STAGED dir
+    without re-staging (``stage=False``).
+    """
+    match options.subcommand:
+        case "generate":
+            handle_generate_workflow_command(options)
+        case "deploy":
+            _exec_workflow_verb(options, ["bundle", "deploy"])
+        case "run":
+            _exec_workflow_verb(options, ["bundle", "run", "deploy_job"])
+        case "destroy":
+            _exec_workflow_verb(options, ["bundle", "destroy", "--auto-approve"])
+
+
+def _exec_workflow_verb(options: Namespace, command: list[str]) -> None:
+    """Run a bundle verb against an already-staged workflow bundle (no restage)."""
+    run_databricks_command(
+        command,
+        profile=options.profile,
+        config=options.config,
+        target=options.target,
+        cloud=options.cloud,
+        dry_run=options.dry_run,
+        deployment_target=options.deployment_target,
+        config_vars=_parse_var_args(options.var),
+        output_dir=options.output_dir,
+        stage=False,
+    )
+
+
 def handle_generate_workflow_command(options: Namespace) -> None:
     logger.debug("Preparing provisioning-workflow configuration...")
     profile: Optional[str] = options.profile
@@ -2980,50 +3093,186 @@ def handle_generate_workflow_command(options: Namespace) -> None:
         )
 
 
-def handle_generate_agent_command(options: Namespace) -> None:
-    logger.debug("Generating bundle...")
-    config_path: str = options.config
-    output_dir: str | None = options.output_dir
-    overwrite: bool = options.overwrite
-    # Resolve the --development/--no-development tri-state to a concrete bool
-    # (None -> auto-detect via is_published()) so write_bundle's bool contract
-    # matches deploy's source-selection semantics.
-    from dao_ai.utils import resolve_use_local_source
+def _resolve_bundle_dir(
+    kind: str, config: AppConfig, output_dir: str | None
+) -> tuple[Path, bool]:
+    """Resolve the staging dir for an App bundle, shared by generate + verbs.
 
-    development: bool = resolve_use_local_source(options.development)
-    profile: str | None = options.profile
+    Returns ``(bundle_dir, is_default)``. ``is_default`` is True when the dir
+    was chosen by dao-ai (``<base>/<kind>/<app>``) rather than supplied via
+    ``-o``. Both ``<noun> generate`` and the standalone ``deploy``/``run``/
+    ``destroy`` verbs call this so they always agree on the same directory.
+    """
+    is_default_dir: bool = output_dir is None
+    bundle_dir: Path = (
+        Path(output_dir)
+        if output_dir is not None
+        else _default_bundle_dir(kind, config.app.name)
+    ).resolve()
+    return bundle_dir, is_default_dir
 
-    _apply_profile_context(profile)
 
+def _load_app_config(options: Namespace, *, what: str) -> AppConfig:
+    """Load the config for a bundle command; exit cleanly if it lacks ``app``.
+
+    ``what`` names the artifact for the error message (e.g. "a bundle",
+    "an MCP bundle"). Applies the profile context first so config loading and
+    later SDK calls resolve against ``-p``.
+    """
+    _apply_profile_context(options.profile)
     try:
         config: AppConfig = AppConfig.from_file(
-            config_path, params=_parse_var_args(options.var), initialize=False
+            options.config, params=_parse_var_args(options.var), initialize=False
         )
     except ConfigVariableError as e:
         _print_config_variable_error(e)
         sys.exit(1)
     if config.app is None:
-        logger.error("Config must have an 'app' section to generate a bundle")
+        logger.error(f"Config must have an 'app' section to generate {what}")
         sys.exit(1)
+    return config
 
-    # Resolve resources so Genie room tables and warehouses can be discovered
+
+def _generate_app_bundle(options: Namespace, *, kind: str, writer, what: str) -> None:
+    """Generate an App bundle (agent or mcp), then run any one-shot actions.
+
+    ``writer`` is ``write_bundle`` / ``write_mcp_bundle``. ``kind`` selects the
+    default staging dir and ``what`` the guard message. After writing, drops the
+    ``.dao-ai-generated`` marker and runs ``--deploy``/``--run``/``--destroy`` if
+    requested.
+    """
+    logger.debug(f"Generating {kind} bundle...")
+    # Resolve the --development/--no-development tri-state to a concrete bool
+    # (None -> auto-detect via is_published()) so the writer's bool contract
+    # matches deploy's source-selection semantics.
+    from dao_ai.utils import resolve_use_local_source
+
+    development: bool = resolve_use_local_source(options.development)
+    config: AppConfig = _load_app_config(options, what=what)
+
+    # Resolve resources so Genie room tables and warehouses can be discovered.
     config._resolve_all_resources()
 
-    is_default_dir: bool = output_dir is None
-    bundle_dir: Path = (
-        Path(output_dir)
-        if output_dir is not None
-        else _default_bundle_dir("agent", config.app.name)
-    ).resolve()
+    bundle_dir, is_default_dir = _resolve_bundle_dir(kind, config, options.output_dir)
     # Regenerate the owned default dir from scratch so a prior --development run
     # can't leave stale dist/ + dev pyproject that a published rebuild mixes in.
-    _clean_default_staging_dir(bundle_dir, is_default=is_default_dir)
+    # Refuses to wipe a default dir that carries hand-edits unless --overwrite.
+    _clean_default_staging_dir(
+        bundle_dir, is_default=is_default_dir, overwrite=options.overwrite, noun=kind
+    )
 
+    writer(config, bundle_dir, overwrite=options.overwrite, development=development)
+    _write_staging_marker(bundle_dir, is_default=is_default_dir)
+
+    _run_bundle_actions(options, config, bundle_dir, options.profile)
+
+
+def _deploy_run_destroy_app_bundle(
+    options: Namespace, *, kind: str, deploy: bool, run: bool, destroy: bool
+) -> None:
+    """Deploy/run/destroy an ALREADY-STAGED App bundle without regenerating.
+
+    Resolves the same staging dir that ``<noun> generate`` writes, errors with
+    guidance if nothing is staged there, then drives :func:`deploy_app_bundle`.
+    For a run-only invocation, best-effort verifies the app is deployed and
+    points at ``<noun> deploy --run`` instead of leaking a raw bundle error.
+    """
+    what = "a bundle" if kind == "agent" else "an MCP bundle"
+    config: AppConfig = _load_app_config(options, what=what)
+    bundle_dir, _ = _resolve_bundle_dir(kind, config, options.output_dir)
+
+    if not (bundle_dir / "databricks.yaml").exists():
+        logger.error(
+            f"No staged {kind} bundle at {bundle_dir}. "
+            f"Run `dao-ai {kind} generate -c {options.config}"
+            f"{f' -o {options.output_dir}' if options.output_dir else ''}` first."
+        )
+        sys.exit(1)
+
+    dry_run: bool = options.dry_run
+    if run and not deploy and not destroy and not dry_run:
+        _verify_app_deployed_or_exit(config.app.name, kind=kind, config=options.config)
+
+    deploy_app_bundle(
+        config,
+        output_dir=bundle_dir,
+        deploy=deploy,
+        run=run,
+        destroy=destroy,
+        profile=options.profile,
+        dry_run=dry_run,
+    )
+
+
+def _verify_app_deployed_or_exit(app_name: str, *, kind: str, config: str) -> None:
+    """Best-effort: exit with guidance if the app has never been deployed.
+
+    A ``run`` against a staged-but-undeployed bundle otherwise fails deep inside
+    ``databricks bundle run`` with an opaque error. Resolves the app via the
+    Apps API; a not-found result means deploy first. Any other lookup failure is
+    swallowed — this is a friendliness check, not a gate.
+    """
+    normalized: str = app_name.lower().replace("_", "-")
+    try:
+        from databricks.sdk import WorkspaceClient
+        from databricks.sdk.errors import NotFound
+
+        try:
+            WorkspaceClient().apps.get(name=normalized)
+        except NotFound:
+            logger.error(
+                f"App '{normalized}' is not deployed yet. "
+                f"Run `dao-ai {kind} deploy -c {config} --run` to deploy then run."
+            )
+            sys.exit(1)
+    except ImportError:
+        return
+
+
+def handle_agent_command(options: Namespace) -> None:
+    """Dispatch `dao-ai agent <generate|deploy|run|destroy>`."""
     from dao_ai.apps.bundle import write_bundle
 
-    write_bundle(config, bundle_dir, overwrite=overwrite, development=development)
+    match options.subcommand:
+        case "generate":
+            _generate_app_bundle(
+                options, kind="agent", writer=write_bundle, what="a bundle"
+            )
+        case "deploy":
+            _deploy_run_destroy_app_bundle(
+                options, kind="agent", deploy=True, run=options.run, destroy=False
+            )
+        case "run":
+            _deploy_run_destroy_app_bundle(
+                options, kind="agent", deploy=False, run=True, destroy=False
+            )
+        case "destroy":
+            _deploy_run_destroy_app_bundle(
+                options, kind="agent", deploy=False, run=False, destroy=True
+            )
 
-    _run_bundle_actions(options, config, bundle_dir, profile)
+
+def handle_mcp_command(options: Namespace) -> None:
+    """Dispatch `dao-ai mcp <generate|deploy|run|destroy>`."""
+    from dao_ai.mcp.generate import write_mcp_bundle
+
+    match options.subcommand:
+        case "generate":
+            _generate_app_bundle(
+                options, kind="mcp", writer=write_mcp_bundle, what="an MCP bundle"
+            )
+        case "deploy":
+            _deploy_run_destroy_app_bundle(
+                options, kind="mcp", deploy=True, run=options.run, destroy=False
+            )
+        case "run":
+            _deploy_run_destroy_app_bundle(
+                options, kind="mcp", deploy=False, run=True, destroy=False
+            )
+        case "destroy":
+            _deploy_run_destroy_app_bundle(
+                options, kind="mcp", deploy=False, run=False, destroy=True
+            )
 
 
 def _run_bundle_actions(
@@ -3057,57 +3306,6 @@ def _run_bundle_actions(
         profile=profile,
         dry_run=dry_run,
     )
-
-
-def handle_generate_mcp_command(options: Namespace) -> None:
-    """Emit a Databricks Apps bundle that runs the dao-ai MCP server.
-
-    The emitted server exposes the whole dao-ai agent graph as a single MCP
-    tool. Requires ``config.app.name`` (used as both the deployed App name
-    and the MCP tool name); ``config.app.description`` is strongly
-    recommended (surfaced to MCP clients as the tool description).
-    """
-    logger.debug("Generating MCP bundle...")
-    config_path: str = options.config
-    output_dir: str | None = options.output_dir
-    overwrite: bool = options.overwrite
-    # Resolve the --development/--no-development tri-state to a concrete bool
-    # (None -> auto-detect via is_published()) so write_mcp_bundle's bool
-    # contract matches deploy's source-selection semantics.
-    from dao_ai.utils import resolve_use_local_source
-
-    development: bool = resolve_use_local_source(options.development)
-    profile: str | None = options.profile
-
-    _apply_profile_context(profile)
-
-    try:
-        config: AppConfig = AppConfig.from_file(
-            config_path, params=_parse_var_args(options.var), initialize=False
-        )
-    except ConfigVariableError as e:
-        _print_config_variable_error(e)
-        sys.exit(1)
-    if config.app is None:
-        logger.error("Config must have an 'app' section to generate an MCP bundle")
-        sys.exit(1)
-
-    # Resolve resources so any Genie / VS lookups can fully bind.
-    config._resolve_all_resources()
-
-    is_default_dir: bool = output_dir is None
-    bundle_dir: Path = (
-        Path(output_dir)
-        if output_dir is not None
-        else _default_bundle_dir("mcp", config.app.name)
-    ).resolve()
-    _clean_default_staging_dir(bundle_dir, is_default=is_default_dir)
-
-    from dao_ai.mcp.generate import write_mcp_bundle
-
-    write_mcp_bundle(config, bundle_dir, overwrite=overwrite, development=development)
-
-    _run_bundle_actions(options, config, bundle_dir, profile)
 
 
 def handle_vars_command(options: Namespace) -> None:
@@ -3202,7 +3400,15 @@ def handle_vars_command(options: Namespace) -> None:
 def main() -> None:
     options: argparse.Namespace = parse_args(sys.argv[1:])
     setup_logging(options.verbose)
-    match options.command:
+
+    # Normalize the flat `generate-<noun>` aliases to the nested `<noun>
+    # generate` form so they share the exact per-noun handler code path.
+    command: str = options.command
+    if command in _ALIAS_TO_NOUN:
+        options.subcommand = "generate"
+        command = _ALIAS_TO_NOUN[command]
+
+    match command:
         case "version":
             handle_version_command(options)
         case "doctor":
@@ -3219,12 +3425,12 @@ def main() -> None:
             handle_validate_command(options)
         case "graph":
             handle_graph_command(options)
-        case "generate-workflow":
-            handle_generate_workflow_command(options)
-        case "generate-agent":
-            handle_generate_agent_command(options)
-        case "generate-mcp":
-            handle_generate_mcp_command(options)
+        case "agent":
+            handle_agent_command(options)
+        case "mcp":
+            handle_mcp_command(options)
+        case "workflow":
+            handle_workflow_command(options)
         case "deploy":
             handle_deploy_command(options)
         case "monitor":

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -249,38 +249,6 @@ def _global_parent_parser() -> ArgumentParser:
     return p
 
 
-def _add_bundle_action_arguments(parser: ArgumentParser) -> None:
-    """Add the deploy/run/destroy continuation flags to a ``generate`` verb.
-
-    These let a single ``<noun> generate`` invocation continue into deploy/run/
-    destroy (the one-shot happy path, e.g. ``dao-ai agent generate --deploy
-    --run``). When none are passed the command stays generate-only (writes the
-    bundle and stops). ``--dry-run`` is added separately via
-    :func:`_add_bundle_common_args` so the standalone ``deploy``/``run``/
-    ``destroy`` verbs get it too.
-    """
-    parser.add_argument(
-        "-d",
-        "--deploy",
-        action="store_true",
-        help="After generating, run `databricks bundle deploy` (and, when "
-        "app.trace_location is set, link the trace destination + grant the App "
-        "SP so spans persist).",
-    )
-    parser.add_argument(
-        "-r",
-        "--run",
-        action="store_true",
-        help="After generating (and deploying, if --deploy), run "
-        "`databricks bundle run <app>` to start the app.",
-    )
-    parser.add_argument(
-        "--destroy",
-        action="store_true",
-        help="Run `databricks bundle destroy` for the generated bundle.",
-    )
-
-
 def _add_bundle_common_args(parser: ArgumentParser, *, kind: str) -> None:
     """Add the flags every bundle verb shares: -c/-o/-p/--dry-run/--param.
 
@@ -420,12 +388,13 @@ def _add_noun_verb_parsers(
     generate_epilog: str,
     parents: list[ArgumentParser],
 ) -> None:
-    """Register the generate/deploy/run/destroy verb parsers for one noun.
+    """Register the up/generate/deploy/run/destroy verb parsers for one noun.
 
-    ``noun`` is ``"agent"``/``"workflow"``. The ``generate`` verb carries
-    the source flags (+ one-shot --deploy/--run/--destroy) and inherits the
-    noun's rich help; deploy/run/destroy carry only the common args. The
-    workflow noun additionally gets target/cloud flags on every verb.
+    ``noun`` is ``"agent"``/``"workflow"``. ``up`` is the orchestration verb
+    (generate-if-needed → deploy → run). ``generate`` is the pure staging verb
+    (writes a bundle, no deploy/run). ``deploy``/``run``/``destroy`` are the
+    DAB-faithful granular primitives. The workflow noun additionally gets
+    target/cloud flags on ``up``/``generate``/``deploy``/``run``/``destroy``.
     ``parents`` is forwarded to every ``add_parser`` call so the global
     ``-p/--profile`` and ``-v/--verbose`` flags are accepted at each level.
     """
@@ -433,7 +402,7 @@ def _add_noun_verb_parsers(
 
     parser: ArgumentParser = subparsers.add_parser(
         noun,
-        help=f"Manage the {noun} bundle (generate | deploy | run | destroy)",
+        help=f"Manage the {noun} bundle (up | generate | deploy | run | destroy)",
         description=noun_description,
         epilog=noun_epilog,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -441,9 +410,44 @@ def _add_noun_verb_parsers(
     )
     verbs = parser.add_subparsers(dest="subcommand", required=True)
 
+    # --- up: orchestration verb (generate-if-needed → deploy → run) ----------
+    up_parser: ArgumentParser = verbs.add_parser(
+        "up",
+        help=(
+            f"Bring the {noun} up: generate (if needed), deploy, and start it — "
+            "the one-command path to a live agent. Use `deploy`/`run` for granular "
+            "control."
+        ),
+        description=(
+            f"Bring the {noun} up: generate (if needed), deploy, and start it.\n\n"
+            "For bundle modes (apps, mcp): stages the bundle when unstaged, runs\n"
+            "`databricks bundle deploy`, links the trace destination, then runs\n"
+            "`databricks bundle run <app>`. Use `--direct` to skip the bundle\n"
+            "entirely and deploy via the SDK (apps/mcp only).\n\n"
+            "For --mode model_serving: registers then deploys the endpoint\n"
+            "(serving once READY; `run` is n/a for endpoints)."
+        ),
+        parents=parents,
+    )
+    _add_bundle_common_args(up_parser, kind=noun)
+    _add_bundle_source_args(up_parser)
+    if is_workflow:
+        _add_workflow_target_args(up_parser)
+    _add_mode_argument(up_parser, choices=["model_serving", "apps", "mcp"])
+    up_parser.add_argument(
+        "--direct",
+        action="store_true",
+        default=False,
+        help=(
+            "Deploy via the SDK directly (no DAB bundle on disk) — fast "
+            "iteration path for --mode apps|mcp. Inherently starts the app."
+        ),
+    )
+
+    # --- generate: pure staging verb (no deploy/run) -------------------------
     generate_parser: ArgumentParser = verbs.add_parser(
         "generate",
-        help=f"Generate the {noun} bundle from a config",
+        help=f"Generate the {noun} bundle from a config (stage only, no deploy)",
         description=generate_description,
         epilog=generate_epilog,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -456,7 +460,6 @@ def _add_noun_verb_parsers(
         _add_mode_argument(generate_parser, choices=["apps", "mcp"])
     else:
         _add_mode_argument(generate_parser, choices=["apps", "mcp"])
-    _add_bundle_action_arguments(generate_parser)
 
     for verb, verb_help in (
         (
@@ -471,7 +474,8 @@ def _add_noun_verb_parsers(
             f"(written by `dao-ai {noun} generate`) it is deployed in place, "
             f"preserving any hand-edits. When nothing is staged, the bundle is "
             f"generated first automatically. Use `--mode` to select the serving "
-            f"target (apps | mcp | model_serving; default: apps)."
+            f"target (apps | mcp | model_serving; default: apps). "
+            f"Use `dao-ai {noun} up` to deploy AND start in one command."
         )
         verb_parser: ArgumentParser = verbs.add_parser(
             verb,
@@ -489,41 +493,6 @@ def _add_noun_verb_parsers(
             _add_mode_argument(verb_parser, choices=["model_serving", "apps", "mcp"])
         else:
             _add_mode_argument(verb_parser, choices=["apps", "mcp"])
-        if verb == "deploy":
-            # Forward chaining: `dao-ai <noun> deploy --run` deploys the staged
-            # bundle then runs it (parity with `generate --deploy --run`).
-            verb_parser.add_argument(
-                "-r",
-                "--run",
-                action="store_true",
-                help="After deploying, run `databricks bundle run <app>`.",
-            )
-            verb_parser.add_argument(
-                "--direct",
-                action="store_true",
-                default=False,
-                help=(
-                    "Deploy via the SDK directly (no DAB bundle on disk) — fast "
-                    "iteration escape hatch for --mode apps|mcp."
-                ),
-            )
-
-
-def _validate_bundle_action_flags(options: Namespace) -> None:
-    """Reject contradictory ``--destroy`` + ``--deploy``/``--run`` combinations.
-
-    ``--destroy`` tears a bundle down; ``--deploy``/``--run`` stand it up.
-    Combining them is contradictory and the two code paths historically
-    diverged (the workflow handler deployed-then-destroyed; the App driver
-    destroyed-only). Fail uniformly with a clean message across all three
-    generate-* commands rather than silently picking one behavior.
-    """
-    destroy: bool = getattr(options, "destroy", False)
-    deploy: bool = getattr(options, "deploy", False)
-    run: bool = getattr(options, "run", False)
-    if destroy and (deploy or run):
-        logger.error("--destroy cannot be combined with --deploy or --run")
-        sys.exit(1)
 
 
 # Env var that overrides the base directory for generated bundles. The
@@ -1030,10 +999,11 @@ Examples:
         help="Path to the model configuration file to visualize",
     )
 
-    # --- Bundle nouns: `dao-ai <noun> <generate|deploy|run|destroy>` ----------
-    # Each noun owns the full generate → deploy → run → destroy lifecycle as
-    # discrete verbs. generate stages (and can one-shot --deploy/--run); deploy/
-    # run/destroy act on the already-staged dir without regenerating it.
+    # --- Bundle nouns: `dao-ai <noun> <up|generate|deploy|run|destroy>` -------
+    # Each noun owns the full up/generate/deploy/run/destroy lifecycle as
+    # discrete verbs. `up` is the orchestration verb (generate-if-needed →
+    # deploy → run). `generate` stages only. `deploy`/`run`/`destroy` are the
+    # DAB-faithful granular primitives acting on the already-staged dir.
     _WORKFLOW_DESC = """
 Manage the provisioning Workflow — a Databricks Job (Lakeflow Workflow) that
 provisions backing infrastructure (schemas, Vector Search, Lakebase, Genie, UC
@@ -1042,42 +1012,40 @@ Databricks Asset Bundle.
 """
     _WORKFLOW_EPILOG = """
 Examples:
-  # Provision infra + deploy the workflow job in one shot
-  dao-ai workflow generate -c config.yaml --deploy -p fevm
+  # One command: generate → deploy → run the provisioning job
+  dao-ai workflow up -c config.yaml -p fevm
 
-  # Run the already-deployed provisioning job
-  dao-ai workflow run -c config.yaml -p fevm
-
-  # Generate bundle only, inspect, then deploy manually
+  # Generate bundle only, inspect, then deploy and run separately
   dao-ai workflow generate -c config.yaml
   dao-ai workflow deploy   -c config.yaml -p fevm
+  dao-ai workflow run      -c config.yaml -p fevm
 """
     _AGENT_DESC = """
 Manage the agent bundle — a Databricks App (or MCP server / Model Serving
-endpoint). `generate` writes a deployable Databricks Asset Bundle; `deploy`
-ships it to Databricks. `deploy` auto-generates when nothing is staged so a
-single command covers both steps.
+endpoint). `up` is the one-command path: generate (if needed) → deploy →
+start. `generate` writes a bundle only. `deploy`/`run` are the DAB-faithful
+granular primitives.
 """
     _AGENT_EPILOG = """
 Examples:
-  # One-shot: generate bundle → deploy → start the App
-  dao-ai agent generate -c config.yaml --deploy --run -p fevm
+  # One command: generate (if needed) → deploy → start the App
+  dao-ai agent up -c config.yaml -p fevm
 
-  # Deploy staged bundle (auto-generates if nothing is staged yet)
+  # One command for an MCP server
+  dao-ai agent up -c config.yaml --mode mcp -p fevm
+
+  # Deploy staged bundle only (auto-generates if nothing is staged yet)
   dao-ai agent deploy -c config.yaml -p fevm
 
   # Deploy to Model Serving endpoint; -m ms is an accepted alias
   dao-ai agent deploy -c config.yaml --mode model_serving -p fevm
   dao-ai agent deploy -c config.yaml -m ms -p fevm
 
-  # Deploy as MCP server
-  dao-ai agent deploy -c config.yaml --mode mcp -p fevm
-
-  # SDK fast-path: deploy without writing a bundle to disk (apps/mcp only)
-  dao-ai agent deploy -c config.yaml --direct -p fevm
+  # SDK fast-path: up via SDK without writing a bundle to disk (apps/mcp only)
+  dao-ai agent up -c config.yaml --direct -p fevm
 
   # Pass -p at the top level (equivalent)
-  dao-ai -p fevm agent deploy -c config.yaml
+  dao-ai -p fevm agent up -c config.yaml
 """
 
     _add_noun_verb_parsers(
@@ -2874,17 +2842,17 @@ def deploy_app_bundle(
     profile: Optional[str],
     dry_run: bool = False,
 ) -> None:
-    """Deploy/run/destroy an already-generated App bundle (agent or MCP).
+    """Deploy/run/destroy an already-staged App bundle (agent or MCP).
 
-    Shared driver for ``agent generate`` / ``agent generate --mode mcp`` action flags. The
-    App bundle uses a single ``dev`` target and is run by its app-name resource
-    key (contrast the workflow job, run by ``deploy_job``). Order when
-    ``--deploy`` and ``--run`` are combined: deploy → auto trace-link+grant →
-    run, matching the sequence the docs prescribe.
+    Shared driver for the ``up``, ``deploy``, ``run``, and ``destroy`` verbs.
+    The App bundle uses a single ``dev`` target and is run by its app-name
+    resource key (contrast the workflow job, run by ``deploy_job``). When both
+    ``deploy`` and ``run`` are True (as in ``up``), the order is: deploy →
+    auto trace-link+grant → run, matching the sequence the docs prescribe.
 
     Args:
         config: loaded AppConfig (for trace_location + app name).
-        output_dir: the generated bundle dir (``bundle`` commands run here).
+        output_dir: the staged bundle dir (``bundle`` commands run here).
         deploy / run / destroy: which action(s) to perform.
         profile: Databricks CLI profile.
         dry_run: print instead of executing.
@@ -2962,14 +2930,15 @@ def _print_endpoint_link(endpoint_name: str) -> None:
 
 
 def handle_workflow_command(options: Namespace) -> None:
-    """Dispatch `dao-ai workflow <generate|deploy|run|destroy>`.
+    """Dispatch `dao-ai workflow <up|generate|deploy|run|destroy>`.
 
-    ``generate`` stages the provisioning-job bundle (and may one-shot
-    ``--deploy``/``--run``/``--destroy``). The standalone verbs run the
-    corresponding ``databricks bundle`` command against the ALREADY-STAGED dir
-    without re-staging (``stage=False``).
+    ``up`` orchestrates generate → deploy → run in one command. ``generate``
+    stages the bundle only. The standalone ``deploy``/``run``/``destroy`` verbs
+    act on the ALREADY-STAGED dir without re-staging (``stage=False``).
     """
     match options.subcommand:
+        case "up":
+            _handle_up_workflow_command(options)
         case "generate":
             handle_generate_workflow_command(options)
         case "deploy":
@@ -2997,6 +2966,7 @@ def _exec_workflow_verb(options: Namespace, command: list[str]) -> None:
 
 
 def handle_generate_workflow_command(options: Namespace) -> None:
+    """Stage the workflow bundle only; no deploy/run (use `up` or standalone verbs)."""
     logger.debug("Preparing provisioning-workflow configuration...")
     profile: Optional[str] = options.profile
     config: Optional[str] = options.config
@@ -3009,71 +2979,67 @@ def handle_generate_workflow_command(options: Namespace) -> None:
     output_dir: str | None = getattr(options, "output_dir", None)
     overwrite: bool = getattr(options, "overwrite", False)
 
-    _validate_bundle_action_flags(options)
+    # Generate-only: stage the bundle so the user can inspect it or deploy
+    # manually (`cd <output-dir> && databricks bundle deploy ...`). Use
+    # `dao-ai workflow up` to generate → deploy → run in one command.
+    logger.info("Staging DAO AI workflow bundle...")
+    run_databricks_command(
+        None,
+        profile=profile,
+        config=config,
+        target=target,
+        cloud=cloud,
+        dry_run=dry_run,
+        mode=mode,
+        development=development,
+        config_vars=config_vars,
+        output_dir=output_dir,
+        overwrite=overwrite,
+    )
 
-    if options.deploy:
-        logger.info("Deploying DAO AI asset bundle...")
-        run_databricks_command(
-            ["bundle", "deploy"],
-            profile=profile,
-            config=config,
-            target=target,
-            cloud=cloud,
-            dry_run=dry_run,
-            mode=mode,
-            development=development,
-            config_vars=config_vars,
-            output_dir=output_dir,
-            overwrite=overwrite,
-        )
-    if options.run:
-        logger.info("Running DAO AI system with current configuration...")
-        run_databricks_command(
-            ["bundle", "run", "deploy_job"],
-            profile=profile,
-            config=config,
-            target=target,
-            cloud=cloud,
-            dry_run=dry_run,
-            mode=mode,
-            development=development,
-            config_vars=config_vars,
-            output_dir=output_dir,
-            overwrite=overwrite,
-        )
-    if options.destroy:
-        logger.info("Destroying DAO AI system with current configuration...")
-        run_databricks_command(
-            ["bundle", "destroy", "--auto-approve"],
-            profile=profile,
-            config=config,
-            target=target,
-            cloud=cloud,
-            dry_run=dry_run,
-            mode=mode,
-            development=development,
-            config_vars=config_vars,
-            output_dir=output_dir,
-            overwrite=overwrite,
-        )
-    if not any([options.deploy, options.run, options.destroy]):
-        # Generate-only: stage the bundle so the user can inspect it or deploy
-        # manually (`cd <output-dir> && databricks bundle deploy ...`). This is
-        # the default for a `generate-*` command — deploy/run/destroy are opt-in.
-        logger.info("Staging DAO AI workflow bundle (no deploy/run requested)...")
-        run_databricks_command(
-            None,
-            profile=profile,
-            config=config,
-            target=target,
-            cloud=cloud,
-            dry_run=dry_run,
-            mode=mode,
-            development=development,
-            config_vars=config_vars,
-            output_dir=output_dir,
-            overwrite=overwrite,
-        )
+
+def _handle_up_workflow_command(options: Namespace) -> None:
+    """Orchestrate workflow up: generate → deploy → run deploy_job."""
+    logger.debug("Bringing workflow up (generate → deploy → run)...")
+    profile: Optional[str] = options.profile
+    config: Optional[str] = options.config
+    target: Optional[str] = options.target
+    cloud: Optional[str] = options.cloud
+    dry_run: bool = options.dry_run
+    mode: Optional[str] = getattr(options, "mode", None)
+    development: bool | None = getattr(options, "development", None)
+    config_vars: dict[str, str] = _parse_var_args(options.var)
+    output_dir: str | None = getattr(options, "output_dir", None)
+    overwrite: bool = getattr(options, "overwrite", False)
+
+    logger.info("Deploying DAO AI asset bundle...")
+    run_databricks_command(
+        ["bundle", "deploy"],
+        profile=profile,
+        config=config,
+        target=target,
+        cloud=cloud,
+        dry_run=dry_run,
+        mode=mode,
+        development=development,
+        config_vars=config_vars,
+        output_dir=output_dir,
+        overwrite=overwrite,
+    )
+    logger.info("Running DAO AI provisioning workflow...")
+    run_databricks_command(
+        ["bundle", "run", "deploy_job"],
+        profile=profile,
+        config=config,
+        target=target,
+        cloud=cloud,
+        dry_run=dry_run,
+        mode=mode,
+        development=development,
+        config_vars=config_vars,
+        output_dir=output_dir,
+        overwrite=overwrite,
+    )
 
 
 def _resolve_bundle_dir(
@@ -3146,12 +3112,12 @@ def _stage_app_bundle(
 
 
 def _generate_app_bundle(options: Namespace, *, kind: str, writer, what: str) -> None:
-    """Generate an App bundle (agent or mcp), then run any one-shot actions.
+    """Stage an App bundle (agent or mcp) — pure staging, no deploy or run.
 
     ``writer`` is ``write_bundle`` / ``write_mcp_bundle``. ``kind`` selects the
-    default staging dir and ``what`` the guard message. After writing, drops the
-    ``.dao-ai-generated`` marker and runs ``--deploy``/``--run``/``--destroy`` if
-    requested.
+    default staging dir and ``what`` the guard message. Drops the
+    ``.dao-ai-generated`` marker after writing. Use ``dao-ai <noun> up`` to
+    generate, deploy, and start in one command.
     """
     logger.debug(f"Generating {kind} bundle...")
     # Resolve the --development/--no-development tri-state to a concrete bool
@@ -3176,25 +3142,28 @@ def _generate_app_bundle(options: Namespace, *, kind: str, writer, what: str) ->
         noun=kind,
     )
 
-    _run_bundle_actions(options, config, bundle_dir, options.profile)
-
 
 def _deploy_run_destroy_app_bundle(
     options: Namespace, *, kind: str, deploy: bool, run: bool, destroy: bool
 ) -> None:
-    """Deploy/run/destroy an App bundle, auto-generating when ``deploy=True`` and unstaged.
+    """Shared driver for deploy/run/destroy/up on an App bundle.
 
-    Routing (deploy-only):
+    Called by the ``up`` verb (deploy=True, run=True) and the standalone
+    ``deploy``/``run``/``destroy`` verbs. Auto-generates when unstaged and
+    ``deploy=True``.
 
-    1. ``--mode model_serving``: call ``config.deploy_agent(target=MODEL_SERVING)``
-       and return — Model Serving has no DAB bundle.
-    2. ``--direct``: call ``config.deploy_agent(target=ServingMode(mode))``
-       (SDK path; no bundle on disk). ``--direct`` + ``--mode model_serving`` is
-       redundant — treated identically to plain model_serving deploy (no error).
-    3. Bundle path: if ``databricks.yaml`` is absent AND ``deploy=True``, auto-stage
-       via :func:`_stage_app_bundle` (CDK/SAM norm), then deploy. If already staged,
-       deploy in-place (preserves hand-edits). ``run`` / ``destroy`` still error when
-       unstaged — you can't run or destroy something never staged.
+    Routing:
+
+    1. ``--mode model_serving``: call ``config.create_agent`` then
+       ``config.deploy_agent(target=MODEL_SERVING)`` — no DAB bundle. ``run``
+       is irrelevant for an endpoint (it serves once READY).
+    2. ``up --direct`` (or any direct=True): call
+       ``config.deploy_agent(target=ServingMode(mode))`` via SDK (no bundle on
+       disk). ``--direct`` + ``--mode model_serving`` is handled by Route 1.
+    3. Bundle path: if ``databricks.yaml`` is absent AND ``deploy=True``,
+       auto-stage via :func:`_stage_app_bundle` (CDK/SAM norm), then deploy.
+       If already staged, deploy in-place (preserves hand-edits). ``run`` /
+       ``destroy`` still error when unstaged.
     """
     from dao_ai.utils import resolve_use_local_source
 
@@ -3297,7 +3266,7 @@ def _verify_app_deployed_or_exit(app_name: str, *, kind: str, config: str) -> No
         except NotFound:
             logger.error(
                 f"App '{normalized}' is not deployed yet. "
-                f"Run `dao-ai {kind} deploy -c {config} --run` to deploy then run."
+                f"Run `dao-ai {kind} up -c {config}` to deploy and run."
             )
             sys.exit(1)
     except ImportError:
@@ -3325,12 +3294,13 @@ def _mode_writer(mode: str) -> Callable[..., None]:
 
 
 def handle_agent_command(options: Namespace) -> None:
-    """Dispatch `dao-ai agent <generate|deploy|run|destroy>`.
+    """Dispatch `dao-ai agent <up|generate|deploy|run|destroy>`.
 
+    ``up``           → generate (if needed) → deploy → run (one-command path).
     ``--mode mcp``   → writes the MCP-server bundle (staging dir ``mcp/<app>``)
     ``--mode apps``  → writes the chat-agent bundle  (staging dir ``agent/<app>``)
-    ``--mode model_serving`` → only valid for `deploy`; bundle path is a no-op
-    here (Task 6 wires the direct deploy path).
+    ``--mode model_serving`` → only valid for `deploy`/`up`; SDK path only.
+    ``--direct``     → only valid for `up`; SDK deploy without a bundle on disk.
     """
     mode: str = getattr(options, "mode", "apps") or "apps"
     kind: str = _mode_bundle_kind(mode)
@@ -3338,11 +3308,15 @@ def handle_agent_command(options: Namespace) -> None:
     what: str = "an MCP bundle" if mode == "mcp" else "a bundle"
 
     match options.subcommand:
+        case "up":
+            _deploy_run_destroy_app_bundle(
+                options, kind=kind, deploy=True, run=True, destroy=False
+            )
         case "generate":
             _generate_app_bundle(options, kind=kind, writer=writer, what=what)
         case "deploy":
             _deploy_run_destroy_app_bundle(
-                options, kind=kind, deploy=True, run=options.run, destroy=False
+                options, kind=kind, deploy=True, run=False, destroy=False
             )
         case "run":
             _deploy_run_destroy_app_bundle(
@@ -3352,39 +3326,6 @@ def handle_agent_command(options: Namespace) -> None:
             _deploy_run_destroy_app_bundle(
                 options, kind=kind, deploy=False, run=False, destroy=True
             )
-
-
-def _run_bundle_actions(
-    options: Namespace,
-    config: AppConfig,
-    output_dir: Path,
-    profile: Optional[str],
-) -> None:
-    """Invoke deploy/run/destroy on a just-generated App bundle, if requested.
-
-    Shared tail for ``agent generate`` (apps or mcp mode): when any of
-    ``--deploy``/``--run``/``--destroy`` is passed, drive the bundle via
-    :func:`deploy_app_bundle`; otherwise the command stays generate-only.
-    """
-    _validate_bundle_action_flags(options)
-
-    deploy: bool = getattr(options, "deploy", False)
-    run: bool = getattr(options, "run", False)
-    destroy: bool = getattr(options, "destroy", False)
-    dry_run: bool = getattr(options, "dry_run", False)
-
-    if not any([deploy, run, destroy]):
-        return
-
-    deploy_app_bundle(
-        config,
-        output_dir=output_dir,
-        deploy=deploy,
-        run=run,
-        destroy=destroy,
-        profile=profile,
-        dry_run=dry_run,
-    )
 
 
 def handle_vars_command(options: Namespace) -> None:

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -2446,7 +2446,7 @@ def run_databricks_command(
     target: Optional[str] = None,
     cloud: Optional[str] = None,
     dry_run: bool = False,
-    deployment_target: Optional[str] = None,
+    mode: Optional[str] = None,
     development: bool | None = None,
     config_vars: Optional[dict[str, str]] = None,
     output_dir: Optional[str] = None,
@@ -2462,7 +2462,7 @@ def run_databricks_command(
         target: Optional bundle target name (if not provided, auto-generated from app name and cloud)
         cloud: Optional cloud provider ('azure', 'aws', 'gcp'). Auto-detected if not specified.
         dry_run: If True, print the command without executing
-        deployment_target: Optional agent deployment target ('model_serving' or 'apps').
+        mode: Optional agent serving mode ('model_serving', 'apps', or 'mcp').
             Passed to the deploy notebook via bundle variable.
         development: Optional tri-state source selection passed to the deploy
             notebook via the ``development`` bundle variable — ``True`` ships
@@ -2633,14 +2633,14 @@ def run_databricks_command(
     for key, value in (config_vars or {}).items():
         extra_vars.append(f'--var="{key}={value}"')
 
-    # Add deployment_target variable for notebooks.
+    # Add mode variable for notebooks.
     # Priority: CLI arg > default (model_serving)
-    resolved_deployment_target: str = deployment_target or "model_serving"
-    logger.debug(f"Using deployment target: {resolved_deployment_target}")
-    extra_vars.append(f'--var="deployment_target={resolved_deployment_target}"')
+    resolved_mode: str = mode or "model_serving"
+    logger.debug(f"Using serving mode: {resolved_mode}")
+    extra_vars.append(f'--var="mode={resolved_mode}"')
 
     # Forward the development tri-state to the deploy notebook via a bundle var.
-    # Always emit (mirrors deployment_target) so the notebook widget default
+    # Always emit (mirrors mode) so the notebook widget default
     # never diverges from the CLI intent. None → "auto" (notebook resolves via
     # is_published()), True → "true" (local source/wheel), False → "false" (PyPI).
     resolved_development: str = (
@@ -2892,7 +2892,7 @@ def _exec_workflow_verb(options: Namespace, command: list[str]) -> None:
         target=options.target,
         cloud=options.cloud,
         dry_run=options.dry_run,
-        deployment_target=getattr(options, "mode", None),
+        mode=getattr(options, "mode", None),
         config_vars=_parse_var_args(options.var),
         output_dir=options.output_dir,
         stage=False,
@@ -2906,7 +2906,7 @@ def handle_generate_workflow_command(options: Namespace) -> None:
     target: Optional[str] = options.target
     cloud: Optional[str] = options.cloud
     dry_run: bool = options.dry_run
-    deployment_target: Optional[str] = getattr(options, "mode", None)
+    mode: Optional[str] = getattr(options, "mode", None)
     development: bool | None = getattr(options, "development", None)
     config_vars: dict[str, str] = _parse_var_args(options.var)
     output_dir: str | None = getattr(options, "output_dir", None)
@@ -2923,7 +2923,7 @@ def handle_generate_workflow_command(options: Namespace) -> None:
             target=target,
             cloud=cloud,
             dry_run=dry_run,
-            deployment_target=deployment_target,
+            mode=mode,
             development=development,
             config_vars=config_vars,
             output_dir=output_dir,
@@ -2938,7 +2938,7 @@ def handle_generate_workflow_command(options: Namespace) -> None:
             target=target,
             cloud=cloud,
             dry_run=dry_run,
-            deployment_target=deployment_target,
+            mode=mode,
             development=development,
             config_vars=config_vars,
             output_dir=output_dir,
@@ -2953,7 +2953,7 @@ def handle_generate_workflow_command(options: Namespace) -> None:
             target=target,
             cloud=cloud,
             dry_run=dry_run,
-            deployment_target=deployment_target,
+            mode=mode,
             development=development,
             config_vars=config_vars,
             output_dir=output_dir,
@@ -2971,7 +2971,7 @@ def handle_generate_workflow_command(options: Namespace) -> None:
             target=target,
             cloud=cloud,
             dry_run=dry_run,
-            deployment_target=deployment_target,
+            mode=mode,
             development=development,
             config_vars=config_vars,
             output_dir=output_dir,
@@ -3091,7 +3091,7 @@ def _deploy_run_destroy_app_bundle(
 
     1. ``--mode model_serving``: call ``config.deploy_agent(target=MODEL_SERVING)``
        and return — Model Serving has no DAB bundle.
-    2. ``--direct``: call ``config.deploy_agent(target=DeploymentTarget(mode))``
+    2. ``--direct``: call ``config.deploy_agent(target=ServingMode(mode))``
        (SDK path; no bundle on disk). ``--direct`` + ``--mode model_serving`` is
        redundant — treated identically to plain model_serving deploy (no error).
     3. Bundle path: if ``databricks.yaml`` is absent AND ``deploy=True``, auto-stage
@@ -3107,7 +3107,7 @@ def _deploy_run_destroy_app_bundle(
 
     # --- Route 1: model_serving (always SDK, never a bundle) ---
     if deploy and mode == "model_serving":
-        from dao_ai.config import DeploymentTarget
+        from dao_ai.config import ServingMode
 
         config: AppConfig = _load_app_config(options, what=what)
         development: bool = resolve_use_local_source(getattr(options, "development", None))
@@ -3116,12 +3116,12 @@ def _deploy_run_destroy_app_bundle(
         # `dao-ai deploy` handler). Without this, deploy_model_serving_agent
         # deploys a stale-or-nonexistent model version.
         config.create_agent(development=development)
-        config.deploy_agent(target=DeploymentTarget.MODEL_SERVING, development=development)
+        config.deploy_agent(target=ServingMode.MODEL_SERVING, development=development)
         return
 
     # --- Route 2: --direct (SDK path for apps/mcp; model_serving is a no-op alias) ---
     if deploy and direct:
-        from dao_ai.config import DeploymentTarget
+        from dao_ai.config import ServingMode
 
         config = _load_app_config(options, what=what)
         development = resolve_use_local_source(getattr(options, "development", None))
@@ -3129,7 +3129,7 @@ def _deploy_run_destroy_app_bundle(
         # register — matches the former `if target != APPS: create_agent()`
         # gate). model_serving is handled by Route 1 above, so mode is apps|mcp here.
         config.deploy_agent(
-            target=DeploymentTarget(mode),
+            target=ServingMode(mode),
             development=development,
         )
         return

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -680,9 +680,17 @@ Examples:
         help="Path to the model configuration file to validate (default: ./config/model_config.yaml)",
     )
 
-    # Create-experiment command
-    create_experiment_parser: ArgumentParser = subparsers.add_parser(
-        "create-experiment",
+    # Trace noun: `dao-ai trace <create|link|grant>`
+    trace_parser: ArgumentParser = subparsers.add_parser(
+        "trace",
+        help="Manage MLflow experiments and UC trace destinations (create | link | grant)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    trace_verbs = trace_parser.add_subparsers(dest="subcommand", required=True)
+
+    # trace create (was: create-experiment)
+    trace_create_parser: ArgumentParser = trace_verbs.add_parser(
+        "create",
         help="Create (or look up) an MLflow experiment and print its id",
         description="""
 Provision or resolve an MLflow experiment on Databricks and print the
@@ -695,14 +703,14 @@ to verify an existing experiment. Exactly one of the two is required.
         """,
         epilog="""
 Examples:
-  dao-ai create-experiment --name /Shared/rcg/hardware_store_traces
-  dao-ai create-experiment --name /Shared/team/agent -p fevm
-  dao-ai create-experiment --id 1952423719449237 --output json
-  dao-ai create-experiment --name /Shared/only-if-exists --no-create
+  dao-ai trace create --name /Shared/rcg/hardware_store_traces
+  dao-ai trace create --name /Shared/team/agent -p fevm
+  dao-ai trace create --id 1952423719449237 --output json
+  dao-ai trace create --name /Shared/only-if-exists --no-create
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    _create_exp_ident_group = create_experiment_parser.add_mutually_exclusive_group(
+    _create_exp_ident_group = trace_create_parser.add_mutually_exclusive_group(
         required=True
     )
     _create_exp_ident_group.add_argument(
@@ -717,18 +725,18 @@ Examples:
         metavar="ID",
         help="Numeric experiment id. Fetched (not created).",
     )
-    create_experiment_parser.add_argument(
+    trace_create_parser.add_argument(
         "--no-create",
         action="store_true",
         help="With --name: fail instead of creating when the experiment is missing.",
     )
-    create_experiment_parser.add_argument(
+    trace_create_parser.add_argument(
         "-p",
         "--profile",
         type=str,
         help="Databricks profile to use for authentication.",
     )
-    create_experiment_parser.add_argument(
+    trace_create_parser.add_argument(
         "-o",
         "--output",
         choices=["text", "json"],
@@ -736,9 +744,9 @@ Examples:
         help="Output format (default: text).",
     )
 
-    # Link-trace-destination command
-    link_trace_parser: ArgumentParser = subparsers.add_parser(
-        "link-trace-destination",
+    # trace link (was: link-trace-destination)
+    trace_link_parser: ArgumentParser = trace_verbs.add_parser(
+        "link",
         help="Link an MLflow experiment to its UC trace destination",
         description="""
 Link an MLflow experiment to the Unity Catalog trace destination
@@ -763,11 +771,11 @@ No-op when ``config.app.trace_location`` is not set.
 Examples:
   # Typical bundle flow — insert between deploy and run
   databricks bundle deploy --target dev -p fevm
-  dao-ai link-trace-destination -c config.yaml -p fevm
+  dao-ai trace link -c config.yaml -p fevm
   databricks bundle run my-app --target dev -p fevm
 
   # Explicit experiment id
-  dao-ai link-trace-destination -c config.yaml --experiment-id 1234567890 -p fevm
+  dao-ai trace link -c config.yaml --experiment-id 1234567890 -p fevm
 
 Notes:
   * Restart the app after linking. MLflow's tracer provider is
@@ -788,7 +796,7 @@ Notes:
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    link_trace_parser.add_argument(
+    trace_link_parser.add_argument(
         "-c",
         "--config",
         type=str,
@@ -796,19 +804,19 @@ Notes:
         metavar="FILE",
         help="Path to the model configuration file (must set app.trace_location).",
     )
-    link_trace_parser.add_argument(
+    trace_link_parser.add_argument(
         "-p",
         "--profile",
         type=str,
         help="Databricks profile to use for authentication.",
     )
-    link_trace_parser.add_argument(
+    trace_link_parser.add_argument(
         "--experiment-id",
         type=str,
         metavar="ID",
         help="Explicit experiment id (skips resolution from config/bundle name).",
     )
-    link_trace_parser.add_argument(
+    trace_link_parser.add_argument(
         "--app-sp",
         type=str,
         metavar="CLIENT_ID",
@@ -821,11 +829,11 @@ Notes:
             "entirely (admin-provisioned scenarios)."
         ),
     )
-    _add_var_argument(link_trace_parser)
+    _add_var_argument(trace_link_parser)
 
-    # Grant trace permissions command
-    grant_trace_parser: ArgumentParser = subparsers.add_parser(
-        "grant-trace-permissions",
+    # trace grant (was: grant-trace-permissions)
+    trace_grant_parser: ArgumentParser = trace_verbs.add_parser(
+        "grant",
         help="Grant an App SP the experiment + UC OTEL table permissions MLflow tracing needs.",
         description="""
 Grant the experiment ``CAN_EDIT`` ACL and the UC OTEL trace-table
@@ -836,14 +844,14 @@ experiment's OTEL Delta tables.
 Standalone counterpart to the grant step that ``dao-ai deploy`` / ``dao-ai
 pipeline`` runs automatically inside ``deploy_app_agent`` /
 ``deploy_model_serving_agent``. Useful for the ``generate-agent`` + ``bundle
-deploy`` + ``link-trace-destination`` flow (where no full deploy fires),
+deploy`` + ``dao-ai trace link`` flow (where no full deploy fires),
 or for retroactively fixing grants when an app was deployed by an
 identity that lacked GRANT rights.
 
 Idempotent — repeated calls with the same principal + privileges no-op
 on the workspace side.
 
-Experiment resolution order matches ``link-trace-destination``:
+Experiment resolution order matches ``dao-ai trace link``:
   1. ``--experiment-id`` flag
   2. ``config.app.experiment.resolved_id`` if ``experiment:`` is set
   3. Bundle-declared name lookup (``/Users/<current-user>/<app-name>``)
@@ -857,14 +865,14 @@ No-op when ``config.app.trace_location`` is not set.
         epilog="""
 Examples:
   # Retroactively grant an already-deployed App its trace-write permissions
-  dao-ai grant-trace-permissions -c config.yaml -p fevm
+  dao-ai trace grant -c config.yaml -p fevm
 
   # Grant a specific SP explicitly (e.g. shared workload identity)
-  dao-ai grant-trace-permissions -c config.yaml --app-sp <uuid> -p fevm
+  dao-ai trace grant -c config.yaml --app-sp <uuid> -p fevm
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    grant_trace_parser.add_argument(
+    trace_grant_parser.add_argument(
         "-c",
         "--config",
         type=str,
@@ -872,19 +880,19 @@ Examples:
         metavar="FILE",
         help="Path to the model configuration file (must set app.trace_location).",
     )
-    grant_trace_parser.add_argument(
+    trace_grant_parser.add_argument(
         "-p",
         "--profile",
         type=str,
         help="Databricks profile to use for authentication.",
     )
-    grant_trace_parser.add_argument(
+    trace_grant_parser.add_argument(
         "--experiment-id",
         type=str,
         metavar="ID",
         help="Explicit experiment id (skips resolution from config/bundle name).",
     )
-    grant_trace_parser.add_argument(
+    trace_grant_parser.add_argument(
         "--app-sp",
         type=str,
         metavar="CLIENT_ID",
@@ -893,7 +901,7 @@ Examples:
             "auto-resolved via ``apps.get(config.app.name)``."
         ),
     )
-    _add_var_argument(grant_trace_parser)
+    _add_var_argument(trace_grant_parser)
 
     # Graph command
     graph_parser: ArgumentParser = subparsers.add_parser(
@@ -1157,8 +1165,8 @@ Examples:
         _add_var_argument(sub)
 
     # Add -p/--profile to the subcommands that touch Databricks but don't
-    # already declare it inline (create-experiment/link-trace/grant-trace
-    # define their own; bundle nouns get it from _add_bundle_common_args).
+    # already declare it inline (trace verb parsers define their own;
+    # bundle nouns get it from _add_bundle_common_args).
     # Without it a shell/.env DATABRICKS_* var silently wins — the hijack
     # _apply_profile_context guards.
     for sub in (
@@ -1547,6 +1555,17 @@ def handle_chat_command(options: Namespace) -> None:
 def handle_schema_command(options: Namespace) -> None:
     logger.debug("Generating JSON schema...")
     print(json.dumps(AppConfig.model_json_schema(), indent=2))
+
+
+def handle_trace_command(options: Namespace) -> None:
+    """Dispatch ``dao-ai trace <create|link|grant>``."""
+    match options.subcommand:
+        case "create":
+            handle_create_experiment_command(options)
+        case "link":
+            handle_link_trace_destination_command(options)
+        case "grant":
+            handle_grant_trace_permissions_command(options)
 
 
 def handle_create_experiment_command(options: Namespace) -> None:
@@ -3352,12 +3371,8 @@ def main() -> None:
             handle_doctor_command(options)
         case "schema":
             handle_schema_command(options)
-        case "create-experiment":
-            handle_create_experiment_command(options)
-        case "link-trace-destination":
-            handle_link_trace_destination_command(options)
-        case "grant-trace-permissions":
-            handle_grant_trace_permissions_command(options)
+        case "trace":
+            handle_trace_command(options)
         case "validate":
             handle_validate_command(options)
         case "graph":

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -475,13 +475,6 @@ def _validate_bundle_action_flags(options: Namespace) -> None:
 _BUNDLE_DIR_ENV_VAR = "DAO_AI_BUNDLE_DIR"
 _DEFAULT_BUNDLE_BASE = ".dao-ai/bundle"
 
-# Back-compat: flat `generate-<noun>` commands map to the nested `<noun>
-# generate` verb. main() rewrites options.command via this table before
-# dispatch, so the aliases share the exact generate code path.
-_ALIAS_TO_NOUN: dict[str, str] = {
-    "generate-agent": "agent",
-    "generate-workflow": "workflow",
-}
 
 
 def _default_bundle_base() -> Path:
@@ -993,75 +986,6 @@ Examples:
 """,
     )
 
-    # --- Back-compat flat aliases: `generate-<noun>` == `<noun> generate` -----
-    # Register each as its own top-level parser reusing the same generate-verb
-    # flags (argparse can't alias a flat name onto a nested subcommand). main()
-    # normalizes options.command back to (noun, "generate") before dispatch.
-    for alias, noun in _ALIAS_TO_NOUN.items():
-        alias_parser: ArgumentParser = subparsers.add_parser(
-            alias,
-            help=f"Alias for `dao-ai {noun} generate` (back-compat).",
-            description=f"Deprecated alias for `dao-ai {noun} generate`. "
-            f"Generates the {noun} bundle; supports the same flags.",
-            formatter_class=argparse.RawDescriptionHelpFormatter,
-        )
-        _add_bundle_common_args(alias_parser, kind=noun)
-        _add_bundle_source_args(alias_parser)
-        if noun == "workflow":
-            _add_workflow_target_args(alias_parser)
-        _add_bundle_action_arguments(alias_parser)
-
-    # Deploy command
-    deploy_parser: ArgumentParser = subparsers.add_parser(
-        "deploy",
-        help="Deploy configuration file syntax and semantics",
-        description="""
-Deploy the DAO AI system using the specified configuration file.
-This command validates the configuration and deploys the DAO AI agents, tools, and models to the
-        """,
-        epilog="""
-Examples:
-  dao-ai deploy                                  # Validate default ./config/model_config.yaml
-  dao-ai deploy -c config/production.yaml       # Validate specific config file
-        """,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    deploy_parser.add_argument(
-        "-c",
-        "--config",
-        type=str,
-        required=True,
-        metavar="FILE",
-        help="Path to the model configuration file to deploy.",
-    )
-    deploy_parser.add_argument(
-        "-t",
-        "--target",
-        type=str,
-        choices=["model_serving", "apps", "both"],
-        default=None,
-        help="Deployment target: 'model_serving', 'apps', or 'both'. "
-        "If not specified, uses app.deployment_target from config file, "
-        "or defaults to 'model_serving'.",
-    )
-    _add_profile_argument(deploy_parser)
-    deploy_parser.add_argument(
-        "--development",
-        dest="development",
-        default=None,
-        action="store_true",
-        help="Ship local dao-ai source/wheel instead of the published PyPI "
-        "package (Apps target). Rebuild the wheel first with 'uv build --wheel'. "
-        "Defaults to auto-detect from the install type.",
-    )
-    deploy_parser.add_argument(
-        "--no-development",
-        dest="development",
-        action="store_false",
-        help="Force the published PyPI dao-ai package even from a local/editable "
-        "install (Apps target).",
-    )
-
     # List MCP tools command
     list_mcp_parser: ArgumentParser = subparsers.add_parser(
         "list-mcp-tools",
@@ -1237,7 +1161,6 @@ Examples:
     for sub in (
         validation_parser,
         graph_parser,
-        deploy_parser,
         list_mcp_parser,
         monitor_parser,
         chat_parser,
@@ -1246,7 +1169,7 @@ Examples:
         _add_var_argument(sub)
 
     # Add -p/--profile to the subcommands that touch Databricks but don't
-    # already declare it inline (deploy/create-experiment/link-trace/grant-trace
+    # already declare it inline (create-experiment/link-trace/grant-trace
     # define their own; bundle nouns get it from _add_bundle_common_args).
     # Without it a shell/.env DATABRICKS_* var silently wins — the hijack
     # _apply_profile_context guards.
@@ -1960,62 +1883,6 @@ def handle_graph_command(options: Namespace) -> None:
         sys.exit(1)
     app = create_dao_ai_graph(config)
     save_image(app, options.output)
-
-
-def handle_deploy_command(options: Namespace) -> None:
-    from dao_ai.config import DeploymentTarget
-
-    # Make --profile authoritative for this process before any WorkspaceClient
-    # is constructed. Both the provider's ``self.w`` and the bare
-    # ``WorkspaceClient()`` instances in the grant helpers read
-    # ``DATABRICKS_CONFIG_PROFILE``, so this routes the whole deploy — log,
-    # register, deploy, and the SP grants — at the selected profile.
-    _apply_profile_context(options.profile)
-
-    logger.debug(f"Validating configuration from {options.config}...")
-    try:
-        try:
-            config: AppConfig = AppConfig.from_file(
-                options.config, params=_parse_var_args(options.var)
-            )
-        except ConfigVariableError as e:
-            _print_config_variable_error(e)
-            sys.exit(1)
-
-        # Hybrid target resolution:
-        # 1. CLI --target takes precedence
-        # 2. Fall back to config.app.deployment_target
-        # 3. Default to MODEL_SERVING (handled in deploy_agent)
-        target: DeploymentTarget | None = None
-        if options.target is not None:
-            target = DeploymentTarget(options.target)
-            logger.info(f"Using CLI-specified deployment target: {target.value}")
-        elif config.app is not None and config.app.deployment_target is not None:
-            target = config.app.deployment_target
-            logger.info(f"Using config file deployment target: {target.value}")
-        else:
-            logger.info("No deployment target specified, defaulting to model_serving")
-
-        # Only log/register the MLflow model for Model Serving deployments.
-        # Apps deploy directly from the config + wheel/PyPI package.
-        development: bool | None = getattr(options, "development", None)
-        if target != DeploymentTarget.APPS:
-            config.create_agent(development=development)
-        config.deploy_agent(target=target, development=development)
-
-        # Surface a link to whatever was deployed (matches the generate-*
-        # commands). `both` prints both; model_serving is the default when no
-        # target resolved. Best-effort — never fails the deploy.
-        resolved = target or DeploymentTarget.MODEL_SERVING
-        if config.app is not None:
-            if resolved in (DeploymentTarget.MODEL_SERVING, DeploymentTarget.BOTH):
-                _print_endpoint_link(config.app.endpoint_name)
-            if resolved in (DeploymentTarget.APPS, DeploymentTarget.BOTH):
-                _print_app_link(config.app.name.lower().replace("_", "-"))
-        sys.exit(0)
-    except Exception as e:
-        logger.error(f"Deployment failed: {e}")
-        sys.exit(1)
 
 
 def handle_monitor_command(options: Namespace) -> None:
@@ -3503,13 +3370,7 @@ def main() -> None:
     options: argparse.Namespace = parse_args(sys.argv[1:])
     setup_logging(options.verbose)
 
-    # Normalize the flat `generate-<noun>` aliases to the nested `<noun>
-    # generate` form so they share the exact per-noun handler code path.
     command: str = options.command
-    if command in _ALIAS_TO_NOUN:
-        options.subcommand = "generate"
-        command = _ALIAS_TO_NOUN[command]
-
     match command:
         case "version":
             handle_version_command(options)
@@ -3531,8 +3392,6 @@ def main() -> None:
             handle_agent_command(options)
         case "workflow":
             handle_workflow_command(options)
-        case "deploy":
-            handle_deploy_command(options)
         case "monitor":
             handle_monitor_command(options)
         case "chat":

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -3099,6 +3099,11 @@ def _deploy_run_destroy_app_bundle(
 
         config: AppConfig = _load_app_config(options, what=what)
         development: bool = resolve_use_local_source(getattr(options, "development", None))
+        # Model Serving deploys a REGISTERED MLflow model, so log/register the
+        # current config first (mirrors the workflow deploy notebook + the former
+        # `dao-ai deploy` handler). Without this, deploy_model_serving_agent
+        # deploys a stale-or-nonexistent model version.
+        config.create_agent(development=development)
         config.deploy_agent(target=DeploymentTarget.MODEL_SERVING, development=development)
         return
 
@@ -3108,6 +3113,9 @@ def _deploy_run_destroy_app_bundle(
 
         config = _load_app_config(options, what=what)
         development = resolve_use_local_source(getattr(options, "development", None))
+        # Apps/MCP deploy directly from config + wheel (no MLflow model to
+        # register — matches the former `if target != APPS: create_agent()`
+        # gate). model_serving is handled by Route 1 above, so mode is apps|mcp here.
         config.deploy_agent(
             target=DeploymentTarget(mode),
             development=development,

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -392,16 +392,21 @@ def _add_mode_argument(parser: ArgumentParser, *, choices: list[str]) -> None:
     canonical value is valid and normalized in :func:`parse_args`.
     """
     accepted: list[str] = _canonical_modes(choices)
+    _mode_choices_str = " | ".join(choices)
+    _mode_aliases_note = (
+        " Aliases accepted for model_serving: ms, model-serving."
+        if "model_serving" in choices
+        else ""
+    )
     parser.add_argument(
         "-m",
         "--mode",
         choices=accepted,
         default="apps",
         metavar="{" + ",".join(choices) + "}",
-        help="How to serve the agent: "
-        + " | ".join(choices)
-        + " (default: apps)."
-        + (" Aliases: ms/model-serving." if "model_serving" in choices else ""),
+        help=(
+            f"Serving target: {_mode_choices_str} (default: apps).{_mode_aliases_note}"
+        ),
     )
 
 
@@ -409,15 +414,17 @@ def _add_noun_verb_parsers(
     subparsers: "argparse._SubParsersAction",
     *,
     noun: str,
+    noun_description: str,
+    noun_epilog: str,
     generate_description: str,
     generate_epilog: str,
     parents: list[ArgumentParser],
 ) -> None:
     """Register the generate/deploy/run/destroy verb parsers for one noun.
 
-    ``noun`` is ``"agent"``/``"mcp"``/``"workflow"``. The ``generate`` verb
-    carries the source flags (+ one-shot --deploy/--run/--destroy) and inherits
-    the noun's rich help; deploy/run/destroy carry only the common args. The
+    ``noun`` is ``"agent"``/``"workflow"``. The ``generate`` verb carries
+    the source flags (+ one-shot --deploy/--run/--destroy) and inherits the
+    noun's rich help; deploy/run/destroy carry only the common args. The
     workflow noun additionally gets target/cloud flags on every verb.
     ``parents`` is forwarded to every ``add_parser`` call so the global
     ``-p/--profile`` and ``-v/--verbose`` flags are accepted at each level.
@@ -427,7 +434,8 @@ def _add_noun_verb_parsers(
     parser: ArgumentParser = subparsers.add_parser(
         noun,
         help=f"Manage the {noun} bundle (generate | deploy | run | destroy)",
-        description=generate_description,
+        description=noun_description,
+        epilog=noun_epilog,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         parents=parents,
     )
@@ -451,15 +459,27 @@ def _add_noun_verb_parsers(
     _add_bundle_action_arguments(generate_parser)
 
     for verb, verb_help in (
-        ("deploy", f"Deploy the already-staged {noun} bundle (no regenerate)"),
+        (
+            "deploy",
+            f"Deploy the {noun} bundle — auto-generates if nothing is staged",
+        ),
         ("run", f"Run the deployed {noun} bundle"),
         ("destroy", f"Destroy the deployed {noun} bundle"),
     ):
+        _deploy_desc = (
+            f"Deploy the {noun} bundle to Databricks. When a staged bundle exists "
+            f"(written by `dao-ai {noun} generate`) it is deployed in place, "
+            f"preserving any hand-edits. When nothing is staged, the bundle is "
+            f"generated first automatically. Use `--mode` to select the serving "
+            f"target (apps | mcp | model_serving; default: apps)."
+        )
         verb_parser: ArgumentParser = verbs.add_parser(
             verb,
             help=verb_help,
-            description=f"{verb_help}. Acts on the staging dir written by "
-            f"`dao-ai {noun} generate` (or -o); errors if nothing is staged.",
+            description=_deploy_desc if verb == "deploy" else (
+                f"{verb_help}. Acts on the staging dir written by "
+                f"`dao-ai {noun} generate` (or -o); errors if nothing is staged."
+            ),
             parents=parents,
         )
         _add_bundle_common_args(verb_parser, kind=noun)
@@ -641,17 +661,34 @@ def parse_args(args: Sequence[str]) -> Namespace:
 
     parser: ArgumentParser = ArgumentParser(
         prog="dao-ai",
-        description="DAO AI Agent Command Line Interface - A comprehensive tool for managing, validating, and visualizing multi-agent DAO AI systems",
+        description="Build and operate multi-agent AI systems on Databricks.",
         epilog="""
-Examples:
-  dao-ai schema                                          # Generate JSON schema for configuration validation
-  dao-ai validate -c config/model_config.yaml            # Validate a specific configuration file
-  dao-ai graph -o architecture.png -c my_config.yaml -v  # Generate visual graph with verbose output
-  dao-ai chat -c config/retail.yaml --custom-input store_num=87887  # Start interactive chat session
-  dao-ai tools -c config/mcp_config.yaml --apply-filters  # List filtered MCP tools only
-  dao-ai validate                                        # Validate with detailed logging
-  dao-ai workflow generate -c my_config.yaml --deploy    # Provision infra + deploy the agent (Workflow Job)
-  dao-ai agent generate -c my_config.yaml --deploy --run # Generate + deploy + start the agent App
+Getting started:
+  dao-ai agent generate -c config.yaml --deploy --run -p fevm   # generate + deploy + start in one shot
+  dao-ai agent deploy   -c config.yaml -p fevm                  # deploy staged bundle (auto-generates if unstaged)
+
+Deploy an agent:
+  dao-ai agent generate -c config.yaml --deploy --run -p fevm          # one-shot: generate → deploy → run (Apps)
+  dao-ai agent deploy   -c config.yaml --mode model_serving -p fevm    # deploy to Model Serving endpoint
+  dao-ai agent deploy   -c config.yaml -m ms -p fevm                   # same, using -m ms alias
+  dao-ai agent deploy   -c config.yaml --mode mcp -p fevm              # deploy as MCP server
+  dao-ai agent deploy   -c config.yaml --direct -p fevm                # SDK fast-path (no bundle on disk)
+  dao-ai -p fevm agent deploy -c config.yaml                           # -p accepted at top level too
+
+Provision infrastructure:
+  dao-ai workflow generate -c config.yaml --deploy -p fevm      # provision infra (VS, Lakebase, Genie…) + deploy
+  dao-ai workflow run      -c config.yaml -p fevm                # run the staged provisioning job
+
+Trace & experiments:
+  dao-ai trace create --name /Shared/team/traces -p fevm
+  dao-ai trace link   -c config.yaml -p fevm
+  dao-ai trace grant  -c config.yaml -p fevm
+
+Inspect & utilities:
+  dao-ai tools      -c config.yaml                 # list MCP tools visible to agents
+  dao-ai validate   -c config.yaml                 # validate config syntax + semantics
+  dao-ai parameters list -c config.yaml            # show declared parameters + resolved values
+  dao-ai schema                                    # dump JSON schema for IDE validation
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         parents=[_GLOBAL],
@@ -735,6 +772,21 @@ Examples:
     trace_parser: ArgumentParser = subparsers.add_parser(
         "trace",
         help="Manage MLflow experiments and UC trace destinations (create | link | grant)",
+        description="Manage MLflow experiments and Unity Catalog trace destinations for deployed agents.",
+        epilog="""
+Examples:
+  # Provision a new experiment (create-if-missing)
+  dao-ai trace create --name /Shared/team/traces -p fevm
+
+  # Link experiment to its UC trace destination (run after bundle deploy, before bundle run)
+  dao-ai trace link -c config.yaml -p fevm
+
+  # Grant an already-deployed App SP its trace-write permissions retroactively
+  dao-ai trace grant -c config.yaml -p fevm
+
+  # Explicit experiment lookup by id
+  dao-ai trace create --id 1952423719449237 --output json -p fevm
+        """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         parents=[_GLOBAL],
     )
@@ -983,74 +1035,87 @@ Examples:
     # discrete verbs. generate stages (and can one-shot --deploy/--run); deploy/
     # run/destroy act on the already-staged dir without regenerating it.
     _WORKFLOW_DESC = """
-Manage the DAO AI provisioning Workflow — a multi-task Databricks Job (Lakeflow
-Workflow) that provisions the backing infra (schemas, Vector Search, Lakebase,
-Genie, UC functions), deploys the agent, and runs evaluation. Emits a
-self-contained Databricks Asset Bundle and wraps `databricks bundle
-deploy/run/destroy`. (This is a Job/Workflow, not a Lakeflow Declarative
-Pipeline.) Sibling of `agent`.
+Manage the provisioning Workflow — a Databricks Job (Lakeflow Workflow) that
+provisions backing infrastructure (schemas, Vector Search, Lakebase, Genie, UC
+functions), deploys the agent, and runs evaluation. Emits a self-contained
+Databricks Asset Bundle.
+"""
+    _WORKFLOW_EPILOG = """
+Examples:
+  # Provision infra + deploy the workflow job in one shot
+  dao-ai workflow generate -c config.yaml --deploy -p fevm
+
+  # Run the already-deployed provisioning job
+  dao-ai workflow run -c config.yaml -p fevm
+
+  # Generate bundle only, inspect, then deploy manually
+  dao-ai workflow generate -c config.yaml
+  dao-ai workflow deploy   -c config.yaml -p fevm
 """
     _AGENT_DESC = """
-Manage the agent's Databricks Apps bundle. `generate` writes a complete,
-deployable bundle directory (databricks.yaml, app.yaml, pyproject.toml, and
-scaffolding) from a dao-ai config; `deploy`/`run`/`destroy` act on that staged
-bundle. Use `--mode mcp` to generate/deploy the MCP-server bundle instead.
+Manage the agent bundle — a Databricks App (or MCP server / Model Serving
+endpoint). `generate` writes a deployable Databricks Asset Bundle; `deploy`
+ships it to Databricks. `deploy` auto-generates when nothing is staged so a
+single command covers both steps.
+"""
+    _AGENT_EPILOG = """
+Examples:
+  # One-shot: generate bundle → deploy → start the App
+  dao-ai agent generate -c config.yaml --deploy --run -p fevm
+
+  # Deploy staged bundle (auto-generates if nothing is staged yet)
+  dao-ai agent deploy -c config.yaml -p fevm
+
+  # Deploy to Model Serving endpoint; -m ms is an accepted alias
+  dao-ai agent deploy -c config.yaml --mode model_serving -p fevm
+  dao-ai agent deploy -c config.yaml -m ms -p fevm
+
+  # Deploy as MCP server
+  dao-ai agent deploy -c config.yaml --mode mcp -p fevm
+
+  # SDK fast-path: deploy without writing a bundle to disk (apps/mcp only)
+  dao-ai agent deploy -c config.yaml --direct -p fevm
+
+  # Pass -p at the top level (equivalent)
+  dao-ai -p fevm agent deploy -c config.yaml
 """
 
     _add_noun_verb_parsers(
         subparsers,
         noun="agent",
+        noun_description=_AGENT_DESC,
+        noun_epilog=_AGENT_EPILOG,
         generate_description=_AGENT_DESC,
-        generate_epilog="""
-Examples:
-  dao-ai agent generate -c config/retail.yaml
-  dao-ai agent generate -c config/retail.yaml --deploy --run -p fevm
-  dao-ai agent generate -c config/retail.yaml --mode mcp  # MCP-server bundle
-  dao-ai agent deploy   -c config/retail.yaml -p fevm      # ship staged bundle
-""",
+        generate_epilog=_AGENT_EPILOG,
         parents=[_GLOBAL],
     )
     _add_noun_verb_parsers(
         subparsers,
         noun="workflow",
+        noun_description=_WORKFLOW_DESC,
+        noun_epilog=_WORKFLOW_EPILOG,
         generate_description=_WORKFLOW_DESC,
-        generate_epilog="""
-Examples:
-  dao-ai workflow generate -c config/retail.yaml --deploy
-  dao-ai workflow run      -c config/retail.yaml   # run staged provisioning job
-""",
+        generate_epilog=_WORKFLOW_EPILOG,
         parents=[_GLOBAL],
     )
 
     # List MCP tools command
     list_mcp_parser: ArgumentParser = subparsers.add_parser(
         "tools",
-        help="List available MCP tools from configuration",
+        help="List MCP tools visible to agents in a configuration",
         description="""
-List all available MCP tools from the configured MCP servers.
-This command shows:
-- All MCP servers/functions in the configuration
-- Available tools from each server
-- Full descriptions for each tool (no truncation)
-- Tool parameters in readable format (type, required/optional, descriptions)
-- Which tools are included/excluded based on filters
-- Filter patterns (include_tools, exclude_tools)
+List the MCP tools declared in a dao-ai config. Shows each tool's name,
+description, parameter schema, and include/exclude filter status. Useful for
+verifying connectivity and discovering tool names before writing agent configs.
 
-Use this command to:
-- Discover available tools before configuring agents
-- Review tool descriptions and parameter schemas
-- Debug tool filtering configuration
-- Verify MCP server connectivity
-
-Options:
-- Use --apply-filters to only show tools that will be loaded (hides excluded tools)
-- Without --apply-filters, see all available tools with include/exclude status
-
-Note: Schemas are displayed in a concise, readable format instead of verbose JSON
+Use --apply-filters to see only the tools that will actually be loaded (hides
+excluded tools). Without it, all available tools are shown with filter status.
         """,
-        epilog="""Examples:
-  dao-ai tools -c config/model_config.yaml
-  dao-ai tools -c config/model_config.yaml --apply-filters
+        epilog="""
+Examples:
+  dao-ai tools -c config.yaml                     # list all tools + filter status
+  dao-ai tools -c config.yaml --apply-filters     # only show tools that pass filters
+  dao-ai tools -c config.yaml -p fevm             # use a specific Databricks profile
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         parents=[_GLOBAL],

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -713,6 +713,11 @@ Trace & experiments:
   dao-ai trace link   -c config.yaml -p fevm
   dao-ai trace grant  -c config.yaml -p fevm
 
+Production monitoring:
+  dao-ai monitor scorers enable  -c config.yaml -p fevm         # register + start monitoring scorers
+  dao-ai monitor scorers status  -c config.yaml -p fevm         # list active scorers
+  dao-ai monitor scorers disable -c config.yaml -p fevm         # stop all monitoring scorers
+
 Inspect & utilities:
   dao-ai tools      -c config.yaml                 # list MCP tools visible to agents
   dao-ai validate   -c config.yaml                 # validate config syntax + semantics
@@ -1166,24 +1171,47 @@ Examples:
     # Monitor command
     monitor_parser: ArgumentParser = subparsers.add_parser(
         "monitor",
-        help="Manage production monitoring scorers",
+        help="Manage production monitoring for the deployed agent (scorers)",
         description="""
-Manage production monitoring scorers for the deployed agent.
-Scorers continuously evaluate production traces for quality,
-safety, and guideline compliance.
+Manage production monitoring for the deployed agent.
+
+Currently exposes the `scorers` sub-group, which registers, inspects, and
+stops MLflow monitoring scorers that continuously evaluate production traces
+for quality, safety, and guideline compliance.
 
 Requires app.monitoring to be configured in the YAML config.
         """,
         epilog="""
 Examples:
-  dao-ai monitor enable -c config/model_config.yaml     # Register and start monitoring scorers
-  dao-ai monitor status -c config/model_config.yaml     # Show active scorers and sample rates
-  dao-ai monitor disable -c config/model_config.yaml    # Stop all monitoring scorers
+  dao-ai monitor scorers enable -c config/model_config.yaml    # Register and start monitoring scorers
+  dao-ai monitor scorers status -c config/model_config.yaml    # Show active scorers and sample rates
+  dao-ai monitor scorers disable -c config/model_config.yaml   # Stop all monitoring scorers
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         parents=[_GLOBAL],
     )
-    monitor_parser.add_argument(
+    monitor_verbs = monitor_parser.add_subparsers(dest="subcommand", required=True)
+
+    monitor_scorers_parser: ArgumentParser = monitor_verbs.add_parser(
+        "scorers",
+        help="Register, inspect, or stop MLflow monitoring scorers",
+        description="""
+Manage MLflow production monitoring scorers for the deployed agent.
+Scorers continuously evaluate production traces for quality, safety, and
+guideline compliance.
+
+Requires app.monitoring to be configured in the YAML config.
+        """,
+        epilog="""
+Examples:
+  dao-ai monitor scorers enable -c config/model_config.yaml    # Register and start monitoring scorers
+  dao-ai monitor scorers status -c config/model_config.yaml    # Show active scorers and sample rates
+  dao-ai monitor scorers disable -c config/model_config.yaml   # Stop all monitoring scorers
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_GLOBAL],
+    )
+    monitor_scorers_parser.add_argument(
         "-c",
         "--config",
         type=str,
@@ -1191,10 +1219,10 @@ Examples:
         metavar="FILE",
         help="Path to the model configuration file",
     )
-    monitor_parser.add_argument(
+    monitor_scorers_parser.add_argument(
         "action",
         choices=["enable", "status", "disable"],
-        help="Monitoring action: enable (register/start scorers), "
+        help="Scorers action: enable (register/start scorers), "
         "status (list active scorers), disable (stop all scorers)",
     )
 
@@ -1296,7 +1324,7 @@ Examples:
         validation_parser,
         graph_parser,
         list_mcp_parser,
-        monitor_parser,
+        monitor_scorers_parser,
         chat_parser,
         vars_parser,
     ):
@@ -2030,7 +2058,18 @@ def handle_graph_command(options: Namespace) -> None:
 
 
 def handle_monitor_command(options: Namespace) -> None:
+    """Dispatch `dao-ai monitor <scorers>`.
+
+    ``scorers enable|status|disable`` manages MLflow production monitoring
+    scorers. (Runtime log/metrics sub-groups are intentionally absent: the
+    Databricks Apps platform exposes no logs or memory/CPU metrics API — see
+    the vault note ``dao-ai-monitor-observability-api-gap``.)
+    """
     from dao_ai.providers.databricks import DatabricksProvider
+
+    if options.subcommand != "scorers":
+        logger.error(f"Unknown monitor sub-command: {options.subcommand}")
+        sys.exit(1)
 
     _apply_profile_context(options.profile)
     logger.debug(f"Loading configuration from {options.config}...")

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -1,6 +1,7 @@
 # PYTHON_ARGCOMPLETE_OK
 import argparse
 import getpass
+import hashlib
 import json
 import os
 import shutil
@@ -535,17 +536,46 @@ def _default_bundle_dir(kind: str, app_name: str) -> Path:
 _STAGING_MARKER = ".dao-ai-generated"
 
 
-def _write_staging_marker(bundle_dir: Path, *, is_default: bool) -> None:
+def _config_fingerprint(config: AppConfig, *, development: bool) -> str:
+    """Stable hash of the config content that determines the generated bundle.
+
+    Computed from the UNRESOLVED config (``model_dump`` with no network resource
+    resolution) plus the resolved ``development`` source-selection flag — the two
+    inputs the bundle writer consumes. MUST be taken before
+    ``config._resolve_all_resources()`` mutates the config in place, so the
+    generate-time stamp and the deploy-time check hash identical inputs.
+
+    Stamped into the staging marker so ``deploy``/``up`` can tell when the source
+    config changed since the bundle was last generated (see
+    :func:`_staged_config_is_stale`) and re-stage instead of silently shipping a
+    stale bundle.
+    """
+    payload: str = json.dumps(
+        {"config": config.model_dump(mode="json"), "development": development},
+        sort_keys=True,
+        default=str,
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def _write_staging_marker(
+    bundle_dir: Path, *, is_default: bool, fingerprint: str = ""
+) -> None:
     """Stamp a default staging dir as freshly dao-ai-generated.
 
     Only marks a dao-ai-owned default dir (never a user ``-o`` dir). Written
     LAST, after the writer, so its mtime post-dates every generated file; a
     later hand-edit then shows an mtime newer than the marker, which
     :func:`_clean_default_staging_dir` uses to protect edits from a re-generate.
+
+    ``fingerprint`` (from :func:`_config_fingerprint`) records the source config
+    the bundle was generated from; :func:`_staged_config_is_stale` reads it back
+    to detect config drift. App bundles pass it; the workflow bundle omits it
+    (empty marker) since ``workflow up`` always re-stages.
     """
     if not is_default or not bundle_dir.exists():
         return
-    (bundle_dir / _STAGING_MARKER).write_text("")
+    (bundle_dir / _STAGING_MARKER).write_text(fingerprint)
 
 
 def _staging_dir_has_local_edits(bundle_dir: Path) -> bool:
@@ -565,6 +595,25 @@ def _staging_dir_has_local_edits(bundle_dir: Path) -> bool:
         if path.stat().st_mtime > marker_mtime:
             return True
     return False
+
+
+def _staged_config_is_stale(bundle_dir: Path, fingerprint: str) -> bool:
+    """True if the staged bundle was generated from a different source config.
+
+    Compares ``fingerprint`` (the current config, from
+    :func:`_config_fingerprint`) against the value stamped into the
+    ``.dao-ai-generated`` marker at generate time. A missing or empty marker (a
+    legacy dir or a workflow bundle) returns False: there is no recorded
+    fingerprint to contradict, and :func:`_staging_dir_has_local_edits` already
+    guards those dirs from an unwanted regenerate.
+    """
+    marker: Path = bundle_dir / _STAGING_MARKER
+    if not marker.exists():
+        return False
+    staged: str = marker.read_text().strip()
+    if not staged:
+        return False
+    return staged != fingerprint
 
 
 def _clean_default_staging_dir(
@@ -3103,6 +3152,7 @@ def _stage_app_bundle(
     development: bool,
     overwrite: bool,
     noun: str,
+    fingerprint: str,
 ) -> None:
     """Write bundle files to *bundle_dir* (clean → write → marker).
 
@@ -3111,6 +3161,10 @@ def _stage_app_bundle(
     :func:`_run_bundle_actions` themselves.  Extracted so the ``deploy``
     auto-generate path can stage without risking recursion through
     ``_run_bundle_actions``.
+
+    ``fingerprint`` is the current config's hash (:func:`_config_fingerprint`),
+    computed by the caller BEFORE ``config._resolve_all_resources()`` and stamped
+    into the marker so a later ``deploy`` can detect source-config drift.
     """
     logger.debug(f"Staging {noun} bundle to {bundle_dir}...")
     # Regenerate the owned default dir from scratch so a prior --development run
@@ -3120,7 +3174,9 @@ def _stage_app_bundle(
         bundle_dir, is_default=is_default_dir, overwrite=overwrite, noun=noun
     )
     writer(config, bundle_dir, overwrite=overwrite, development=development)
-    _write_staging_marker(bundle_dir, is_default=is_default_dir)
+    _write_staging_marker(
+        bundle_dir, is_default=is_default_dir, fingerprint=fingerprint
+    )
 
 
 def _generate_app_bundle(options: Namespace, *, kind: str, writer, what: str) -> None:
@@ -3140,6 +3196,11 @@ def _generate_app_bundle(options: Namespace, *, kind: str, writer, what: str) ->
     development: bool = resolve_use_local_source(options.development)
     config: AppConfig = _load_app_config(options, what=what)
 
+    # Fingerprint the UNRESOLVED config before _resolve_all_resources() mutates
+    # it, so the stamp matches the deploy-time staleness check (which also hashes
+    # the unresolved config).
+    fingerprint: str = _config_fingerprint(config, development=development)
+
     # Resolve resources so Genie room tables and warehouses can be discovered.
     config._resolve_all_resources()
 
@@ -3152,6 +3213,7 @@ def _generate_app_bundle(options: Namespace, *, kind: str, writer, what: str) ->
         development=development,
         overwrite=options.overwrite,
         noun=kind,
+        fingerprint=fingerprint,
     )
 
 
@@ -3215,35 +3277,71 @@ def _deploy_run_destroy_app_bundle(
     # --- Route 3: bundle path ---
     config = _load_app_config(options, what=what)
     bundle_dir, is_default_dir = _resolve_bundle_dir(kind, config, options.output_dir)
+    is_staged: bool = (bundle_dir / "databricks.yaml").exists()
 
-    if not (bundle_dir / "databricks.yaml").exists():
-        if deploy:
-            # Auto-generate (CDK/SAM norm): stage the bundle, then fall through
-            # to deploy_app_bundle below.  run/destroy still error — nothing to
-            # run or destroy if the bundle was never staged.
-            logger.info(
-                f"No staged {kind} bundle at {bundle_dir}; auto-generating before deploy."
+    if not is_staged and not deploy:
+        # run/destroy on an unstaged dir: nothing to act on.
+        logger.error(
+            f"No staged {kind} bundle at {bundle_dir}. "
+            f"Run `dao-ai {kind} generate -c {options.config}"
+            f"{f' -o {options.output_dir}' if options.output_dir else ''}` first."
+        )
+        sys.exit(1)
+
+    if deploy:
+        development = resolve_use_local_source(options.development)
+        overwrite: bool = options.overwrite
+        # Fingerprint the UNRESOLVED config (matches the generate-time stamp).
+        fingerprint: str = _config_fingerprint(config, development=development)
+
+        # Decide whether to (re)stage. Fresh dir → stage (CDK/SAM auto-generate
+        # norm). Already staged → stage only when the source config drifted from
+        # the staged fingerprint, and only if the dir carries no hand-edits (or
+        # --overwrite). A stale bundle with hand-edits deploys in place with a
+        # warning so the user's edits win but they're told source changes aren't
+        # reflected. run/destroy never reach here unstaged (guarded above).
+        should_stage: bool = not is_staged
+        if is_staged and _staged_config_is_stale(bundle_dir, fingerprint):
+            # Only a dao-ai-owned default dir is safe to regenerate; a user `-o`
+            # dir is never touched. --overwrite forces regen even over hand-edits;
+            # otherwise a clean default dir regenerates and an edited one is left
+            # in place with a warning so the user's edits win.
+            can_regen: bool = is_default_dir and (
+                overwrite or not _staging_dir_has_local_edits(bundle_dir)
             )
+            if can_regen:
+                logger.info(
+                    f"Source config changed since {bundle_dir} was generated; "
+                    f"regenerating the {kind} bundle before deploy."
+                )
+                should_stage = True
+            else:
+                logger.warning(
+                    f"Source config changed since {bundle_dir} was generated, but "
+                    f"the staging dir has local edits — deploying it as-is. Pass "
+                    f"--overwrite (or re-run `dao-ai {kind} generate --overwrite`) "
+                    f"to discard the edits and regenerate from the current config."
+                )
+
+        if should_stage:
+            if not is_staged:
+                logger.info(
+                    f"No staged {kind} bundle at {bundle_dir}; "
+                    f"auto-generating before deploy."
+                )
             # Resolve resources so Genie room tables and warehouses can be discovered.
             config._resolve_all_resources()
             writer: Callable[..., None] = _mode_writer(mode)
-            development = resolve_use_local_source(getattr(options, "development", None))
             _stage_app_bundle(
                 config,
                 bundle_dir,
                 is_default_dir=is_default_dir,
                 writer=writer,
                 development=development,
-                overwrite=getattr(options, "overwrite", False),
+                overwrite=overwrite,
                 noun=kind,
+                fingerprint=fingerprint,
             )
-        else:
-            logger.error(
-                f"No staged {kind} bundle at {bundle_dir}. "
-                f"Run `dao-ai {kind} generate -c {options.config}"
-                f"{f' -o {options.output_dir}' if options.output_dir else ''}` first."
-            )
-            sys.exit(1)
 
     dry_run: bool = options.dry_run
     if run and not deploy and not destroy and not dry_run:

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -491,6 +491,11 @@ def _add_noun_verb_parsers(
             _add_workflow_target_args(verb_parser)
         if verb == "deploy":
             _add_mode_argument(verb_parser, choices=["model_serving", "apps", "mcp"])
+            # Source-selection flags: deploy can auto-generate (needs development
+            # for the bundle writer) and handles --mode model_serving (needs
+            # development for create_agent/deploy_agent). run/destroy act on
+            # already-built artifacts so source flags are omitted there.
+            _add_bundle_source_args(verb_parser)
         else:
             _add_mode_argument(verb_parser, choices=["apps", "mcp"])
 

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -57,7 +57,7 @@ def _apply_profile_context(profile: Optional[str]) -> None:
     # the profile's ``databricks-cli`` (OAuth U2M) auth.
     #
     # Why: OAuth U2M mints tokens by forking the ``databricks`` binary. During
-    # ``dao-ai deploy``, MLflow's ``log_model`` validation runs the full agent
+    # ``dao-ai agent deploy``, MLflow's ``log_model`` validation runs the full agent
     # in-process (LLMs, tools, tracing) with live gRPC channels / threads, and
     # any SDK token refresh then forks unsafely — producing
     # ``forced token refresh: cache update: exit status 45`` and a ``401`` that
@@ -596,8 +596,8 @@ Examples:
   dao-ai chat -c config/retail.yaml --custom-input store_num=87887  # Start interactive chat session
   dao-ai tools -c config/mcp_config.yaml --apply-filters  # List filtered MCP tools only
   dao-ai validate                                        # Validate with detailed logging
-  dao-ai generate-workflow -c my_config.yaml --deploy    # Provision infra + deploy the agent (Workflow Job)
-  dao-ai generate-agent -c my_config.yaml --deploy --run # Generate + deploy + start the agent App
+  dao-ai workflow generate -c my_config.yaml --deploy    # Provision infra + deploy the agent (Workflow Job)
+  dao-ai agent generate -c my_config.yaml --deploy --run # Generate + deploy + start the agent App
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -696,7 +696,7 @@ Examples:
 Provision or resolve an MLflow experiment on Databricks and print the
 resulting id + metadata. Delegates to
 ``DatabricksProvider.create_experiment`` — same code path used by
-``dao-ai deploy`` when it resolves ``app.experiment`` from a config.
+``dao-ai agent deploy`` when it resolves ``app.experiment`` from a config.
 
 Pass ``--name`` for create-if-missing behavior (default) or ``--id``
 to verify an existing experiment. Exactly one of the two is required.
@@ -762,7 +762,7 @@ Experiment resolution order:
   1. ``--experiment-id`` flag (explicit override)
   2. ``config.app.experiment.resolved_id`` if ``experiment:`` is set
   3. Bundle-declared experiment name (``/Users/<current-user>/<app-name>``)
-     looked up via MlflowClient — matches what dao-ai generate-agent
+     looked up via MlflowClient — matches what dao-ai agent generate
      writes for the auto-declared experiment path.
 
 No-op when ``config.app.trace_location`` is not set.
@@ -841,9 +841,9 @@ Grant the experiment ``CAN_EDIT`` ACL and the UC OTEL trace-table
 MLflow tracing needs at runtime to persist traces into a UC-backed
 experiment's OTEL Delta tables.
 
-Standalone counterpart to the grant step that ``dao-ai deploy`` / ``dao-ai
-pipeline`` runs automatically inside ``deploy_app_agent`` /
-``deploy_model_serving_agent``. Useful for the ``generate-agent`` + ``bundle
+Standalone counterpart to the grant step that ``dao-ai agent deploy`` /
+``dao-ai workflow`` runs automatically inside ``deploy_app_agent`` /
+``deploy_model_serving_agent``. Useful for the ``agent generate`` + ``bundle
 deploy`` + ``dao-ai trace link`` flow (where no full deploy fires),
 or for retroactively fixing grants when an app was deployed by an
 identity that lacked GRANT rights.
@@ -1625,8 +1625,8 @@ def handle_link_trace_destination_command(options: Namespace) -> None:
     SELECT+MODIFY privileges MLflow tracing needs — matching the grant
     step that ``dao-ai deploy_app_agent`` / ``deploy_model_serving_agent``
     perform automatically on their own deploy paths. Without this the
-    bundle-based flow (``generate-agent`` + ``bundle deploy`` +
-    ``link-trace-destination``) leaves the App SP without table-write
+    bundle-based flow (``agent generate`` + ``bundle deploy`` +
+    ``dao-ai trace link``) leaves the App SP without table-write
     permissions and traces are silently dropped at runtime.
     """
     _apply_profile_context(options.profile)
@@ -1720,8 +1720,8 @@ def _grant_trace_writes_to_app_sp(
 ) -> None:
     """Resolve the App SP and grant it the trace-write privileges.
 
-    Shared implementation for ``link-trace-destination`` (post-link grant)
-    and ``grant-trace-permissions`` (standalone). Respects
+    Shared implementation for ``dao-ai trace link`` (post-link grant)
+    and ``dao-ai trace grant`` (standalone). Respects
     ``config.app.manage_permissions`` — when False, skips silently on the
     assumption that an admin has pre-provisioned grants.
 
@@ -1803,7 +1803,7 @@ def _resolve_experiment_id_for_link(
     config: AppConfig,
     override: Optional[str],
 ) -> Optional[str]:
-    """Resolve the MLflow experiment id for link-trace-destination.
+    """Resolve the MLflow experiment id for dao-ai trace link.
 
     Resolution order:
       1. ``override`` from ``--experiment-id`` flag.
@@ -1825,7 +1825,7 @@ def _resolve_experiment_id_for_link(
             return resolved
         print(
             "app.experiment is set but resolved_id is None — pass "
-            "--experiment-id explicitly or run `dao-ai create-experiment` first.",
+            "--experiment-id explicitly or run `dao-ai trace create` first.",
             file=sys.stderr,
         )
         return None
@@ -2370,8 +2370,8 @@ def _exec_bundle_command(
 ) -> None:
     """Run ``databricks bundle <command>`` from ``cwd`` and stream its output.
 
-    Shared executor for every dao-ai DAB generator (``generate-agent``,
-    ``generate-mcp``, ``generate-workflow``). Assembles ``databricks [--profile P]
+    Shared executor for every dao-ai DAB generator (``agent generate``,
+    ``agent generate --mode mcp``, ``workflow generate``). Assembles ``databricks [--profile P]
     <command...> [--target T] [--var ...]``, runs it with ``cwd`` set to the
     staged/generated bundle dir, streams stdout, and ``sys.exit(1)`` on failure.
 
@@ -2642,7 +2642,7 @@ def run_databricks_command(
     extra_vars.append(f'--var="dao_ai_dep={dao_ai_dep}"')
 
     # command=None -> stage-only (generate the bundle, don't run a bundle verb).
-    # This is what `generate-workflow` with no --deploy/--run/--destroy does.
+    # This is what `workflow generate` with no --deploy/--run/--destroy does.
     if command is None:
         logger.info(f"Workflow bundle staged in {staging_dir}")
         return
@@ -2710,7 +2710,7 @@ def _link_and_grant_trace(
     """Link the experiment trace destination and grant the App SP, if configured.
 
     No-op unless ``config.app.trace_location`` is set. Runs the same logic as
-    ``dao-ai link-trace-destination`` (which also grants) — it MUST run after
+    ``dao-ai trace link`` (which also grants) — it MUST run after
     ``bundle deploy`` (the experiment + app exist) and before ``bundle run``
     (the app's own runtime link is rejected on re-deploys with "already contains
     traces", causing silent trace loss). Reuses the existing helpers so there is
@@ -2729,10 +2729,10 @@ def _link_and_grant_trace(
     experiment_id: Optional[str] = _resolve_experiment_id_for_link(config, None)
     if experiment_id is None:
         # Diagnostic already printed; don't abort the deploy — the operator can
-        # run `dao-ai link-trace-destination` manually.
+        # run `dao-ai trace link` manually.
         logger.warning(
             "Could not resolve experiment id for trace linking; skipping. "
-            "Run `dao-ai link-trace-destination -c <config>` manually."
+            "Run `dao-ai trace link -c <config>` manually."
         )
         return
 
@@ -2748,7 +2748,7 @@ def _link_and_grant_trace(
     except Exception as e:  # noqa: BLE001
         logger.warning(
             f"Trace-destination link failed ({type(e).__name__}: {e}); "
-            "run `dao-ai link-trace-destination` manually."
+            "run `dao-ai trace link` manually."
         )
         return
 
@@ -2767,7 +2767,7 @@ def deploy_app_bundle(
 ) -> None:
     """Deploy/run/destroy an already-generated App bundle (agent or MCP).
 
-    Shared driver for ``generate-agent`` / ``generate-mcp`` action flags. The
+    Shared driver for ``agent generate`` / ``agent generate --mode mcp`` action flags. The
     App bundle uses a single ``dev`` target and is run by its app-name resource
     key (contrast the workflow job, run by ``deploy_job``). Order when
     ``--deploy`` and ``--run`` are combined: deploy → auto trace-link+grant →

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -10,6 +10,7 @@ import sys
 import traceback
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
+from collections.abc import Callable
 from typing import Any, Optional, Sequence
 
 from dotenv import find_dotenv, load_dotenv
@@ -951,7 +952,7 @@ Workflow) that provisions the backing infra (schemas, Vector Search, Lakebase,
 Genie, UC functions), deploys the agent, and runs evaluation. Emits a
 self-contained Databricks Asset Bundle and wraps `databricks bundle
 deploy/run/destroy`. (This is a Job/Workflow, not a Lakeflow Declarative
-Pipeline.) Sibling of `agent` / `mcp`.
+Pipeline.) Sibling of `agent`.
 """
     _AGENT_DESC = """
 Manage the agent's Databricks Apps bundle. `generate` writes a complete,
@@ -3242,7 +3243,7 @@ def _mode_bundle_kind(mode: str) -> str:
     return "mcp" if mode == "mcp" else "agent"
 
 
-def _mode_writer(mode: str):
+def _mode_writer(mode: str) -> Callable[..., None]:
     """Bundle writer function for the given serving mode."""
     if mode == "mcp":
         from dao_ai.mcp.generate import write_mcp_bundle

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -470,7 +470,6 @@ _DEFAULT_BUNDLE_BASE = ".dao-ai/bundle"
 # dispatch, so the aliases share the exact generate code path.
 _ALIAS_TO_NOUN: dict[str, str] = {
     "generate-agent": "agent",
-    "generate-mcp": "mcp",
     "generate-workflow": "workflow",
 }
 
@@ -958,13 +957,7 @@ Pipeline.) Sibling of `agent` / `mcp`.
 Manage the agent's Databricks Apps bundle. `generate` writes a complete,
 deployable bundle directory (databricks.yaml, app.yaml, pyproject.toml, and
 scaffolding) from a dao-ai config; `deploy`/`run`/`destroy` act on that staged
-bundle. Sibling of `mcp` (the MCP-server App bundle).
-"""
-    _MCP_DESC = """
-Manage the dao-ai MCP-server Databricks Apps bundle. `generate` writes a
-deploy-ready bundle that exposes the configured Genie cache + Vector Search
-retriever tools as MCP tools over Streamable HTTP; `deploy`/`run`/`destroy` act
-on that staged bundle. Mirrors `agent` but emits the MCP-only artifact.
+bundle. Use `--mode mcp` to generate/deploy the MCP-server bundle instead.
 """
 
     _add_noun_verb_parsers(
@@ -975,17 +968,8 @@ on that staged bundle. Mirrors `agent` but emits the MCP-only artifact.
 Examples:
   dao-ai agent generate -c config/retail.yaml
   dao-ai agent generate -c config/retail.yaml --deploy --run -p fevm
+  dao-ai agent generate -c config/retail.yaml --mode mcp  # MCP-server bundle
   dao-ai agent deploy   -c config/retail.yaml -p fevm      # ship staged bundle
-""",
-    )
-    _add_noun_verb_parsers(
-        subparsers,
-        noun="mcp",
-        generate_description=_MCP_DESC,
-        generate_epilog="""
-Examples:
-  dao-ai mcp generate -c config/retail.yaml -o ./retail-mcp
-  dao-ai mcp deploy   -c config/retail.yaml -p fevm
 """,
     )
     _add_noun_verb_parsers(
@@ -3249,49 +3233,53 @@ def _verify_app_deployed_or_exit(app_name: str, *, kind: str, config: str) -> No
         return
 
 
-def handle_agent_command(options: Namespace) -> None:
-    """Dispatch `dao-ai agent <generate|deploy|run|destroy>`."""
+def _mode_bundle_kind(mode: str) -> str:
+    """Staging-dir kind derived from serving mode.
+
+    ``mcp`` keeps its own dir so apps and mcp bundles never clobber each
+    other; every other mode (apps, model_serving) maps to ``"agent"``.
+    """
+    return "mcp" if mode == "mcp" else "agent"
+
+
+def _mode_writer(mode: str):
+    """Bundle writer function for the given serving mode."""
+    if mode == "mcp":
+        from dao_ai.mcp.generate import write_mcp_bundle
+
+        return write_mcp_bundle
     from dao_ai.apps.bundle import write_bundle
 
-    match options.subcommand:
-        case "generate":
-            _generate_app_bundle(
-                options, kind="agent", writer=write_bundle, what="a bundle"
-            )
-        case "deploy":
-            _deploy_run_destroy_app_bundle(
-                options, kind="agent", deploy=True, run=options.run, destroy=False
-            )
-        case "run":
-            _deploy_run_destroy_app_bundle(
-                options, kind="agent", deploy=False, run=True, destroy=False
-            )
-        case "destroy":
-            _deploy_run_destroy_app_bundle(
-                options, kind="agent", deploy=False, run=False, destroy=True
-            )
+    return write_bundle
 
 
-def handle_mcp_command(options: Namespace) -> None:
-    """Dispatch `dao-ai mcp <generate|deploy|run|destroy>`."""
-    from dao_ai.mcp.generate import write_mcp_bundle
+def handle_agent_command(options: Namespace) -> None:
+    """Dispatch `dao-ai agent <generate|deploy|run|destroy>`.
+
+    ``--mode mcp``   → writes the MCP-server bundle (staging dir ``mcp/<app>``)
+    ``--mode apps``  → writes the chat-agent bundle  (staging dir ``agent/<app>``)
+    ``--mode model_serving`` → only valid for `deploy`; bundle path is a no-op
+    here (Task 6 wires the direct deploy path).
+    """
+    mode: str = getattr(options, "mode", "apps") or "apps"
+    kind: str = _mode_bundle_kind(mode)
+    writer = _mode_writer(mode)
+    what: str = "an MCP bundle" if mode == "mcp" else "a bundle"
 
     match options.subcommand:
         case "generate":
-            _generate_app_bundle(
-                options, kind="mcp", writer=write_mcp_bundle, what="an MCP bundle"
-            )
+            _generate_app_bundle(options, kind=kind, writer=writer, what=what)
         case "deploy":
             _deploy_run_destroy_app_bundle(
-                options, kind="mcp", deploy=True, run=options.run, destroy=False
+                options, kind=kind, deploy=True, run=options.run, destroy=False
             )
         case "run":
             _deploy_run_destroy_app_bundle(
-                options, kind="mcp", deploy=False, run=True, destroy=False
+                options, kind=kind, deploy=False, run=True, destroy=False
             )
         case "destroy":
             _deploy_run_destroy_app_bundle(
-                options, kind="mcp", deploy=False, run=False, destroy=True
+                options, kind=kind, deploy=False, run=False, destroy=True
             )
 
 
@@ -3303,7 +3291,7 @@ def _run_bundle_actions(
 ) -> None:
     """Invoke deploy/run/destroy on a just-generated App bundle, if requested.
 
-    Shared tail for ``generate-agent`` / ``generate-mcp``: when any of
+    Shared tail for ``agent generate`` (apps or mcp mode): when any of
     ``--deploy``/``--run``/``--destroy`` is passed, drive the bundle via
     :func:`deploy_app_bundle`; otherwise the command stays generate-only.
     """
@@ -3447,8 +3435,6 @@ def main() -> None:
             handle_graph_command(options)
         case "agent":
             handle_agent_command(options)
-        case "mcp":
-            handle_mcp_command(options)
         case "workflow":
             handle_workflow_command(options)
         case "deploy":

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -360,6 +360,17 @@ def _add_workflow_target_args(parser: ArgumentParser) -> None:
     )
 
 
+def _add_mode_argument(parser: ArgumentParser, *, choices: list[str]) -> None:
+    """Add the serving-mode flag. Choices are per-verb so an unusable value is
+    rejected at parse time (never offered when it cannot succeed)."""
+    parser.add_argument(
+        "--mode",
+        choices=choices,
+        default="apps",
+        help="How to serve the agent: " + " | ".join(choices) + " (default: apps).",
+    )
+
+
 def _add_noun_verb_parsers(
     subparsers: "argparse._SubParsersAction",
     *,
@@ -395,6 +406,9 @@ def _add_noun_verb_parsers(
     _add_bundle_source_args(generate_parser)
     if is_workflow:
         _add_workflow_target_args(generate_parser)
+    else:
+        # Workflow gets --mode in Task 8; agent/mcp get it here.
+        _add_mode_argument(generate_parser, choices=["apps", "mcp"])
     _add_bundle_action_arguments(generate_parser)
 
     for verb, verb_help in (
@@ -411,6 +425,12 @@ def _add_noun_verb_parsers(
         _add_bundle_common_args(verb_parser, kind=noun)
         if is_workflow:
             _add_workflow_target_args(verb_parser)
+        else:
+            # Workflow gets --mode in Task 8; agent/mcp get it here.
+            if verb == "deploy":
+                _add_mode_argument(verb_parser, choices=["model_serving", "apps", "mcp"])
+            else:
+                _add_mode_argument(verb_parser, choices=["apps", "mcp"])
         if verb == "deploy":
             # Forward chaining: `dao-ai <noun> deploy --run` deploys the staged
             # bundle then runs it (parity with `generate --deploy --run`).

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -218,19 +218,35 @@ def _add_var_argument(parser: ArgumentParser) -> None:
     )
 
 
-def _add_profile_argument(parser: ArgumentParser) -> None:
-    """Add the ``-p/--profile`` flag to a subparser.
+def _global_parent_parser() -> ArgumentParser:
+    """Shared parent parser carrying ``-p/--profile`` and ``-v/--verbose``.
 
-    Shared so every subcommand spells the Databricks profile flag identically.
-    Handlers must call ``_apply_profile_context(options.profile)`` before
-    constructing any WorkspaceClient so the profile is authoritative.
+    Passed via ``parents=[_global_parent_parser()]`` to BOTH the top-level
+    ``ArgumentParser`` and every subparser / nested-verb parser so that either
+    flag is accepted at any level. ``default=argparse.SUPPRESS`` prevents a
+    level that *didn't* set the flag from clobbering a value that a higher
+    (or lower) level *did* set — the last parse that actually saw the flag
+    wins (subcommand beats top-level when both are present). Callers must do
+    ``getattr(options, "profile", None)`` / ``getattr(options, "verbose", 0)``
+    since SUPPRESS means the attribute may be absent when the flag is omitted
+    everywhere.
     """
-    parser.add_argument(
+    p = ArgumentParser(add_help=False)
+    p.add_argument(
         "-p",
         "--profile",
         type=str,
-        help="The Databricks CLI profile to use for authentication.",
+        default=argparse.SUPPRESS,
+        help="The Databricks CLI profile to use (accepted at any level).",
     )
+    p.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=argparse.SUPPRESS,
+        help="Increase verbosity (-v..-vvvv). Accepted at any level.",
+    )
+    return p
 
 
 def _add_bundle_action_arguments(parser: ArgumentParser) -> None:
@@ -296,7 +312,6 @@ def _add_bundle_common_args(parser: ArgumentParser, *, kind: str) -> None:
         action="store_true",
         help="Print the databricks bundle commands without executing them.",
     )
-    _add_profile_argument(parser)
     _add_var_argument(parser)
 
 
@@ -368,6 +383,7 @@ def _add_noun_verb_parsers(
     noun: str,
     generate_description: str,
     generate_epilog: str,
+    parents: list[ArgumentParser],
 ) -> None:
     """Register the generate/deploy/run/destroy verb parsers for one noun.
 
@@ -375,6 +391,8 @@ def _add_noun_verb_parsers(
     carries the source flags (+ one-shot --deploy/--run/--destroy) and inherits
     the noun's rich help; deploy/run/destroy carry only the common args. The
     workflow noun additionally gets target/cloud flags on every verb.
+    ``parents`` is forwarded to every ``add_parser`` call so the global
+    ``-p/--profile`` and ``-v/--verbose`` flags are accepted at each level.
     """
     is_workflow: bool = noun == "workflow"
 
@@ -383,6 +401,7 @@ def _add_noun_verb_parsers(
         help=f"Manage the {noun} bundle (generate | deploy | run | destroy)",
         description=generate_description,
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=parents,
     )
     verbs = parser.add_subparsers(dest="subcommand", required=True)
 
@@ -392,6 +411,7 @@ def _add_noun_verb_parsers(
         description=generate_description,
         epilog=generate_epilog,
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=parents,
     )
     _add_bundle_common_args(generate_parser, kind=noun)
     _add_bundle_source_args(generate_parser)
@@ -412,6 +432,7 @@ def _add_noun_verb_parsers(
             help=verb_help,
             description=f"{verb_help}. Acts on the staging dir written by "
             f"`dao-ai {noun} generate` (or -o); errors if nothing is staged.",
+            parents=parents,
         )
         _add_bundle_common_args(verb_parser, kind=noun)
         if is_workflow:
@@ -585,6 +606,11 @@ def _print_config_variable_error(err: ConfigVariableError) -> None:
 
 
 def parse_args(args: Sequence[str]) -> Namespace:
+    # One shared parent holds -p/--profile and -v/--verbose with SUPPRESS
+    # defaults so that a level which doesn't see the flag never overwrites
+    # a value that was written at another level.  See _global_parent_parser().
+    _GLOBAL: ArgumentParser = _global_parent_parser()
+
     parser: ArgumentParser = ArgumentParser(
         prog="dao-ai",
         description="DAO AI Agent Command Line Interface - A comprehensive tool for managing, validating, and visualizing multi-agent DAO AI systems",
@@ -600,13 +626,7 @@ Examples:
   dao-ai agent generate -c my_config.yaml --deploy --run # Generate + deploy + start the agent App
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="count",
-        default=0,
-        help="Increase verbosity level (use -v, -vv, -vvv, or -vvvv for ERROR, WARNING, INFO, DEBUG, or TRACE levels)",
+        parents=[_GLOBAL],
     )
 
     subparsers = parser.add_subparsers(
@@ -621,6 +641,7 @@ Examples:
         "version",
         help="Show dao-ai version and build metadata",
         description="Display the dao-ai version along with Python, key dependency versions, and platform details. Side-effect free: no network calls or Databricks auth resolution.",
+        parents=[_GLOBAL],
     )
 
     # Doctor command
@@ -628,8 +649,8 @@ Examples:
         "doctor",
         help="Show the resolved Databricks environment and connection details",
         description="Resolve and display the Databricks host, profile, and auth type. May make network calls or fail when no credentials are configured.",
+        parents=[_GLOBAL],
     )
-    _add_profile_argument(_doctor_parser)
 
     # Schema command
     _: ArgumentParser = subparsers.add_parser(
@@ -643,6 +664,7 @@ including agents, tools, models, orchestration patterns, and guardrails.
         """,
         epilog="Example: dao-ai schema > config_schema.json",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_GLOBAL],
     )
 
     # Validation command
@@ -670,6 +692,7 @@ Examples:
   dao-ai validate -c config/production.yaml       # Validate specific config file
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_GLOBAL],
     )
     validation_parser.add_argument(
         "-c",
@@ -685,6 +708,7 @@ Examples:
         "trace",
         help="Manage MLflow experiments and UC trace destinations (create | link | grant)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_GLOBAL],
     )
     trace_verbs = trace_parser.add_subparsers(dest="subcommand", required=True)
 
@@ -709,6 +733,7 @@ Examples:
   dao-ai trace create --name /Shared/only-if-exists --no-create
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_GLOBAL],
     )
     _create_exp_ident_group = trace_create_parser.add_mutually_exclusive_group(
         required=True
@@ -729,12 +754,6 @@ Examples:
         "--no-create",
         action="store_true",
         help="With --name: fail instead of creating when the experiment is missing.",
-    )
-    trace_create_parser.add_argument(
-        "-p",
-        "--profile",
-        type=str,
-        help="Databricks profile to use for authentication.",
     )
     trace_create_parser.add_argument(
         "-o",
@@ -795,6 +814,7 @@ Notes:
     continues writing to its original UC destination forever.
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_GLOBAL],
     )
     trace_link_parser.add_argument(
         "-c",
@@ -803,12 +823,6 @@ Notes:
         required=True,
         metavar="FILE",
         help="Path to the model configuration file (must set app.trace_location).",
-    )
-    trace_link_parser.add_argument(
-        "-p",
-        "--profile",
-        type=str,
-        help="Databricks profile to use for authentication.",
     )
     trace_link_parser.add_argument(
         "--experiment-id",
@@ -871,6 +885,7 @@ Examples:
   dao-ai trace grant -c config.yaml --app-sp <uuid> -p fevm
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_GLOBAL],
     )
     trace_grant_parser.add_argument(
         "-c",
@@ -879,12 +894,6 @@ Examples:
         required=True,
         metavar="FILE",
         help="Path to the model configuration file (must set app.trace_location).",
-    )
-    trace_grant_parser.add_argument(
-        "-p",
-        "--profile",
-        type=str,
-        help="Databricks profile to use for authentication.",
     )
     trace_grant_parser.add_argument(
         "--experiment-id",
@@ -922,6 +931,7 @@ Examples:
   dao-ai graph -o workflow.png -c prod.yaml       # Generate PNG from specific config
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_GLOBAL],
     )
     graph_parser.add_argument(
         "-o",
@@ -970,6 +980,7 @@ Examples:
   dao-ai agent generate -c config/retail.yaml --mode mcp  # MCP-server bundle
   dao-ai agent deploy   -c config/retail.yaml -p fevm      # ship staged bundle
 """,
+        parents=[_GLOBAL],
     )
     _add_noun_verb_parsers(
         subparsers,
@@ -980,6 +991,7 @@ Examples:
   dao-ai workflow generate -c config/retail.yaml --deploy
   dao-ai workflow run      -c config/retail.yaml   # run staged provisioning job
 """,
+        parents=[_GLOBAL],
     )
 
     # List MCP tools command
@@ -1013,6 +1025,7 @@ Note: Schemas are displayed in a concise, readable format instead of verbose JSO
   dao-ai tools -c config/model_config.yaml --apply-filters
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_GLOBAL],
     )
     list_mcp_parser.add_argument(
         "-c",
@@ -1047,6 +1060,7 @@ Examples:
   dao-ai monitor disable -c config/model_config.yaml    # Stop all monitoring scorers
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_GLOBAL],
     )
     monitor_parser.add_argument(
         "-c",
@@ -1085,6 +1099,7 @@ Examples:
   dao-ai chat -c config/retail.yaml --custom-input store_num=123 --custom-input region=west  # Multiple custom inputs
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_GLOBAL],
     )
     chat_parser.add_argument(
         "-c",
@@ -1136,6 +1151,7 @@ Examples:
   dao-ai vars list -c config/model_config.yaml             # legacy alias
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_GLOBAL],
     )
     vars_parser.add_argument(
         "action",
@@ -1151,9 +1167,10 @@ Examples:
         help="Path to the model configuration file to inspect.",
     )
 
-    # The bundle nouns (agent/mcp/workflow) and their generate-* aliases get
-    # --param/--var and -p/--profile from `_add_bundle_common_args`, so they are
-    # NOT listed here — only the non-bundle subcommands are.
+    # Add --param/--var to the non-bundle subcommands (bundle verbs get it from
+    # _add_bundle_common_args; trace verbs add it inline above).
+    # -p/--profile and -v/--verbose are now global (from _GLOBAL parent) so
+    # they no longer need per-subcommand attachment here.
     for sub in (
         validation_parser,
         graph_parser,
@@ -1163,21 +1180,6 @@ Examples:
         vars_parser,
     ):
         _add_var_argument(sub)
-
-    # Add -p/--profile to the subcommands that touch Databricks but don't
-    # already declare it inline (trace verb parsers define their own;
-    # bundle nouns get it from _add_bundle_common_args).
-    # Without it a shell/.env DATABRICKS_* var silently wins — the hijack
-    # _apply_profile_context guards.
-    for sub in (
-        validation_parser,
-        graph_parser,
-        list_mcp_parser,
-        monitor_parser,
-        chat_parser,
-        vars_parser,
-    ):
-        _add_profile_argument(sub)
 
     # Shell completion via argcomplete (a core dep; enable in your shell — see
     # docs/cli-reference.md). Still guarded so a stripped env without argcomplete
@@ -1191,6 +1193,15 @@ Examples:
         pass
 
     options = parser.parse_args(args)
+
+    # Normalize the SUPPRESS-defaulted globals so handlers can use plain
+    # attribute access.  When neither level saw the flag, the attribute is
+    # absent from the namespace; set safe defaults here so downstream code
+    # (handlers, setup_logging, _apply_profile_context) never needs getattr.
+    if not hasattr(options, "profile"):
+        options.profile = None
+    if not hasattr(options, "verbose"):
+        options.verbose = 0
 
     # Generate a new thread_id UUID if not provided (only for chat command)
     if hasattr(options, "thread_id") and options.thread_id is None:
@@ -3369,6 +3380,7 @@ def handle_vars_command(options: Namespace) -> None:
 
 def main() -> None:
     options: argparse.Namespace = parse_args(sys.argv[1:])
+    # parse_args already normalizes profile/verbose (SUPPRESS → None/0).
     setup_logging(options.verbose)
 
     command: str = options.command

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -441,6 +441,15 @@ def _add_noun_verb_parsers(
                 action="store_true",
                 help="After deploying, run `databricks bundle run <app>`.",
             )
+            verb_parser.add_argument(
+                "--direct",
+                action="store_true",
+                default=False,
+                help=(
+                    "Deploy via the SDK directly (no DAB bundle on disk) — fast "
+                    "iteration escape hatch for --mode apps|mcp."
+                ),
+            )
 
 
 def _validate_bundle_action_flags(options: Namespace) -> None:
@@ -3138,6 +3147,35 @@ def _load_app_config(options: Namespace, *, what: str) -> AppConfig:
     return config
 
 
+def _stage_app_bundle(
+    config: AppConfig,
+    bundle_dir: Path,
+    *,
+    is_default_dir: bool,
+    writer: Callable[..., None],
+    development: bool,
+    overwrite: bool,
+    noun: str,
+) -> None:
+    """Write bundle files to *bundle_dir* (clean → write → marker).
+
+    This is the staging-only half of :func:`_generate_app_bundle`.  It does NOT
+    run any bundle actions (deploy/run/destroy); callers that want actions invoke
+    :func:`_run_bundle_actions` themselves.  Extracted so the ``deploy``
+    auto-generate path can stage without risking recursion through
+    ``_run_bundle_actions``.
+    """
+    logger.debug(f"Staging {noun} bundle to {bundle_dir}...")
+    # Regenerate the owned default dir from scratch so a prior --development run
+    # can't leave stale dist/ + dev pyproject that a published rebuild mixes in.
+    # Refuses to wipe a default dir that carries hand-edits unless --overwrite.
+    _clean_default_staging_dir(
+        bundle_dir, is_default=is_default_dir, overwrite=overwrite, noun=noun
+    )
+    writer(config, bundle_dir, overwrite=overwrite, development=development)
+    _write_staging_marker(bundle_dir, is_default=is_default_dir)
+
+
 def _generate_app_bundle(options: Namespace, *, kind: str, writer, what: str) -> None:
     """Generate an App bundle (agent or mcp), then run any one-shot actions.
 
@@ -3159,15 +3197,15 @@ def _generate_app_bundle(options: Namespace, *, kind: str, writer, what: str) ->
     config._resolve_all_resources()
 
     bundle_dir, is_default_dir = _resolve_bundle_dir(kind, config, options.output_dir)
-    # Regenerate the owned default dir from scratch so a prior --development run
-    # can't leave stale dist/ + dev pyproject that a published rebuild mixes in.
-    # Refuses to wipe a default dir that carries hand-edits unless --overwrite.
-    _clean_default_staging_dir(
-        bundle_dir, is_default=is_default_dir, overwrite=options.overwrite, noun=kind
+    _stage_app_bundle(
+        config,
+        bundle_dir,
+        is_default_dir=is_default_dir,
+        writer=writer,
+        development=development,
+        overwrite=options.overwrite,
+        noun=kind,
     )
-
-    writer(config, bundle_dir, overwrite=options.overwrite, development=development)
-    _write_staging_marker(bundle_dir, is_default=is_default_dir)
 
     _run_bundle_actions(options, config, bundle_dir, options.profile)
 
@@ -3175,24 +3213,77 @@ def _generate_app_bundle(options: Namespace, *, kind: str, writer, what: str) ->
 def _deploy_run_destroy_app_bundle(
     options: Namespace, *, kind: str, deploy: bool, run: bool, destroy: bool
 ) -> None:
-    """Deploy/run/destroy an ALREADY-STAGED App bundle without regenerating.
+    """Deploy/run/destroy an App bundle, auto-generating when ``deploy=True`` and unstaged.
 
-    Resolves the same staging dir that ``<noun> generate`` writes, errors with
-    guidance if nothing is staged there, then drives :func:`deploy_app_bundle`.
-    For a run-only invocation, best-effort verifies the app is deployed and
-    points at ``<noun> deploy --run`` instead of leaking a raw bundle error.
+    Routing (deploy-only):
+
+    1. ``--mode model_serving``: call ``config.deploy_agent(target=MODEL_SERVING)``
+       and return — Model Serving has no DAB bundle.
+    2. ``--direct``: call ``config.deploy_agent(target=DeploymentTarget(mode))``
+       (SDK path; no bundle on disk). ``--direct`` + ``--mode model_serving`` is
+       redundant — treated identically to plain model_serving deploy (no error).
+    3. Bundle path: if ``databricks.yaml`` is absent AND ``deploy=True``, auto-stage
+       via :func:`_stage_app_bundle` (CDK/SAM norm), then deploy. If already staged,
+       deploy in-place (preserves hand-edits). ``run`` / ``destroy`` still error when
+       unstaged — you can't run or destroy something never staged.
     """
-    what = "a bundle" if kind == "agent" else "an MCP bundle"
-    config: AppConfig = _load_app_config(options, what=what)
-    bundle_dir, _ = _resolve_bundle_dir(kind, config, options.output_dir)
+    from dao_ai.utils import resolve_use_local_source
+
+    what: str = "a bundle" if kind == "agent" else "an MCP bundle"
+    mode: str = getattr(options, "mode", "apps") or "apps"
+    direct: bool = getattr(options, "direct", False)
+
+    # --- Route 1: model_serving (always SDK, never a bundle) ---
+    if deploy and mode == "model_serving":
+        from dao_ai.config import DeploymentTarget
+
+        config: AppConfig = _load_app_config(options, what=what)
+        development: bool = resolve_use_local_source(getattr(options, "development", None))
+        config.deploy_agent(target=DeploymentTarget.MODEL_SERVING, development=development)
+        return
+
+    # --- Route 2: --direct (SDK path for apps/mcp; model_serving is a no-op alias) ---
+    if deploy and direct:
+        from dao_ai.config import DeploymentTarget
+
+        config = _load_app_config(options, what=what)
+        development = resolve_use_local_source(getattr(options, "development", None))
+        config.deploy_agent(
+            target=DeploymentTarget(mode),
+            development=development,
+        )
+        return
+
+    # --- Route 3: bundle path ---
+    config = _load_app_config(options, what=what)
+    bundle_dir, is_default_dir = _resolve_bundle_dir(kind, config, options.output_dir)
 
     if not (bundle_dir / "databricks.yaml").exists():
-        logger.error(
-            f"No staged {kind} bundle at {bundle_dir}. "
-            f"Run `dao-ai {kind} generate -c {options.config}"
-            f"{f' -o {options.output_dir}' if options.output_dir else ''}` first."
-        )
-        sys.exit(1)
+        if deploy:
+            # Auto-generate (CDK/SAM norm): stage the bundle, then fall through
+            # to deploy_app_bundle below.  run/destroy still error — nothing to
+            # run or destroy if the bundle was never staged.
+            logger.info(
+                f"No staged {kind} bundle at {bundle_dir}; auto-generating before deploy."
+            )
+            writer: Callable[..., None] = _mode_writer(mode)
+            development = resolve_use_local_source(getattr(options, "development", None))
+            _stage_app_bundle(
+                config,
+                bundle_dir,
+                is_default_dir=is_default_dir,
+                writer=writer,
+                development=development,
+                overwrite=getattr(options, "overwrite", False),
+                noun=kind,
+            )
+        else:
+            logger.error(
+                f"No staged {kind} bundle at {bundle_dir}. "
+                f"Run `dao-ai {kind} generate -c {options.config}"
+                f"{f' -o {options.output_dir}' if options.output_dir else ''}` first."
+            )
+            sys.exit(1)
 
     dry_run: bool = options.dry_run
     if run and not deploy and not destroy and not dry_run:

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -3266,6 +3266,8 @@ def _deploy_run_destroy_app_bundle(
             logger.info(
                 f"No staged {kind} bundle at {bundle_dir}; auto-generating before deploy."
             )
+            # Resolve resources so Genie room tables and warehouses can be discovered.
+            config._resolve_all_resources()
             writer: Callable[..., None] = _mode_writer(mode)
             development = resolve_use_local_source(getattr(options, "development", None))
             _stage_app_bundle(

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -366,15 +366,42 @@ def _add_workflow_target_args(parser: ArgumentParser) -> None:
     )
 
 
+# Convenience input aliases for serving-mode values -> canonical ServingMode
+# value. Accepted on the CLI and normalized post-parse so ``options.mode`` is
+# always canonical downstream (matches the enum / bundle --var / notebook).
+_MODE_ALIASES: dict[str, str] = {
+    "ms": "model_serving",
+    "model-serving": "model_serving",
+}
+
+
+def _canonical_modes(choices: list[str]) -> list[str]:
+    """Expand a canonical mode-choice list with its accepted input aliases."""
+    return choices + [a for a, canon in _MODE_ALIASES.items() if canon in choices]
+
+
+def _normalize_mode(value: str) -> str:
+    """Map a mode alias (``ms``, ``model-serving``) to its canonical value."""
+    return _MODE_ALIASES.get(value, value)
+
+
 def _add_mode_argument(parser: ArgumentParser, *, choices: list[str]) -> None:
     """Add the serving-mode flag. Choices are per-verb so an unusable value is
-    rejected at parse time (never offered when it cannot succeed)."""
+    rejected at parse time (never offered when it cannot succeed). Input aliases
+    (``ms``/``model-serving`` -> ``model_serving``) are accepted where the
+    canonical value is valid and normalized in :func:`parse_args`.
+    """
+    accepted: list[str] = _canonical_modes(choices)
     parser.add_argument(
         "-m",
         "--mode",
-        choices=choices,
+        choices=accepted,
         default="apps",
-        help="How to serve the agent: " + " | ".join(choices) + " (default: apps).",
+        metavar="{" + ",".join(choices) + "}",
+        help="How to serve the agent: "
+        + " | ".join(choices)
+        + " (default: apps)."
+        + (" Aliases: ms/model-serving." if "model_serving" in choices else ""),
     )
 
 
@@ -1203,6 +1230,11 @@ Examples:
         options.profile = None
     if not hasattr(options, "verbose"):
         options.verbose = 0
+
+    # Normalize serving-mode input aliases (ms/model-serving -> model_serving)
+    # so options.mode is always the canonical ServingMode value downstream.
+    if getattr(options, "mode", None) is not None:
+        options.mode = _normalize_mode(options.mode)
 
     # Generate a new thread_id UUID if not provided (only for chat command)
     if hasattr(options, "thread_id") and options.thread_id is None:

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -638,20 +638,26 @@ def parse_args(args: Sequence[str]) -> Namespace:
         description="Build and operate multi-agent AI systems on Databricks.",
         epilog="""
 Getting started:
-  dao-ai agent generate -c config.yaml --deploy --run -p fevm   # generate + deploy + start in one shot
-  dao-ai agent deploy   -c config.yaml -p fevm                  # deploy staged bundle (auto-generates if unstaged)
+  dao-ai agent up      -c config.yaml -p fevm                   # generate + deploy + start — one command to a live agent
+  dao-ai agent deploy  -c config.yaml -p fevm                   # push the bundle (auto-generates if unstaged); start with `run`
 
-Deploy an agent:
-  dao-ai agent generate -c config.yaml --deploy --run -p fevm          # one-shot: generate → deploy → run (Apps)
-  dao-ai agent deploy   -c config.yaml --mode model_serving -p fevm    # deploy to Model Serving endpoint
-  dao-ai agent deploy   -c config.yaml -m ms -p fevm                   # same, using -m ms alias
-  dao-ai agent deploy   -c config.yaml --mode mcp -p fevm              # deploy as MCP server
-  dao-ai agent deploy   -c config.yaml --direct -p fevm                # SDK fast-path (no bundle on disk)
-  dao-ai -p fevm agent deploy -c config.yaml                           # -p accepted at top level too
+Bring an agent up (generate → deploy → run):
+  dao-ai agent up -c config.yaml -p fevm                        # live agent (Apps, default --mode apps)
+  dao-ai agent up -c config.yaml --mode model_serving -p fevm  # deploy to a Model Serving endpoint
+  dao-ai agent up -c config.yaml -m ms -p fevm                 # same, using the -m ms alias
+  dao-ai agent up -c config.yaml --mode mcp -p fevm            # bring up an MCP server
+  dao-ai agent up -c config.yaml --direct -p fevm             # SDK fast-path (no bundle on disk)
+  dao-ai -p fevm agent up -c config.yaml                       # -p accepted at the top level too
+
+Granular lifecycle (DAB-style primitives):
+  dao-ai agent generate -c config.yaml -p fevm                 # stage the bundle only (inspect / hand-edit)
+  dao-ai agent deploy   -c config.yaml -p fevm                 # push resources (bundle deploy)
+  dao-ai agent run      -c config.yaml -p fevm                 # start the deployed app (bundle run)
+  dao-ai agent destroy  -c config.yaml -p fevm                 # tear it down
 
 Provision infrastructure:
-  dao-ai workflow generate -c config.yaml --deploy -p fevm      # provision infra (VS, Lakebase, Genie…) + deploy
-  dao-ai workflow run      -c config.yaml -p fevm                # run the staged provisioning job
+  dao-ai workflow up  -c config.yaml -p fevm                    # provision infra (VS, Lakebase, Genie…) + deploy the agent
+  dao-ai workflow run -c config.yaml -p fevm                    # run the staged provisioning job
 
 Trace & experiments:
   dao-ai trace create --name /Shared/team/traces -p fevm
@@ -2724,7 +2730,8 @@ def run_databricks_command(
     extra_vars.append(f'--var="dao_ai_dep={dao_ai_dep}"')
 
     # command=None -> stage-only (generate the bundle, don't run a bundle verb).
-    # This is what `workflow generate` with no --deploy/--run/--destroy does.
+    # This is what `workflow generate` does (staging only; deploy/run/up drive
+    # the bundle verbs).
     if command is None:
         logger.info(f"Workflow bundle staged in {staging_dir}")
         return

--- a/src/dao_ai/code_paths.py
+++ b/src/dao_ai/code_paths.py
@@ -16,7 +16,7 @@ reach all deployment targets:
   CWD is that directory and ``AppConfig.add_code_paths_to_sys_path`` (a config
   validator) inserts each entry's parent onto ``sys.path``, so the module imports.
 
-* **generate-workflow / generate-agent / generate-mcp bundles** — the bundle
+* **workflow / agent bundles (dao-ai <noun> generate)** — the bundle
   generators stage each entry next to the staged config using the same
   :func:`iter_code_path_stagings` plan, so the job/app finds them.
 

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -620,7 +620,7 @@ class IsDatabricksResource(ABC, BaseModel):
         return self.workspace_client
 
 
-class DeploymentTarget(str, Enum):
+class ServingMode(str, Enum):
     """Target platform for agent deployment (a deploy-action parameter — NOT a
     field on AppConfig)."""
 
@@ -11023,7 +11023,7 @@ class AppConfig(BaseModel):
 
     def deploy_agent(
         self,
-        target: DeploymentTarget | None = None,
+        target: ServingMode | None = None,
         w: WorkspaceClient | None = None,
         vsc: "VectorSearchClient | None" = None,
         pat: str | None = None,
@@ -11055,7 +11055,7 @@ class AppConfig(BaseModel):
 
         # Mode is a deploy-action parameter, not config: the caller supplies it
         # (the CLI defaults it). No AppConfig fallback.
-        resolved_target: DeploymentTarget = target or DeploymentTarget.MODEL_SERVING
+        resolved_target: ServingMode = target or ServingMode.MODEL_SERVING
 
         provider: ServiceProvider = DatabricksProvider(
             w=w,

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -9441,7 +9441,7 @@ class AppModel(BaseModel):
         "file's directory; absolute paths pass through) shipped with EVERY "
         "deployment target: Model Serving via ``log_model(code_paths=...)``, "
         "Databricks Apps by uploading them next to the config (importable via "
-        "``sys.path``), and the generate-workflow job by staging them into the "
+        "``sys.path``), and the ``workflow generate`` job by staging them into the "
         "bundle. Use for custom ``type: python`` tool modules or agent code. "
         "(Apps bundles also still support hand-packaged code under ``src/<package>/``.)",
     )
@@ -9469,7 +9469,7 @@ class AppModel(BaseModel):
         default=None,
         description=(
             "Server-side MCP capabilities exposed when dao-ai is deployed as an "
-            "MCP server (``dao-ai generate-mcp``). Declares static resources, "
+            "MCP server (``dao-ai agent generate --mode mcp``). Declares static resources, "
             "prompt templates, and whether progress + logging notifications are "
             "emitted from the agent tool. When None the server publishes only "
             "the single agent-as-tool surface with no notifications."

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -9457,11 +9457,6 @@ class AppModel(BaseModel):
         "which is supported by Databricks Model Serving. This allows deploying from "
         "environments with different Python versions (e.g., Databricks Apps with 3.11).",
     )
-    deployment_target: Optional[DeploymentTarget] = Field(
-        default=None,
-        description="Default deployment target. If not specified, defaults to MODEL_SERVING. "
-        "Can be overridden via CLI --target flag. Options: 'model_serving' or 'apps'.",
-    )
     trace_location: Optional[TraceLocationModel] = Field(
         default=None,
         description="Unity Catalog location for storing MLflow traces in OTEL-format Delta tables. "
@@ -9639,19 +9634,6 @@ class AppModel(BaseModel):
             if color[name] == WHITE:
                 visit(name, [name])
 
-        return self
-
-    @model_validator(mode="after")
-    def validate_registered_model_required_for_serving(self) -> Self:
-        """Ensure registered_model is provided when deployment target is not apps."""
-        if (
-            self.registered_model is None
-            and self.deployment_target != DeploymentTarget.APPS
-        ):
-            raise ValueError(
-                "registered_model is required when deployment_target is not 'apps'. "
-                "Either add a registered_model section or set deployment_target to 'apps'."
-            )
         return self
 
     @staticmethod
@@ -11053,14 +11035,12 @@ class AppConfig(BaseModel):
         """
         Deploy the agent to the specified target.
 
-        Target resolution follows this priority:
-        1. Explicit `target` parameter (if provided)
-        2. `app.deployment_target` from config file (if set)
-        3. Default: MODEL_SERVING
+        Target resolution: the caller supplies ``target`` (the CLI defaults it).
+        If not provided, defaults to MODEL_SERVING.
 
         Args:
-            target: The deployment target (MODEL_SERVING or APPS). If None, uses
-                config.app.deployment_target or defaults to MODEL_SERVING.
+            target: The deployment target (MODEL_SERVING, APPS, or MCP). If None,
+                defaults to MODEL_SERVING.
             w: Optional WorkspaceClient instance
             vsc: Optional VectorSearchClient instance
             pat: Optional personal access token for authentication
@@ -11073,17 +11053,9 @@ class AppConfig(BaseModel):
         from dao_ai.providers.base import ServiceProvider
         from dao_ai.providers.databricks import DatabricksProvider
 
-        # Resolve target using hybrid logic:
-        # 1. Explicit parameter takes precedence
-        # 2. Fall back to config.app.deployment_target
-        # 3. Default to MODEL_SERVING
-        resolved_target: DeploymentTarget
-        if target is not None:
-            resolved_target = target
-        elif self.app is not None and self.app.deployment_target is not None:
-            resolved_target = self.app.deployment_target
-        else:
-            resolved_target = DeploymentTarget.MODEL_SERVING
+        # Mode is a deploy-action parameter, not config: the caller supplies it
+        # (the CLI defaults it). No AppConfig fallback.
+        resolved_target: DeploymentTarget = target or DeploymentTarget.MODEL_SERVING
 
         provider: ServiceProvider = DatabricksProvider(
             w=w,

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -9388,18 +9388,22 @@ class AppModel(BaseModel):
         description="Model Serving workload size (Small, Medium, Large).",
     )
     workers: Optional[int] = Field(
-        default=2,
+        default=1,
         gt=0,
         description=(
             "Number of uvicorn worker processes for the Databricks Apps backend "
-            "server. Each worker is a separate process, raising the app's "
-            "concurrent-request ceiling on multi-core Apps compute. Defaults to "
-            "2 (a modest bump over uvicorn's single-worker default that is safe "
-            "on the small default Apps compute); raise it to match larger compute "
-            "cores. Emitted to the app as the ``DAO_AI_APP_WORKERS`` env var and "
-            "forwarded to the backend as ``--workers``. Too many workers on a "
-            "small instance contends for CPU. Apps-target only (no effect on "
-            "Model Serving, which manages its own worker pool via workload_size)."
+            "server. Each worker is a SEPARATE PROCESS that re-imports the app "
+            "and rebuilds the full agent graph, so its memory footprint is "
+            "duplicated per worker (uvicorn spawns workers — there is no "
+            "copy-on-write sharing). Defaults to 1: on the default MEDIUM Apps "
+            "compute (2 vCPU / 6 GB) a second full graph OOM-kills the workers "
+            "in a respawn loop. Because this agent is async and I/O-bound, a "
+            "single worker's event loop already serves many concurrent requests, "
+            "so 1 is the right default. Raise ONLY on larger Apps compute with "
+            "headroom for N resident graphs. Emitted as the ``DAO_AI_APP_WORKERS`` "
+            "env var and forwarded to the backend as ``--workers``. Apps-target "
+            "only (no effect on Model Serving, which manages its own worker pool "
+            "via workload_size)."
         ),
     )
     permissions: Optional[list[AppPermissionModel]] = Field(

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -621,16 +621,17 @@ class IsDatabricksResource(ABC, BaseModel):
 
 
 class DeploymentTarget(str, Enum):
-    """Target platform for agent deployment."""
+    """Target platform for agent deployment (a deploy-action parameter — NOT a
+    field on AppConfig)."""
 
     MODEL_SERVING = "model_serving"
-    """Deploy to Databricks Model Serving endpoint."""
+    """Deploy to a Databricks Model Serving endpoint (no DAB bundle)."""
 
     APPS = "apps"
-    """Deploy as a Databricks App."""
+    """Deploy as a Databricks App (chat UI) from a DAB bundle."""
 
-    BOTH = "both"
-    """Deploy to both Model Serving and Apps."""
+    MCP = "mcp"
+    """Deploy the MCP server as a Databricks App from a DAB bundle."""
 
 
 class Privilege(str, Enum):

--- a/src/dao_ai/pipeline/bundle.py
+++ b/src/dao_ai/pipeline/bundle.py
@@ -149,7 +149,7 @@ def generate_pipeline_databricks_yaml(config: AppConfig, development: bool) -> s
                 "description": "Cloud provider (azure, aws, gcp) - set per target.",
             },
             "deployment_target": {
-                "description": "Agent deployment target (model_serving, apps, both).",
+                "description": "Agent deployment target (model_serving, apps, mcp).",
                 "default": "model_serving",
             },
             "development": {

--- a/src/dao_ai/pipeline/bundle.py
+++ b/src/dao_ai/pipeline/bundle.py
@@ -150,7 +150,7 @@ def generate_pipeline_databricks_yaml(config: AppConfig, development: bool) -> s
             },
             "deployment_target": {
                 "description": "Agent deployment target (model_serving, apps, mcp).",
-                "default": "model_serving",
+                "default": "apps",
             },
             "development": {
                 "description": (

--- a/src/dao_ai/pipeline/bundle.py
+++ b/src/dao_ai/pipeline/bundle.py
@@ -64,7 +64,7 @@ _PIPELINE_TASKS: tuple[tuple[str, str, tuple[str, ...], dict[str, str]], ...] = 
      ("provision-vector-search", "provision-lakebase"), {}),
     ("provision-genie", "05_provision_genie.py", ("unity-catalog-tools",), {}),
     ("deploy-agents", "06_deploy_agent.py", ("provision-genie",),
-     {"deployment-target": "${var.deployment_target}",
+     {"mode": "${var.mode}",
       "development": "${var.development}"}),
     ("generate-evaluation-data", "07_generate_evaluation_data.py",
      ("provision-vector-search",), {}),
@@ -148,8 +148,8 @@ def generate_pipeline_databricks_yaml(config: AppConfig, development: bool) -> s
             "cloud": {
                 "description": "Cloud provider (azure, aws, gcp) - set per target.",
             },
-            "deployment_target": {
-                "description": "Agent deployment target (model_serving, apps, mcp).",
+            "mode": {
+                "description": "Agent serving mode (model_serving, apps, mcp).",
                 "default": "apps",
             },
             "development": {

--- a/src/dao_ai/pipeline/notebooks/06_deploy_agent.py
+++ b/src/dao_ai/pipeline/notebooks/06_deploy_agent.py
@@ -36,7 +36,7 @@ def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
 
 dbutils.widgets.text(name="config-path", defaultValue="")
 dbutils.widgets.dropdown(
-    name="deployment-target",
+    name="mode",
     choices=["", "model_serving", "apps", "mcp"],
     defaultValue="",
 )
@@ -51,12 +51,12 @@ dbutils.widgets.dropdown(name="config-paths", choices=config_files, defaultValue
 
 config_path: str | None = dbutils.widgets.get("config-path") or None
 project_path: str = dbutils.widgets.get("config-paths") or None
-deployment_target_str: str | None = dbutils.widgets.get("deployment-target") or None
+mode_str: str | None = dbutils.widgets.get("mode") or None
 
 config_path: str = config_path or project_path
 
 print(f"Config path: {config_path}")
-print(f"Deployment target: {deployment_target_str or '(using config default)'}")
+print(f"Serving mode: {mode_str or '(using config default)'}")
 
 # COMMAND ----------
 
@@ -96,10 +96,10 @@ nest_asyncio.apply()
 
 # COMMAND ----------
 
-from dao_ai.config import AppConfig, DeploymentTarget
+from dao_ai.config import AppConfig, ServingMode
 
 config_path: str = dbutils.widgets.get("config-path") or dbutils.widgets.get("config-paths")
-deployment_target_str: str | None = dbutils.widgets.get("deployment-target") or None
+mode_str: str | None = dbutils.widgets.get("mode") or None
 
 # Source selection tri-state forwarded by `dao-ai generate-workflow` via the
 # `development` bundle var: "true" ships local dao-ai source/wheel, "false"
@@ -115,7 +115,7 @@ else:
     development = None
 
 print(f"Config path: {config_path}")
-print(f"Deployment target: {deployment_target_str or '(using config default)'}")
+print(f"Serving mode: {mode_str or '(using config default)'}")
 print(f"Development source: {development_str}")
 
 # Pull any resolved parameter values that upstream provisioning tasks
@@ -129,13 +129,13 @@ config: AppConfig = AppConfig.from_file(
 )
 print(f"Substituted parameters: {config.substitution_vars}")
 
-deployment_target: DeploymentTarget
-if deployment_target_str:
-    deployment_target = DeploymentTarget(deployment_target_str)
-    print(f"Using widget-specified deployment target: {deployment_target.value}")
+mode: ServingMode
+if mode_str:
+    mode = ServingMode(mode_str)
+    print(f"Using widget-specified serving mode: {mode.value}")
 else:
-    deployment_target = DeploymentTarget.APPS
-    print("Using default deployment target: apps")
+    mode = ServingMode.APPS
+    print("Using default serving mode: apps")
 
 # COMMAND ----------
 
@@ -145,9 +145,9 @@ config.display_graph()
 
 # Only log/register the MLflow model for Model Serving deployments.
 # Apps and MCP deploy directly from the config + PyPI package (no MLflow model registration).
-if deployment_target not in (DeploymentTarget.APPS, DeploymentTarget.MCP):
+if mode not in (ServingMode.APPS, ServingMode.MCP):
     config.create_agent(development=development)
 
 # COMMAND ----------
 
-config.deploy_agent(target=deployment_target, development=development)
+config.deploy_agent(target=mode, development=development)

--- a/src/dao_ai/pipeline/notebooks/06_deploy_agent.py
+++ b/src/dao_ai/pipeline/notebooks/06_deploy_agent.py
@@ -134,8 +134,8 @@ if deployment_target_str:
     deployment_target = DeploymentTarget(deployment_target_str)
     print(f"Using widget-specified deployment target: {deployment_target.value}")
 else:
-    deployment_target = DeploymentTarget.MODEL_SERVING
-    print("Using default deployment target: model_serving")
+    deployment_target = DeploymentTarget.APPS
+    print("Using default deployment target: apps")
 
 # COMMAND ----------
 

--- a/src/dao_ai/pipeline/notebooks/06_deploy_agent.py
+++ b/src/dao_ai/pipeline/notebooks/06_deploy_agent.py
@@ -37,7 +37,7 @@ def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
 dbutils.widgets.text(name="config-path", defaultValue="")
 dbutils.widgets.dropdown(
     name="deployment-target",
-    choices=["", "model_serving", "apps", "both"],
+    choices=["", "model_serving", "apps", "mcp"],
     defaultValue="",
 )
 dbutils.widgets.dropdown(
@@ -133,9 +133,6 @@ deployment_target: DeploymentTarget
 if deployment_target_str:
     deployment_target = DeploymentTarget(deployment_target_str)
     print(f"Using widget-specified deployment target: {deployment_target.value}")
-elif config.app and config.app.deployment_target:
-    deployment_target = config.app.deployment_target
-    print(f"Using config file deployment target: {deployment_target.value}")
 else:
     deployment_target = DeploymentTarget.MODEL_SERVING
     print("Using default deployment target: model_serving")
@@ -147,14 +144,10 @@ config.display_graph()
 # COMMAND ----------
 
 # Only log/register the MLflow model for Model Serving deployments.
-# Apps deploy directly from the config + PyPI package.
-if deployment_target != DeploymentTarget.APPS:
+# Apps and MCP deploy directly from the config + PyPI package (no MLflow model registration).
+if deployment_target not in (DeploymentTarget.APPS, DeploymentTarget.MCP):
     config.create_agent(development=development)
 
 # COMMAND ----------
 
-if deployment_target == DeploymentTarget.BOTH:
-    config.deploy_agent(target=DeploymentTarget.MODEL_SERVING, development=development)
-    config.deploy_agent(target=DeploymentTarget.APPS, development=development)
-else:
-    config.deploy_agent(target=deployment_target, development=development)
+config.deploy_agent(target=deployment_target, development=development)

--- a/src/dao_ai/providers/base.py
+++ b/src/dao_ai/providers/base.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Any, Sequence
 from dao_ai.config import (
     AppModel,
     DatasetModel,
-    DeploymentTarget,
     SchemaModel,
+    ServingMode,
     UnityCatalogFunctionSqlModel,
     VectorStoreModel,
     VolumeModel,
@@ -71,7 +71,7 @@ class ServiceProvider(ABC):
     def deploy_agent(
         self,
         config: "AppConfig",
-        target: DeploymentTarget = DeploymentTarget.MODEL_SERVING,
+        target: ServingMode = ServingMode.MODEL_SERVING,
         development: bool | None = None,
     ) -> Any:
         """
@@ -79,6 +79,6 @@ class ServiceProvider(ABC):
 
         Args:
             config: The AppConfig containing deployment configuration
-            target: The deployment target (MODEL_SERVING or APPS)
+            target: The serving mode (MODEL_SERVING or APPS)
         """
         ...

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -53,7 +53,6 @@ from dao_ai.config import (
     DatabaseModel,
     DatabricksAppModel,
     DatasetModel,
-    DeploymentTarget,
     FunctionModel,
     GenieEntitlement,
     GenieRoomModel,
@@ -62,6 +61,7 @@ from dao_ai.config import (
     InferenceEndpointModel,
     IsDatabricksResource,
     SchemaModel,
+    ServingMode,
     TableModel,
     UnityCatalogFunctionSqlModel,
     VectorStoreModel,
@@ -2405,7 +2405,7 @@ class DatabricksProvider(ServiceProvider):
     def deploy_agent(
         self,
         config: AppConfig,
-        target: DeploymentTarget = DeploymentTarget.MODEL_SERVING,
+        target: ServingMode = ServingMode.MODEL_SERVING,
         development: bool | None = None,
     ) -> None:
         """
@@ -2416,19 +2416,19 @@ class DatabricksProvider(ServiceProvider):
 
         Args:
             config: The AppConfig containing deployment configuration
-            target: The deployment target (MODEL_SERVING, APPS, or MCP)
+            target: The serving mode (MODEL_SERVING, APPS, or MCP)
             development: When True, ship local dao-ai source/wheel; when False,
                 the published PyPI package; when None, auto-detect from the
                 install type. Only the Apps path consumes this today.
         """
-        if target == DeploymentTarget.MODEL_SERVING:
+        if target == ServingMode.MODEL_SERVING:
             self.deploy_model_serving_agent(config)
-        elif target == DeploymentTarget.APPS:
+        elif target == ServingMode.APPS:
             self.deploy_apps_agent(config, development=development)
-        elif target == DeploymentTarget.MCP:
+        elif target == ServingMode.MCP:
             self.deploy_mcp_agent(config, development=development)
         else:
-            raise ValueError(f"Unknown deployment target: {target}")
+            raise ValueError(f"Unknown serving mode: {target}")
 
     def create_catalog(self, schema: SchemaModel) -> CatalogInfo:
         catalog_info: CatalogInfo

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -1715,14 +1715,23 @@ class DatabricksProvider(ServiceProvider):
             count += 1
         return count
 
-    def deploy_apps_agent(
-        self, config: AppConfig, development: bool | None = None
+    def _deploy_app(
+        self,
+        config: AppConfig,
+        *,
+        app_command: list[str],
+        extras: set[str],
+        include_chat_ui: bool,
+        development: bool | None = None,
     ) -> None:
         """
-        Deploy agent as a Databricks App.
+        Deploy a dao-ai app to Databricks Apps via the SDK-native path.
 
-        This method creates or updates a Databricks App that serves the agent
-        using the app_server module.
+        Shared machinery for both the chat App (:meth:`deploy_apps_agent`) and
+        the MCP server (:meth:`deploy_mcp_agent`). Creates or updates a
+        Databricks App, uploading config + code + a portable pyproject/uv.lock,
+        then deploys and waits, links the trace destination, and grants the
+        App SP the trace-persistence privileges.
 
         The deployment process:
         1. Determine the workspace source path for the app
@@ -1731,7 +1740,14 @@ class DatabricksProvider(ServiceProvider):
         4. Deploy the app
 
         Args:
-            config: The AppConfig containing deployment configuration
+            config: The AppConfig containing deployment configuration.
+            app_command: The container command to run (e.g. the chat proxy or
+                the MCP server entrypoint).
+            extras: The dao-ai optional-feature extras to install.
+            include_chat_ui: Whether the generated app.yaml should inject the
+                chat-UI proxy env vars.
+            development: When True, ship local dao-ai source/wheel; when False,
+                the published PyPI package; when None, auto-detect.
 
         Note:
             The config file must be loaded via AppConfig.from_file() so that
@@ -1759,16 +1775,12 @@ class DatabricksProvider(ServiceProvider):
 
         logger.info("Deploying agent to Databricks Apps", app_name=app_name)
 
-        # Resolve optional-feature extras so the uploaded requirements install
-        # exactly what this config's features need (e.g. dao-ai[a2a,rerank]).
-        from dao_ai._extras import (
-            format_extras_suffix,
-            resolve_required_extras_or_all,
-        )
+        # Format the caller-resolved optional-feature extras so the uploaded
+        # requirements install exactly what this deploy needs (e.g.
+        # dao-ai[a2a,rerank]).
+        from dao_ai._extras import format_extras_suffix
 
-        extras_suffix: str = format_extras_suffix(
-            resolve_required_extras_or_all(config, target="apps")
-        )
+        extras_suffix: str = format_extras_suffix(extras)
         # User-declared extra pip packages for their custom app code — appended
         # to the uploaded requirements.txt so Apps installs them (parity with
         # Model Serving, which bakes them into the model's conda_env).
@@ -1894,18 +1906,9 @@ class DatabricksProvider(ServiceProvider):
         # app's uv sync (packages=["src"]) builds them into the app wheel.
         self._upload_src_packages(config, source_path)
 
-        # Determine install command based on dev vs published mode.
-        # Respect config.app.enable_chat_proxy (default True) so the deployed
-        # app spawns the chat UI alongside the agent backend, matching the
-        # behavior of `dao-ai generate-agent`.
-        enable_chat_proxy: bool = (
-            config.app.enable_chat_proxy
-            if config.app and config.app.enable_chat_proxy is not None
-            else True
-        )
-        entrypoint_module: str = (
-            "dao_ai.apps.start_app" if enable_chat_proxy else "dao_ai.apps.server"
-        )
+        # Determine install command based on dev vs published mode. The
+        # container command (chat proxy vs MCP server) is chosen by the caller
+        # and threaded in via ``app_command``.
         if not _use_local_source(development):
             # Ship ``pyproject.toml`` (sole ``dao-ai>={ver}`` dep) + a portable
             # ``uv.lock`` so Databricks Apps' build phase runs
@@ -1967,12 +1970,10 @@ class DatabricksProvider(ServiceProvider):
                 overwrite=True,
             )
 
-            app_command = ["python", "-m", entrypoint_module]
             logger.info(
                 "dao-ai source for app: PyPI package",
                 version=dao_ai_version(),
-                entrypoint=entrypoint_module,
-                chat_proxy=enable_chat_proxy,
+                command=app_command,
             )
         else:
             dev_wheel: Path | None = find_dev_wheel()
@@ -2060,10 +2061,8 @@ class DatabricksProvider(ServiceProvider):
             logger.info(
                 "dao-ai source for app: dev wheel (uv.lock)",
                 wheel=wheel_path.name,
-                entrypoint=entrypoint_module,
-                chat_proxy=enable_chat_proxy,
+                command=app_command,
             )
-            app_command = ["python", "-m", entrypoint_module]
 
         # The chat UI (e2e-chatbot-app-next) is cloned and built at runtime
         # by start_app.py, matching the official Databricks agent template
@@ -2076,6 +2075,7 @@ class DatabricksProvider(ServiceProvider):
             config,
             command=app_command,
             include_resources=True,
+            include_chat_ui=include_chat_ui,
         )
 
         app_yaml_path: str = f"{source_path}/app.yaml"
@@ -2366,6 +2366,42 @@ class DatabricksProvider(ServiceProvider):
                     error=str(e),
                 )
 
+    def deploy_apps_agent(
+        self, config: AppConfig, development: bool | None = None
+    ) -> None:
+        """Deploy the agent as a Databricks App (chat UI) via the SDK path."""
+        from dao_ai._extras import resolve_required_extras_or_all
+
+        enable_chat_proxy: bool = (
+            config.app.enable_chat_proxy
+            if config.app and config.app.enable_chat_proxy is not None
+            else True
+        )
+        entrypoint: str = (
+            "dao_ai.apps.start_app" if enable_chat_proxy else "dao_ai.apps.server"
+        )
+        self._deploy_app(
+            config,
+            app_command=["python", "-m", entrypoint],
+            extras=set(resolve_required_extras_or_all(config, target="apps")),
+            include_chat_ui=enable_chat_proxy,
+            development=development,
+        )
+
+    def deploy_mcp_agent(
+        self, config: AppConfig, development: bool | None = None
+    ) -> None:
+        """Deploy the dao-ai MCP server as a Databricks App via the SDK path."""
+        from dao_ai._extras import expand_all, resolve_required_extras_or_all
+
+        self._deploy_app(
+            config,
+            app_command=["python", "-m", "dao_ai.mcp.server"],
+            extras={"mcp", *expand_all(resolve_required_extras_or_all(config, target="mcp"))},
+            include_chat_ui=False,
+            development=development,
+        )
+
     def deploy_agent(
         self,
         config: AppConfig,
@@ -2380,18 +2416,17 @@ class DatabricksProvider(ServiceProvider):
 
         Args:
             config: The AppConfig containing deployment configuration
-            target: The deployment target (MODEL_SERVING or APPS)
+            target: The deployment target (MODEL_SERVING, APPS, or MCP)
             development: When True, ship local dao-ai source/wheel; when False,
                 the published PyPI package; when None, auto-detect from the
                 install type. Only the Apps path consumes this today.
         """
-        if target == DeploymentTarget.BOTH:
-            self.deploy_model_serving_agent(config)
-            self.deploy_apps_agent(config, development=development)
-        elif target == DeploymentTarget.MODEL_SERVING:
+        if target == DeploymentTarget.MODEL_SERVING:
             self.deploy_model_serving_agent(config)
         elif target == DeploymentTarget.APPS:
             self.deploy_apps_agent(config, development=development)
+        elif target == DeploymentTarget.MCP:
+            self.deploy_mcp_agent(config, development=development)
         else:
             raise ValueError(f"Unknown deployment target: {target}")
 

--- a/src/dao_ai/utils.py
+++ b/src/dao_ai/utils.py
@@ -136,7 +136,7 @@ def dev_local_version(pyproject_path: Path) -> Iterator[None]:
     restored on exit so the working tree is left unchanged.
 
     Wrap every ``uv build --wheel`` call that produces a dev wheel with this
-    (generate-agent, deploy, generate-mcp) so ``--development`` behaves
+    (agent generate, agent deploy, agent generate --mode mcp) so ``--development`` behaves
     uniformly across all deploy paths.
     """
     original = pyproject_path.read_text()

--- a/tests/dao_ai/mcp/_fixtures.py
+++ b/tests/dao_ai/mcp/_fixtures.py
@@ -37,7 +37,6 @@ app:
   name: mcp-dao-ai-test
   description: "Test MCP agent server exposing the dao-ai graph."
   log_level: WARNING
-  deployment_target: apps
   trace_location:
     schema:
       catalog_name: test_catalog

--- a/tests/dao_ai/test_a2a_agent_card.py
+++ b/tests/dao_ai/test_a2a_agent_card.py
@@ -26,7 +26,6 @@ from dao_ai.config import (
     AppConfig,
     AppModel,
     DatabaseModel,
-    DeploymentTarget,
     InferenceEndpointModel,
     ProviderModel,
 )
@@ -53,7 +52,6 @@ def _minimal_config(
         app=AppModel(
             name="dao-ai-test",
             description=description,
-            deployment_target=DeploymentTarget.APPS,
             agents=agents,
             **extra,
         ),

--- a/tests/dao_ai/test_a2a_executor.py
+++ b/tests/dao_ai/test_a2a_executor.py
@@ -45,7 +45,6 @@ from dao_ai.config import (
     AgentModel,
     AppConfig,
     AppModel,
-    DeploymentTarget,
     InferenceEndpointModel,
 )
 
@@ -59,7 +58,6 @@ def _minimal_config() -> AppConfig:
         app=AppModel(
             name="dao-ai-exec-test",
             description="executor test",
-            deployment_target=DeploymentTarget.APPS,
             agents=[
                 AgentModel(
                     name="greeter",

--- a/tests/dao_ai/test_a2a_integration.py
+++ b/tests/dao_ai/test_a2a_integration.py
@@ -37,7 +37,6 @@ from dao_ai.config import (
     AgentModel,
     AppConfig,
     AppModel,
-    DeploymentTarget,
     InferenceEndpointModel,
 )
 
@@ -47,7 +46,6 @@ def _config() -> AppConfig:
         app=AppModel(
             name="dao-ai-int-test",
             description="integration test agent",
-            deployment_target=DeploymentTarget.APPS,
             agents=[
                 AgentModel(
                     name="greeter",

--- a/tests/dao_ai/test_a2a_routes.py
+++ b/tests/dao_ai/test_a2a_routes.py
@@ -16,7 +16,6 @@ from dao_ai.config import (
     AgentModel,
     AppConfig,
     AppModel,
-    DeploymentTarget,
     InferenceEndpointModel,
 )
 
@@ -37,7 +36,6 @@ def _config(*, a2a: A2AModel | None = None) -> AppConfig:
         app=AppModel(
             name="dao-ai-routes-test",
             description="test agent",
-            deployment_target=DeploymentTarget.APPS,
             agents=[_agent()],
             **extra,
         ),

--- a/tests/dao_ai/test_a2a_security.py
+++ b/tests/dao_ai/test_a2a_security.py
@@ -36,7 +36,6 @@ from dao_ai.config import (
     AgentModel,
     AppConfig,
     AppModel,
-    DeploymentTarget,
     InferenceEndpointModel,
 )
 
@@ -46,7 +45,6 @@ def _config_with_schemes(schemes: dict) -> AppConfig:
         app=AppModel(
             name="dao-ai-test",
             description="test",
-            deployment_target=DeploymentTarget.APPS,
             a2a=A2AModel(security_schemes=schemes),
             agents=[
                 AgentModel(

--- a/tests/dao_ai/test_a2a_task_store.py
+++ b/tests/dao_ai/test_a2a_task_store.py
@@ -18,7 +18,6 @@ from dao_ai.config import (
     AppModel,
     BackgroundModel,
     DatabaseModel,
-    DeploymentTarget,
     InferenceEndpointModel,
 )
 
@@ -52,7 +51,6 @@ def _config(
         app=AppModel(
             name="dao-ai-test",
             description="test",
-            deployment_target=DeploymentTarget.APPS,
             background=background,
             agents=[_agent()],
             **extra,

--- a/tests/dao_ai/test_apps_obo_partition.py
+++ b/tests/dao_ai/test_apps_obo_partition.py
@@ -39,7 +39,6 @@ from dao_ai.config import (
     AppConfig,
     AppModel,
     ConnectionModel,
-    DeploymentTarget,
     FunctionModel,
     GenieRoomModel,
     IndexModel,
@@ -199,7 +198,6 @@ class TestGenerateAppResourcesPartition:
             agents={"a": agent},
             app=AppModel(
                 name="obo-test",
-                deployment_target=DeploymentTarget.APPS,
                 agents=[agent],
             ),
         )

--- a/tests/dao_ai/test_bundle_app_space.py
+++ b/tests/dao_ai/test_bundle_app_space.py
@@ -15,7 +15,6 @@ from dao_ai.config import (
     AgentModel,
     AppConfig,
     AppModel,
-    DeploymentTarget,
     InferenceEndpointModel,
 )
 
@@ -28,7 +27,6 @@ def _config(*, space: str | None = None) -> AppConfig:
         app=AppModel(
             name="dao-ai-space-test",
             description="test agent",
-            deployment_target=DeploymentTarget.APPS,
             enable_chat_proxy=False,
             agents=[
                 AgentModel(

--- a/tests/dao_ai/test_bundle_app_workers.py
+++ b/tests/dao_ai/test_bundle_app_workers.py
@@ -15,7 +15,6 @@ from dao_ai.config import (
     AgentModel,
     AppConfig,
     AppModel,
-    DeploymentTarget,
     InferenceEndpointModel,
 )
 
@@ -28,7 +27,6 @@ def _config(*, workers: int | None = None) -> AppConfig:
         app=AppModel(
             name="dao-ai-workers-test",
             description="test agent",
-            deployment_target=DeploymentTarget.APPS,
             enable_chat_proxy=False,
             agents=[
                 AgentModel(

--- a/tests/dao_ai/test_bundle_app_workers.py
+++ b/tests/dao_ai/test_bundle_app_workers.py
@@ -2,8 +2,9 @@
 
 Locks in the contract that ``_build_app_block`` emits the ``DAO_AI_APP_WORKERS``
 env var, which ``start_app.py`` forwards to the backend as ``--workers``. The
-field defaults to 2 (a modest bump over uvicorn's single-worker default, safe on
-the small default Apps compute).
+field defaults to 1: on the default MEDIUM Apps compute a second full graph
+OOM-kills the workers in a respawn loop, and the async I/O-bound agent already
+serves many concurrent requests on one worker's event loop.
 """
 
 from __future__ import annotations
@@ -50,12 +51,12 @@ def _workers_env(apps_block: dict) -> str | None:
 
 @pytest.mark.unit
 class TestAppWorkersEmission:
-    def test_default_workers_is_two(self) -> None:
-        assert _config().app.workers == 2
+    def test_default_workers_is_one(self) -> None:
+        assert _config().app.workers == 1
 
     def test_emits_default_workers_env(self) -> None:
         _, _, apps_block = _build_app_block(_config(), "dao_ai.yaml")
-        assert _workers_env(apps_block) == "2"
+        assert _workers_env(apps_block) == "1"
 
     def test_emits_explicit_workers_env(self) -> None:
         _, _, apps_block = _build_app_block(_config(workers=4), "dao_ai.yaml")

--- a/tests/dao_ai/test_config_vars.py
+++ b/tests/dao_ai/test_config_vars.py
@@ -1679,6 +1679,15 @@ def test_cli_var_flag_appears_in_subparser_help(
             f"--var flag missing from `{command} --help` output"
         )
 
+    # Bundle-noun verbs get --var from the shared _add_bundle_common_args helper.
+    for argv in (["agent", "generate", "--help"], ["workflow", "deploy", "--help"]):
+        with pytest.raises(SystemExit):
+            parse_args(argv)
+        captured = capsys.readouterr()
+        assert "--var" in captured.out, (
+            f"--var flag missing from `{' '.join(argv)}` output"
+        )
+
 
 @pytest.mark.unit
 def test_cli_run_databricks_command_forwards_vars_to_databricks_cli(

--- a/tests/dao_ai/test_config_vars.py
+++ b/tests/dao_ai/test_config_vars.py
@@ -1668,13 +1668,14 @@ def test_cli_var_flag_appears_in_subparser_help(
     """Every config-aware subparser must surface --var in its help."""
     from dao_ai.cli import parse_args
 
-    for command in ("validate", "graph", "monitor", "chat", "vars"):
+    simple_help = (["validate"], ["graph"], ["chat"], ["vars"])
+    for argv in (*simple_help, ["monitor", "scorers"]):
         with pytest.raises(SystemExit):
             # --help triggers a clean SystemExit(0) after printing.
-            parse_args([command, "--help"])
+            parse_args([*argv, "--help"])
         captured = capsys.readouterr()
         assert "--var" in captured.out, (
-            f"--var flag missing from `{command} --help` output"
+            f"--var flag missing from `{' '.join(argv)} --help` output"
         )
 
     # Bundle-noun verbs get --var from the shared _add_bundle_common_args helper.

--- a/tests/dao_ai/test_config_vars.py
+++ b/tests/dao_ai/test_config_vars.py
@@ -1035,7 +1035,6 @@ def parameterised_config_path(tmp_path: Path) -> Path:
             app:
               name: dao_ai_test_${var.module_id}
               description: "test"
-              deployment_target: apps
               agents:
                 - *hello
             """
@@ -1336,7 +1335,6 @@ def anchored_config_path(tmp_path: Path) -> Path:
             app:
               name: dao_ai_test_${var.module_id}
               description: "test"
-              deployment_target: apps
               agents:
                 - *hello
             """
@@ -1741,3 +1739,62 @@ def test_cli_run_databricks_command_forwards_vars_to_databricks_cli(
     cmd_str = " ".join(cmd)
     assert '--var="module_id=09"' in cmd_str
     assert '--var="catalog=nfleming"' in cmd_str
+
+
+@pytest.mark.unit
+def test_appconfig_has_no_deployment_target_field():
+    from dao_ai.config import AppModel
+
+    assert "deployment_target" not in AppModel.model_fields
+
+
+@pytest.mark.unit
+def test_appconfig_no_registered_model_no_config_time_error():
+    """Removing deployment_target also removes the config-time validator that
+    raised when registered_model was absent.  The check now lives at deploy
+    time in deploy_model_serving_agent.  Constructing AppConfig with a missing
+    registered_model must not raise."""
+    import tempfile
+
+    from dao_ai.config import AppConfig
+
+    yaml_text = dedent(
+        """\
+        schemas:
+          s:
+            catalog_name: cat
+            schema_name: sch
+
+        agents:
+          hello:
+            name: hello
+            description: hello
+            model:
+              name: databricks-meta-llama-3-1-70b-instruct
+            prompt: hi
+
+        app:
+          name: no_model_app
+          description: "app without registered_model"
+          agents:
+            - name: hello
+              description: hello
+              model:
+                name: databricks-meta-llama-3-1-70b-instruct
+              prompt: hi
+        """
+    )
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as fh:
+        fh.write(yaml_text)
+        tmp_path = Path(fh.name)
+
+    try:
+        # Should not raise — the registered_model check moved to deploy time.
+        config = AppConfig.from_file(tmp_path, initialize=False)
+        assert config.app is not None
+        assert config.app.registered_model is None
+    finally:
+        tmp_path.unlink(missing_ok=True)

--- a/tests/dao_ai/test_config_vars.py
+++ b/tests/dao_ai/test_config_vars.py
@@ -1668,7 +1668,7 @@ def test_cli_var_flag_appears_in_subparser_help(
     """Every config-aware subparser must surface --var in its help."""
     from dao_ai.cli import parse_args
 
-    for command in ("validate", "graph", "deploy", "monitor", "chat", "vars"):
+    for command in ("validate", "graph", "monitor", "chat", "vars"):
         with pytest.raises(SystemExit):
             # --help triggers a clean SystemExit(0) after printing.
             parse_args([command, "--help"])

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -109,7 +109,6 @@ def test_from_file_stamps_base_path_on_models(tmp_path):
         "    prompt: You are concise.\n"
         "app:\n"
         "  name: hw_app\n"
-        "  deployment_target: apps\n"
         "  agents:\n"
         "    - *greeter\n"
         "datasets:\n"

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -845,7 +845,7 @@ def test_deploy_agent_routes_to_model_serving_explicitly():
     """Test that deploy_agent routes to deploy_model_serving_agent when target=MODEL_SERVING."""
     from unittest.mock import MagicMock, patch
 
-    from dao_ai.config import AppConfig, AppModel, DeploymentTarget
+    from dao_ai.config import AppConfig, AppModel, ServingMode
     from dao_ai.providers.databricks import DatabricksProvider
 
     mock_config = MagicMock(spec=AppConfig)
@@ -868,7 +868,7 @@ def test_deploy_agent_routes_to_model_serving_explicitly():
             provider = DatabricksProvider()
             _stamp_extras_resolvable(mock_config)
             provider.deploy_agent(
-                config=mock_config, target=DeploymentTarget.MODEL_SERVING
+                config=mock_config, target=ServingMode.MODEL_SERVING
             )
 
             mock_model_serving.assert_called_once_with(mock_config)
@@ -880,7 +880,7 @@ def test_deploy_agent_routes_to_apps_when_specified():
     """Test that deploy_agent routes to deploy_apps_agent when target=APPS."""
     from unittest.mock import MagicMock, patch
 
-    from dao_ai.config import AppConfig, AppModel, DeploymentTarget
+    from dao_ai.config import AppConfig, AppModel, ServingMode
     from dao_ai.providers.databricks import DatabricksProvider
 
     mock_config = MagicMock(spec=AppConfig)
@@ -895,7 +895,7 @@ def test_deploy_agent_routes_to_apps_when_specified():
         with patch.object(DatabricksProvider, "deploy_apps_agent") as mock_apps:
             provider = DatabricksProvider()
             _stamp_extras_resolvable(mock_config)
-            provider.deploy_agent(config=mock_config, target=DeploymentTarget.APPS)
+            provider.deploy_agent(config=mock_config, target=ServingMode.APPS)
 
             mock_apps.assert_called_once_with(mock_config, development=None)
             mock_model_serving.assert_not_called()
@@ -904,7 +904,7 @@ def test_deploy_agent_routes_to_apps_when_specified():
 @pytest.mark.unit
 def test_deploy_agent_routes_mcp(monkeypatch):
     """deploy_agent routes target=MCP to deploy_mcp_agent."""
-    from dao_ai.config import DeploymentTarget
+    from dao_ai.config import ServingMode
     from dao_ai.providers.databricks import DatabricksProvider
 
     p = DatabricksProvider.__new__(DatabricksProvider)  # no __init__ / no WorkspaceClient
@@ -912,7 +912,7 @@ def test_deploy_agent_routes_mcp(monkeypatch):
     monkeypatch.setattr(p, "deploy_model_serving_agent", lambda c: calls.append("ms"), raising=False)
     monkeypatch.setattr(p, "deploy_apps_agent", lambda c, development=None: calls.append("apps"), raising=False)
     monkeypatch.setattr(p, "deploy_mcp_agent", lambda c, development=None: calls.append("mcp"), raising=False)
-    p.deploy_agent(config=object(), target=DeploymentTarget.MCP)
+    p.deploy_agent(config=object(), target=ServingMode.MCP)
     assert calls == ["mcp"]
 
 
@@ -1332,27 +1332,27 @@ def test_deploy_apps_agent_serializes_python_built_config(tmp_path):
 
 
 @pytest.mark.unit
-def test_deployment_target_enum_values():
-    """Test that DeploymentTarget enum has expected values."""
-    from dao_ai.config import DeploymentTarget
+def test_serving_mode_enum_values():
+    """Test that ServingMode enum has expected values."""
+    from dao_ai.config import ServingMode
 
-    assert DeploymentTarget.MODEL_SERVING.value == "model_serving"
-    assert DeploymentTarget.APPS.value == "apps"
+    assert ServingMode.MODEL_SERVING.value == "model_serving"
+    assert ServingMode.APPS.value == "apps"
 
     # Test enum can be created from string
-    assert DeploymentTarget("model_serving") == DeploymentTarget.MODEL_SERVING
-    assert DeploymentTarget("apps") == DeploymentTarget.APPS
+    assert ServingMode("model_serving") == ServingMode.MODEL_SERVING
+    assert ServingMode("apps") == ServingMode.APPS
 
 
 @pytest.mark.unit
-def test_deployment_target_members():
-    from dao_ai.config import DeploymentTarget
-    assert {t.value for t in DeploymentTarget} == {"model_serving", "apps", "mcp"}
-    assert DeploymentTarget("mcp") is DeploymentTarget.MCP
+def test_serving_mode_members():
+    from dao_ai.config import ServingMode
+    assert {t.value for t in ServingMode} == {"model_serving", "apps", "mcp"}
+    assert ServingMode("mcp") is ServingMode.MCP
     with pytest.raises(ValueError):
-        DeploymentTarget("both")
+        ServingMode("both")
     with pytest.raises(AttributeError):
-        _ = DeploymentTarget.BOTH
+        _ = ServingMode.BOTH
 
 
 # =============================================================================

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -1302,6 +1302,17 @@ def test_deployment_target_enum_values():
     assert DeploymentTarget("apps") == DeploymentTarget.APPS
 
 
+@pytest.mark.unit
+def test_deployment_target_members():
+    from dao_ai.config import DeploymentTarget
+    assert {t.value for t in DeploymentTarget} == {"model_serving", "apps", "mcp"}
+    assert DeploymentTarget("mcp") is DeploymentTarget.MCP
+    with pytest.raises(ValueError):
+        DeploymentTarget("both")
+    with pytest.raises(AttributeError):
+        _ = DeploymentTarget.BOTH
+
+
 # =============================================================================
 # WorkspaceClient OBO with Forwarded Headers Tests
 # =============================================================================

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -903,6 +903,49 @@ def test_deploy_agent_routes_to_apps_when_specified():
 
 
 @pytest.mark.unit
+def test_deploy_agent_routes_mcp(monkeypatch):
+    """deploy_agent routes target=MCP to deploy_mcp_agent."""
+    from dao_ai.config import DeploymentTarget
+    from dao_ai.providers.databricks import DatabricksProvider
+
+    p = DatabricksProvider.__new__(DatabricksProvider)  # no __init__ / no WorkspaceClient
+    calls = []
+    monkeypatch.setattr(p, "deploy_model_serving_agent", lambda c: calls.append("ms"), raising=False)
+    monkeypatch.setattr(p, "deploy_apps_agent", lambda c, development=None: calls.append("apps"), raising=False)
+    monkeypatch.setattr(p, "deploy_mcp_agent", lambda c, development=None: calls.append("mcp"), raising=False)
+    p.deploy_agent(config=object(), target=DeploymentTarget.MCP)
+    assert calls == ["mcp"]
+
+
+@pytest.mark.unit
+def test_deploy_mcp_agent_command_and_extras(monkeypatch):
+    """deploy_mcp_agent forwards the MCP command, mcp extras, and chat-UI off."""
+    import dao_ai._extras as _extras
+    from dao_ai.providers.databricks import DatabricksProvider
+
+    monkeypatch.setattr(_extras, "resolve_required_extras_or_all", lambda config, target="mcp": set())
+
+    p = DatabricksProvider.__new__(DatabricksProvider)
+    captured = {}
+
+    def _fake_deploy_app(config, *, app_command, extras, include_chat_ui, development):
+        captured.update(app_command=app_command, extras=extras, include_chat_ui=include_chat_ui)
+
+    monkeypatch.setattr(p, "_deploy_app", _fake_deploy_app, raising=False)
+
+    class _App:
+        enable_chat_proxy = None
+
+    class _Cfg:
+        app = _App()
+
+    p.deploy_mcp_agent(_Cfg())
+    assert captured["app_command"] == ["python", "-m", "dao_ai.mcp.server"]
+    assert "mcp" in captured["extras"]
+    assert captured["include_chat_ui"] is False
+
+
+@pytest.mark.unit
 def test_deploy_apps_agent_creates_new_app():
     """Test that deploy_apps_agent creates a new app when it doesn't exist."""
     from unittest.mock import MagicMock, patch

--- a/tests/dao_ai/test_deep_agent_graph.py
+++ b/tests/dao_ai/test_deep_agent_graph.py
@@ -50,7 +50,6 @@ class TestCreateDeepAgentGraph:
             resources=ResourcesModel(),
             app=AppModel(
                 name="test_app",
-                deployment_target="apps",
                 agents=[AgentModel(name="main", model=LLMModel(name="x"))],
                 orchestration=OrchestrationModel(
                     deep_agent=DeepAgentModel(
@@ -70,7 +69,6 @@ class TestCreateDeepAgentGraph:
             ),
             app=AppModel(
                 name="test_app",
-                deployment_target="apps",
                 agents=[AgentModel(name="main", model=LLMModel(name="x"))],
                 orchestration=OrchestrationModel(
                     deep_agent=DeepAgentModel(
@@ -89,7 +87,6 @@ class TestCreateDeepAgentGraph:
             resources=ResourcesModel(),
             app=AppModel(
                 name="test_app",
-                deployment_target="apps",
                 agents=[AgentModel(name="main", model=LLMModel(name="x"))],
                 orchestration=OrchestrationModel(
                     deep_agent=DeepAgentModel(
@@ -120,7 +117,6 @@ class TestCreateDeepAgentGraph:
             resources=ResourcesModel(),
             app=AppModel(
                 name="test_app",
-                deployment_target="apps",
                 agents=[
                     AgentModel(name="main", model=LLMModel(name="x")),
                     researcher,
@@ -145,7 +141,6 @@ class TestCreateOrchestrationGraphDispatch:
             resources=ResourcesModel(),
             app=AppModel(
                 name="test_app",
-                deployment_target="apps",
                 agents=[AgentModel(name="main", model=LLMModel(name="x"))],
                 orchestration=OrchestrationModel(
                     deep_agent=DeepAgentModel(system_prompt="hi")

--- a/tests/dao_ai/test_deep_agent_refinements.py
+++ b/tests/dao_ai/test_deep_agent_refinements.py
@@ -42,7 +42,6 @@ class TestAgentSkillsTranslation:
             resources=ResourcesModel(),
             app=AppModel(
                 name="test_app",
-                deployment_target="apps",
                 agents=[agent],
                 orchestration=OrchestrationModel(deep_agent=DeepAgentModel()),
             ),
@@ -73,7 +72,6 @@ class TestAgentSkillsTranslation:
             resources=ResourcesModel(skills={"research": skill}),
             app=AppModel(
                 name="test_app",
-                deployment_target="apps",
                 agents=[agent],
                 orchestration=OrchestrationModel(deep_agent=DeepAgentModel()),
             ),
@@ -94,7 +92,6 @@ class TestAgentSkillsTranslation:
                 resources=ResourcesModel(),
                 app=AppModel(
                     name="test_app",
-                    deployment_target="apps",
                     agents=[agent],
                 ),
             )
@@ -114,7 +111,6 @@ class TestAgentSkillsTranslation:
             resources=ResourcesModel(),
             app=AppModel(
                 name="test_app",
-                deployment_target="apps",
                 agents=[agent],
                 orchestration=OrchestrationModel(deep_agent=DeepAgentModel()),
             ),
@@ -133,7 +129,6 @@ class TestAgentSkillsTranslation:
             resources=ResourcesModel(),
             app=AppModel(
                 name="test_app",
-                deployment_target="apps",
                 agents=[agent],
                 orchestration=OrchestrationModel(deep_agent=DeepAgentModel()),
             ),
@@ -144,7 +139,6 @@ class TestAgentSkillsTranslation:
             resources=ResourcesModel(),
             app=AppModel(
                 name="test_app",
-                deployment_target="apps",
                 agents=[agent],
                 orchestration=OrchestrationModel(deep_agent=DeepAgentModel()),
             ),
@@ -220,7 +214,6 @@ class TestImplicitSubagents:
             resources=ResourcesModel(),
             app=AppModel(
                 name="test_app",
-                deployment_target="apps",
                 agents=[],
                 orchestration=OrchestrationModel(
                     deep_agent=DeepAgentModel(system_prompt="hi")
@@ -234,7 +227,6 @@ class TestImplicitSubagents:
                 resources=ResourcesModel(),
                 app=AppModel(
                     name="test_app",
-                    deployment_target="apps",
                     agents=[],
                 ),
             )
@@ -256,7 +248,6 @@ class TestImplicitSubagents:
             resources=ResourcesModel(),
             app=AppModel(
                 name="test_app",
-                deployment_target="apps",
                 agents=[researcher],
                 orchestration=OrchestrationModel(
                     deep_agent=DeepAgentModel(system_prompt="plan")
@@ -297,7 +288,6 @@ class TestImplicitSubagents:
             resources=ResourcesModel(),
             app=AppModel(
                 name="test_app",
-                deployment_target="apps",
                 agents=[base],
                 orchestration=OrchestrationModel(
                     deep_agent=DeepAgentModel(subagents=[override])

--- a/tests/dao_ai/test_deep_agent_resolution.py
+++ b/tests/dao_ai/test_deep_agent_resolution.py
@@ -54,7 +54,6 @@ def _minimal_config(*, agents: list[AgentModel] | None = None) -> AppConfig:
         resources=ResourcesModel(),
         app=AppModel(
             name="test_app",
-            deployment_target="apps",
             agents=agents,
             orchestration=OrchestrationModel(deep_agent=DeepAgentModel()),
         ),

--- a/tests/dao_ai/test_deterministic_handoffs.py
+++ b/tests/dao_ai/test_deterministic_handoffs.py
@@ -1072,7 +1072,6 @@ class TestSwarmCycleDetectionIntegration:
             "agents": agents,
             "app": {
                 "name": "tier-routing",
-                "deployment_target": "apps",
                 "agents": list(agents.values()),
                 "orchestration": {
                     "swarm": {
@@ -1102,7 +1101,6 @@ class TestSwarmCycleDetectionIntegration:
             "agents": agents,
             "app": {
                 "name": "tier-routing",
-                "deployment_target": "apps",
                 "agents": list(agents.values()),
                 "orchestration": {
                     "swarm": {

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -954,3 +954,65 @@ class TestDeployAutoGenerate:
         with pytest.raises(SystemExit) as exc:
             cli.handle_agent_command(opts)
         assert exc.value.code == 1
+
+    def test_deploy_autogenerate_calls_resolve_all_resources(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On auto-generate (unstaged deploy), _resolve_all_resources must be called."""
+        cfg = self._write_cfg(tmp_path)
+        out = tmp_path / "out"
+
+        resolve_calls: list[str] = []
+
+        def fake_writer(config: object, bundle_dir: object, **kw: object) -> None:
+            import pathlib
+
+            pathlib.Path(str(bundle_dir)).mkdir(parents=True, exist_ok=True)
+            (pathlib.Path(str(bundle_dir)) / "databricks.yaml").write_text("bundle: {}\n")
+
+        def track_resolve(self_config: object) -> None:
+            resolve_calls.append("called")
+
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(
+            "dao_ai.apps.bundle.write_bundle",
+            fake_writer,
+        )
+        monkeypatch.setattr(
+            "dao_ai.config.AppConfig._resolve_all_resources",
+            track_resolve,
+        )
+        with patch.object(cli, "deploy_app_bundle"):
+            opts = parse_args(["agent", "deploy", "-c", str(cfg), "-o", str(out)])
+            cli.handle_agent_command(opts)
+
+        assert resolve_calls == [
+            "called"
+        ], "auto-generate path must call _resolve_all_resources"
+
+    def test_deploy_inplace_does_not_call_resolve_all_resources(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On in-place deploy (already staged), _resolve_all_resources must NOT be called."""
+        cfg = self._write_cfg(tmp_path)
+        out = tmp_path / "staged"
+        out.mkdir()
+        (out / "databricks.yaml").write_text("bundle: {}\n")
+
+        resolve_calls: list[str] = []
+
+        def track_resolve(self_config: object) -> None:
+            resolve_calls.append("called")
+
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(
+            "dao_ai.config.AppConfig._resolve_all_resources",
+            track_resolve,
+        )
+        with patch.object(cli, "deploy_app_bundle"):
+            opts = parse_args(["agent", "deploy", "-c", str(cfg), "-o", str(out)])
+            cli.handle_agent_command(opts)
+
+        assert (
+            resolve_calls == []
+        ), "in-place deploy path must NOT call _resolve_all_resources"

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -1,10 +1,11 @@
 """Tests for the --development / --no-development tri-state across CLI commands.
 
 The flag must resolve identically on every deploy-capable command:
-``deploy``, ``generate-workflow``, ``generate-agent``, ``generate-mcp`` —
-``--development`` -> True, ``--no-development`` -> False, omitted -> None
-(auto-detect). For ``generate-workflow`` it is additionally forwarded to the
-deploy notebook as a ``--var development=auto|true|false`` bundle variable.
+``deploy``, ``<noun> generate`` (agent/mcp/workflow) and the flat
+``generate-<noun>`` aliases — ``--development`` -> True, ``--no-development`` ->
+False, omitted -> None (auto-detect). For the workflow it is additionally
+forwarded to the deploy notebook as a ``--var development=auto|true|false``
+bundle variable.
 """
 
 from __future__ import annotations
@@ -20,13 +21,23 @@ from dao_ai.config import AppConfig
 
 
 def _base(cmd: str) -> list[str]:
-    return [cmd, "-c", "config.yaml"]
+    """Build argv for a command, splitting a nested `"agent generate"` on space."""
+    return cmd.split() + ["-c", "config.yaml"]
 
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "command",
-    ["deploy", "generate-workflow", "generate-agent", "generate-mcp"],
+    [
+        "deploy",
+        "workflow generate",
+        "agent generate",
+        "mcp generate",
+        # Flat aliases carry the same source flags.
+        "generate-workflow",
+        "generate-agent",
+        "generate-mcp",
+    ],
 )
 class TestDevelopmentTriState:
     def test_development_true(self, command: str) -> None:
@@ -43,14 +54,31 @@ class TestDevelopmentTriState:
 
 
 @pytest.mark.unit
-class TestRemovedCommandAliases:
-    """0.2.0 removed the old command names; only the new verbs are accepted."""
+class TestNounVerbParsing:
+    """Nested `<noun> <verb>` parses to (command=noun, subcommand=verb); the
+    flat `generate-<noun>` aliases still parse; truly-removed names are rejected.
+    """
 
-    def test_new_names_parse(self) -> None:
+    @pytest.mark.parametrize("noun", ["agent", "mcp", "workflow"])
+    @pytest.mark.parametrize("verb", ["generate", "deploy", "run", "destroy"])
+    def test_nested_verbs_parse(self, noun: str, verb: str) -> None:
+        opts = parse_args([noun, verb, "-c", "config.yaml"])
+        assert opts.command == noun
+        assert opts.subcommand == verb
+
+    @pytest.mark.parametrize("noun", ["agent", "mcp", "workflow"])
+    def test_bare_noun_requires_verb(self, noun: str) -> None:
+        with pytest.raises(SystemExit):
+            parse_args([noun, "-c", "config.yaml"])
+
+    def test_flat_aliases_parse(self) -> None:
         assert parse_args(_base("generate-agent")).command == "generate-agent"
-        assert (
-            parse_args(_base("generate-workflow")).command == "generate-workflow"
-        )
+        assert parse_args(_base("generate-mcp")).command == "generate-mcp"
+        assert parse_args(_base("generate-workflow")).command == "generate-workflow"
+
+    def test_deploy_verb_accepts_run_chain(self) -> None:
+        # `<noun> deploy --run` deploys then runs; run flag is on the deploy verb.
+        assert parse_args(["agent", "deploy", "-c", "c.yaml", "--run"]).run is True
 
     @pytest.mark.parametrize("old", ["generate-bundle", "pipeline"])
     def test_old_names_rejected(self, old: str) -> None:
@@ -99,14 +127,84 @@ class TestDefaultBundleDir:
         under = base / "agent" / "app"
         under.mkdir(parents=True)
         (under / "sentinel").write_text("x")
-        cli._clean_default_staging_dir(under, is_default=True)
+        cli._write_staging_marker(under, is_default=True)  # mark as our output
+        cli._clean_default_staging_dir(
+            under, is_default=True, overwrite=False, noun="agent"
+        )
         assert not under.exists(), "path under env base must be cleaned"
 
         outside = tmp_path / "user_dir"
         outside.mkdir()
         (outside / "keep").write_text("x")
-        cli._clean_default_staging_dir(outside, is_default=True)
+        cli._clean_default_staging_dir(
+            outside, is_default=True, overwrite=False, noun="agent"
+        )
         assert (outside / "keep").exists(), "path outside base must be protected"
+
+
+@pytest.mark.unit
+class TestEditSafety:
+    """A default staging dir with hand-edits is protected from re-generate."""
+
+    def _staged(self, tmp_path: Path) -> Path:
+        base = tmp_path / "base"
+        d = base / "agent" / "app"
+        d.mkdir(parents=True)
+        (d / "app.yaml").write_text("orig\n")
+        cli._write_staging_marker(d, is_default=True)
+        return d
+
+    def test_untouched_dir_wiped_silently(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DAO_AI_BUNDLE_DIR", str(tmp_path / "base"))
+        d = self._staged(tmp_path)
+        cli._clean_default_staging_dir(
+            d, is_default=True, overwrite=False, noun="agent"
+        )
+        assert not d.exists()
+
+    def test_hand_edit_refuses_without_overwrite(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DAO_AI_BUNDLE_DIR", str(tmp_path / "base"))
+        d = self._staged(tmp_path)
+        # Edit a file so its mtime post-dates the marker.
+        marker_mtime = (d / cli._STAGING_MARKER).stat().st_mtime
+        import os
+
+        (d / "app.yaml").write_text("edited\n")
+        os.utime(d / "app.yaml", (marker_mtime + 10, marker_mtime + 10))
+        with pytest.raises(SystemExit) as exc:
+            cli._clean_default_staging_dir(
+                d, is_default=True, overwrite=False, noun="agent"
+            )
+        assert exc.value.code == 1
+        assert d.exists(), "edited dir must be preserved"
+
+    def test_overwrite_wipes_edited_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DAO_AI_BUNDLE_DIR", str(tmp_path / "base"))
+        d = self._staged(tmp_path)
+        (d / "app.yaml").write_text("edited\n")
+        cli._clean_default_staging_dir(
+            d, is_default=True, overwrite=True, noun="agent"
+        )
+        assert not d.exists()
+
+    def test_missing_marker_treated_as_edited(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DAO_AI_BUNDLE_DIR", str(tmp_path / "base"))
+        d = tmp_path / "base" / "agent" / "app"
+        d.mkdir(parents=True)
+        (d / "app.yaml").write_text("user file\n")  # no marker written
+        with pytest.raises(SystemExit):
+            cli._clean_default_staging_dir(
+                d, is_default=True, overwrite=False, noun="agent"
+            )
+        assert d.exists()
 
 
 @pytest.mark.unit
@@ -192,6 +290,68 @@ class TestPipelineEmitsDevelopmentVar:
         assert staged.get("wrote") is True, "bundle must be staged"
         exec_mock.assert_not_called()
 
+    def test_stage_false_skips_write_and_execs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`workflow deploy` (stage=False) runs the bundle verb WITHOUT
+        re-staging: write_pipeline_bundle must not be called, and the existing
+        staged databricks.yaml is executed against in place."""
+        cfg = tmp_path / "c.yaml"
+        cfg.write_text(
+            "resources:\n  models:\n    m: &m\n      name: databricks-gpt-5-4-mini\n"
+            "agents:\n  g: &g\n    name: g\n    description: d\n    model: *m\n"
+            "    prompt: p\n"
+            "app:\n  name: stage_only_app\n  deployment_target: apps\n  agents:\n    - *g\n"
+        )
+        out = tmp_path / "out"
+        out.mkdir()
+        (out / "databricks.yaml").write_text("bundle: {}\n")  # pretend pre-staged
+
+        wrote: dict[str, object] = {}
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(cli, "detect_cloud_provider", lambda p: "aws")
+        monkeypatch.setattr(
+            "dao_ai.pipeline.bundle.write_pipeline_bundle",
+            lambda *a, **k: wrote.setdefault("wrote", True),
+        )
+        exec_mock = patch.object(cli, "_exec_bundle_command").start()
+
+        run_databricks_command(
+            ["bundle", "deploy"],
+            config=str(cfg),
+            output_dir=str(out),
+            development=False,
+            stage=False,
+        )
+        patch.stopall()
+
+        assert "wrote" not in wrote, "stage=False must NOT regenerate the bundle"
+        exec_mock.assert_called_once()
+        assert exec_mock.call_args.kwargs["cwd"] == out
+
+    def test_stage_false_errors_when_not_staged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`workflow deploy` against an unstaged dir exits with guidance."""
+        cfg = tmp_path / "c.yaml"
+        cfg.write_text(
+            "resources:\n  models:\n    m: &m\n      name: databricks-gpt-5-4-mini\n"
+            "agents:\n  g: &g\n    name: g\n    description: d\n    model: *m\n"
+            "    prompt: p\n"
+            "app:\n  name: stage_only_app\n  deployment_target: apps\n  agents:\n    - *g\n"
+        )
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(cli, "detect_cloud_provider", lambda p: "aws")
+        with pytest.raises(SystemExit) as exc:
+            run_databricks_command(
+                ["bundle", "deploy"],
+                config=str(cfg),
+                output_dir=str(tmp_path / "nonexistent"),
+                development=False,
+                stage=False,
+            )
+        assert exc.value.code == 1
+
 
 @pytest.mark.unit
 class TestValidateBundleActionFlags:
@@ -200,7 +360,9 @@ class TestValidateBundleActionFlags:
     workflow handler deployed-then-destroyed while the App driver destroyed-only).
     """
 
-    @pytest.mark.parametrize("cmd", ["generate-workflow", "generate-agent", "generate-mcp"])
+    @pytest.mark.parametrize(
+        "cmd", ["workflow generate", "agent generate", "mcp generate"]
+    )
     @pytest.mark.parametrize("bad", [["--deploy", "--destroy"], ["--run", "--destroy"], ["--deploy", "--run", "--destroy"]])
     def test_destroy_with_deploy_or_run_exits(self, cmd: str, bad: list[str]) -> None:
         options = parse_args(_base(cmd) + bad)
@@ -208,7 +370,9 @@ class TestValidateBundleActionFlags:
             cli._validate_bundle_action_flags(options)
         assert exc.value.code == 1
 
-    @pytest.mark.parametrize("cmd", ["generate-workflow", "generate-agent", "generate-mcp"])
+    @pytest.mark.parametrize(
+        "cmd", ["workflow generate", "agent generate", "mcp generate"]
+    )
     @pytest.mark.parametrize("ok", [["--deploy"], ["--run"], ["--deploy", "--run"], ["--destroy"], []])
     def test_valid_combinations_pass(self, cmd: str, ok: list[str]) -> None:
         options = parse_args(_base(cmd) + ok)
@@ -438,3 +602,78 @@ class TestDeployLinks:
         with patch.object(_sp, "run", return_value=_R()):
             cli._print_job_link(tmp_path, profile=None, target=None)  # no raise
         assert "Job URL" not in capsys.readouterr().out
+
+
+@pytest.mark.unit
+class TestNounVerbDispatch:
+    """main() routes nouns to per-noun handlers; aliases share the generate path;
+    standalone deploy/run act on the staged dir without regenerating."""
+
+    def test_alias_equivalent_to_generate_verb(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`generate-agent` and `agent generate` reach _generate_app_bundle with
+        the same subcommand normalized in."""
+        seen: list[tuple[str, str]] = []
+        monkeypatch.setattr(
+            cli,
+            "_generate_app_bundle",
+            lambda opts, **kw: seen.append((opts.command, opts.subcommand)),
+        )
+        monkeypatch.setattr(cli, "setup_logging", lambda v: None)
+
+        for argv in (["agent", "generate", "-c", "c.yaml"], ["generate-agent", "-c", "c.yaml"]):
+            monkeypatch.setattr("sys.argv", ["dao-ai", *argv])
+            cli.main()
+        # Both routed to agent generate; the alias was normalized to subcommand.
+        assert seen == [("agent", "generate"), ("generate-agent", "generate")]
+
+    def test_deploy_verb_no_regenerate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`agent deploy` on a staged dir calls deploy_app_bundle and never a
+        bundle writer; the sentinel on disk survives."""
+        cfg = tmp_path / "c.yaml"
+        cfg.write_text(
+            "resources:\n  models:\n    m: &m\n      name: databricks-gpt-5-4-mini\n"
+            "agents:\n  g: &g\n    name: g\n    description: d\n    model: *m\n"
+            "    prompt: p\n"
+            "app:\n  name: my_app\n  deployment_target: apps\n  agents:\n    - *g\n"
+        )
+        out = tmp_path / "staged"
+        out.mkdir()
+        (out / "databricks.yaml").write_text("bundle: {}\n")
+        (out / "sentinel").write_text("keep\n")
+
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        wrote: dict[str, object] = {}
+        monkeypatch.setattr(
+            "dao_ai.apps.bundle.write_bundle",
+            lambda *a, **k: wrote.setdefault("wrote", True),
+        )
+        with patch.object(cli, "deploy_app_bundle") as dep:
+            opts = parse_args(["agent", "deploy", "-c", str(cfg), "-o", str(out)])
+            cli.handle_agent_command(opts)
+
+        assert "wrote" not in wrote, "deploy must not regenerate"
+        dep.assert_called_once()
+        assert dep.call_args.kwargs["output_dir"] == out
+        assert (out / "sentinel").read_text() == "keep\n"
+
+    def test_deploy_verb_errors_when_not_staged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = tmp_path / "c.yaml"
+        cfg.write_text(
+            "resources:\n  models:\n    m: &m\n      name: databricks-gpt-5-4-mini\n"
+            "agents:\n  g: &g\n    name: g\n    description: d\n    model: *m\n"
+            "    prompt: p\n"
+            "app:\n  name: my_app\n  deployment_target: apps\n  agents:\n    - *g\n"
+        )
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        opts = parse_args(
+            ["agent", "deploy", "-c", str(cfg), "-o", str(tmp_path / "nope")]
+        )
+        with pytest.raises(SystemExit) as exc:
+            cli.handle_agent_command(opts)
+        assert exc.value.code == 1

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -32,11 +32,9 @@ def _base(cmd: str) -> list[str]:
         "deploy",
         "workflow generate",
         "agent generate",
-        "mcp generate",
         # Flat aliases carry the same source flags.
         "generate-workflow",
         "generate-agent",
-        "generate-mcp",
     ],
 )
 class TestDevelopmentTriState:
@@ -59,21 +57,20 @@ class TestNounVerbParsing:
     flat `generate-<noun>` aliases still parse; truly-removed names are rejected.
     """
 
-    @pytest.mark.parametrize("noun", ["agent", "mcp", "workflow"])
+    @pytest.mark.parametrize("noun", ["agent", "workflow"])
     @pytest.mark.parametrize("verb", ["generate", "deploy", "run", "destroy"])
     def test_nested_verbs_parse(self, noun: str, verb: str) -> None:
         opts = parse_args([noun, verb, "-c", "config.yaml"])
         assert opts.command == noun
         assert opts.subcommand == verb
 
-    @pytest.mark.parametrize("noun", ["agent", "mcp", "workflow"])
+    @pytest.mark.parametrize("noun", ["agent", "workflow"])
     def test_bare_noun_requires_verb(self, noun: str) -> None:
         with pytest.raises(SystemExit):
             parse_args([noun, "-c", "config.yaml"])
 
     def test_flat_aliases_parse(self) -> None:
         assert parse_args(_base("generate-agent")).command == "generate-agent"
-        assert parse_args(_base("generate-mcp")).command == "generate-mcp"
         assert parse_args(_base("generate-workflow")).command == "generate-workflow"
 
     def test_deploy_verb_accepts_run_chain(self) -> None:
@@ -361,7 +358,7 @@ class TestValidateBundleActionFlags:
     """
 
     @pytest.mark.parametrize(
-        "cmd", ["workflow generate", "agent generate", "mcp generate"]
+        "cmd", ["workflow generate", "agent generate"]
     )
     @pytest.mark.parametrize("bad", [["--deploy", "--destroy"], ["--run", "--destroy"], ["--deploy", "--run", "--destroy"]])
     def test_destroy_with_deploy_or_run_exits(self, cmd: str, bad: list[str]) -> None:
@@ -371,7 +368,7 @@ class TestValidateBundleActionFlags:
         assert exc.value.code == 1
 
     @pytest.mark.parametrize(
-        "cmd", ["workflow generate", "agent generate", "mcp generate"]
+        "cmd", ["workflow generate", "agent generate"]
     )
     @pytest.mark.parametrize("ok", [["--deploy"], ["--run"], ["--deploy", "--run"], ["--destroy"], []])
     def test_valid_combinations_pass(self, cmd: str, ok: list[str]) -> None:
@@ -405,6 +402,85 @@ class TestModeChoices:
 
     def test_mode_defaults_to_apps(self) -> None:
         assert parse_args(["agent", "deploy", "-c", "c.yaml"]).mode == "apps"
+
+
+@pytest.mark.unit
+class TestMcpNounRemoved:
+    """The `mcp` noun has been removed; its modes are now routed via `agent --mode mcp`."""
+
+    def test_mcp_noun_removed(self) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(["mcp", "generate", "-c", "c.yaml"])
+
+
+_MINIMAL_CONFIG_YAML = (
+    "resources:\n  models:\n    m: &m\n      name: databricks-gpt-5-4-mini\n"
+    "agents:\n  g: &g\n    name: g\n    description: d\n    model: *m\n"
+    "    prompt: p\n"
+    "app:\n  name: test_app\n  agents:\n    - *g\n"
+)
+
+
+@pytest.mark.unit
+class TestAgentModeWriterSelection:
+    """handle_agent_command selects the correct bundle writer based on --mode."""
+
+    def _write_config(self, tmp_path: Path) -> Path:
+        cfg = tmp_path / "c.yaml"
+        cfg.write_text(_MINIMAL_CONFIG_YAML)
+        return cfg
+
+    def test_agent_generate_mcp_uses_mcp_writer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--mode mcp must call write_mcp_bundle, not write_bundle."""
+        called: dict[str, bool] = {}
+        monkeypatch.setattr(
+            "dao_ai.mcp.generate.write_mcp_bundle",
+            lambda *a, **k: called.setdefault("mcp", True),
+        )
+        monkeypatch.setattr(
+            "dao_ai.apps.bundle.write_bundle",
+            lambda *a, **k: called.setdefault("apps", True),
+        )
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(cli, "detect_cloud_provider", lambda p: "aws")
+
+        cfg = self._write_config(tmp_path)
+        opts = parse_args(
+            ["agent", "generate", "-c", str(cfg), "-o", str(tmp_path / "out"), "--mode", "mcp"]
+        )
+        cli.handle_agent_command(opts)
+
+        assert called == {"mcp": True}, (
+            f"Expected only write_mcp_bundle to be called; got called={called}"
+        )
+
+    def test_agent_generate_apps_uses_default_writer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mode omitted (defaults to apps) must call write_bundle, not write_mcp_bundle."""
+        called: dict[str, bool] = {}
+        monkeypatch.setattr(
+            "dao_ai.mcp.generate.write_mcp_bundle",
+            lambda *a, **k: called.setdefault("mcp", True),
+        )
+        monkeypatch.setattr(
+            "dao_ai.apps.bundle.write_bundle",
+            lambda *a, **k: called.setdefault("apps", True),
+        )
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(cli, "detect_cloud_provider", lambda p: "aws")
+
+        cfg = self._write_config(tmp_path)
+        opts = parse_args(
+            ["agent", "generate", "-c", str(cfg), "-o", str(tmp_path / "out")]
+        )
+        cli.handle_agent_command(opts)
+
+        assert called == {"apps": True}, (
+            f"Expected only write_bundle to be called; got called={called}"
+        )
 
 
 @pytest.mark.unit

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -1066,3 +1066,125 @@ class TestDeployAutoGenerate:
         assert (
             resolve_calls == []
         ), "in-place deploy path must NOT call _resolve_all_resources"
+
+
+@pytest.mark.unit
+class TestTraceNoun:
+    """``dao-ai trace create|link|grant`` is the new surface; old flat names are gone."""
+
+    def test_trace_create_parses(self) -> None:
+        o = parse_args(["trace", "create", "--name", "/Shared/my-exp"])
+        assert o.command == "trace"
+        assert o.subcommand == "create"
+        assert o.name == "/Shared/my-exp"
+
+    def test_trace_create_id_flag(self) -> None:
+        o = parse_args(["trace", "create", "--id", "1234"])
+        assert o.command == "trace"
+        assert o.subcommand == "create"
+        assert o.id == "1234"
+
+    def test_trace_create_output_default(self) -> None:
+        o = parse_args(["trace", "create", "--name", "/foo"])
+        assert o.output == "text"
+
+    def test_trace_create_output_json(self) -> None:
+        o = parse_args(["trace", "create", "--name", "/foo", "-o", "json"])
+        assert o.output == "json"
+
+    def test_trace_create_no_create_flag(self) -> None:
+        o = parse_args(["trace", "create", "--name", "/foo", "--no-create"])
+        assert o.no_create is True
+
+    def test_trace_link_parses(self) -> None:
+        o = parse_args(["trace", "link", "-c", "config.yaml"])
+        assert o.command == "trace"
+        assert o.subcommand == "link"
+        assert o.config == "config.yaml"
+
+    def test_trace_link_optional_flags(self) -> None:
+        o = parse_args(
+            ["trace", "link", "-c", "c.yaml", "--experiment-id", "9999", "--app-sp", "uuid-1"]
+        )
+        assert o.experiment_id == "9999"
+        assert o.app_sp == "uuid-1"
+
+    def test_trace_grant_parses(self) -> None:
+        o = parse_args(["trace", "grant", "-c", "config.yaml"])
+        assert o.command == "trace"
+        assert o.subcommand == "grant"
+        assert o.config == "config.yaml"
+
+    def test_trace_grant_optional_flags(self) -> None:
+        o = parse_args(
+            ["trace", "grant", "-c", "c.yaml", "--experiment-id", "8888", "--app-sp", "uuid-2"]
+        )
+        assert o.experiment_id == "8888"
+        assert o.app_sp == "uuid-2"
+
+    @pytest.mark.parametrize(
+        "old",
+        ["create-experiment", "link-trace-destination", "grant-trace-permissions"],
+    )
+    def test_old_flat_names_rejected(self, old: str) -> None:
+        with pytest.raises(SystemExit):
+            parse_args([old])
+
+    def test_bare_trace_requires_verb(self) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(["trace"])
+
+    def test_trace_link_var_flag(self) -> None:
+        o = parse_args(["trace", "link", "-c", "c.yaml", "--var", "k=v"])
+        assert o.var == ["k=v"]
+
+    def test_trace_grant_var_flag(self) -> None:
+        o = parse_args(["trace", "grant", "-c", "c.yaml", "--var", "k=v"])
+        assert o.var == ["k=v"]
+
+
+@pytest.mark.unit
+class TestTraceNounDispatch:
+    """main() routes ``trace <verb>`` to the correct handler via handle_trace_command."""
+
+    def _invoke(
+        self, monkeypatch: pytest.MonkeyPatch, argv: list[str]
+    ) -> dict[str, int]:
+        called: dict[str, int] = {}
+        monkeypatch.setattr(
+            cli,
+            "handle_create_experiment_command",
+            lambda o: called.update(create=called.get("create", 0) + 1),
+        )
+        monkeypatch.setattr(
+            cli,
+            "handle_link_trace_destination_command",
+            lambda o: called.update(link=called.get("link", 0) + 1),
+        )
+        monkeypatch.setattr(
+            cli,
+            "handle_grant_trace_permissions_command",
+            lambda o: called.update(grant=called.get("grant", 0) + 1),
+        )
+        monkeypatch.setattr(cli, "setup_logging", lambda v: None)
+        monkeypatch.setattr("sys.argv", ["dao-ai"] + argv)
+        cli.main()
+        return called
+
+    def test_trace_create_routes_to_create_handler(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        called = self._invoke(monkeypatch, ["trace", "create", "--name", "/foo"])
+        assert called == {"create": 1}
+
+    def test_trace_link_routes_to_link_handler(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        called = self._invoke(monkeypatch, ["trace", "link", "-c", "c.yaml"])
+        assert called == {"link": 1}
+
+    def test_trace_grant_routes_to_grant_handler(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        called = self._invoke(monkeypatch, ["trace", "grant", "-c", "c.yaml"])
+        assert called == {"grant": 1}

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -410,6 +410,20 @@ class TestModeChoices:
     def test_short_alias_m(self) -> None:
         assert parse_args(["agent", "deploy", "-c", "c.yaml", "-m", "mcp"]).mode == "mcp"
 
+    @pytest.mark.parametrize("alias", ["ms", "model-serving", "model_serving"])
+    def test_model_serving_aliases_normalize_on_deploy(self, alias: str) -> None:
+        # ms / model-serving normalize to the canonical model_serving value.
+        assert (
+            parse_args(["agent", "deploy", "-c", "c.yaml", "-m", alias]).mode
+            == "model_serving"
+        )
+
+    @pytest.mark.parametrize("bad", ["ms", "model-serving", "model_serving"])
+    def test_model_serving_aliases_rejected_on_generate(self, bad: str) -> None:
+        # model_serving (and its aliases) are not valid on generate — no bundle.
+        with pytest.raises(SystemExit):
+            parse_args(["agent", "generate", "-c", "c.yaml", "--mode", bad])
+
 
 @pytest.mark.unit
 class TestWorkflowModeChoices:

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -806,3 +806,151 @@ class TestNounVerbDispatch:
         with pytest.raises(SystemExit) as exc:
             cli.handle_agent_command(opts)
         assert exc.value.code == 1
+
+
+_MINIMAL_CONFIG_NO_TARGET = (
+    "resources:\n  models:\n    m: &m\n      name: databricks-gpt-5-4-mini\n"
+    "agents:\n  g: &g\n    name: g\n    description: d\n    model: *m\n"
+    "    prompt: p\n"
+    "app:\n  name: my_app\n  agents:\n    - *g\n"
+)
+
+
+@pytest.mark.unit
+class TestDeployAutoGenerate:
+    """Task 6: deploy auto-generates when unstaged; --direct; model_serving routing."""
+
+    def _write_cfg(self, tmp_path: Path) -> Path:
+        cfg = tmp_path / "c.yaml"
+        cfg.write_text(_MINIMAL_CONFIG_NO_TARGET)
+        return cfg
+
+    def test_deploy_autogenerates_when_unstaged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`agent deploy` on an empty dir stages first, then deploys the bundle."""
+        cfg = self._write_cfg(tmp_path)
+        out = tmp_path / "out"  # does NOT pre-exist with databricks.yaml
+
+        wrote: dict[str, bool] = {}
+
+        def fake_writer(config: object, bundle_dir: object, **kw: object) -> None:
+            wrote["called"] = True
+            # Create databricks.yaml so deploy_app_bundle finds it staged.
+            import pathlib
+
+            pathlib.Path(str(bundle_dir)).mkdir(parents=True, exist_ok=True)
+            (pathlib.Path(str(bundle_dir)) / "databricks.yaml").write_text("bundle: {}\n")
+
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(
+            "dao_ai.apps.bundle.write_bundle",
+            fake_writer,
+        )
+        with patch.object(cli, "deploy_app_bundle") as dep:
+            opts = parse_args(["agent", "deploy", "-c", str(cfg), "-o", str(out)])
+            cli.handle_agent_command(opts)
+
+        assert wrote.get("called"), "writer must be called to auto-generate the bundle"
+        dep.assert_called_once()
+
+    def test_deploy_in_place_when_staged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`agent deploy` on an already-staged dir deploys in-place without regenerating."""
+        cfg = self._write_cfg(tmp_path)
+        out = tmp_path / "staged"
+        out.mkdir()
+        (out / "databricks.yaml").write_text("bundle: {}\n")
+        (out / "sentinel").write_text("keep\n")
+
+        wrote: dict[str, bool] = {}
+
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(
+            "dao_ai.apps.bundle.write_bundle",
+            lambda *a, **k: wrote.setdefault("called", True),
+        )
+        with patch.object(cli, "deploy_app_bundle") as dep:
+            opts = parse_args(["agent", "deploy", "-c", str(cfg), "-o", str(out)])
+            cli.handle_agent_command(opts)
+
+        assert not wrote, "deploy must NOT regenerate when already staged"
+        dep.assert_called_once()
+        assert (out / "sentinel").read_text() == "keep\n"
+
+    def test_direct_flag_uses_sdk_not_bundle(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`agent deploy --direct` calls deploy_agent (SDK path) without touching bundles."""
+        cfg = self._write_cfg(tmp_path)
+
+        deploy_agent_calls: list[dict[str, object]] = []
+
+        def fake_deploy_agent(
+            self_config: object,
+            target: object = None,
+            development: object = None,
+        ) -> None:
+            deploy_agent_calls.append({"target": target, "development": development})
+
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(
+            "dao_ai.config.AppConfig.deploy_agent",
+            fake_deploy_agent,
+        )
+        with patch.object(cli, "deploy_app_bundle") as dep, patch.object(
+            cli, "_exec_bundle_command"
+        ) as exec_cmd:
+            opts = parse_args(["agent", "deploy", "-c", str(cfg), "--direct"])
+            cli.handle_agent_command(opts)
+
+        assert deploy_agent_calls, "--direct must call deploy_agent"
+        dep.assert_not_called()
+        exec_cmd.assert_not_called()
+
+    def test_model_serving_deploy_uses_provider_not_bundle(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`agent deploy --mode model_serving` routes to deploy_agent, not the bundle path."""
+        cfg = self._write_cfg(tmp_path)
+
+        deploy_agent_calls: list[dict[str, object]] = []
+
+        def fake_deploy_agent(
+            self_config: object,
+            target: object = None,
+            development: object = None,
+        ) -> None:
+            deploy_agent_calls.append({"target": target, "development": development})
+
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(
+            "dao_ai.config.AppConfig.deploy_agent",
+            fake_deploy_agent,
+        )
+        with patch.object(cli, "deploy_app_bundle") as dep:
+            opts = parse_args(["agent", "deploy", "-c", str(cfg), "--mode", "model_serving"])
+            cli.handle_agent_command(opts)
+
+        from dao_ai.config import DeploymentTarget
+
+        assert deploy_agent_calls, "--mode model_serving must call deploy_agent"
+        assert deploy_agent_calls[0]["target"] == DeploymentTarget.MODEL_SERVING
+        dep.assert_not_called()
+
+    def test_direct_flag_parses(self) -> None:
+        """`--direct` is accepted on the deploy verb."""
+        opts = parse_args(["agent", "deploy", "-c", "c.yaml", "--direct"])
+        assert opts.direct is True
+
+    def test_run_still_errors_when_unstaged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`agent run` on an empty dir must still error (auto-generate is deploy-only)."""
+        cfg = self._write_cfg(tmp_path)
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        opts = parse_args(["agent", "run", "-c", str(cfg), "-o", str(tmp_path / "nope")])
+        with pytest.raises(SystemExit) as exc:
+            cli.handle_agent_command(opts)
+        assert exc.value.code == 1

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -267,7 +267,7 @@ class TestPipelineEmitsDevelopmentVar:
             "resources:\n  models:\n    m: &m\n      name: databricks-gpt-5-4-mini\n"
             "agents:\n  g: &g\n    name: g\n    description: d\n    model: *m\n"
             "    prompt: p\n"
-            "app:\n  name: stage_only_app\n  deployment_target: apps\n  agents:\n    - *g\n"
+            "app:\n  name: stage_only_app\n  agents:\n    - *g\n"
         )
         staged: dict[str, object] = {}
         monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
@@ -302,7 +302,7 @@ class TestPipelineEmitsDevelopmentVar:
             "resources:\n  models:\n    m: &m\n      name: databricks-gpt-5-4-mini\n"
             "agents:\n  g: &g\n    name: g\n    description: d\n    model: *m\n"
             "    prompt: p\n"
-            "app:\n  name: stage_only_app\n  deployment_target: apps\n  agents:\n    - *g\n"
+            "app:\n  name: stage_only_app\n  agents:\n    - *g\n"
         )
         out = tmp_path / "out"
         out.mkdir()
@@ -339,7 +339,7 @@ class TestPipelineEmitsDevelopmentVar:
             "resources:\n  models:\n    m: &m\n      name: databricks-gpt-5-4-mini\n"
             "agents:\n  g: &g\n    name: g\n    description: d\n    model: *m\n"
             "    prompt: p\n"
-            "app:\n  name: stage_only_app\n  deployment_target: apps\n  agents:\n    - *g\n"
+            "app:\n  name: stage_only_app\n  agents:\n    - *g\n"
         )
         monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
         monkeypatch.setattr(cli, "detect_cloud_provider", lambda p: "aws")
@@ -406,6 +406,54 @@ class TestModeChoices:
 
     def test_mode_defaults_to_apps(self) -> None:
         assert parse_args(["agent", "deploy", "-c", "c.yaml"]).mode == "apps"
+
+
+@pytest.mark.unit
+class TestWorkflowModeChoices:
+    """workflow verbs must accept --mode with the same choices as agent verbs."""
+
+    def test_workflow_deploy_accepts_all_three(self) -> None:
+        for m in ("model_serving", "apps", "mcp"):
+            assert (
+                parse_args(["workflow", "deploy", "-c", "c.yaml", "--mode", m]).mode
+                == m
+            )
+
+    def test_workflow_generate_accepts_apps_and_mcp(self) -> None:
+        for m in ("apps", "mcp"):
+            assert (
+                parse_args(["workflow", "generate", "-c", "c.yaml", "--mode", m]).mode
+                == m
+            )
+
+    def test_workflow_run_accepts_apps_and_mcp(self) -> None:
+        for m in ("apps", "mcp"):
+            assert (
+                parse_args(["workflow", "run", "-c", "c.yaml", "--mode", m]).mode == m
+            )
+
+    def test_workflow_destroy_accepts_apps_and_mcp(self) -> None:
+        for m in ("apps", "mcp"):
+            assert (
+                parse_args(["workflow", "destroy", "-c", "c.yaml", "--mode", m]).mode
+                == m
+            )
+
+    def test_workflow_run_rejects_model_serving(self) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(["workflow", "run", "-c", "c.yaml", "--mode", "model_serving"])
+
+    def test_workflow_destroy_rejects_model_serving(self) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(
+                ["workflow", "destroy", "-c", "c.yaml", "--mode", "model_serving"]
+            )
+
+    def test_workflow_generate_rejects_model_serving(self) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(
+                ["workflow", "generate", "-c", "c.yaml", "--mode", "model_serving"]
+            )
 
 
 @pytest.mark.unit
@@ -769,7 +817,7 @@ class TestNounVerbDispatch:
             "resources:\n  models:\n    m: &m\n      name: databricks-gpt-5-4-mini\n"
             "agents:\n  g: &g\n    name: g\n    description: d\n    model: *m\n"
             "    prompt: p\n"
-            "app:\n  name: my_app\n  deployment_target: apps\n  agents:\n    - *g\n"
+            "app:\n  name: my_app\n  agents:\n    - *g\n"
         )
         out = tmp_path / "staged"
         out.mkdir()
@@ -799,7 +847,7 @@ class TestNounVerbDispatch:
             "resources:\n  models:\n    m: &m\n      name: databricks-gpt-5-4-mini\n"
             "agents:\n  g: &g\n    name: g\n    description: d\n    model: *m\n"
             "    prompt: p\n"
-            "app:\n  name: my_app\n  deployment_target: apps\n  agents:\n    - *g\n"
+            "app:\n  name: my_app\n  agents:\n    - *g\n"
         )
         monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
         opts = parse_args(

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -567,6 +567,33 @@ class TestMcpNounRemoved:
             parse_args(["mcp", "generate", "-c", "c.yaml"])
 
 
+@pytest.mark.unit
+class TestMonitorScorersRegroup:
+    """`monitor <action>` is regrouped under `monitor scorers <action>` (breaking)."""
+
+    @pytest.mark.parametrize("action", ["enable", "status", "disable"])
+    def test_scorers_subcommand_parses(self, action: str) -> None:
+        opts = parse_args(["monitor", "scorers", action, "-c", "c.yaml"])
+        assert opts.command == "monitor"
+        assert opts.subcommand == "scorers"
+        assert opts.action == action
+
+    @pytest.mark.parametrize("action", ["enable", "status", "disable"])
+    def test_flat_monitor_action_rejected(self, action: str) -> None:
+        # The old flat form `monitor enable` is gone; the action is now a
+        # positional on the `scorers` sub-verb, so `enable` is an unknown verb.
+        with pytest.raises(SystemExit):
+            parse_args(["monitor", action, "-c", "c.yaml"])
+
+    def test_bare_monitor_requires_subcommand(self) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(["monitor", "-c", "c.yaml"])
+
+    def test_scorers_rejects_unknown_action(self) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(["monitor", "scorers", "bogus", "-c", "c.yaml"])
+
+
 _MINIMAL_CONFIG_YAML = (
     "resources:\n  models:\n    m: &m\n      name: databricks-gpt-5-4-mini\n"
     "agents:\n  g: &g\n    name: g\n    description: d\n    model: *m\n"

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -56,7 +56,7 @@ class TestNounVerbParsing:
     """
 
     @pytest.mark.parametrize("noun", ["agent", "workflow"])
-    @pytest.mark.parametrize("verb", ["generate", "deploy", "run", "destroy"])
+    @pytest.mark.parametrize("verb", ["up", "generate", "deploy", "run", "destroy"])
     def test_nested_verbs_parse(self, noun: str, verb: str) -> None:
         opts = parse_args([noun, verb, "-c", "config.yaml"])
         assert opts.command == noun
@@ -67,9 +67,25 @@ class TestNounVerbParsing:
         with pytest.raises(SystemExit):
             parse_args([noun, "-c", "config.yaml"])
 
-    def test_deploy_verb_accepts_run_chain(self) -> None:
-        # `<noun> deploy --run` deploys then runs; run flag is on the deploy verb.
-        assert parse_args(["agent", "deploy", "-c", "c.yaml", "--run"]).run is True
+    def test_deploy_verb_rejects_run(self) -> None:
+        # deploy no longer has --run; use `up` to deploy+run in one command.
+        with pytest.raises(SystemExit):
+            parse_args(["agent", "deploy", "-c", "c.yaml", "--run"])
+
+    def test_deploy_verb_rejects_direct(self) -> None:
+        # --direct moved to `up`; deploy is the pure push verb.
+        with pytest.raises(SystemExit):
+            parse_args(["agent", "deploy", "-c", "c.yaml", "--direct"])
+
+    def test_up_verb_parses(self) -> None:
+        opts = parse_args(["agent", "up", "-c", "c.yaml", "--mode", "mcp"])
+        assert opts.command == "agent"
+        assert opts.subcommand == "up"
+        assert opts.mode == "mcp"
+
+    def test_up_verb_direct_flag(self) -> None:
+        opts = parse_args(["agent", "up", "-c", "c.yaml", "--direct"])
+        assert opts.direct is True
 
     @pytest.mark.parametrize(
         "argv",
@@ -355,29 +371,21 @@ class TestPipelineEmitsDevelopmentVar:
 
 
 @pytest.mark.unit
-class TestValidateBundleActionFlags:
-    """``--destroy`` + ``--deploy``/``--run`` is contradictory and must be
-    rejected uniformly across all three generate-* commands (previously the
-    workflow handler deployed-then-destroyed while the App driver destroyed-only).
+class TestGenerateIsStageOnly:
+    """``generate`` is now a pure staging verb — ``--deploy``/``--run``/``--destroy``
+    are rejected by the parser (use ``up`` for orchestration).
     """
 
-    @pytest.mark.parametrize(
-        "cmd", ["workflow generate", "agent generate"]
-    )
-    @pytest.mark.parametrize("bad", [["--deploy", "--destroy"], ["--run", "--destroy"], ["--deploy", "--run", "--destroy"]])
-    def test_destroy_with_deploy_or_run_exits(self, cmd: str, bad: list[str]) -> None:
-        options = parse_args(_base(cmd) + bad)
-        with pytest.raises(SystemExit) as exc:
-            cli._validate_bundle_action_flags(options)
-        assert exc.value.code == 1
+    @pytest.mark.parametrize("noun", ["agent", "workflow"])
+    @pytest.mark.parametrize("flag", ["--deploy", "--run", "--destroy"])
+    def test_generate_rejects_action_flags(self, noun: str, flag: str) -> None:
+        with pytest.raises(SystemExit):
+            parse_args([noun, "generate", "-c", "config.yaml", flag])
 
-    @pytest.mark.parametrize(
-        "cmd", ["workflow generate", "agent generate"]
-    )
-    @pytest.mark.parametrize("ok", [["--deploy"], ["--run"], ["--deploy", "--run"], ["--destroy"], []])
-    def test_valid_combinations_pass(self, cmd: str, ok: list[str]) -> None:
-        options = parse_args(_base(cmd) + ok)
-        cli._validate_bundle_action_flags(options)  # must not raise
+    @pytest.mark.parametrize("noun", ["agent", "workflow"])
+    def test_generate_without_action_flags_parses(self, noun: str) -> None:
+        opts = parse_args([noun, "generate", "-c", "config.yaml"])
+        assert opts.subcommand == "generate"
 
 
 def _app_config(*, trace: bool) -> AppConfig:
@@ -949,7 +957,7 @@ class TestDeployAutoGenerate:
     def test_direct_flag_uses_sdk_not_bundle(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """`agent deploy --direct` calls deploy_agent (SDK path) without touching bundles."""
+        """`agent up --direct` calls deploy_agent (SDK path) without touching bundles."""
         cfg = self._write_cfg(tmp_path)
 
         deploy_agent_calls: list[dict[str, object]] = []
@@ -969,7 +977,7 @@ class TestDeployAutoGenerate:
         with patch.object(cli, "deploy_app_bundle") as dep, patch.object(
             cli, "_exec_bundle_command"
         ) as exec_cmd:
-            opts = parse_args(["agent", "deploy", "-c", str(cfg), "--direct"])
+            opts = parse_args(["agent", "up", "-c", str(cfg), "--direct"])
             cli.handle_agent_command(opts)
 
         assert deploy_agent_calls, "--direct must call deploy_agent"
@@ -1017,10 +1025,15 @@ class TestDeployAutoGenerate:
         assert deploy_agent_calls[0]["target"] == ServingMode.MODEL_SERVING
         dep.assert_not_called()
 
-    def test_direct_flag_parses(self) -> None:
-        """`--direct` is accepted on the deploy verb."""
-        opts = parse_args(["agent", "deploy", "-c", "c.yaml", "--direct"])
+    def test_direct_flag_parses_on_up(self) -> None:
+        """`--direct` is accepted on the `up` verb (moved from deploy)."""
+        opts = parse_args(["agent", "up", "-c", "c.yaml", "--direct"])
         assert opts.direct is True
+
+    def test_direct_flag_rejected_on_deploy(self) -> None:
+        """`--direct` is NOT accepted on `deploy` — use `up --direct` instead."""
+        with pytest.raises(SystemExit):
+            parse_args(["agent", "deploy", "-c", "c.yaml", "--direct"])
 
     def test_run_still_errors_when_unstaged(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1094,6 +1107,27 @@ class TestDeployAutoGenerate:
         assert (
             resolve_calls == []
         ), "in-place deploy path must NOT call _resolve_all_resources"
+
+    def test_up_deploys_and_runs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`agent up --mode apps` bundle path calls deploy_app_bundle with deploy=True AND run=True."""
+        cfg = self._write_cfg(tmp_path)
+        out = tmp_path / "staged"
+        out.mkdir()
+        (out / "databricks.yaml").write_text("bundle: {}\n")
+
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        with patch.object(cli, "deploy_app_bundle") as dep:
+            opts = parse_args(
+                ["agent", "up", "-c", str(cfg), "-o", str(out), "--mode", "apps"]
+            )
+            cli.handle_agent_command(opts)
+
+        dep.assert_called_once()
+        call_kwargs = dep.call_args.kwargs
+        assert call_kwargs["deploy"] is True, "up must call deploy_app_bundle(deploy=True)"
+        assert call_kwargs["run"] is True, "up must call deploy_app_bundle(run=True)"
 
 
 @pytest.mark.unit

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -231,6 +231,77 @@ class TestEditSafety:
 
 
 @pytest.mark.unit
+class TestConfigFingerprint:
+    """The staging marker records a config fingerprint for staleness detection."""
+
+    def _config(self, name: str = "greeter") -> AppConfig:
+        from dao_ai.config import AgentModel, AppModel, InferenceEndpointModel
+
+        return AppConfig(
+            app=AppModel(
+                name="fp-test",
+                agents=[
+                    AgentModel(
+                        name=name,
+                        description="says hi",
+                        model=InferenceEndpointModel(name="databricks-gpt-5-4-mini"),
+                    )
+                ],
+            )
+        )
+
+    def test_fingerprint_stable_for_identical_config(self) -> None:
+        a = cli._config_fingerprint(self._config(), development=False)
+        b = cli._config_fingerprint(self._config(), development=False)
+        assert a == b
+
+    def test_fingerprint_changes_with_config(self) -> None:
+        a = cli._config_fingerprint(self._config(name="greeter"), development=False)
+        b = cli._config_fingerprint(self._config(name="farewell"), development=False)
+        assert a != b
+
+    def test_fingerprint_changes_with_development_flag(self) -> None:
+        a = cli._config_fingerprint(self._config(), development=False)
+        b = cli._config_fingerprint(self._config(), development=True)
+        assert a != b
+
+    def test_marker_records_fingerprint(self, tmp_path: Path) -> None:
+        d = tmp_path / "base" / "agent" / "app"
+        d.mkdir(parents=True)
+        cli._write_staging_marker(d, is_default=True, fingerprint="abc123")
+        assert (d / cli._STAGING_MARKER).read_text() == "abc123"
+
+
+@pytest.mark.unit
+class TestStagedConfigStaleness:
+    """_staged_config_is_stale compares current config vs the stamped fingerprint."""
+
+    def _marked(self, tmp_path: Path, fingerprint: str) -> Path:
+        d = tmp_path / "base" / "agent" / "app"
+        d.mkdir(parents=True)
+        cli._write_staging_marker(d, is_default=True, fingerprint=fingerprint)
+        return d
+
+    def test_matching_fingerprint_not_stale(self, tmp_path: Path) -> None:
+        d = self._marked(tmp_path, "fp-1")
+        assert cli._staged_config_is_stale(d, "fp-1") is False
+
+    def test_differing_fingerprint_is_stale(self, tmp_path: Path) -> None:
+        d = self._marked(tmp_path, "fp-1")
+        assert cli._staged_config_is_stale(d, "fp-2") is True
+
+    def test_missing_marker_not_stale(self, tmp_path: Path) -> None:
+        d = tmp_path / "base" / "agent" / "app"
+        d.mkdir(parents=True)  # no marker (legacy / -o dir)
+        assert cli._staged_config_is_stale(d, "fp-1") is False
+
+    def test_empty_marker_not_stale(self, tmp_path: Path) -> None:
+        # A workflow bundle stamps an empty marker; never treat it as stale.
+        d = self._marked(tmp_path, "")
+        assert cli._staged_config_is_stale(d, "fp-1") is False
+
+
+@pytest.mark.unit
 class TestPipelineEmitsDevelopmentVar:
     """run_databricks_command forwards development as a bundle --var."""
 
@@ -598,6 +669,122 @@ class TestAgentModeWriterSelection:
         _, resolved_path = resolved_bundle_dirs["mcp"]
         assert "/mcp/" in str(resolved_path), (
             f"Expected mcp staging dir path to contain /mcp/, got {resolved_path}"
+        )
+
+
+@pytest.mark.unit
+class TestDeployRestagesOnConfigDrift:
+    """agent deploy re-stages an already-staged bundle when the source config drifts."""
+
+    def _write_config(self, tmp_path: Path) -> Path:
+        cfg = tmp_path / "c.yaml"
+        cfg.write_text(_MINIMAL_CONFIG_YAML)
+        return cfg
+
+    def _run_deploy(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        marker_fingerprint: str | None,
+        has_edits: bool = False,
+        overwrite: bool = False,
+    ) -> bool:
+        """Drive `agent deploy` against a pre-staged dir. Returns True if re-staged.
+
+        ``marker_fingerprint`` seeds the staged marker: None omits it (legacy
+        dir), "" is a workflow-style empty marker, a string is a recorded hash.
+        ``has_edits`` simulates hand-edits; ``overwrite`` passes --overwrite.
+        """
+        cfg = self._write_config(tmp_path)
+        staged = tmp_path / "staged" / "agent" / "test_app"
+        staged.mkdir(parents=True)
+        (staged / "databricks.yaml").write_text("bundle: {}\n")
+        if marker_fingerprint is not None:
+            (staged / cli._STAGING_MARKER).write_text(marker_fingerprint)
+
+        restaged: dict[str, bool] = {}
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(
+            cli, "_resolve_bundle_dir", lambda kind, config, output_dir: (staged, True)
+        )
+        monkeypatch.setattr(
+            cli, "_staging_dir_has_local_edits", lambda d: has_edits
+        )
+        monkeypatch.setattr(cli, "deploy_app_bundle", lambda *a, **k: None)
+        monkeypatch.setattr(AppConfig, "_resolve_all_resources", lambda self: None)
+        monkeypatch.setattr(
+            cli,
+            "_stage_app_bundle",
+            lambda *a, **k: restaged.setdefault("staged", True),
+        )
+
+        argv = ["agent", "deploy", "-c", str(cfg)]
+        if overwrite:
+            argv.append("--overwrite")
+        opts = parse_args(argv)
+        cli.handle_agent_command(opts)
+        return restaged.get("staged", False)
+
+    def test_restages_when_marker_fingerprint_differs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A fingerprint that cannot match the current config -> stale -> re-stage.
+        assert (
+            self._run_deploy(tmp_path, monkeypatch, marker_fingerprint="stale-hash")
+            is True
+        )
+
+    def test_deploys_in_place_when_fingerprint_matches(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Stamp the marker with the CURRENT config's real fingerprint -> not stale.
+        # Resolve development exactly as the deploy path does (options.development
+        # is None here -> auto-detect), so the seeded hash matches.
+        from dao_ai.utils import resolve_use_local_source
+
+        cfg = self._write_config(tmp_path)
+        config = AppConfig.from_file(str(cfg), initialize=False)
+        current_fp = cli._config_fingerprint(
+            config, development=resolve_use_local_source(None)
+        )
+        assert (
+            self._run_deploy(tmp_path, monkeypatch, marker_fingerprint=current_fp)
+            is False
+        )
+
+    def test_deploys_in_place_when_marker_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Legacy staged dir with no marker -> no recorded fingerprint -> in place.
+        assert (
+            self._run_deploy(tmp_path, monkeypatch, marker_fingerprint=None) is False
+        )
+
+    def test_stale_with_edits_deploys_in_place(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Config drifted but the dir has hand-edits and no --overwrite -> in place.
+        assert (
+            self._run_deploy(
+                tmp_path, monkeypatch, marker_fingerprint="stale", has_edits=True
+            )
+            is False
+        )
+
+    def test_stale_with_edits_and_overwrite_regenerates(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # --overwrite forces regen even over hand-edits when the config drifted.
+        assert (
+            self._run_deploy(
+                tmp_path,
+                monkeypatch,
+                marker_fingerprint="stale",
+                has_edits=True,
+                overwrite=True,
+            )
+            is True
         )
 
 

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -959,11 +959,21 @@ class TestDeployAutoGenerate:
         dep.assert_not_called()
         exec_cmd.assert_not_called()
 
-    def test_model_serving_deploy_uses_provider_not_bundle(
+    def test_model_serving_deploy_registers_then_deploys_not_bundle(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """`agent deploy --mode model_serving` routes to deploy_agent, not the bundle path."""
+        """`agent deploy --mode model_serving` must register the model
+        (create_agent) BEFORE deploy_agent, and NOT touch the bundle path.
+
+        Model Serving deploys a registered MLflow model version, so skipping
+        create_agent would deploy a stale/nonexistent version.
+        """
         cfg = self._write_cfg(tmp_path)
+
+        calls: list[str] = []
+
+        def fake_create_agent(self_config: object, development: object = None) -> None:
+            calls.append("create")
 
         deploy_agent_calls: list[dict[str, object]] = []
 
@@ -972,20 +982,21 @@ class TestDeployAutoGenerate:
             target: object = None,
             development: object = None,
         ) -> None:
+            calls.append("deploy")
             deploy_agent_calls.append({"target": target, "development": development})
 
         monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
-        monkeypatch.setattr(
-            "dao_ai.config.AppConfig.deploy_agent",
-            fake_deploy_agent,
-        )
+        monkeypatch.setattr("dao_ai.config.AppConfig.create_agent", fake_create_agent)
+        monkeypatch.setattr("dao_ai.config.AppConfig.deploy_agent", fake_deploy_agent)
         with patch.object(cli, "deploy_app_bundle") as dep:
             opts = parse_args(["agent", "deploy", "-c", str(cfg), "--mode", "model_serving"])
             cli.handle_agent_command(opts)
 
         from dao_ai.config import DeploymentTarget
 
-        assert deploy_agent_calls, "--mode model_serving must call deploy_agent"
+        # create_agent (register) must run BEFORE deploy_agent, and the bundle
+        # path must not be touched.
+        assert calls == ["create", "deploy"], calls
         assert deploy_agent_calls[0]["target"] == DeploymentTarget.MODEL_SERVING
         dep.assert_not_called()
 

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -995,12 +995,12 @@ class TestDeployAutoGenerate:
             opts = parse_args(["agent", "deploy", "-c", str(cfg), "--mode", "model_serving"])
             cli.handle_agent_command(opts)
 
-        from dao_ai.config import DeploymentTarget
+        from dao_ai.config import ServingMode
 
         # create_agent (register) must run BEFORE deploy_agent, and the bundle
         # path must not be touched.
         assert calls == ["create", "deploy"], calls
-        assert deploy_agent_calls[0]["target"] == DeploymentTarget.MODEL_SERVING
+        assert deploy_agent_calls[0]["target"] == ServingMode.MODEL_SERVING
         dep.assert_not_called()
 
     def test_direct_flag_parses(self) -> None:

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -1069,6 +1069,20 @@ class TestDeployAutoGenerate:
 
 
 @pytest.mark.unit
+class TestToolsCommandRenamed:
+    """list-mcp-tools renamed to tools."""
+
+    def test_tools_renamed(self) -> None:
+        """tools command parses successfully with the new name."""
+        assert parse_args(["tools", "-c", "c.yaml"]).command == "tools"
+
+    def test_list_mcp_tools_rejected(self) -> None:
+        """Old list-mcp-tools name is rejected by the parser."""
+        with pytest.raises(SystemExit):
+            parse_args(["list-mcp-tools", "-c", "c.yaml"])
+
+
+@pytest.mark.unit
 class TestTraceNoun:
     """``dao-ai trace create|link|grant`` is the new surface; old flat names are gone."""
 

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -1213,3 +1213,52 @@ class TestTraceNounDispatch:
     ) -> None:
         called = self._invoke(monkeypatch, ["trace", "grant", "-c", "c.yaml"])
         assert called == {"grant": 1}
+
+
+@pytest.mark.unit
+class TestGlobalProfileVerbose:
+    """``-p/--profile`` and ``-v/--verbose`` work at both top level and subcommand level."""
+
+    def test_profile_before_subcommand(self) -> None:
+        o = parse_args(["-p", "fevm", "agent", "deploy", "-c", "c.yaml"])
+        assert o.profile == "fevm"
+
+    def test_profile_after_subcommand(self) -> None:
+        o = parse_args(["agent", "deploy", "-c", "c.yaml", "-p", "fevm"])
+        assert o.profile == "fevm"
+
+    def test_profile_subcommand_wins_when_both(self) -> None:
+        o = parse_args(["-p", "top", "agent", "deploy", "-c", "c.yaml", "-p", "sub"])
+        assert o.profile == "sub"
+
+    def test_profile_absent_defaults_none(self) -> None:
+        o = parse_args(["agent", "generate", "-c", "c.yaml"])
+        assert getattr(o, "profile", None) is None
+
+    def test_verbose_before_subcommand(self) -> None:
+        o = parse_args(["-v", "agent", "deploy", "-c", "c.yaml"])
+        assert o.verbose >= 1
+
+    def test_verbose_after_subcommand(self) -> None:
+        o = parse_args(["agent", "deploy", "-c", "c.yaml", "-vv"])
+        assert o.verbose >= 2
+
+    def test_verbose_absent_defaults_zero(self) -> None:
+        o = parse_args(["agent", "generate", "-c", "c.yaml"])
+        assert getattr(o, "verbose", 0) == 0
+
+    def test_profile_before_trace_subcommand(self) -> None:
+        o = parse_args(["-p", "fevm", "trace", "link", "-c", "c.yaml"])
+        assert o.profile == "fevm"
+
+    def test_profile_after_trace_subcommand(self) -> None:
+        o = parse_args(["trace", "link", "-c", "c.yaml", "-p", "fevm"])
+        assert o.profile == "fevm"
+
+    def test_verbose_before_workflow_subcommand(self) -> None:
+        o = parse_args(["-vv", "workflow", "generate", "-c", "c.yaml"])
+        assert o.verbose >= 2
+
+    def test_verbose_after_workflow_subcommand(self) -> None:
+        o = parse_args(["workflow", "deploy", "-c", "c.yaml", "-v"])
+        assert o.verbose >= 1

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -1,11 +1,13 @@
 """Tests for the --development / --no-development tri-state across CLI commands.
 
 The flag must resolve identically on every deploy-capable command:
-``deploy``, ``<noun> generate`` (agent/mcp/workflow) and the flat
-``generate-<noun>`` aliases — ``--development`` -> True, ``--no-development`` ->
-False, omitted -> None (auto-detect). For the workflow it is additionally
-forwarded to the deploy notebook as a ``--var development=auto|true|false``
-bundle variable.
+``<noun> generate`` (agent/workflow) — ``--development`` -> True,
+``--no-development`` -> False, omitted -> None (auto-detect). For the workflow
+it is additionally forwarded to the deploy notebook as a
+``--var development=auto|true|false`` bundle variable.
+
+The removed commands ``deploy``, ``generate-agent``, ``generate-workflow``, and
+``generate-mcp`` must now be rejected by the parser.
 """
 
 from __future__ import annotations
@@ -29,12 +31,8 @@ def _base(cmd: str) -> list[str]:
 @pytest.mark.parametrize(
     "command",
     [
-        "deploy",
         "workflow generate",
         "agent generate",
-        # Flat aliases carry the same source flags.
-        "generate-workflow",
-        "generate-agent",
     ],
 )
 class TestDevelopmentTriState:
@@ -53,8 +51,8 @@ class TestDevelopmentTriState:
 
 @pytest.mark.unit
 class TestNounVerbParsing:
-    """Nested `<noun> <verb>` parses to (command=noun, subcommand=verb); the
-    flat `generate-<noun>` aliases still parse; truly-removed names are rejected.
+    """Nested `<noun> <verb>` parses to (command=noun, subcommand=verb);
+    removed top-level names are rejected by the parser.
     """
 
     @pytest.mark.parametrize("noun", ["agent", "workflow"])
@@ -69,19 +67,25 @@ class TestNounVerbParsing:
         with pytest.raises(SystemExit):
             parse_args([noun, "-c", "config.yaml"])
 
-    def test_flat_aliases_parse(self) -> None:
-        assert parse_args(_base("generate-agent")).command == "generate-agent"
-        assert parse_args(_base("generate-workflow")).command == "generate-workflow"
-
     def test_deploy_verb_accepts_run_chain(self) -> None:
         # `<noun> deploy --run` deploys then runs; run flag is on the deploy verb.
         assert parse_args(["agent", "deploy", "-c", "c.yaml", "--run"]).run is True
 
-    @pytest.mark.parametrize("old", ["generate-bundle", "pipeline"])
-    def test_old_names_rejected(self, old: str) -> None:
-        # argparse rejects an unknown subcommand with SystemExit(2).
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["deploy", "-c", "c.yaml"],
+            ["generate-agent", "-c", "c.yaml"],
+            ["generate-mcp", "-c", "c.yaml"],
+            ["generate-workflow", "-c", "c.yaml"],
+            ["generate-bundle", "-c", "c.yaml"],
+            ["pipeline", "-c", "c.yaml"],
+        ],
+    )
+    def test_removed_commands_rejected(self, argv: list[str]) -> None:
+        # argparse rejects unknown subcommands with SystemExit(2).
         with pytest.raises(SystemExit):
-            parse_args(_base(old))
+            parse_args(argv)
 
 
 @pytest.mark.unit
@@ -738,11 +742,11 @@ class TestNounVerbDispatch:
     """main() routes nouns to per-noun handlers; aliases share the generate path;
     standalone deploy/run act on the staged dir without regenerating."""
 
-    def test_alias_equivalent_to_generate_verb(
+    def test_generate_verb_routes_to_bundle(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """`generate-agent` and `agent generate` reach _generate_app_bundle with
-        the same subcommand normalized in."""
+        """`agent generate` reaches _generate_app_bundle with the correct command
+        and subcommand."""
         seen: list[tuple[str, str]] = []
         monkeypatch.setattr(
             cli,
@@ -751,11 +755,9 @@ class TestNounVerbDispatch:
         )
         monkeypatch.setattr(cli, "setup_logging", lambda v: None)
 
-        for argv in (["agent", "generate", "-c", "c.yaml"], ["generate-agent", "-c", "c.yaml"]):
-            monkeypatch.setattr("sys.argv", ["dao-ai", *argv])
-            cli.main()
-        # Both routed to agent generate; the alias was normalized to subcommand.
-        assert seen == [("agent", "generate"), ("generate-agent", "generate")]
+        monkeypatch.setattr("sys.argv", ["dao-ai", "agent", "generate", "-c", "c.yaml"])
+        cli.main()
+        assert seen == [("agent", "generate")]
 
     def test_deploy_verb_no_regenerate(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -390,6 +390,24 @@ def _app_config(*, trace: bool) -> AppConfig:
 
 
 @pytest.mark.unit
+class TestModeChoices:
+    def test_deploy_accepts_all_three(self) -> None:
+        for m in ("model_serving", "apps", "mcp"):
+            assert parse_args(["agent", "deploy", "-c", "c.yaml", "--mode", m]).mode == m
+
+    def test_generate_rejects_model_serving(self) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(["agent", "generate", "-c", "c.yaml", "--mode", "model_serving"])
+
+    def test_generate_accepts_apps_and_mcp(self) -> None:
+        for m in ("apps", "mcp"):
+            assert parse_args(["agent", "generate", "-c", "c.yaml", "--mode", m]).mode == m
+
+    def test_mode_defaults_to_apps(self) -> None:
+        assert parse_args(["agent", "deploy", "-c", "c.yaml"]).mode == "apps"
+
+
+@pytest.mark.unit
 class TestDeployAppBundle:
     """Shared App deploy driver: deploy -> (link+grant) -> run, by app name."""
 

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -482,6 +482,41 @@ class TestAgentModeWriterSelection:
             f"Expected only write_bundle to be called; got called={called}"
         )
 
+    def test_agent_deploy_mcp_uses_mcp_staging_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """agent deploy --mode mcp passes the mcp-kind staging dir to deploy_app_bundle."""
+        cfg = self._write_config(tmp_path)
+        # Capture what _resolve_bundle_dir is asked to return: (Path, is_default).
+        resolved_bundle_dirs: dict[str, tuple[str, Path]] = {}
+
+        def mock_resolve_bundle_dir(
+            kind: str, config: object, output_dir: str | None
+        ) -> tuple[Path, bool]:
+            # Record: kind -> (output_dir passed in, resolved path)
+            mcp_staging = tmp_path / "staged" / kind / "test_app"
+            mcp_staging.mkdir(parents=True, exist_ok=True)
+            (mcp_staging / "databricks.yaml").write_text("bundle: {}\n")
+            resolved_bundle_dirs[kind] = (output_dir or "default", mcp_staging)
+            return mcp_staging, output_dir is None
+
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+
+        with patch.object(cli, "_resolve_bundle_dir", side_effect=mock_resolve_bundle_dir):
+            with patch.object(cli, "deploy_app_bundle"):
+                opts = parse_args(
+                    ["agent", "deploy", "-c", str(cfg), "--mode", "mcp"]
+                )
+                cli.handle_agent_command(opts)
+
+        assert "mcp" in resolved_bundle_dirs, (
+            "deploy must call _resolve_bundle_dir with kind='mcp' when --mode mcp"
+        )
+        _, resolved_path = resolved_bundle_dirs["mcp"]
+        assert "/mcp/" in str(resolved_path), (
+            f"Expected mcp staging dir path to contain /mcp/, got {resolved_path}"
+        )
+
 
 @pytest.mark.unit
 class TestDeployAppBundle:

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -33,6 +33,12 @@ def _base(cmd: str) -> list[str]:
     [
         "workflow generate",
         "agent generate",
+        # deploy and up also have source-selection flags (deploy can
+        # auto-generate and handles model_serving create_agent/deploy_agent).
+        "agent deploy",
+        "agent up",
+        "workflow deploy",
+        "workflow up",
     ],
 )
 class TestDevelopmentTriState:

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -407,6 +407,9 @@ class TestModeChoices:
     def test_mode_defaults_to_apps(self) -> None:
         assert parse_args(["agent", "deploy", "-c", "c.yaml"]).mode == "apps"
 
+    def test_short_alias_m(self) -> None:
+        assert parse_args(["agent", "deploy", "-c", "c.yaml", "-m", "mcp"]).mode == "mcp"
+
 
 @pytest.mark.unit
 class TestWorkflowModeChoices:

--- a/tests/dao_ai/test_extras.py
+++ b/tests/dao_ai/test_extras.py
@@ -39,9 +39,6 @@ from dao_ai.config import (
 def _app(**kwargs) -> AppModel:
     """A minimal valid AppModel (requires a name + at least one agent)."""
     kwargs.setdefault("name", "my-app")
-    # deployment_target=apps avoids the registered_model requirement; the
-    # resolver's target arg is independent of this field.
-    kwargs.setdefault("deployment_target", "apps")
     kwargs.setdefault(
         "agents",
         [AgentModel(name="ag", model=InferenceEndpointModel(name="databricks-gpt-oss-120b"))],

--- a/tests/dao_ai/test_inference_endpoint_alias.py
+++ b/tests/dao_ai/test_inference_endpoint_alias.py
@@ -115,7 +115,6 @@ class TestAppConfigEndToEnd:
             },
             "app": {
                 "name": "alias-test",
-                "deployment_target": "apps",
                 "agents": [
                     {
                         "name": "tester",

--- a/tests/dao_ai/test_lakebase_app_resources.py
+++ b/tests/dao_ai/test_lakebase_app_resources.py
@@ -352,7 +352,6 @@ class TestAppResourcesIntegration:
             AppConfig,
             AppModel,
             DatabaseModel,
-            DeploymentTarget,
             LLMModel,
             ResourcesModel,
         )
@@ -372,7 +371,6 @@ class TestAppResourcesIntegration:
             agents={"a": agent},
             app=AppModel(
                 name="lakebase-test",
-                deployment_target=DeploymentTarget.APPS,
                 agents=[agent],
             ),
         )

--- a/tests/dao_ai/test_orchestration_review_fixes.py
+++ b/tests/dao_ai/test_orchestration_review_fixes.py
@@ -46,18 +46,13 @@ from dao_ai.state import (
 
 
 def _basic_app_config(agent_names: list[str]) -> AppConfig:
-    """Build a minimal AppConfig with the given agent names.
-
-    ``deployment_target='apps'`` lets us skip the ``registered_model`` field
-    that's otherwise required.
-    """
+    """Build a minimal AppConfig with the given agent names."""
     agents = [
         AgentModel(name=name, model=LLMModel(name="test-model")) for name in agent_names
     ]
     return AppConfig(
         app=AppModel(
             name="dao_ai_test",
-            deployment_target="apps",
             agents=agents,
             orchestration=OrchestrationModel(
                 supervisor=SupervisorModel(model=LLMModel(name="test-model"))

--- a/tests/dao_ai/test_pipeline_bundle.py
+++ b/tests/dao_ai/test_pipeline_bundle.py
@@ -146,9 +146,9 @@ class TestGeneratePipelineDatabricksYaml:
         # run-evaluation fans in from deploy-agents + generate-evaluation-data.
         deps = {d["task_key"] for d in by_key["run-evaluation"]["depends_on"]}
         assert deps == {"deploy-agents", "generate-evaluation-data"}
-        # deploy-agents forwards the deployment_target + development vars.
+        # deploy-agents forwards the mode + development vars.
         params = by_key["deploy-agents"]["notebook_task"]["base_parameters"]
-        assert params["deployment-target"] == "${var.deployment_target}"
+        assert params["mode"] == "${var.mode}"
         assert params["development"] == "${var.development}"
 
     def test_development_includes_wheel_in_sync(self) -> None:

--- a/tests/dao_ai/test_pipeline_bundle.py
+++ b/tests/dao_ai/test_pipeline_bundle.py
@@ -48,7 +48,6 @@ agents:
     prompt: You are a concise assistant.
 app:
   name: pipeline_test_app
-  deployment_target: apps
   agents:
     - *greeter
 """
@@ -316,7 +315,6 @@ class TestWritePipelineBundle:
         "    prompt: You are a concise assistant.\n"
         "app:\n"
         "  name: hw_app\n"
-        "  deployment_target: apps\n"
         "  agents:\n"
         "    - *greeter\n"
         "datasets:\n"
@@ -362,7 +360,6 @@ class TestWritePipelineBundle:
         "    prompt: You are a concise assistant.\n"
         "app:\n"
         "  name: cp_app\n"
-        "  deployment_target: apps\n"
         "  code_paths:\n"
         "    - tools/custom_tool.py\n"
         "  agents:\n"

--- a/tests/dao_ai/test_skills.py
+++ b/tests/dao_ai/test_skills.py
@@ -74,7 +74,6 @@ def _config_with_deep_agent(
         resources=ResourcesModel(skills=resource_skills or {}),
         app=AppModel(
             name="test_app",
-            deployment_target="apps",
             agents=[AgentModel(name="a", model=LLMModel(name="x"))],
             orchestration=OrchestrationModel(deep_agent=deep),
         ),
@@ -101,7 +100,6 @@ class TestIterDeepAgentSkills:
             agents={"a": AgentModel(name="a", model=LLMModel(name="x"))},
             app=AppModel(
                 name="test_app",
-                deployment_target="apps",
                 agents=[AgentModel(name="a", model=LLMModel(name="x"))],
                 orchestration=OrchestrationModel(),
             ),


### PR DESCRIPTION
## Deploy-model redesign (major, breaking)

Redesigns the dao-ai CLI deploy model around two orthogonal axes and one canonical deploy path.

### The two axes
- **Noun = what's packaged:** `agent` | `workflow`
- **`--mode` = how it's served:** `model_serving` | `apps` | `mcp` (mutually exclusive)

`mcp` folds from a top-level noun into a `--mode` value. `BOTH` is dropped.

### Highlights
- **`--mode`** (`-m`), default `apps`. Per-verb choices: `generate`/`run`/`destroy` accept only bundle modes `{apps, mcp}`; `deploy`/`up` also accept `model_serving`. Input aliases `ms`/`model-serving` normalize to `model_serving`.
- **`up`** orchestration verb: generate (if needed) → deploy → run. Retires the one-shot `generate --deploy/--run` flags and `deploy --run`.
- **DAB bundle is canonical**; `--direct` is the SDK escape hatch (apps/mcp only, no bundle on disk).
- **`deploy` auto-generates** when nothing is staged, deploys in place when staged — and now **re-stages when the source config drifts** (see below).
- **`trace` noun** groups the former `create-experiment` / `link-trace-destination` / `grant-trace-permissions` into `trace create|link|grant`.
- **`monitor scorers <action>`** replaces flat `monitor enable|status|disable` (breaking). Runtime `logs`/`mem` were deliberately not added — Databricks Apps exposes no logs or metrics API.
- `list-mcp-tools` → `tools`. Global `--profile`/`--verbose`. CLI help overhaul with grouped examples.

### Config
- `DeploymentTarget` → `ServingMode` (`model_serving`|`apps`|`mcp`); `deployment_target` field **removed** from `AppConfig` (it's a deploy-action parameter, not a property of the artifact).

### Stale-staged-bundle fix
`deploy`/`up` previously only auto-generated when `databricks.yaml` was absent, so editing the source config (e.g. `app.workers`) and re-running silently shipped the stale staged bundle. A config fingerprint is now stamped into the `.dao-ai-generated` marker at generate time; deploy compares the current config against it and regenerates a clean default staging dir on drift. Edited dirs deploy in place with a warning (`--overwrite` forces regen); `-o` dirs and legacy/empty markers are never touched.

### Tests
Full parser + behavioral coverage for modes, `up`/`deploy` routing, trace regroup, monitor regroup, and the drift-restage matrix. Also corrects `test_bundle_app_workers` (asserted a stale default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This pull request and its description were written by Isaac.
