### PR TITLE
feat(cli): add `monitor logs` subcommand for Apps and Model Serving

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -487,6 +487,55 @@ databricks apps restart <new-app-name> -p <profile>
 
 The **old** experiment stays linked to its original destination — Databricks does not allow un-linking. If you no longer need the old data, delete the experiment outright via `mlflow.delete_experiment(<old-id>)` (or the workspace UI). That's a soft-delete; a hard purge is a workspace cleanup job. The OTEL Delta tables the old experiment wrote to are not affected by experiment deletion — drop them separately if you want the storage back.
 
+## Monitor
+
+`dao-ai monitor` groups production observability for the deployed agent.
+
+### `dao-ai monitor scorers enable|status|disable`
+
+Register, inspect, or stop MLflow monitoring scorers that continuously evaluate
+production traces for quality, safety, and guideline compliance. Requires
+`app.monitoring` in the YAML config.
+
+```bash
+dao-ai monitor scorers enable  -c config/model_config.yaml   # register + start
+dao-ai monitor scorers status  -c config/model_config.yaml   # list active scorers
+dao-ai monitor scorers disable -c config/model_config.yaml   # stop all scorers
+```
+
+### `dao-ai monitor logs`
+
+Fetch or stream runtime logs for the deployed agent, to stdout. Provide either
+`-c/--config` (derives the app/endpoint name from the YAML) or `--name` (an
+explicit name, used literally) — the two are mutually exclusive.
+
+```bash
+# Databricks Apps (default mode) — last 200 lines, then last 500
+dao-ai monitor logs -c config/model_config.yaml
+dao-ai monitor logs -c config/model_config.yaml --lines 500
+
+# Stream continuously until Ctrl-C (apps only)
+dao-ai monitor logs -c config/model_config.yaml --follow
+
+# Model Serving snapshot (no streaming)
+dao-ai monitor logs -c config/model_config.yaml -m model_serving
+
+# Explicit name instead of a config file
+dao-ai monitor logs --name my-app -p fevm
+```
+
+**Capability matrix** — the two deployment targets expose logs differently:
+
+| Capability | `-m apps` (default) | `-m model_serving` |
+|---|---|---|
+| Snapshot (last N via `--lines`) | ✅ | ✅ |
+| Streaming (`--follow`) | ✅ | ❌ (snapshot only — `--follow` is rejected) |
+| Mechanism | `databricks apps logs` (CLI; requires the `databricks` CLI ≥ 1.3.0 on `PATH`) | Databricks SDK `serving_endpoints.logs` |
+
+The Apps path shells out to the `databricks` CLI because the Databricks Python
+SDK exposes no Apps-logs API; the CLI streams the app's `logz/stream` websocket.
+`--lines 0` fetches all buffered lines (apps only).
+
 ## Interactive Chat
 
 Start an interactive chat session with your agent:

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -372,7 +372,7 @@ def _build_app_block(
     Returns:
         (app_name, experiments_block, apps_block)
     """
-    app_name: str = config.app.name.lower().replace("_", "-")
+    app_name: str = config.app.app_resource_name
 
     enable_chat_proxy: bool = (
         config.app.enable_chat_proxy
@@ -730,7 +730,7 @@ def write_bundle(
         )
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    app_name: str = config.app.name.lower().replace("_", "-")
+    app_name: str = config.app.app_resource_name
     written: list[str] = []
     skipped: list[str] = []
     # User code (src/ + code_paths + source config) that already existed at the

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -1171,21 +1171,24 @@ Examples:
     # Monitor command
     monitor_parser: ArgumentParser = subparsers.add_parser(
         "monitor",
-        help="Manage production monitoring for the deployed agent (scorers)",
+        help="Manage production monitoring for the deployed agent (scorers, logs)",
         description="""
 Manage production monitoring for the deployed agent.
 
-Currently exposes the `scorers` sub-group, which registers, inspects, and
-stops MLflow monitoring scorers that continuously evaluate production traces
-for quality, safety, and guideline compliance.
-
-Requires app.monitoring to be configured in the YAML config.
+Sub-groups:
+  scorers  Register, inspect, and stop MLflow monitoring scorers that
+           continuously evaluate production traces for quality, safety, and
+           guideline compliance. Requires app.monitoring in the YAML config.
+  logs     Fetch or stream runtime logs for the deployed agent (Databricks
+           Apps or Model Serving).
         """,
         epilog="""
 Examples:
   dao-ai monitor scorers enable -c config/model_config.yaml    # Register and start monitoring scorers
   dao-ai monitor scorers status -c config/model_config.yaml    # Show active scorers and sample rates
   dao-ai monitor scorers disable -c config/model_config.yaml   # Stop all monitoring scorers
+  dao-ai monitor logs -c config/model_config.yaml              # Last 200 lines of app logs
+  dao-ai monitor logs -c config/model_config.yaml --follow     # Stream app logs (apps only)
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         parents=[_GLOBAL],
@@ -1224,6 +1227,61 @@ Examples:
         choices=["enable", "status", "disable"],
         help="Scorers action: enable (register/start scorers), "
         "status (list active scorers), disable (stop all scorers)",
+    )
+
+    monitor_logs_parser: ArgumentParser = monitor_verbs.add_parser(
+        "logs",
+        help="Fetch or stream logs for the deployed agent (apps or model_serving)",
+        description="""
+Fetch or stream runtime logs for the deployed agent.
+
+Capability matrix:
+  apps           snapshot (--lines) AND streaming (--follow)   [via databricks CLI]
+  model_serving  snapshot only (--lines); --follow NOT supported [via Databricks SDK]
+
+Provide either -c/--config (to derive the app/endpoint name from the YAML) or
+--name (an explicit app/endpoint name), but not both.
+        """,
+        epilog="""
+Examples:
+  dao-ai monitor logs -c config/model_config.yaml                    # last 200 lines (apps, default)
+  dao-ai monitor logs -c config/model_config.yaml --lines 500        # last 500 lines
+  dao-ai monitor logs -c config/model_config.yaml --follow           # stream (apps only)
+  dao-ai monitor logs -c config/model_config.yaml -m model_serving   # model serving snapshot
+  dao-ai monitor logs --name my-app -p fevm                          # explicit app name
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_GLOBAL],
+    )
+    monitor_logs_source = monitor_logs_parser.add_mutually_exclusive_group(
+        required=True
+    )
+    monitor_logs_source.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        metavar="FILE",
+        help="Path to the model configuration file (derives the app/endpoint name)",
+    )
+    monitor_logs_source.add_argument(
+        "--name",
+        type=str,
+        metavar="NAME",
+        help="Explicit App name (apps) or endpoint name (model_serving), used "
+        "literally. Mutually exclusive with --config.",
+    )
+    _add_mode_argument(monitor_logs_parser, choices=["apps", "model_serving"])
+    monitor_logs_parser.add_argument(
+        "--lines",
+        type=int,
+        default=200,
+        metavar="N",
+        help="Number of trailing log lines to fetch (default: 200; 0 = all, apps only)",
+    )
+    monitor_logs_parser.add_argument(
+        "--follow",
+        action="store_true",
+        help="Stream logs continuously (apps only; not supported for model_serving)",
     )
 
     chat_parser: ArgumentParser = subparsers.add_parser(
@@ -1325,6 +1383,7 @@ Examples:
         graph_parser,
         list_mcp_parser,
         monitor_scorers_parser,
+        monitor_logs_parser,
         chat_parser,
         vars_parser,
     ):
@@ -2058,18 +2117,21 @@ def handle_graph_command(options: Namespace) -> None:
 
 
 def handle_monitor_command(options: Namespace) -> None:
-    """Dispatch `dao-ai monitor <scorers>`.
+    """Dispatch `dao-ai monitor <scorers|logs>`.
 
     ``scorers enable|status|disable`` manages MLflow production monitoring
-    scorers. (Runtime log/metrics sub-groups are intentionally absent: the
-    Databricks Apps platform exposes no logs or memory/CPU metrics API — see
-    the vault note ``dao-ai-monitor-observability-api-gap``.)
+    scorers. ``logs`` fetches or streams runtime logs for the deployed agent
+    (Databricks Apps via the ``databricks`` CLI, Model Serving via the SDK).
     """
-    from dao_ai.providers.databricks import DatabricksProvider
+    if options.subcommand == "logs":
+        _handle_monitor_logs(options)
+        return
 
     if options.subcommand != "scorers":
         logger.error(f"Unknown monitor sub-command: {options.subcommand}")
         sys.exit(1)
+
+    from dao_ai.providers.databricks import DatabricksProvider
 
     _apply_profile_context(options.profile)
     logger.debug(f"Loading configuration from {options.config}...")
@@ -2138,6 +2200,82 @@ def handle_monitor_command(options: Namespace) -> None:
         raise
     except Exception as e:
         logger.error(f"Monitor command failed: {e}")
+        sys.exit(1)
+
+
+def _handle_monitor_logs(options: Namespace) -> None:
+    """Fetch or stream logs for the deployed agent.
+
+    Resolves the app/endpoint name from ``--name`` (used literally) or
+    ``--config`` (derived from the YAML), then dispatches on ``--mode``:
+    ``apps`` streams via the ``databricks`` CLI; ``model_serving`` returns a
+    point-in-time snapshot via the Databricks SDK (``--follow`` unsupported).
+    """
+    if options.lines < 0:
+        logger.error(f"--lines must be >= 0 (got {options.lines}); 0 means all")
+        sys.exit(1)
+
+    # Make the profile authoritative before any SDK call (model_serving) and
+    # before the CLI subprocess (apps) inherits this process's environment:
+    # this strips ambient DATABRICKS_* vars a `.env`/shell may have injected so
+    # they can't hijack the child CLI even though we also pass it ``-p``.
+    _apply_profile_context(options.profile)
+
+    config: AppConfig | None = None
+    if options.config:
+        logger.debug(f"Loading configuration from {options.config}...")
+        try:
+            config = AppConfig.from_file(
+                options.config, params=_parse_var_args(options.var)
+            )
+        except ConfigVariableError as e:
+            _print_config_variable_error(e)
+            sys.exit(1)
+        if not config.app:
+            logger.error("app must be configured in the YAML to fetch logs")
+            sys.exit(1)
+
+    try:
+        from dao_ai.monitoring import fetch_model_serving_logs, stream_app_logs
+
+        if options.mode == "model_serving":
+            if options.follow:
+                logger.error(
+                    "--follow is not supported for mode=model_serving "
+                    "(snapshot only); omit --follow for the current snapshot"
+                )
+                sys.exit(1)
+            # endpoint_name defaults to app.name via set_default_endpoint_name;
+            # fall back explicitly so a partially-built config still resolves.
+            endpoint_name: str = options.name or (
+                config.app.endpoint_name or config.app.name
+            )
+            print(
+                fetch_model_serving_logs(
+                    endpoint_name=endpoint_name, lines=options.lines
+                )
+            )
+            sys.exit(0)
+
+        # apps mode
+        app_name: str = options.name or config.app.app_resource_name
+        sys.exit(
+            stream_app_logs(
+                app_name=app_name,
+                lines=options.lines,
+                follow=options.follow,
+                profile=options.profile,
+            )
+        )
+    except KeyboardInterrupt:
+        # Expected way to stop `--follow`; exit cleanly instead of dumping a
+        # traceback (KeyboardInterrupt is a BaseException, so it would escape
+        # the `except Exception` below and reach the un-guarded main()).
+        sys.exit(130)
+    except SystemExit:
+        raise
+    except Exception as e:
+        logger.error(f"Monitor logs command failed: {e}")
         sys.exit(1)
 
 

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -9713,6 +9713,16 @@ class AppModel(BaseModel):
             self.endpoint_name = self.name
         return self
 
+    @property
+    def app_resource_name(self) -> str:
+        """Workspace Databricks App name derived from ``name``.
+
+        Lowercased with underscores replaced by hyphens. This is the name the
+        app is deployed under (see ``dao_ai.apps.bundle``); log retrieval and
+        any other App API call must use this form, not the raw ``name``.
+        """
+        return self.name.lower().replace("_", "-")
+
     @model_validator(mode="after")
     def set_default_agent(self) -> Self:
         # Only meaningful when agents are declared. Under deep_agent solo

--- a/src/dao_ai/monitoring.py
+++ b/src/dao_ai/monitoring.py
@@ -1,0 +1,95 @@
+"""Runtime log retrieval for the deployed agent.
+
+Two deployment targets, two mechanisms:
+
+- ``apps`` mode shells out to ``databricks apps logs`` (streaming + tail). The
+  Databricks Python SDK exposes no Apps logs API, so the CLI is the only way to
+  reach the app's ``logz/stream`` websocket.
+- ``model_serving`` mode uses the Databricks SDK ``serving_endpoints.logs``,
+  which returns a point-in-time snapshot (no streaming).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+from loguru import logger
+
+
+def stream_app_logs(
+    *,
+    app_name: str,
+    lines: int = 200,
+    follow: bool = False,
+    profile: str | None = None,
+) -> int:
+    """Fetch or stream Databricks App logs to stdout via the ``databricks`` CLI.
+
+    Args:
+        app_name: The workspace App name.
+        lines: Number of trailing log lines to fetch (``0`` = all).
+        follow: When True, stream continuously until interrupted.
+        profile: Optional Databricks CLI profile.
+
+    Returns:
+        The CLI process return code.
+
+    Raises:
+        RuntimeError: If the ``databricks`` CLI is not on ``PATH``.
+    """
+    if shutil.which("databricks") is None:
+        raise RuntimeError(
+            "The `databricks` CLI (>= 1.3.0) is required to fetch Apps logs but "
+            "was not found on PATH. Install it or use -m model_serving."
+        )
+    cmd: list[str] = [
+        "databricks",
+        "apps",
+        "logs",
+        app_name,
+        "--tail-lines",
+        str(lines),
+    ]
+    if follow:
+        cmd.append("--follow")
+    if profile:
+        cmd.extend(["-p", profile])
+    logger.debug(f"Running: {' '.join(cmd)}")
+    # Inherit stdout/stderr so --follow streams live and Ctrl-C reaches the child.
+    return subprocess.run(cmd).returncode
+
+
+def fetch_model_serving_logs(*, endpoint_name: str, lines: int = 200) -> str:
+    """Return a snapshot of Model Serving endpoint logs (most-recent lines).
+
+    Args:
+        endpoint_name: The serving endpoint name.
+        lines: Number of trailing lines to return (``<= 0`` = full snapshot).
+
+    Returns:
+        The (possibly trimmed) log text.
+
+    Raises:
+        RuntimeError: If the endpoint has no served entities yet.
+    """
+    from dao_ai.providers.databricks import DatabricksProvider
+
+    w = DatabricksProvider().w
+    endpoint = w.serving_endpoints.get(endpoint_name)
+    entities = endpoint.config.served_entities if endpoint.config else None
+    if not entities:
+        raise RuntimeError(f"Endpoint {endpoint_name} has no served entities yet")
+    served_model_name: str = entities[0].name
+    if len(entities) > 1:
+        logger.warning(
+            "Endpoint {} has {} served entities; Model Serving logs are "
+            "per-served-model, so showing logs for {!r} only.",
+            endpoint_name,
+            len(entities),
+            served_model_name,
+        )
+    text: str = w.serving_endpoints.logs(endpoint_name, served_model_name).logs or ""
+    if lines and lines > 0:
+        text = "\n".join(text.splitlines()[-lines:])
+    return text

--- a/tests/dao_ai/test_config_vars.py
+++ b/tests/dao_ai/test_config_vars.py
@@ -1669,7 +1669,7 @@ def test_cli_var_flag_appears_in_subparser_help(
     from dao_ai.cli import parse_args
 
     simple_help = (["validate"], ["graph"], ["chat"], ["vars"])
-    for argv in (*simple_help, ["monitor", "scorers"]):
+    for argv in (*simple_help, ["monitor", "scorers"], ["monitor", "logs"]):
         with pytest.raises(SystemExit):
             # --help triggers a clean SystemExit(0) after printing.
             parse_args([*argv, "--help"])

--- a/tests/dao_ai/test_monitor_logs_cli.py
+++ b/tests/dao_ai/test_monitor_logs_cli.py
@@ -1,0 +1,116 @@
+"""Tests for the ``dao-ai monitor logs`` subcommand.
+
+Covers argument parsing (mutually-exclusive name source, mode default, flags)
+and handler dispatch (Apps -> ``stream_app_logs``, Model Serving snapshot ->
+``fetch_model_serving_logs``, and the ``--follow`` rejection for model_serving).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dao_ai.cli import parse_args
+from dao_ai.monitoring import stream_app_logs
+
+
+@pytest.mark.unit
+class TestMonitorLogsParsing:
+    def test_mode_defaults_to_apps(self) -> None:
+        opts = parse_args(["monitor", "logs", "-c", "config.yaml"])
+        assert opts.subcommand == "logs"
+        assert opts.mode == "apps"
+        assert opts.lines == 200
+        assert opts.follow is False
+
+    def test_name_source_used_literally(self) -> None:
+        opts = parse_args(["monitor", "logs", "--name", "my-app"])
+        assert opts.name == "my-app"
+        assert opts.config is None
+
+    def test_mode_alias_normalized(self) -> None:
+        opts = parse_args(["monitor", "logs", "--name", "ep", "-m", "ms"])
+        assert opts.mode == "model_serving"
+
+    def test_config_and_name_mutually_exclusive(self) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(["monitor", "logs", "-c", "config.yaml", "--name", "x"])
+
+    def test_one_name_source_required(self) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(["monitor", "logs"])
+
+
+@pytest.mark.unit
+class TestMonitorLogsDispatch:
+    def _run(self, argv: list[str]):
+        """Parse ``argv`` and run the monitor handler, returning the SystemExit."""
+        from dao_ai.cli import handle_monitor_command
+
+        opts = parse_args(argv)
+        with pytest.raises(SystemExit) as exc:
+            handle_monitor_command(opts)
+        return exc.value
+
+    def test_model_serving_follow_rejected(self) -> None:
+        exc = self._run(
+            ["monitor", "logs", "--name", "ep", "-m", "model_serving", "--follow"]
+        )
+        assert exc.code == 1
+
+    @patch("dao_ai.monitoring.fetch_model_serving_logs", return_value="hello logs")
+    def test_model_serving_snapshot_prints(
+        self, mock_fetch: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        exc = self._run(
+            ["monitor", "logs", "--name", "ep", "-m", "model_serving", "--lines", "50"]
+        )
+        assert exc.code == 0
+        mock_fetch.assert_called_once_with(endpoint_name="ep", lines=50)
+        assert "hello logs" in capsys.readouterr().out
+
+    @patch("dao_ai.monitoring.stream_app_logs", return_value=0)
+    def test_apps_streams_via_name(self, mock_stream: MagicMock) -> None:
+        exc = self._run(
+            ["monitor", "logs", "--name", "my-app", "-p", "fevm", "--follow"]
+        )
+        assert exc.code == 0
+        mock_stream.assert_called_once_with(
+            app_name="my-app", lines=200, follow=True, profile="fevm"
+        )
+
+    @patch("dao_ai.monitoring.stream_app_logs", return_value=0)
+    @patch("dao_ai.cli.AppConfig.from_file")
+    def test_apps_derives_name_from_config(
+        self, mock_from_file: MagicMock, mock_stream: MagicMock
+    ) -> None:
+        # app.name "minimal_dao" -> workspace app "minimal-dao" (underscore->hyphen)
+        cfg = MagicMock()
+        cfg.app.app_resource_name = "minimal-dao"
+        mock_from_file.return_value = cfg
+        exc = self._run(["monitor", "logs", "-c", "config.yaml", "-p", "fevm"])
+        assert exc.code == 0
+        mock_stream.assert_called_once_with(
+            app_name="minimal-dao", lines=200, follow=False, profile="fevm"
+        )
+
+    def test_negative_lines_rejected(self) -> None:
+        exc = self._run(["monitor", "logs", "--name", "x", "--lines", "-3"])
+        assert exc.code == 1
+
+    @patch("dao_ai.monitoring.stream_app_logs", side_effect=KeyboardInterrupt)
+    def test_follow_keyboard_interrupt_exits_cleanly(
+        self, mock_stream: MagicMock
+    ) -> None:
+        # Ctrl-C on a follow stream must not escape as a raw traceback.
+        exc = self._run(["monitor", "logs", "--name", "x", "--follow"])
+        assert exc.code == 130
+
+
+@pytest.mark.unit
+class TestStreamAppLogs:
+    @patch("dao_ai.monitoring.shutil.which", return_value=None)
+    def test_missing_databricks_cli_raises(self, _which: MagicMock) -> None:
+        with pytest.raises(RuntimeError, match="databricks.*CLI"):
+            stream_app_logs(app_name="x")


### PR DESCRIPTION
## Summary

Adds `dao-ai monitor logs` to fetch or stream the deployed agent's runtime logs to stdout, for both deployment targets. Fills the observability gap where operators previously had to open the workspace UI to see app/endpoint logs.

Usage:
```bash
dao-ai monitor logs -c config/model_config.yaml               # last 200 lines (apps, default)
dao-ai monitor logs -c config/model_config.yaml --lines 500   # last 500
dao-ai monitor logs -c config/model_config.yaml --follow      # stream (apps only)
dao-ai monitor logs -c config/model_config.yaml -m model_serving  # MS snapshot
dao-ai monitor logs --name my-app -p fevm                     # explicit name
```

The log source name comes from either `-c/--config` (derived from the YAML) or `--name` (used literally) — mutually exclusive, one required.

## Capability matrix

| Capability | `-m apps` (default) | `-m model_serving` |
|---|---|---|
| Snapshot (last N via `--lines`) | ✅ | ✅ |
| Streaming (`--follow`) | ✅ | ❌ rejected, exit 1 |
| Mechanism | `databricks apps logs` (CLI) | SDK `serving_endpoints.logs` |

**Why apps uses the CLI, not the SDK:** the Databricks Python SDK exposes no Apps-logs method. The `databricks` CLI (≥ 1.3.0) does — it streams the app's `wss://<app-url>/logz/stream` websocket with `--follow`/`--tail-lines`. So the apps path shells out (reusing dao-ai's existing subprocess convention); the model_serving path stays on the SDK.

## Changes

- **New `src/dao_ai/monitoring.py`** — `stream_app_logs` (apps), `fetch_model_serving_logs` (MS snapshot).
- **`src/dao_ai/cli.py`** — `monitor logs` parser + `_handle_monitor_logs` dispatch; fixes stale "Apps exposes no logs API" help/docstring.
- **`src/dao_ai/config.py`** — shared `AppModel.app_resource_name` property (workspace App-name derivation, defined once).
- **`src/dao_ai/apps/bundle.py`** — reuse the shared property (was hand-copied twice).
- **`docs/cli-reference.md`** — new Monitor section with the capability matrix.
- **Tests** — `test_monitor_logs_cli.py` (parsing, dispatch, config-derived name, negative-lines rejection, Ctrl-C clean exit, missing-CLI guard) + the `--var` help invariant.

No config schema change (`app_resource_name` is a property, not a field) — `make schema` is a no-op.

## Verification

Live-verified on the `fevm` workspace against a deployed sample app (`minimal-dao`) and a Model Serving endpoint:
- apps snapshot (real `[BUILD]`/`[APP]` lines), apps `--follow` (streamed live startup), config-derived name (`minimal_dao`→`minimal-dao`)
- MS snapshot; MS `--follow` rejected with exit 1; negative `--lines` rejected with exit 1
- 12 unit tests pass; ruff lint/format clean (project uses `--ignore E501`)

Reviewed with Isaac Review (`/code-review`): 8 findings surfaced and all resolved (7 fixed, 1 verified correct-as-is).

This pull request and its description were written by Isaac.