### PR TITLE
chore: repo-wide ruff format + resolve lint errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -308,3 +308,11 @@ exclude = [
     "node_modules",
     "venv",
 ]
+
+# Databricks notebooks (`# Databricks notebook source`) legitimately break two
+# lint rules: imports live inside `# COMMAND ----------` cells rather than at the
+# top of the module (E402), and the runtime injects globals like `spark`,
+# `dbutils`, `dlt`, and `display` that are undefined to a static checker (F821).
+# Scope the ignores to the notebooks dir so the rest of the tree stays strict.
+[tool.ruff.lint.per-file-ignores]
+"src/dao_ai/pipeline/notebooks/*.py" = ["E402", "F821"]

--- a/src/dao_ai/_locking.py
+++ b/src/dao_ai/_locking.py
@@ -74,9 +74,7 @@ def generate_bundle_lock(bundle_dir: Path) -> None:
         raise RuntimeError(f"uv lock did not produce {lock_path}")
 
     original = lock_path.read_text()
-    rewritten = original.replace(
-        f"https://{_MIRROR_HOST}/", f"https://{_PUBLIC_HOST}/"
-    )
+    rewritten = original.replace(f"https://{_MIRROR_HOST}/", f"https://{_PUBLIC_HOST}/")
     if rewritten != original:
         lock_path.write_text(rewritten)
         logger.info(

--- a/src/dao_ai/apps/a2a/executor.py
+++ b/src/dao_ai/apps/a2a/executor.py
@@ -75,11 +75,7 @@ class A2AAgentExecutor(AgentExecutor):
     @property
     def _tool_models(self) -> list["ToolModel"]:
         """Flattened tool_models across every agent — used by the HITL audit tap."""
-        return [
-            tool
-            for agent in self.config.agents.values()
-            for tool in agent.tools
-        ]
+        return [tool for agent in self.config.agents.values() for tool in agent.tools]
 
     async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
         task_id = context.task_id

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -689,9 +689,7 @@ def generate_resources_app_yaml(
 def _write_file(path: Path, content: str, overwrite: bool) -> bool:
     """Write content to a file, respecting overwrite. Returns True if written."""
     if path.exists() and not overwrite:
-        print(
-            f"  WARNING: Skipping {path.name} (already exists; use --overwrite)"
-        )
+        print(f"  WARNING: Skipping {path.name} (already exists; use --overwrite)")
         return False
     path.write_text(content)
     logger.info(f"Wrote {path.name}")
@@ -796,9 +794,7 @@ def write_bundle(
         if dest.resolve() == Path(source_config).resolve():
             preserved.append(config_filename)
         elif dest.exists() and not overwrite:
-            print(
-                f"  WARNING: Skipping {config_filename} (exists; use --overwrite)"
-            )
+            print(f"  WARNING: Skipping {config_filename} (exists; use --overwrite)")
             skipped.append(config_filename)
         else:
             # Prefer the rendered YAML (with ${param.NAME} already substituted

--- a/src/dao_ai/apps/model_serving.py
+++ b/src/dao_ai/apps/model_serving.py
@@ -1,7 +1,6 @@
 # Apply nest_asyncio FIRST before any other imports
 # This allows dao-ai's async/sync patterns to work in Model Serving
 # where there may already be an event loop running (e.g., notebook context)
-import os  # noqa: E402
 import time  # noqa: E402
 
 import nest_asyncio

--- a/src/dao_ai/apps/server.py
+++ b/src/dao_ai/apps/server.py
@@ -255,8 +255,12 @@ def _run_gunicorn_preload(port: int, workers: int) -> None:
     from gunicorn.app.base import BaseApplication
     from loguru import logger
 
-    def _post_fork(_server: Any, worker: Any) -> None:  # pragma: no cover — runtime hook
-        logger.info("gunicorn worker forked | pid={} worker={}", os.getpid(), worker.pid)
+    def _post_fork(
+        _server: Any, worker: Any
+    ) -> None:  # pragma: no cover — runtime hook
+        logger.info(
+            "gunicorn worker forked | pid={} worker={}", os.getpid(), worker.pid
+        )
 
     class _DaoAiGunicornApp(BaseApplication):
         def load_config(self) -> None:

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -10,8 +10,8 @@ import subprocess
 import sys
 import traceback
 from argparse import ArgumentParser, Namespace
-from pathlib import Path
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any, Optional, Sequence
 
 from dotenv import find_dotenv, load_dotenv
@@ -484,7 +484,9 @@ def _add_noun_verb_parsers(
         verb_parser: ArgumentParser = verbs.add_parser(
             verb,
             help=verb_help,
-            description=_deploy_desc if verb == "deploy" else (
+            description=_deploy_desc
+            if verb == "deploy"
+            else (
                 f"{verb_help}. Acts on the staging dir written by "
                 f"`dao-ai {noun} generate` (or -o); errors if nothing is staged."
             ),
@@ -509,7 +511,6 @@ def _add_noun_verb_parsers(
 # per-config isolation is preserved regardless of the base.
 _BUNDLE_DIR_ENV_VAR = "DAO_AI_BUNDLE_DIR"
 _DEFAULT_BUNDLE_BASE = ".dao-ai/bundle"
-
 
 
 def _default_bundle_base() -> Path:
@@ -1422,7 +1423,10 @@ Examples:
     # --direct is only meaningful for the bundle-less SDK path (apps/mcp).
     # model_serving always deploys via the SDK, so pairing the two is a
     # contradiction — reject it here rather than silently ignoring --direct.
-    if getattr(options, "direct", False) and getattr(options, "mode", None) == "model_serving":
+    if (
+        getattr(options, "direct", False)
+        and getattr(options, "mode", None) == "model_serving"
+    ):
         parser.error(
             "--direct is not valid with --mode model_serving; "
             "model_serving always deploys via the SDK (no bundle)."
@@ -1944,9 +1948,7 @@ def handle_grant_trace_permissions_command(options: Namespace) -> None:
     if experiment_id is None:
         sys.exit(1)
 
-    _grant_trace_writes_to_app_sp(
-        config, experiment_id, sp_override=options.app_sp
-    )
+    _grant_trace_writes_to_app_sp(config, experiment_id, sp_override=options.app_sp)
 
 
 def _grant_trace_writes_to_app_sp(
@@ -2017,9 +2019,7 @@ def _grant_trace_writes_to_app_sp(
 
     table_prefix: str = _resolve_trace_table_prefix(
         config,
-        None
-        if config.app.trace_location.resolved_table_prefix
-        else experiment_id,
+        None if config.app.trace_location.resolved_table_prefix else experiment_id,
     )
     _grant_uc_trace_table_permissions_to_principal(
         principal=sp_id,
@@ -2093,8 +2093,7 @@ def _resolve_experiment_id_for_link(
                 break
     except Exception as e:  # noqa: BLE001
         print(
-            f"Could not look up bundle-declared experiment: "
-            f"{type(e).__name__}: {e}",
+            f"Could not look up bundle-declared experiment: {type(e).__name__}: {e}",
             file=sys.stderr,
         )
         return None
@@ -3456,7 +3455,9 @@ def _deploy_run_destroy_app_bundle(
         from dao_ai.config import ServingMode
 
         config: AppConfig = _load_app_config(options, what=what)
-        development: bool = resolve_use_local_source(getattr(options, "development", None))
+        development: bool = resolve_use_local_source(
+            getattr(options, "development", None)
+        )
         # Model Serving deploys a REGISTERED MLflow model, so log/register the
         # current config first (mirrors the workflow deploy notebook + the former
         # `dao-ai deploy` handler). Without this, deploy_model_serving_agent

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -30,8 +30,6 @@ from typing import (
 import yaml
 
 if TYPE_CHECKING:
-    from a2a.types import SecurityScheme
-
     from dao_ai.audit import LakebaseAuditSink
     from dao_ai.genie.cache.context_aware.optimization import (
         ContextAwareCacheEvalDataset,
@@ -9263,6 +9261,7 @@ class A2AModel(BaseModel):
         # SecurityScheme instances against the discriminated union.
         adapter: TypeAdapter = TypeAdapter(SecurityScheme)
         return {key: adapter.validate_python(scheme) for key, scheme in value.items()}
+
     default_input_modes: list[str] = Field(
         default_factory=lambda: ["text/plain", "application/json"],
         description="Default supported input MIME types on the Agent Card.",

--- a/src/dao_ai/config_vars.py
+++ b/src/dao_ai/config_vars.py
@@ -132,6 +132,7 @@ def _in_any_span(pos: int, spans: list[tuple[int, int]]) -> bool:
             return False
     return False
 
+
 _SUPPORTED_WORKSPACE_PATHS: frozenset[str] = frozenset(
     {
         "host",

--- a/src/dao_ai/genie/agent_chat_model.py
+++ b/src/dao_ai/genie/agent_chat_model.py
@@ -45,7 +45,6 @@ together (see ``GenieAgentModel.chat_model_for_workspace_client``).
 from __future__ import annotations
 
 import json
-from textwrap import dedent
 from typing import Any, AsyncIterator, Iterator, Optional
 
 import httpx
@@ -84,7 +83,9 @@ class GenieAgentError(RuntimeError):
     or a non-2xx HTTP status."""
 
 
-def _parse_sse_lines(lines: list[str]) -> Iterator[tuple[Optional[str], dict[str, Any]]]:
+def _parse_sse_lines(
+    lines: list[str],
+) -> Iterator[tuple[Optional[str], dict[str, Any]]]:
     """Yield ``(event, data)`` pairs from buffered SSE lines.
 
     Parses the standard ``event:`` / ``data:`` line format; a blank line
@@ -129,7 +130,9 @@ def _format_function_call_block(item: dict[str, Any]) -> str:
     elif isinstance(arguments_raw, dict):
         arguments = arguments_raw
 
-    title: Optional[str] = arguments.get("title") if isinstance(arguments, dict) else None
+    title: Optional[str] = (
+        arguments.get("title") if isinstance(arguments, dict) else None
+    )
     sql: Optional[str] = arguments.get("sql") if isinstance(arguments, dict) else None
 
     if name == "execute_sql" and sql:
@@ -179,14 +182,18 @@ class _StreamState:
         self.terminal_status: Optional[str] = None
         self.terminal_error: Optional[str] = None
 
-    def handle(self, event_type: Optional[str], payload: dict[str, Any]) -> Optional[str]:
+    def handle(
+        self, event_type: Optional[str], payload: dict[str, Any]
+    ) -> Optional[str]:
         """Process one event. Returns text to stream, or ``None``."""
         self.event_count += 1
         kind: str = event_type or payload.get("type") or ""
 
         if kind == "response.created":
             response_obj: dict[str, Any] = payload.get("response") or {}
-            self.conversation_id = response_obj.get("conversation_id") or self.conversation_id
+            self.conversation_id = (
+                response_obj.get("conversation_id") or self.conversation_id
+            )
             self.response_id = response_obj.get("id") or self.response_id
             return None
 
@@ -208,7 +215,9 @@ class _StreamState:
 
         if kind in {"response.completed", "response.failed"}:
             response_obj = payload.get("response") or {}
-            self.conversation_id = response_obj.get("conversation_id") or self.conversation_id
+            self.conversation_id = (
+                response_obj.get("conversation_id") or self.conversation_id
+            )
             self.response_id = response_obj.get("id") or self.response_id
             self.terminal_status = response_obj.get("status") or kind
             error: Optional[dict[str, Any]] = response_obj.get("error")
@@ -248,7 +257,8 @@ def _latest_human_text(messages: list[BaseMessage]) -> str:
                 parts: list[str] = [
                     block.get("text", "")
                     for block in content
-                    if isinstance(block, dict) and block.get("type") in {"text", "input_text"}
+                    if isinstance(block, dict)
+                    and block.get("type") in {"text", "input_text"}
                 ]
                 return "\n".join(p for p in parts if p)
     raise GenieAgentError("GenieAgentChatModel: no HumanMessage found in the input.")
@@ -428,7 +438,9 @@ class GenieAgentChatModel(BaseChatModel):
             state.handle(event_type, payload)
         self._set_span_attributes(state)
         state.raise_on_error()
-        return ChatResult(generations=[ChatGeneration(message=self._final_message(state))])
+        return ChatResult(
+            generations=[ChatGeneration(message=self._final_message(state))]
+        )
 
     # -- sync path (aggregating) ---------------------------------------
 
@@ -458,4 +470,6 @@ class GenieAgentChatModel(BaseChatModel):
             state.handle(event_type, payload)
         self._set_span_attributes(state)
         state.raise_on_error()
-        return ChatResult(generations=[ChatGeneration(message=self._final_message(state))])
+        return ChatResult(
+            generations=[ChatGeneration(message=self._final_message(state))]
+        )

--- a/src/dao_ai/hitl.py
+++ b/src/dao_ai/hitl.py
@@ -327,12 +327,12 @@ async def _record_hitl_non_executions(
             ),
             decision=decision_type if isinstance(decision_type, str) else None,
             decision_detail=decision_detail,
-            approver_sub=(
-                stash_entry.approver_sub if stash_entry is not None else None
-            ) or approver_sub,
+            approver_sub=(stash_entry.approver_sub if stash_entry is not None else None)
+            or approver_sub,
             confirmed_via=(
                 stash_entry.confirmed_via if stash_entry is not None else None
-            ) or "chat_ui",
+            )
+            or "chat_ui",
             nonce=stash_entry.nonce if stash_entry is not None else None,
             nonce_exp=stash_entry.nonce_exp if stash_entry is not None else None,
             execution_status=ExecutionStatus.NOT_EXECUTED_REJECTED,
@@ -363,9 +363,7 @@ async def _record_hitl_non_executions(
         try:
             from dao_ai.audit import dispatch_audit_receipt_notification
 
-            await dispatch_audit_receipt_notification(
-                receipt, config=runtime_config
-            )
+            await dispatch_audit_receipt_notification(receipt, config=runtime_config)
         except Exception as exc:  # noqa: BLE001
             logger.debug(
                 "Failed to dispatch HITL non-execution receipt notification",
@@ -391,5 +389,3 @@ def _thread_id_from_config(runtime_config: dict[str, Any]) -> str:
         if isinstance(candidate, str) and candidate:
             return candidate
     return "unknown-thread"
-
-

--- a/src/dao_ai/lakebase.py
+++ b/src/dao_ai/lakebase.py
@@ -84,9 +84,7 @@ def backfill_embeddings(
         return 0
 
     update_sql: str = (
-        f"UPDATE {qualified} "
-        f"SET {embedding_column} = %s::vector "
-        f"WHERE {id_column} = %s"
+        f"UPDATE {qualified} SET {embedding_column} = %s::vector WHERE {id_column} = %s"
     )
     total: int = 0
     for start in range(0, len(rows), batch_size):

--- a/src/dao_ai/mcp/agent_tool.py
+++ b/src/dao_ai/mcp/agent_tool.py
@@ -50,11 +50,11 @@ import time
 from collections.abc import Mapping
 from typing import Any, Optional
 
+import mlflow
 from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.shared.context import RequestContext
 from mcp.types import CallToolResult, RequestParams, TextContent
-import mlflow
 from mlflow.types.responses import ResponsesAgentRequest, ResponsesAgentResponse
 from pydantic import BaseModel, Field
 
@@ -485,9 +485,7 @@ def register_agent_as_tool(mcp: FastMCP, config: AppConfig) -> str:
             obo_token_fingerprint=(
                 _token_fingerprint(obo_token) if obo_present else None
             ),
-            obo_token_subject=(
-                _token_subject(obo_token) if obo_present else None
-            ),
+            obo_token_subject=(_token_subject(obo_token) if obo_present else None),
             header_count=len(headers),
             # ``meta`` | ``header`` | None → None means no conversation id
             # was supplied on either transport channel and the agent will
@@ -524,7 +522,9 @@ def register_agent_as_tool(mcp: FastMCP, config: AppConfig) -> str:
         heartbeat_task: asyncio.Task[None] | None = None
         if progress_enabled:
             try:
-                await ctx.report_progress(progress=0.0, total=100.0, message="agent_start")
+                await ctx.report_progress(
+                    progress=0.0, total=100.0, message="agent_start"
+                )
             except Exception as _exc:
                 # Progress channel failures must not fail the tool call —
                 # log at debug so operators can surface if needed.
@@ -533,9 +533,7 @@ def register_agent_as_tool(mcp: FastMCP, config: AppConfig) -> str:
                     tool_name=tool_name,
                     error=str(_exc),
                 )
-            heartbeat_task = asyncio.create_task(
-                _heartbeat_progress(ctx, tool_name)
-            )
+            heartbeat_task = asyncio.create_task(_heartbeat_progress(ctx, tool_name))
         # SEP-414: when the caller supplied W3C trace context on the inbound
         # _meta, wrap apredict in an explicit MCP-boundary span and stamp the
         # context onto it. The span (and its attributes) export atomically with

--- a/src/dao_ai/mcp/server.py
+++ b/src/dao_ai/mcp/server.py
@@ -109,9 +109,7 @@ def build_app(config: AppConfig) -> FastAPI:
     # is on, opt into the stateful transport; otherwise keep the stateless
     # default (needed for horizontal scaling on Databricks Apps without
     # sticky sessions).
-    caps = (
-        getattr(config.app, "mcp_server", None) if config.app is not None else None
-    )
+    caps = getattr(config.app, "mcp_server", None) if config.app is not None else None
     needs_stateful: bool = caps is not None and caps.progress
 
     # Keep FastMCP's default ``streamable_http_path="/mcp"`` and mount the

--- a/src/dao_ai/middleware/audit_hitl.py
+++ b/src/dao_ai/middleware/audit_hitl.py
@@ -37,8 +37,6 @@ from langgraph.runtime import Runtime
 from loguru import logger
 
 from dao_ai.audit import (
-    AuditSinkManager,
-    LakebaseAuditSink,
     args_hash_of,
     canonical_jcs,
 )
@@ -148,7 +146,9 @@ class AuditedHumanInTheLoopMiddleware(HumanInTheLoopMiddleware):
         entry: Optional[AuditStashEntry] = AuditStash.take(thread_id, tool_call_id)
         if entry is None:
             return
-        decision_type: Any = decision.get("type") if isinstance(decision, dict) else None
+        decision_type: Any = (
+            decision.get("type") if isinstance(decision, dict) else None
+        )
         if isinstance(decision_type, str):
             entry.decision = decision_type
         # Copy every field except ``type`` into decision_detail so the
@@ -180,9 +180,7 @@ class AuditedHumanInTheLoopMiddleware(HumanInTheLoopMiddleware):
         encapsulated lookup. Returns ``"unknown-thread"`` when no entry
         matches (e.g. process restart between interrupt and resume).
         """
-        found: Optional[str] = AuditStash.find_thread_id_by_tool_call_id(
-            tool_call_id
-        )
+        found: Optional[str] = AuditStash.find_thread_id_by_tool_call_id(tool_call_id)
         return found if found is not None else "unknown-thread"
 
     # ------------------------------------------------------------------

--- a/src/dao_ai/middleware/audit_receipt.py
+++ b/src/dao_ai/middleware/audit_receipt.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     from langgraph.prebuilt import ToolRuntime
 
     from dao_ai.config import AuditModel, ToolModel
-    from dao_ai.state import AgentState, Context
+    from dao_ai.state import Context
 
 
 __all__ = [
@@ -132,17 +132,13 @@ class AuditStash:
             cls._entries[(thread_id, tool_call_id)] = entry
 
     @classmethod
-    def take(
-        cls, thread_id: str, tool_call_id: str
-    ) -> Optional[AuditStashEntry]:
+    def take(cls, thread_id: str, tool_call_id: str) -> Optional[AuditStashEntry]:
         """Retrieve and remove the stash entry — single-use, mirrors nonce lifecycle."""
         with cls._lock:
             return cls._entries.pop((thread_id, tool_call_id), None)
 
     @classmethod
-    def find_thread_id_by_tool_call_id(
-        cls, tool_call_id: str
-    ) -> Optional[str]:
+    def find_thread_id_by_tool_call_id(cls, tool_call_id: str) -> Optional[str]:
         """
         Return the ``thread_id`` under which ``tool_call_id`` was stashed,
         or ``None`` if no matching entry exists.
@@ -153,7 +149,7 @@ class AuditStash:
         locate the stash entry when it only has the tool_call_id in hand.
         """
         with cls._lock:
-            for (thread_id, existing_id) in cls._entries:
+            for thread_id, existing_id in cls._entries:
                 if existing_id == tool_call_id:
                     return thread_id
         return None
@@ -200,9 +196,7 @@ def put_stash(thread_id: str, tool_call_id: str, entry: AuditStashEntry) -> None
     AuditStash.put(thread_id, tool_call_id, entry)
 
 
-def take_stash(
-    thread_id: str, tool_call_id: str
-) -> Optional[AuditStashEntry]:
+def take_stash(thread_id: str, tool_call_id: str) -> Optional[AuditStashEntry]:
     """Public helper for tests to consume a stash entry directly."""
     return AuditStash.take(thread_id, tool_call_id)
 
@@ -488,12 +482,10 @@ async def _record_execution_receipt(
         displayed_summary=stash.displayed_summary if stash is not None else None,
         decision=stash.decision if stash is not None else None,
         decision_detail=stash.decision_detail if stash is not None else None,
-        approver_sub=(
-            stash.approver_sub if stash is not None else None
-        ) or (context.user_id if stash is not None else None),
-        approver_email=(
-            stash.approver_email if stash is not None else None
-        ) or (approver_email if stash is not None else None),
+        approver_sub=(stash.approver_sub if stash is not None else None)
+        or (context.user_id if stash is not None else None),
+        approver_email=(stash.approver_email if stash is not None else None)
+        or (approver_email if stash is not None else None),
         confirmed_via=stash.confirmed_via if stash is not None else None,
         obo_access_token=obo_token,
         obo_token_exp=obo_exp,

--- a/src/dao_ai/middleware/obo.py
+++ b/src/dao_ai/middleware/obo.py
@@ -43,9 +43,7 @@ class OBOModelMiddleware(AgentMiddleware[AgentState, Context]):
     4. Swaps the model via ``request.override(model=...)``
     """
 
-    def __init__(
-        self, llm_model: InferenceEndpointModel | GenieAgentModel
-    ) -> None:
+    def __init__(self, llm_model: InferenceEndpointModel | GenieAgentModel) -> None:
         self.llm_model = llm_model
 
     def _create_obo_model(self, context: Context | None) -> LanguageModelLike:

--- a/src/dao_ai/models.py
+++ b/src/dao_ai/models.py
@@ -3,7 +3,6 @@ import json
 import uuid
 from os import PathLike
 from pathlib import Path
-from uuid import UUID
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -14,6 +13,7 @@ from typing import (
     Sequence,
     Union,
 )
+from uuid import UUID
 
 import mlflow
 from databricks_langchain import ChatDatabricks
@@ -1361,8 +1361,7 @@ class LanggraphResponsesAgent(ResponsesAgent):
                     return
                 channel = data.get("channel")
                 if not isinstance(channel, str) or not (
-                    channel.startswith("mcp.")
-                    or channel.startswith("dao_ai.audit.")
+                    channel.startswith("mcp.") or channel.startswith("dao_ai.audit.")
                 ):
                     return
                 await self._queue.put(data)
@@ -1374,9 +1373,7 @@ class LanggraphResponsesAgent(ResponsesAgent):
             existing_callbacks = [existing_callbacks]
         custom_inputs["callbacks"] = [*existing_callbacks, _mcp_collector]
 
-        async def _drain_mcp_queue() -> (
-            AsyncGenerator[ResponsesAgentStreamEvent, None]
-        ):
+        async def _drain_mcp_queue() -> AsyncGenerator[ResponsesAgentStreamEvent, None]:
             nonlocal mcp_event_seq
             while not mcp_event_queue.empty():
                 envelope = mcp_event_queue.get_nowait()

--- a/src/dao_ai/nodes.py
+++ b/src/dao_ai/nodes.py
@@ -35,11 +35,11 @@ from dao_ai.middleware.guardrails import GuardrailMiddleware
 from dao_ai.middleware.human_in_the_loop import (
     create_hitl_middleware_from_tool_models,
 )
-from dao_ai.middleware.summarization import (
-    create_summarization_middleware,
-)
 from dao_ai.middleware.model_call_limit import (
     create_model_call_limit_middleware,
+)
+from dao_ai.middleware.summarization import (
+    create_summarization_middleware,
 )
 from dao_ai.middleware.tool_call_limit import (
     create_tool_call_limit_middlewares_from_tool_models,

--- a/src/dao_ai/orchestration/core.py
+++ b/src/dao_ai/orchestration/core.py
@@ -167,11 +167,7 @@ def filter_messages_for_agent(
             # non-internal (customer-facing) agents. Internal agents can
             # still see each other's outputs — a planner needs to read a
             # supervisor's intent classification to route.
-            if (
-                not is_own
-                and msg.name in _internal
-                and not _current_is_internal
-            ):
+            if not is_own and msg.name in _internal and not _current_is_internal:
                 continue
             if msg.tool_calls:
                 if is_own:
@@ -256,11 +252,7 @@ def filter_messages_for_agent(
     # ``tool_result`` and provoke Claude's ``tool_use ids were found
     # without tool_result blocks immediately after`` 400 (a different
     # constraint from the prefill one, but same class of error).
-    if (
-        filtered
-        and isinstance(filtered[-1], AIMessage)
-        and not filtered[-1].tool_calls
-    ):
+    if filtered and isinstance(filtered[-1], AIMessage) and not filtered[-1].tool_calls:
         bridge_target: str = current_agent_name or "next agent"
         # Content matters — Claude interprets the last user message
         # as "what the user just asked." A cryptic "[filter bridge to X]"
@@ -287,9 +279,7 @@ def filter_messages_for_agent(
                 f"Continue this pipeline as {bridge_target}. "
                 f"Do your job based on the prior agents' work above."
             )
-        filtered.append(
-            HumanMessage(content=bridge_content, name="__filter_bridge__")
-        )
+        filtered.append(HumanMessage(content=bridge_content, name="__filter_bridge__"))
     return filtered
 
 

--- a/src/dao_ai/orchestration/swarm.py
+++ b/src/dao_ai/orchestration/swarm.py
@@ -244,9 +244,7 @@ def _handoffs_for_agent(
             target_ref, config.app.agents
         )
         if handoff_to_agent is None:
-            logger.warning(
-                "Handoff agent not found in configuration", agent=agent.name
-            )
+            logger.warning("Handoff agent not found in configuration", agent=agent.name)
             continue
 
         # Skip self-referencing handoffs (deterministic self-ref is a

--- a/src/dao_ai/pipeline/bundle.py
+++ b/src/dao_ai/pipeline/bundle.py
@@ -57,19 +57,38 @@ _CLOUDS = ("azure", "aws", "gcp")
 # is (task_key, notebook, depends_on, extra_base_parameters).
 _PIPELINE_TASKS: tuple[tuple[str, str, tuple[str, ...], dict[str, str]], ...] = (
     ("ingest-and-transform", "01_ingest_and_transform.py", (), {}),
-    ("provision-vector-search", "02_provision_vector_search.py",
-     ("ingest-and-transform",), {}),
+    (
+        "provision-vector-search",
+        "02_provision_vector_search.py",
+        ("ingest-and-transform",),
+        {},
+    ),
     ("provision-lakebase", "03_provision_lakebase.py", (), {}),
-    ("unity-catalog-tools", "04_unity_catalog_tools.py",
-     ("provision-vector-search", "provision-lakebase"), {}),
+    (
+        "unity-catalog-tools",
+        "04_unity_catalog_tools.py",
+        ("provision-vector-search", "provision-lakebase"),
+        {},
+    ),
     ("provision-genie", "05_provision_genie.py", ("unity-catalog-tools",), {}),
-    ("deploy-agents", "06_deploy_agent.py", ("provision-genie",),
-     {"mode": "${var.mode}",
-      "development": "${var.development}"}),
-    ("generate-evaluation-data", "07_generate_evaluation_data.py",
-     ("provision-vector-search",), {}),
-    ("run-evaluation", "08_run_evaluation.py",
-     ("deploy-agents", "generate-evaluation-data"), {}),
+    (
+        "deploy-agents",
+        "06_deploy_agent.py",
+        ("provision-genie",),
+        {"mode": "${var.mode}", "development": "${var.development}"},
+    ),
+    (
+        "generate-evaluation-data",
+        "07_generate_evaluation_data.py",
+        ("provision-vector-search",),
+        {},
+    ),
+    (
+        "run-evaluation",
+        "08_run_evaluation.py",
+        ("deploy-agents", "generate-evaluation-data"),
+        {},
+    ),
 )
 
 

--- a/src/dao_ai/pipeline/notebooks/01_ingest_and_transform.py
+++ b/src/dao_ai/pipeline/notebooks/01_ingest_and_transform.py
@@ -6,7 +6,9 @@
 # installed package importable in the cells below.
 import glob
 
-_dao_ai_dep = next(iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai")
+_dao_ai_dep = next(
+    iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai"
+)
 
 # MAGIC %uv pip install --quiet {_dao_ai_dep}
 # MAGIC %restart_python
@@ -27,8 +29,9 @@ print(f"mlflow=={version('mlflow')}")
 
 # COMMAND ----------
 
-from typing import Sequence
 import os
+from typing import Sequence
+
 
 def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
     # Tolerate a missing/non-dir base path: when the pipeline runs from a
@@ -36,22 +39,25 @@ def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
     # `../config` discovery dropdown is optional. Return [] instead of raising.
     if not os.path.isdir(base_path):
         return []
-    
+
     yaml_files = []
-    
+
     for root, dirs, files in os.walk(base_path):
         for file in files:
-            if file.lower().endswith(('.yaml', '.yml')):
+            if file.lower().endswith((".yaml", ".yml")):
                 yaml_files.append(os.path.join(root, file))
-    
+
     return sorted(yaml_files)
+
 
 # COMMAND ----------
 
 dbutils.widgets.text(name="config-path", defaultValue="")
 
 config_files: Sequence[str] = find_yaml_files_os_walk("../config")
-dbutils.widgets.dropdown(name="config-paths", choices=config_files, defaultValue=next(iter(config_files), ""))
+dbutils.widgets.dropdown(
+    name="config-paths", choices=config_files, defaultValue=next(iter(config_files), "")
+)
 
 config_path: str | None = dbutils.widgets.get("config-path") or None
 project_path: str = dbutils.widgets.get("config-paths") or None
@@ -80,22 +86,22 @@ config: AppConfig = AppConfig.from_file(path=config_path)
 # COMMAND ----------
 
 from databricks.sdk import WorkspaceClient
-from dao_ai.config import SchemaModel, VolumeModel
 
+from dao_ai.config import SchemaModel, VolumeModel
 
 w: WorkspaceClient = WorkspaceClient()
 
 for _, schema in config.schemas.items():
-  schema: SchemaModel
-  _ = schema.create(w=w)
+    schema: SchemaModel
+    _ = schema.create(w=w)
 
-  print(f"schema: {schema.full_name}")
+    print(f"schema: {schema.full_name}")
 
 for _, volume in config.resources.volumes.items():
-  volume: VolumeModel
-  
-  _ = volume.create(w=w)
-  print(f"volume: {volume.full_name}")
+    volume: VolumeModel
+
+    _ = volume.create(w=w)
+    print(f"volume: {volume.full_name}")
 
 # COMMAND ----------
 

--- a/src/dao_ai/pipeline/notebooks/02_provision_vector_search.py
+++ b/src/dao_ai/pipeline/notebooks/02_provision_vector_search.py
@@ -6,7 +6,9 @@
 # installed package importable in the cells below.
 import glob
 
-_dao_ai_dep = next(iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai")
+_dao_ai_dep = next(
+    iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai"
+)
 
 # MAGIC %uv pip install --quiet {_dao_ai_dep}
 # MAGIC %restart_python
@@ -27,8 +29,9 @@ print(f"mlflow=={version('mlflow')}")
 
 # COMMAND ----------
 
-from typing import Sequence
 import os
+from typing import Sequence
+
 
 def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
     # Tolerate a missing/non-dir base path: when the pipeline runs from a
@@ -36,22 +39,25 @@ def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
     # `../config` discovery dropdown is optional. Return [] instead of raising.
     if not os.path.isdir(base_path):
         return []
-    
+
     yaml_files = []
-    
+
     for root, dirs, files in os.walk(base_path):
         for file in files:
-            if file.lower().endswith(('.yaml', '.yml')):
+            if file.lower().endswith((".yaml", ".yml")):
                 yaml_files.append(os.path.join(root, file))
-    
+
     return sorted(yaml_files)
+
 
 # COMMAND ----------
 
 dbutils.widgets.text(name="config-path", defaultValue="")
 
 config_files: Sequence[str] = find_yaml_files_os_walk("../config")
-dbutils.widgets.dropdown(name="config-paths", choices=config_files, defaultValue=next(iter(config_files), ""))
+dbutils.widgets.dropdown(
+    name="config-paths", choices=config_files, defaultValue=next(iter(config_files), "")
+)
 
 config_path: str | None = dbutils.widgets.get("config-path") or None
 project_path: str = dbutils.widgets.get("config-paths") or None
@@ -84,40 +90,40 @@ from dao_ai.config import VectorStoreModel
 vector_stores: dict[str, VectorStoreModel] = config.resources.vector_stores
 
 for _, vector_store in vector_stores.items():
-  vector_store: VectorStoreModel
+    vector_store: VectorStoreModel
 
-  print(f"vector_store: {vector_store}")
-  vector_store.create()
+    print(f"vector_store: {vector_store}")
+    vector_store.create()
 
 
 # COMMAND ----------
 
-from typing import Dict, Any, List
+from typing import Any, Dict
 
 from databricks.ai_search.index import VectorSearchIndex
-from dao_ai.config import AiSearchRetrieverModel
 
+from dao_ai.config import AiSearchRetrieverModel
 
 question: str = "How many grills do we have in stock?"
 
 for name, retriever in config.retrievers.items():
-  # AppConfig.retrievers is a discriminated union of AiSearchRetrieverModel
-  # and LakebaseRetrieverModel. This notebook is Vector Search only, so
-  # skip Lakebase entries.
-  if not isinstance(retriever, AiSearchRetrieverModel):
-    continue
-  index: VectorSearchIndex = retriever.vector_store.as_index()
-  k: int = 3
+    # AppConfig.retrievers is a discriminated union of AiSearchRetrieverModel
+    # and LakebaseRetrieverModel. This notebook is Vector Search only, so
+    # skip Lakebase entries.
+    if not isinstance(retriever, AiSearchRetrieverModel):
+        continue
+    index: VectorSearchIndex = retriever.vector_store.as_index()
+    k: int = 3
 
-  search_results: Dict[str, Any] = index.similarity_search(
-    query_text=question,
-    columns=retriever.columns,
-    **retriever.search_parameters.model_dump()
-  )
+    search_results: Dict[str, Any] = index.similarity_search(
+        query_text=question,
+        columns=retriever.columns,
+        **retriever.search_parameters.model_dump(),
+    )
 
-  chunks: list[str] = search_results.get('result', {}).get('data_array', [])
-  print(len(chunks))
-  print(chunks)
+    chunks: list[str] = search_results.get("result", {}).get("data_array", [])
+    print(len(chunks))
+    print(chunks)
 
 # COMMAND ----------
 
@@ -129,14 +135,14 @@ from langchain_core.vectorstores.base import VectorStore
 
 content = "What grills do you have in stock?"
 for name, retriever in config.retrievers.items():
-  vector_search: VectorStore = DatabricksVectorSearch(
-      endpoint=retriever.vector_store.endpoint.name,
-      index_name=retriever.vector_store.index.full_name,
-      columns=retriever.columns,
-      client_args={},
-  )
+    vector_search: VectorStore = DatabricksVectorSearch(
+        endpoint=retriever.vector_store.endpoint.name,
+        index_name=retriever.vector_store.index.full_name,
+        columns=retriever.columns,
+        client_args={},
+    )
 
-  documents: Sequence[Document] = vector_search.similarity_search(
-      query=content, **retriever.search_parameters.model_dump()
-  )
-  print(len(documents))
+    documents: Sequence[Document] = vector_search.similarity_search(
+        query=content, **retriever.search_parameters.model_dump()
+    )
+    print(len(documents))

--- a/src/dao_ai/pipeline/notebooks/03_provision_lakebase.py
+++ b/src/dao_ai/pipeline/notebooks/03_provision_lakebase.py
@@ -6,7 +6,9 @@
 # installed package importable in the cells below.
 import glob
 
-_dao_ai_dep = next(iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai")
+_dao_ai_dep = next(
+    iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai"
+)
 
 # MAGIC %uv pip install --quiet {_dao_ai_dep}
 # MAGIC %restart_python
@@ -27,8 +29,9 @@ print(f"mlflow=={version('mlflow')}")
 
 # COMMAND ----------
 
-from typing import Sequence
 import os
+from typing import Sequence
+
 
 def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
     # Tolerate a missing/non-dir base path: when the pipeline runs from a
@@ -36,22 +39,25 @@ def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
     # `../config` discovery dropdown is optional. Return [] instead of raising.
     if not os.path.isdir(base_path):
         return []
-    
+
     yaml_files = []
-    
+
     for root, dirs, files in os.walk(base_path):
         for file in files:
-            if file.lower().endswith(('.yaml', '.yml')):
+            if file.lower().endswith((".yaml", ".yml")):
                 yaml_files.append(os.path.join(root, file))
-    
+
     return sorted(yaml_files)
+
 
 # COMMAND ----------
 
 dbutils.widgets.text(name="config-path", defaultValue="")
 
 config_files: Sequence[str] = find_yaml_files_os_walk("../config")
-dbutils.widgets.dropdown(name="config-paths", choices=config_files, defaultValue=next(iter(config_files), ""))
+dbutils.widgets.dropdown(
+    name="config-paths", choices=config_files, defaultValue=next(iter(config_files), "")
+)
 
 config_path: str | None = dbutils.widgets.get("config-path") or None
 project_path: str = dbutils.widgets.get("config-paths") or None
@@ -84,9 +90,7 @@ from dao_ai.config import DatabaseModel
 databases: dict[str, DatabaseModel] = config.resources.databases
 
 for _, database in databases.items():
-  database: DatabaseModel
+    database: DatabaseModel
 
-  print(f"database: {database}")
-  database.create()
-
-
+    print(f"database: {database}")
+    database.create()

--- a/src/dao_ai/pipeline/notebooks/04_unity_catalog_tools.py
+++ b/src/dao_ai/pipeline/notebooks/04_unity_catalog_tools.py
@@ -6,7 +6,9 @@
 # installed package importable in the cells below.
 import glob
 
-_dao_ai_dep = next(iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai")
+_dao_ai_dep = next(
+    iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai"
+)
 
 # MAGIC %uv pip install --quiet {_dao_ai_dep}
 # MAGIC %restart_python
@@ -27,8 +29,9 @@ print(f"mlflow=={version('mlflow')}")
 
 # COMMAND ----------
 
-from typing import Sequence
 import os
+from typing import Sequence
+
 
 def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
     # Tolerate a missing/non-dir base path: when the pipeline runs from a
@@ -36,22 +39,25 @@ def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
     # `../config` discovery dropdown is optional. Return [] instead of raising.
     if not os.path.isdir(base_path):
         return []
-    
+
     yaml_files = []
-    
+
     for root, dirs, files in os.walk(base_path):
         for file in files:
-            if file.lower().endswith(('.yaml', '.yml')):
+            if file.lower().endswith((".yaml", ".yml")):
                 yaml_files.append(os.path.join(root, file))
-    
+
     return sorted(yaml_files)
+
 
 # COMMAND ----------
 
 dbutils.widgets.text(name="config-path", defaultValue="")
 
 config_files: Sequence[str] = find_yaml_files_os_walk("../config")
-dbutils.widgets.dropdown(name="config-paths", choices=config_files, defaultValue=next(iter(config_files), ""))
+dbutils.widgets.dropdown(
+    name="config-paths", choices=config_files, defaultValue=next(iter(config_files), "")
+)
 
 config_path: str | None = dbutils.widgets.get("config-path") or None
 project_path: str = dbutils.widgets.get("config-paths") or None
@@ -80,8 +86,8 @@ config: AppConfig = AppConfig.from_file(path=config_path)
 # COMMAND ----------
 
 from typing import Sequence
-from dao_ai.config import UnityCatalogFunctionSqlModel
 
+from dao_ai.config import UnityCatalogFunctionSqlModel
 
 unity_catalog_functions: Sequence[UnityCatalogFunctionSqlModel] = (
     config.unity_catalog_functions

--- a/src/dao_ai/pipeline/notebooks/05_provision_genie.py
+++ b/src/dao_ai/pipeline/notebooks/05_provision_genie.py
@@ -6,7 +6,9 @@
 # installed package importable in the cells below.
 import glob
 
-_dao_ai_dep = next(iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai")
+_dao_ai_dep = next(
+    iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai"
+)
 
 # MAGIC %uv pip install --quiet {_dao_ai_dep}
 # MAGIC %restart_python
@@ -27,8 +29,8 @@ print(f"mlflow=={version('mlflow')}")
 
 # COMMAND ----------
 
-from typing import Sequence
 import os
+from typing import Sequence
 
 
 def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
@@ -83,6 +85,7 @@ _ = load_dotenv(find_dotenv())
 # deploy-agents can inject it at config load time.
 
 import json
+
 from dao_ai.config import (
     AppConfig,
     GenieRoomModel,
@@ -113,10 +116,9 @@ if config.resources is not None and config.resources.genie_rooms:
         # room's configuration changes (e.g., new warehouse, new table
         # sources), delete the existing space first or rename the room
         # title so provision-genie creates a fresh one.
-        existing: GenieRoomModel | None = (
-            GenieRoomModel.from_space_id(value_of(room.space_id), w=room.workspace_client)
-            or GenieRoomModel.from_name(value_of(room.name), w=room.workspace_client)
-        )
+        existing: GenieRoomModel | None = GenieRoomModel.from_space_id(
+            value_of(room.space_id), w=room.workspace_client
+        ) or GenieRoomModel.from_name(value_of(room.name), w=room.workspace_client)
         if existing is not None:
             room.space_id = existing.space_id
             print(f"[{room_key}] reusing existing space {room.space_id}")

--- a/src/dao_ai/pipeline/notebooks/06_deploy_agent.py
+++ b/src/dao_ai/pipeline/notebooks/06_deploy_agent.py
@@ -6,15 +6,18 @@
 # installed package importable in the cells below.
 import glob
 
-_dao_ai_dep = next(iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai")
+_dao_ai_dep = next(
+    iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai"
+)
 
 # MAGIC %uv pip install --quiet {_dao_ai_dep}
 # MAGIC %restart_python
 
 # COMMAND ----------
 
-from typing import Sequence
 import os
+from typing import Sequence
+
 
 def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
     # Tolerate a missing/non-dir base path: when the pipeline runs from a
@@ -22,15 +25,16 @@ def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
     # `../config` discovery dropdown is optional. Return [] instead of raising.
     if not os.path.isdir(base_path):
         return []
-    
+
     yaml_files = []
-    
+
     for root, dirs, files in os.walk(base_path):
         for file in files:
-            if file.lower().endswith(('.yaml', '.yml')):
+            if file.lower().endswith((".yaml", ".yml")):
                 yaml_files.append(os.path.join(root, file))
-    
+
     return sorted(yaml_files)
+
 
 # COMMAND ----------
 
@@ -47,7 +51,9 @@ dbutils.widgets.dropdown(
 )
 
 config_files: Sequence[str] = find_yaml_files_os_walk("../config")
-dbutils.widgets.dropdown(name="config-paths", choices=config_files, defaultValue=next(iter(config_files), ""))
+dbutils.widgets.dropdown(
+    name="config-paths", choices=config_files, defaultValue=next(iter(config_files), "")
+)
 
 config_path: str | None = dbutils.widgets.get("config-path") or None
 project_path: str = dbutils.widgets.get("config-paths") or None
@@ -74,17 +80,10 @@ print(f"mlflow=={version('mlflow')}")
 
 # COMMAND ----------
 
-import dao_ai.providers
-import dao_ai.providers.base
-import dao_ai.providers.databricks
-
 # COMMAND ----------
-
 # MAGIC %load_ext autoreload
 # MAGIC %autoreload 2
-
 # COMMAND ----------
-
 from dotenv import find_dotenv, load_dotenv
 
 _ = load_dotenv(find_dotenv())
@@ -92,13 +91,16 @@ _ = load_dotenv(find_dotenv())
 # COMMAND ----------
 
 import nest_asyncio
+
 nest_asyncio.apply()
 
 # COMMAND ----------
 
 from dao_ai.config import AppConfig, ServingMode
 
-config_path: str = dbutils.widgets.get("config-path") or dbutils.widgets.get("config-paths")
+config_path: str = dbutils.widgets.get("config-path") or dbutils.widgets.get(
+    "config-paths"
+)
 mode_str: str | None = dbutils.widgets.get("mode") or None
 
 # Source selection tri-state forwarded by `dao-ai generate-workflow` via the

--- a/src/dao_ai/pipeline/notebooks/07_generate_evaluation_data.py
+++ b/src/dao_ai/pipeline/notebooks/07_generate_evaluation_data.py
@@ -6,7 +6,9 @@
 # installed package importable in the cells below.
 import glob
 
-_dao_ai_dep = next(iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai")
+_dao_ai_dep = next(
+    iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai"
+)
 
 # MAGIC %uv pip install --quiet {_dao_ai_dep}
 # MAGIC %restart_python
@@ -27,8 +29,9 @@ print(f"mlflow=={version('mlflow')}")
 
 # COMMAND ----------
 
-from typing import Sequence
 import os
+from typing import Sequence
+
 
 def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
     # Tolerate a missing/non-dir base path: when the pipeline runs from a
@@ -36,22 +39,25 @@ def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
     # `../config` discovery dropdown is optional. Return [] instead of raising.
     if not os.path.isdir(base_path):
         return []
-    
+
     yaml_files = []
-    
+
     for root, dirs, files in os.walk(base_path):
         for file in files:
-            if file.lower().endswith(('.yaml', '.yml')):
+            if file.lower().endswith((".yaml", ".yml")):
                 yaml_files.append(os.path.join(root, file))
-    
+
     return sorted(yaml_files)
+
 
 # COMMAND ----------
 
 dbutils.widgets.text(name="config-path", defaultValue="")
 
 config_files: Sequence[str] = find_yaml_files_os_walk("../config")
-dbutils.widgets.dropdown(name="config-paths", choices=config_files, defaultValue=next(iter(config_files), ""))
+dbutils.widgets.dropdown(
+    name="config-paths", choices=config_files, defaultValue=next(iter(config_files), "")
+)
 
 config_path: str | None = dbutils.widgets.get("config-path") or None
 project_path: str = dbutils.widgets.get("config-paths") or None
@@ -74,46 +80,44 @@ config: AppConfig = AppConfig.from_file(path=config_path)
 
 # COMMAND ----------
 
-from typing import Any, Dict, Optional, List
 
-from mlflow.models import ModelConfig
-from dao_ai.config import AppConfig, VectorStoreModel, EvaluationModel
-from pyspark.sql import DataFrame, Column
-import pyspark.sql.functions as F
 import pandas as pd
-from pyspark.sql import DataFrame
+import pyspark.sql.functions as F
 from databricks.agents.evals import generate_evals_df
+from pyspark.sql import Column, DataFrame
 
-
+from dao_ai.config import AppConfig, EvaluationModel, VectorStoreModel
 
 evaluation: EvaluationModel = config.evaluation
 
 if not evaluation:
-  dbutils.notebook.exit("Missing evaluation configuration")
+    dbutils.notebook.exit("Missing evaluation configuration")
 
 if evaluation.replace:
-  spark.sql(f"DROP TABLE IF EXISTS `{evaluation.table.full_name}`")
+    spark.sql(f"DROP TABLE IF EXISTS `{evaluation.table.full_name}`")
 elif evaluation.table.exists():
-  print(f"Table already exists, skipping generation: {evaluation.table.full_name}")
-  dbutils.notebook.exit(f"Table already exists: {evaluation.table.full_name}")
+    print(f"Table already exists, skipping generation: {evaluation.table.full_name}")
+    dbutils.notebook.exit(f"Table already exists: {evaluation.table.full_name}")
 
 for _, vector_store in config.resources.vector_stores.items():
-  vector_store: VectorStoreModel    
+    vector_store: VectorStoreModel
 
-  doc_uri: Column = F.col(vector_store.doc_uri) if vector_store.doc_uri else F.lit("source")
-  parsed_docs_df: DataFrame = (
-    spark.table(vector_store.source_table.full_name)
-    .withColumn("id", F.col(vector_store.primary_key))
-    .withColumn("content", F.col(vector_store.embedding_source_column))
-    .withColumn("doc_uri", doc_uri)
-  )
-  parsed_docs_pdf: pd.DataFrame = parsed_docs_df.toPandas()
+    doc_uri: Column = (
+        F.col(vector_store.doc_uri) if vector_store.doc_uri else F.lit("source")
+    )
+    parsed_docs_df: DataFrame = (
+        spark.table(vector_store.source_table.full_name)
+        .withColumn("id", F.col(vector_store.primary_key))
+        .withColumn("content", F.col(vector_store.embedding_source_column))
+        .withColumn("doc_uri", doc_uri)
+    )
+    parsed_docs_pdf: pd.DataFrame = parsed_docs_df.toPandas()
 
-  display(parsed_docs_pdf)
+    display(parsed_docs_pdf)
 
-  agent_description: str = evaluation.agent_description
-  if not agent_description:
-      agent_description = """
+    agent_description: str = evaluation.agent_description
+    if not agent_description:
+        agent_description = """
   A general-purpose chatbot AI agent is designed to engage in natural conversations 
   across diverse topics and tasks, drawing from broad knowledge to answer questions, 
   assist with writing, solve problems, and provide explanations while maintaining 
@@ -122,9 +126,9 @@ for _, vector_store in config.resources.vector_stores.items():
   adjusting its communication style and level of detail based on user needs.
       """
 
-  question_guidelines: str = evaluation.question_guidelines
-  if not question_guidelines:
-      question_guidelines = f"""
+    question_guidelines: str = evaluation.question_guidelines
+    if not question_guidelines:
+        question_guidelines = """
 # User personas
 - A curious individual seeking information or explanations
 - A student looking for homework help or learning assistance  
@@ -144,17 +148,15 @@ for _, vector_store in config.resources.vector_stores.items():
 - Tone can vary from casual chat to formal assistance
   """
 
-  evals_pdf: pd.DataFrame = generate_evals_df(
-      docs=parsed_docs_pdf[
-          :500
-      ],  
-      num_evals=evaluation.num_evals, 
-      agent_description=agent_description,
-      question_guidelines=question_guidelines,
-  )
+    evals_pdf: pd.DataFrame = generate_evals_df(
+        docs=parsed_docs_pdf[:500],
+        num_evals=evaluation.num_evals,
+        agent_description=agent_description,
+        question_guidelines=question_guidelines,
+    )
 
-  evals_df: DataFrame = spark.createDataFrame(evals_pdf)
+    evals_df: DataFrame = spark.createDataFrame(evals_pdf)
 
-  evals_df.write.mode("append").saveAsTable(evaluation.table.full_name)
+    evals_df.write.mode("append").saveAsTable(evaluation.table.full_name)
 
-  display(spark.table(evaluation.table.full_name))
+    display(spark.table(evaluation.table.full_name))

--- a/src/dao_ai/pipeline/notebooks/08_run_evaluation.py
+++ b/src/dao_ai/pipeline/notebooks/08_run_evaluation.py
@@ -6,7 +6,9 @@
 # installed package importable in the cells below.
 import glob
 
-_dao_ai_dep = next(iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai")
+_dao_ai_dep = next(
+    iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai"
+)
 
 # MAGIC %uv pip install --quiet {_dao_ai_dep}
 # MAGIC %restart_python
@@ -27,8 +29,9 @@ print(f"mlflow=={version('mlflow')}")
 
 # COMMAND ----------
 
-from typing import Sequence
 import os
+from typing import Sequence
+
 
 def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
     # Tolerate a missing/non-dir base path: when the pipeline runs from a
@@ -44,26 +47,25 @@ def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
                 yaml_files.append(os.path.join(root, file))
     return sorted(yaml_files)
 
+
 # COMMAND ----------
 
 dbutils.widgets.text(name="config-path", defaultValue="")
 
 config_files: Sequence[str] = find_yaml_files_os_walk("../config")
-dbutils.widgets.dropdown(name="config-paths", choices=config_files, defaultValue=next(iter(config_files), ""))
+dbutils.widgets.dropdown(
+    name="config-paths", choices=config_files, defaultValue=next(iter(config_files), "")
+)
 
-config_path: str = dbutils.widgets.get("config-path") or dbutils.widgets.get("config-paths")
+config_path: str = dbutils.widgets.get("config-path") or dbutils.widgets.get(
+    "config-paths"
+)
 print(config_path)
 
 # COMMAND ----------
 
-import dao_ai.providers
-import dao_ai.providers.base
-import dao_ai.providers.databricks
-import dao_ai.memory.postgres
-import dao_ai.memory.databricks
 
 # COMMAND ----------
-
 # DBTITLE 1,Load Application Config
 from dao_ai.config import AppConfig, EvaluationModel
 from dao_ai.logging import configure_logging
@@ -90,10 +92,14 @@ _eval_custom_inputs: dict[str, Any] = evaluation.custom_inputs or {}
 _input_example_custom_inputs: dict[str, Any] = (
     getattr(config.app.input_example, "custom_inputs", None) or {}
 )
-custom_inputs: dict[str, Any] = _eval_custom_inputs or _input_example_custom_inputs or {}
+custom_inputs: dict[str, Any] = (
+    _eval_custom_inputs or _input_example_custom_inputs or {}
+)
 _custom_inputs_source: str = (
-    "evaluation" if _eval_custom_inputs
-    else "input_example" if _input_example_custom_inputs
+    "evaluation"
+    if _eval_custom_inputs
+    else "input_example"
+    if _input_example_custom_inputs
     else "empty"
 )
 
@@ -106,6 +112,7 @@ print(f"Custom inputs (source={_custom_inputs_source}): {custom_inputs}")
 import mlflow
 from mlflow import MlflowClient
 from mlflow.entities.model_registry.model_version import ModelVersion
+
 from dao_ai.models import get_latest_model_version
 
 mlflow.set_registry_uri("databricks-uc")
@@ -118,7 +125,9 @@ mlflow_client: MlflowClient = MlflowClient()
 registered_model_name: str = config.app.registered_model.full_name
 latest_version: int = get_latest_model_version(registered_model_name)
 model_uri: str = f"models:/{registered_model_name}/{latest_version}"
-model_version: ModelVersion = mlflow_client.get_model_version(registered_model_name, str(latest_version))
+model_version: ModelVersion = mlflow_client.get_model_version(
+    registered_model_name, str(latest_version)
+)
 
 print(f"Registered model: {registered_model_name}")
 print(f"Latest version:   {latest_version}")
@@ -139,7 +148,9 @@ print(f"Model ID:         {model_version.model_id}")
 # predict_fn below pins those singletons to a single loop for the whole run.
 from typing import Literal
 
-dbutils.widgets.dropdown(name="agent-source", defaultValue="registry", choices=["registry", "config"])
+dbutils.widgets.dropdown(
+    name="agent-source", defaultValue="registry", choices=["registry", "config"]
+)
 agent_source: Literal["registry", "config"] = dbutils.widgets.get("agent-source")  # type: ignore[assignment]
 
 if agent_source == "registry":
@@ -209,14 +220,16 @@ def predict_fn(messages: list[dict[str, Any]]) -> dict[str, Any]:
     response: ResponsesAgentResponse = future.result(timeout=300)
     return response.model_dump()
 
+
 # COMMAND ----------
 
 # DBTITLE 1,Load and Prepare Evaluation Data
 import pandas as pd
+
 from dao_ai.evaluation import (
-    prepare_eval_dataframe,
     build_scorers,
     create_or_get_eval_dataset,
+    prepare_eval_dataframe,
     prepare_eval_results_for_display,
 )
 
@@ -231,6 +244,7 @@ display(eval_df)
 
 # DBTITLE 1,Run Evaluation
 from datetime import datetime
+
 from mlflow.models.evaluation import EvaluationResult
 
 scorers = build_scorers(config.evaluation)
@@ -285,6 +299,11 @@ if eval_results is not None:
     if not eval_results_df.empty:
         display(eval_results_df.head(100))
     else:
-        print("No detailed results table available. Available tables:", list(eval_results.tables.keys()))
+        print(
+            "No detailed results table available. Available tables:",
+            list(eval_results.tables.keys()),
+        )
 else:
-    print("Evaluation results not available. Check the MLflow run for logged metrics and traces.")
+    print(
+        "Evaluation results not available. Check the MLflow run for logged metrics and traces."
+    )

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -53,6 +53,7 @@ from dao_ai.config import (
     DatabaseModel,
     DatabricksAppModel,
     DatasetModel,
+    ExperimentModel,
     FunctionModel,
     GenieEntitlement,
     GenieRoomModel,
@@ -340,9 +341,7 @@ def _source_table_delta_uuid(source_table_full_name: str) -> str | None:
         spark = SparkSession.getActiveSession()
         if spark is None:
             return None
-        row = spark.sql(
-            f"DESCRIBE DETAIL {source_table_full_name}"
-        ).select("id").head()
+        row = spark.sql(f"DESCRIBE DETAIL {source_table_full_name}").select("id").head()
         return row["id"] if row is not None else None
     except Exception as exc:  # noqa: BLE001
         logger.debug(
@@ -455,9 +454,7 @@ def _wait_until_index_absent(
     )
 
 
-def link_experiment_trace_location(
-    config: AppConfig, experiment_id: str
-) -> None:
+def link_experiment_trace_location(config: AppConfig, experiment_id: str) -> None:
     """Link an MLflow experiment to its UC trace location.
 
     Wraps ``mlflow.set_experiment(experiment_id=..., trace_location=
@@ -832,11 +829,7 @@ def _grant_uc_trace_table_permissions_to_principal(
             w.api_client.do(
                 "PATCH",
                 f"/api/2.1/unity-catalog/permissions/{securable_type}/{full_name}",
-                body={
-                    "changes": [
-                        {"principal": principal, "add": list(privileges)}
-                    ]
-                },
+                body={"changes": [{"principal": principal, "add": list(privileges)}]},
             )
             logger.debug(
                 "Granted UC privileges for trace persistence",
@@ -872,9 +865,7 @@ def _grant_uc_trace_table_permissions_to_principal(
     )
 
 
-def _resolve_trace_table_prefix(
-    config: AppConfig, experiment_id: Optional[str]
-) -> str:
+def _resolve_trace_table_prefix(config: AppConfig, experiment_id: Optional[str]) -> str:
     """Return the table prefix MLflow uses for OTEL trace tables.
 
     Mirrors ``mlflow.set_experiment(trace_location=UnityCatalog(
@@ -1589,8 +1580,7 @@ class DatabricksProvider(ServiceProvider):
                     )
             except Exception as e:
                 logger.warning(
-                    "Failed to grant trace-persistence privileges to Model "
-                    "Serving SP",
+                    "Failed to grant trace-persistence privileges to Model Serving SP",
                     endpoint_name=endpoint_name,
                     error=str(e),
                 )
@@ -1684,9 +1674,7 @@ class DatabricksProvider(ServiceProvider):
                 source_path=source_path,
             )
 
-    def _upload_dir_files(
-        self, src: "Path", dest: str, source_path: str
-    ) -> int:
+    def _upload_dir_files(self, src: "Path", dest: str, source_path: str) -> int:
         """Upload one staging pair's files under ``source_path`` (workspace).
 
         ``workspace.upload`` has no recursive form, so directories are walked
@@ -2397,7 +2385,10 @@ class DatabricksProvider(ServiceProvider):
         self._deploy_app(
             config,
             app_command=["python", "-m", "dao_ai.mcp.server"],
-            extras={"mcp", *expand_all(resolve_required_extras_or_all(config, target="mcp"))},
+            extras={
+                "mcp",
+                *expand_all(resolve_required_extras_or_all(config, target="mcp")),
+            },
             include_chat_ui=False,
             development=development,
         )
@@ -2439,9 +2430,7 @@ class DatabricksProvider(ServiceProvider):
             catalog_info = self.w.catalogs.create(name=schema.catalog_name)
         return catalog_info
 
-    def create_experiment(
-        self, experiment: "ExperimentModel"
-    ) -> Experiment:
+    def create_experiment(self, experiment: ExperimentModel) -> Experiment:
         """Resolve an ``ExperimentModel`` to a live MLflow ``Experiment``,
         creating the experiment if only ``name`` was provided and it does
         not exist yet.
@@ -2791,9 +2780,12 @@ class DatabricksProvider(ServiceProvider):
             try:
                 import inspect
 
-                if "custom_tags" in inspect.signature(
-                    self.vsc.create_delta_sync_index_and_wait
-                ).parameters:
+                if (
+                    "custom_tags"
+                    in inspect.signature(
+                        self.vsc.create_delta_sync_index_and_wait
+                    ).parameters
+                ):
                     create_kwargs["custom_tags"] = {
                         _index_source_uuid_key(): source_uuid
                     }

--- a/src/dao_ai/retrievers/lakebase.py
+++ b/src/dao_ai/retrievers/lakebase.py
@@ -74,9 +74,7 @@ class LakebaseRetriever(BaseRetriever):
 
     def model_post_init(self, __context: Any) -> None:
         metadata = self.vector_store.metadata_columns or []
-        self._allowed_filter_cols = frozenset(
-            [*metadata, self.vector_store.id_column]
-        )
+        self._allowed_filter_cols = frozenset([*metadata, self.vector_store.id_column])
 
     # ------------------------------------------------------------------
     # LangChain BaseRetriever interface
@@ -155,9 +153,14 @@ class LakebaseRetriever(BaseRetriever):
             sql.Identifier(self.vector_store.table),
         )
 
-    def _select_columns(self, extra: list[sql.Composable] | None = None) -> sql.Composed:
+    def _select_columns(
+        self, extra: list[sql.Composable] | None = None
+    ) -> sql.Composed:
         vs = self.vector_store
-        cols: list[sql.Composable] = [sql.Identifier(vs.id_column), sql.Identifier(vs.content_column)]
+        cols: list[sql.Composable] = [
+            sql.Identifier(vs.id_column),
+            sql.Identifier(vs.content_column),
+        ]
         cols.extend(sql.Identifier(c) for c in (vs.metadata_columns or []))
         if extra:
             cols.extend(extra)
@@ -175,9 +178,7 @@ class LakebaseRetriever(BaseRetriever):
                 return key[: -len(suffix)], suffix
         return key, ""
 
-    def _build_where(
-        self, filters: dict[str, Any]
-    ) -> tuple[sql.Composable, list[Any]]:
+    def _build_where(self, filters: dict[str, Any]) -> tuple[sql.Composable, list[Any]]:
         """Translate a suffix-keyed filter dict into a WHERE fragment + params.
 
         Keys use ai_search's operator-suffix convention (``"col LIKE"``,

--- a/src/dao_ai/state.py
+++ b/src/dao_ai/state.py
@@ -223,9 +223,7 @@ class AgentState(MessagesState, total=False):
     # target agent names from N parallel-handoff tools invoked in one LLM
     # turn. The source-agent wrapper reads this to build the fan-out
     # ``Send`` list, then clears it. See ``concat_parallel_dispatches``.
-    parallel_dispatches: NotRequired[
-        Annotated[list[str], concat_parallel_dispatches]
-    ]
+    parallel_dispatches: NotRequired[Annotated[list[str], concat_parallel_dispatches]]
 
 
 class Context(BaseModel):

--- a/src/dao_ai/tools/audit_query.py
+++ b/src/dao_ai/tools/audit_query.py
@@ -295,8 +295,7 @@ def create_query_audit_receipts_tool(audit: AuditConfigInput) -> BaseTool:
         )
         capped_limit: int = max(1, min(int(limit), 200))
         query: sql.Composed = sql.SQL(
-            "SELECT {cols} FROM {table} {where} "
-            "ORDER BY recorded_at DESC LIMIT %s"
+            "SELECT {cols} FROM {table} {where} ORDER BY recorded_at DESC LIMIT %s"
         ).format(
             cols=sql.SQL(", ").join(sql.Identifier(c) for c in _QUERY_SAFE_COLUMNS),
             table=sql.Identifier(receipts_table),
@@ -634,8 +633,7 @@ def create_summarize_audit_activity_tool(audit: AuditConfigInput) -> BaseTool:
 
                 await cur.execute(
                     sql.SQL(
-                        "SELECT COUNT(DISTINCT approver_sub) AS n "
-                        "FROM {table} {where}"
+                        "SELECT COUNT(DISTINCT approver_sub) AS n FROM {table} {where}"
                     ).format(table=table_id, where=where_with_approver_sql),
                     tuple(params),
                 )

--- a/src/dao_ai/tools/genie.py
+++ b/src/dao_ai/tools/genie.py
@@ -458,9 +458,7 @@ def _create_simple_genie_tool(
 
     tool_name: str = name if name is not None else "genie_tool"
     tool_description: str = _build_tool_description(description, verbatim)
-    question_desc: str = (
-        _QUESTION_ARG_VERBATIM if verbatim else _QUESTION_ARG_DEFAULT
-    )
+    question_desc: str = _QUESTION_ARG_VERBATIM if verbatim else _QUESTION_ARG_DEFAULT
 
     _cached_genie_service: GenieServiceBase | None = None
 
@@ -585,9 +583,7 @@ def _create_genie_toolkit_impl(
 
     tool_name: str = name if name is not None else "genie_tool"
     tool_description: str = _build_tool_description(description, verbatim)
-    question_desc: str = (
-        _QUESTION_ARG_VERBATIM if verbatim else _QUESTION_ARG_DEFAULT
-    )
+    question_desc: str = _QUESTION_ARG_VERBATIM if verbatim else _QUESTION_ARG_DEFAULT
 
     # ---- Shared service stack (one LRU, one closure) ----
 

--- a/src/dao_ai/tools/instructed_pipeline.py
+++ b/src/dao_ai/tools/instructed_pipeline.py
@@ -19,13 +19,14 @@ embedding, and any other retriever-specific state.
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Callable, Literal, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional
 
 import mlflow
 from langchain_core.documents import Document
 from loguru import logger
 from mlflow.entities import SpanType
 
+from dao_ai._tracing import in_caller_context
 from dao_ai.config import (
     ColumnInfo,
     DecompositionModel,
@@ -36,7 +37,6 @@ from dao_ai.config import (
     SearchQuery,
     VerifierModel,
 )
-from dao_ai._tracing import in_caller_context
 from dao_ai.tools.instructed_retriever import (
     _get_cached_llm,
     decompose_query,
@@ -195,7 +195,11 @@ def _normalize_filter_values(
             normalized[key] = value.upper() if case == "uppercase" else value.lower()
         elif isinstance(value, list):
             normalized[key] = [
-                v.upper() if case == "uppercase" else v.lower() if isinstance(v, str) else v
+                v.upper()
+                if case == "uppercase"
+                else v.lower()
+                if isinstance(v, str)
+                else v
                 for v in value
             ]
         else:
@@ -248,9 +252,7 @@ def _execute_instructed_search(
         )
 
         if not subqueries:
-            logger.warning(
-                "Query decomposition returned no subqueries, using original"
-            )
+            logger.warning("Query decomposition returned no subqueries, using original")
             return run_search(query, base_filters)
 
         normalized_base_filters = _normalize_filter_values(
@@ -263,9 +265,7 @@ def _execute_instructed_search(
             if sq.filters:
                 for item in sq.filters:
                     sq_filters_dict[item.key] = item.value
-            sq_filters_dict = coerce_filter_values(
-                sq_filters_dict, instructed_columns
-            )
+            sq_filters_dict = coerce_filter_values(sq_filters_dict, instructed_columns)
             sq_filters = _normalize_filter_values(
                 sq_filters_dict, decomposition_config.normalize_filter_case
             )

--- a/src/dao_ai/tools/lakebase_search.py
+++ b/src/dao_ai/tools/lakebase_search.py
@@ -18,12 +18,10 @@ from langchain_core.documents import Document
 from langchain_core.tools import StructuredTool
 from loguru import logger
 from mlflow.entities import SpanType
-from psycopg import sql
 from psycopg.rows import dict_row
 from pydantic import BaseModel, Field, create_model
 
 from dao_ai.config import (
-    ColumnInfo,
     FilterItem,
     LakebaseRetrieverModel,
     LakebaseVectorStoreModel,
@@ -37,7 +35,6 @@ from dao_ai.tools.vector_search import (
     build_flashrank_ranker,
     rerank_documents,
 )
-
 
 # Rough map from Postgres ``information_schema.columns.data_type`` values
 # to the labels ``ColumnInfo.type`` uses. Anything we can't classify falls
@@ -306,9 +303,7 @@ def create_lakebase_search_tool(
         if _is_array_type(type_str):
             operator_overrides[col_name] = [""]
 
-    schema_cls = _build_lakebase_search_input_model(
-        columns, operator_overrides or None
-    )
+    schema_cls = _build_lakebase_search_input_model(columns, operator_overrides or None)
 
     logger.debug(
         "Lakebase search columns resolved",

--- a/src/dao_ai/tools/mcp_callbacks.py
+++ b/src/dao_ai/tools/mcp_callbacks.py
@@ -37,7 +37,7 @@ proven end-to-end by langchain-core's own test
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Literal, Optional
 
 import mlflow
 from langchain_core.callbacks import adispatch_custom_event

--- a/src/dao_ai/tools/vector_search.py
+++ b/src/dao_ai/tools/vector_search.py
@@ -17,13 +17,12 @@ LangChain's ``@tool`` decorator introspects live annotations to inject
 
 import json
 import os
-from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import mlflow
-from databricks.sdk import WorkspaceClient
 from databricks.ai_search.client import VectorSearchClient
 from databricks.ai_search.reranker import DatabricksReranker
+from databricks.sdk import WorkspaceClient
 from databricks_langchain import DatabricksVectorSearch
 from langchain.tools import ToolRuntime, tool
 from langchain_core.documents import Document
@@ -32,44 +31,29 @@ from loguru import logger
 from mlflow.entities import SpanType
 from pydantic import BaseModel, ConfigDict, Field, create_model
 
-from dao_ai._tracing import in_caller_context
 from dao_ai.config import (
+    AiSearchRetrieverModel,
     ColumnInfo,
     DecompositionModel,
     FilterItem,
     InstructedRetrieverModel,
     InstructionAwareRerankModel,
     RerankParametersModel,
-    AiSearchRetrieverModel,
     RouterModel,
     SearchParametersModel,
-    SearchQuery,
     VectorStoreModel,
     VerifierModel,
     value_of,
 )
 from dao_ai.state import Context
-from dao_ai.tools.instructed_retriever import (
-    _get_cached_llm,
-    decompose_query,
-    rrf_merge,
-)
-from dao_ai.tools.instruction_reranker import instruction_aware_rerank
-from dao_ai.tools.router import route_query
 from dao_ai.tools.tracing import (
-    ATTR_ROUTER_BYPASSED,
-    ATTR_ROUTER_FALLBACK,
-    ATTR_ROUTER_MODE,
-    ATTR_VERIFIER_OUTCOME,
-    ATTR_VERIFIER_RETRIES,
     ResourceInfo,
     set_resource_attributes,
 )
-from dao_ai.tools.verifier import add_verification_metadata, verify_results
 from dao_ai.utils import is_in_model_serving, normalize_host
 
 if TYPE_CHECKING:
-    from flashrank import Ranker, RerankRequest
+    from flashrank import Ranker
 
 
 # auth_type values that the databricks-langchain library (as of 0.20.0) extracts
@@ -142,7 +126,7 @@ def _client_args_from_ambient_wc(wc: WorkspaceClient) -> dict[str, Any] | None:
             return None
         return {
             "workspace_url": normalize_host(host),
-            "personal_access_token": bearer[len("Bearer "):],
+            "personal_access_token": bearer[len("Bearer ") :],
         }
     except Exception as e:
         logger.warning("dao_ai.vector_search.ambient_auth.exception", error=str(e))
@@ -358,8 +342,7 @@ def _fetch_index_columns(
         cols = getattr(table, "columns", None) or []
     except Exception as e:  # noqa: BLE001
         logger.debug(
-            "UC Tables lookup on VS index failed; "
-            "column auto-discovery unavailable",
+            "UC Tables lookup on VS index failed; column auto-discovery unavailable",
             index=vector_store.index.full_name,
             error=f"{type(e).__name__}: {e}",
         )
@@ -865,9 +848,7 @@ def create_ai_search_tool(
     # No source-table fallback — matches upstream. Users with permission
     # asymmetries (SP has source-table grants but not index-UC-entity
     # grants) should hand-declare via ``ColumnInfo``.
-    declared_items: list[Any] = list(
-        retriever.columns or vector_store.columns or []
-    )
+    declared_items: list[Any] = list(retriever.columns or vector_store.columns or [])
     (
         declared_names,
         declared_types,
@@ -920,7 +901,10 @@ def create_ai_search_tool(
             for col_name in declared_names:
                 if col_name not in description_types and col_name in uc_type_map:
                     description_types[col_name] = uc_type_map[col_name]
-                if col_name not in description_descriptions and col_name in uc_comment_map:
+                if (
+                    col_name not in description_descriptions
+                    and col_name in uc_comment_map
+                ):
                     description_descriptions[col_name] = uc_comment_map[col_name]
     else:
         # Mode C — nothing declared. Discover via UC.
@@ -954,7 +938,9 @@ def create_ai_search_tool(
     logger.debug(
         "Vector Search columns resolved",
         index=index_name,
-        mode="hand-declared" if any_hand_declared else ("declared" if declared_names else "discovered"),
+        mode="hand-declared"
+        if any_hand_declared
+        else ("declared" if declared_names else "discovered"),
         columns=columns,
         have_types=bool(description_types),
         have_operator_overrides=bool(operator_overrides),

--- a/tests/dao_ai/audit/test_audit_config.py
+++ b/tests/dao_ai/audit/test_audit_config.py
@@ -219,5 +219,7 @@ class TestAuditModelYamlAnchorScenario:
         # Both audited tools resolve to the same table + database identity.
         assert fn_a.audit.table == fn_b.audit.table == "shared_receipts"
         assert (
-            fn_a.audit.database.project == fn_b.audit.database.project == "shared-lakebase"
+            fn_a.audit.database.project
+            == fn_b.audit.database.project
+            == "shared-lakebase"
         )

--- a/tests/dao_ai/audit/test_audit_middleware.py
+++ b/tests/dao_ai/audit/test_audit_middleware.py
@@ -128,7 +128,9 @@ class TestOboExtraction:
             .rstrip(b"=")
             .decode()
         )
-        signature: str = base64.urlsafe_b64encode(b"fake-signature").rstrip(b"=").decode()
+        signature: str = (
+            base64.urlsafe_b64encode(b"fake-signature").rstrip(b"=").decode()
+        )
         return f"{header}.{payload}.{signature}"
 
     def test_extract_evidence_populated_when_header_present(self) -> None:
@@ -150,16 +152,12 @@ class TestOboExtraction:
 
     def test_extract_evidence_lowercase_header_key(self) -> None:
         token: str = self._make_jwt()
-        raw, _exp, _sub = _extract_obo_evidence(
-            {"x-forwarded-access-token": token}
-        )
+        raw, _exp, _sub = _extract_obo_evidence({"x-forwarded-access-token": token})
         assert raw == token
 
     def test_extract_evidence_malformed_jwt(self) -> None:
         """Non-JWT string is retained verbatim but no claims are extracted."""
-        raw, exp, sub = _extract_obo_evidence(
-            {"X-Forwarded-Access-Token": "not-a-jwt"}
-        )
+        raw, exp, sub = _extract_obo_evidence({"X-Forwarded-Access-Token": "not-a-jwt"})
         # Even a malformed token is preserved verbatim — never fabricate,
         # but never drop the caller-provided value either.
         assert raw == "not-a-jwt"

--- a/tests/dao_ai/audit/test_auditor_tools.py
+++ b/tests/dao_ai/audit/test_auditor_tools.py
@@ -84,9 +84,7 @@ class TestBuildWindowClauses:
         assert len(params) == 1
 
     def test_thread_id_and_tool_name(self) -> None:
-        clauses, params = _build_window_clauses(
-            thread_id="t-1", tool_name="refund"
-        )
+        clauses, params = _build_window_clauses(thread_id="t-1", tool_name="refund")
         assert "thread_id = %s" in clauses
         assert "tool_name = %s" in clauses
         assert params == ["t-1", "refund"]

--- a/tests/dao_ai/audit/test_hitl_audit_enrichment.py
+++ b/tests/dao_ai/audit/test_hitl_audit_enrichment.py
@@ -60,12 +60,12 @@ class _FakeRuntime:
 
     def __init__(self, thread_id: str) -> None:
         self.context = _FakeContext(thread_id)
-        self.config: dict[str, Any] = {
-            "configurable": {"thread_id": thread_id}
-        }
+        self.config: dict[str, Any] = {"configurable": {"thread_id": thread_id}}
 
 
-def _build_middleware(monkeypatch: Any) -> tuple[AuditedHumanInTheLoopMiddleware, _FakeSink]:
+def _build_middleware(
+    monkeypatch: Any,
+) -> tuple[AuditedHumanInTheLoopMiddleware, _FakeSink]:
     """Wire an AuditedHumanInTheLoopMiddleware whose sink is a fake."""
     fake_sink = _FakeSink()
     monkeypatch.setattr(

--- a/tests/dao_ai/audit/test_lakebase_sink_integration.py
+++ b/tests/dao_ai/audit/test_lakebase_sink_integration.py
@@ -274,9 +274,7 @@ def test_hitl_involved_generated_column_semantics(
         audit_only = _build_receipt(thread_id="thread-D", hitl=False)
         await audit_sink.record(audit_only)
 
-        hitl_row = _build_receipt(
-            thread_id="thread-D", hitl=True, decision="approve"
-        )
+        hitl_row = _build_receipt(thread_id="thread-D", hitl=True, decision="approve")
         await audit_sink.record(hitl_row)
         return audit_only, hitl_row
 
@@ -294,8 +292,7 @@ def test_hitl_involved_generated_column_semantics(
             row = cur.fetchone()
             assert row is not None
             assert row[0] is False, (
-                f"audit-only rows must land hitl_involved=FALSE, "
-                f"got {row[0]!r}"
+                f"audit-only rows must land hitl_involved=FALSE, got {row[0]!r}"
             )
 
             cur.execute(

--- a/tests/dao_ai/audit/test_nonces.py
+++ b/tests/dao_ai/audit/test_nonces.py
@@ -15,9 +15,7 @@ class _StubNonceSink:
     """In-memory implementation of NonceStore for tests."""
 
     def __init__(self) -> None:
-        self._records: dict[
-            str, tuple[str, str, datetime, datetime | None]
-        ] = {}
+        self._records: dict[str, tuple[str, str, datetime, datetime | None]] = {}
 
     async def record_nonce(
         self,
@@ -62,9 +60,7 @@ def test_issue_and_consume_happy_path() -> None:
         nonce, exp = await issuer.issue("thread-1", "call-1")
         assert nonce
         assert exp > datetime.now(timezone.utc)
-        await issuer.consume(
-            nonce=nonce, thread_id="thread-1", tool_call_id="call-1"
-        )
+        await issuer.consume(nonce=nonce, thread_id="thread-1", tool_call_id="call-1")
 
     asyncio.run(scenario())
 
@@ -74,9 +70,7 @@ def test_reuse_rejected() -> None:
         sink = _StubNonceSink()
         issuer = NonceIssuer(sink, ttl_seconds=300)
         nonce, _ = await issuer.issue("thread-1", "call-1")
-        await issuer.consume(
-            nonce=nonce, thread_id="thread-1", tool_call_id="call-1"
-        )
+        await issuer.consume(nonce=nonce, thread_id="thread-1", tool_call_id="call-1")
         with pytest.raises(AuditNonceError):
             await issuer.consume(
                 nonce=nonce, thread_id="thread-1", tool_call_id="call-1"

--- a/tests/dao_ai/audit/test_notifications.py
+++ b/tests/dao_ai/audit/test_notifications.py
@@ -62,9 +62,7 @@ class TestBuildReceiptNotification:
         assert envelope["execution_status"] == "ok"
 
     def test_hitl_approve_execution(self) -> None:
-        envelope = build_receipt_notification(
-            _receipt(decision="approve", hitl=True)
-        )
+        envelope = build_receipt_notification(_receipt(decision="approve", hitl=True))
         assert envelope["hitl_involved"] is True
         assert envelope["decision"] == "approve"
         assert envelope["approver_sub"] == "alice@example.com"
@@ -97,9 +95,7 @@ class TestBuildReceiptNotification:
             "this_hash",
             "displayed_summary",
         ):
-            assert forbidden not in envelope, (
-                f"envelope must not carry {forbidden}"
-            )
+            assert forbidden not in envelope, f"envelope must not carry {forbidden}"
 
 
 class TestDispatchAuditReceiptNotification:
@@ -107,13 +103,9 @@ class TestDispatchAuditReceiptNotification:
 
     def test_no_config_is_noop(self) -> None:
         # Should complete without raising.
-        asyncio.run(
-            dispatch_audit_receipt_notification(_receipt(), config=None)
-        )
+        asyncio.run(dispatch_audit_receipt_notification(_receipt(), config=None))
 
     def test_config_without_callbacks_is_noop(self) -> None:
         asyncio.run(
-            dispatch_audit_receipt_notification(
-                _receipt(), config={"configurable": {}}
-            )
+            dispatch_audit_receipt_notification(_receipt(), config={"configurable": {}})
         )

--- a/tests/dao_ai/audit/test_process_decision_decoration.py
+++ b/tests/dao_ai/audit/test_process_decision_decoration.py
@@ -9,7 +9,7 @@ fields.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from dao_ai.audit import AuditSinkManager, args_hash_of
 from dao_ai.config import (
@@ -52,13 +52,12 @@ def _build_middleware(monkeypatch: Any) -> AuditedHumanInTheLoopMiddleware:
     )
     audit_cfg = AuditModel(database=DatabaseModel(project="test-lake"))
     hitl_cfg = HumanInTheLoopModel(
-        review_prompt="Approve?", allowed_decisions=["approve", "edit", "reject", "respond"]
+        review_prompt="Approve?",
+        allowed_decisions=["approve", "edit", "reject", "respond"],
     )
     return AuditedHumanInTheLoopMiddleware(
         interrupt_on={
-            "refund": {
-                "allowed_decisions": ["approve", "edit", "reject", "respond"]
-            }
+            "refund": {"allowed_decisions": ["approve", "edit", "reject", "respond"]}
         },
         audited_tools={"refund": audit_cfg},
         hitl_configs={"refund": hitl_cfg},
@@ -155,9 +154,7 @@ def test_process_decision_respond_captures_synthetic_reply(monkeypatch: Any) -> 
     entry = AuditStash.take("t-1", tool_call_id)
     assert entry is not None
     assert entry.decision == "respond"
-    assert entry.decision_detail == {
-        "message": "Reviewer answered on behalf of tool."
-    }
+    assert entry.decision_detail == {"message": "Reviewer answered on behalf of tool."}
 
 
 def test_process_decision_unaudited_tool_is_noop(monkeypatch: Any) -> None:
@@ -168,7 +165,12 @@ def test_process_decision_unaudited_tool_is_noop(monkeypatch: Any) -> None:
 
     middleware._process_decision(
         {"type": "approve"},
-        {"name": "not_audited_tool", "args": {}, "id": tool_call_id, "type": "tool_call"},  # type: ignore[arg-type]
+        {
+            "name": "not_audited_tool",
+            "args": {},
+            "id": tool_call_id,
+            "type": "tool_call",
+        },  # type: ignore[arg-type]
         _interrupt_config(),
     )
     # No stash entry was ever placed for a non-audited tool.
@@ -185,8 +187,7 @@ def test_thread_id_from_stash_recovers_thread(monkeypatch: Any) -> None:
         == "thread-alpha"
     )
     assert (
-        AuditedHumanInTheLoopMiddleware._thread_id_from_stash("call-B")
-        == "thread-beta"
+        AuditedHumanInTheLoopMiddleware._thread_id_from_stash("call-B") == "thread-beta"
     )
     assert (
         AuditedHumanInTheLoopMiddleware._thread_id_from_stash("call-missing")

--- a/tests/dao_ai/audit/test_rejection_receipts.py
+++ b/tests/dao_ai/audit/test_rejection_receipts.py
@@ -141,7 +141,7 @@ def test_rejection_tap_writes_receipt_for_audited_hitl_tool(monkeypatch: Any) ->
 
     # Seed the AuditStash as the interrupt-time middleware would — this is
     # what the reject-path tap now looks up via take_by_tool_name.
-    from datetime import datetime, timedelta, timezone
+    from datetime import timedelta
 
     from dao_ai.middleware.audit_receipt import AuditStash, AuditStashEntry
 
@@ -163,9 +163,7 @@ def test_rejection_tap_writes_receipt_for_audited_hitl_tool(monkeypatch: Any) ->
             graph=graph,  # type: ignore[arg-type]
             messages=[],
             custom_inputs={
-                "decisions": [
-                    {"type": "reject", "message": "Not authorised."}
-                ]
+                "decisions": [{"type": "reject", "message": "Not authorised."}]
             },
             runtime_config=runtime_config,
             tool_models=tool_models,
@@ -222,9 +220,7 @@ def test_rejection_tap_ignores_non_audited_tool(monkeypatch: Any) -> None:
         await decide_graph_turn(
             graph=graph,  # type: ignore[arg-type]
             messages=[],
-            custom_inputs={
-                "decisions": [{"type": "reject", "message": "Nope."}]
-            },
+            custom_inputs={"decisions": [{"type": "reject", "message": "Nope."}]},
             runtime_config=runtime_config,
             tool_models=tool_models,
         )
@@ -262,9 +258,7 @@ def test_rejection_tap_ignores_non_reject_decisions(monkeypatch: Any) -> None:
         await decide_graph_turn(
             graph=graph,  # type: ignore[arg-type]
             messages=[],
-            custom_inputs={
-                "decisions": [{"type": "approve"}]
-            },
+            custom_inputs={"decisions": [{"type": "approve"}]},
             runtime_config=runtime_config,
             tool_models=tool_models,
         )

--- a/tests/dao_ai/capabilities_mcp_server.py
+++ b/tests/dao_ai/capabilities_mcp_server.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 from typing import Any
 
 from mcp.server.fastmcp import Context, FastMCP
-from mcp.types import ResourceLink
 
 
 def build_server(name: str = "capabilities_probe") -> FastMCP:

--- a/tests/dao_ai/genie/test_prompt_history.py
+++ b/tests/dao_ai/genie/test_prompt_history.py
@@ -6,18 +6,18 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-# The live Genie space this test exercises. Overridable via env so the test
-# isn't brittle to workspace drift (the default may be deleted/rotated in FEVM).
-GENIE_SPACE_ID: str = os.getenv(
-    "DAO_AI_TEST_GENIE_SPACE_ID", "01f0c482e842191587af6a40ad4044d8"
-)
-
 from dao_ai.config import (
     DatabaseModel,
     GenieContextAwareCacheParametersModel,
     WarehouseModel,
 )
 from dao_ai.genie.cache import PostgresContextAwareGenieService
+
+# The live Genie space this test exercises. Overridable via env so the test
+# isn't brittle to workspace drift (the default may be deleted/rotated in FEVM).
+GENIE_SPACE_ID: str = os.getenv(
+    "DAO_AI_TEST_GENIE_SPACE_ID", "01f0c482e842191587af6a40ad4044d8"
+)
 
 
 def _sql_to_str(query: Any) -> str:

--- a/tests/dao_ai/mcp/test_capabilities_integration.py
+++ b/tests/dao_ai/mcp/test_capabilities_integration.py
@@ -117,9 +117,7 @@ class _RecordingProgress:
         pass
 
     async def __call__(self, progress, total, message, context) -> None:
-        _RecordingProgress.events.append(
-            (progress, total, message, context.tool_name)
-        )
+        _RecordingProgress.events.append((progress, total, message, context.tool_name))
 
 
 class _RecordingStructured:
@@ -196,9 +194,9 @@ class TestProgressCapability:
             assert "completed 5" in str(result)
 
         asyncio.run(run())
-        assert (
-            len(_RecordingProgress.events) == 5
-        ), f"expected 5 progress events, got {len(_RecordingProgress.events)}: {_RecordingProgress.events}"
+        assert len(_RecordingProgress.events) == 5, (
+            f"expected 5 progress events, got {len(_RecordingProgress.events)}: {_RecordingProgress.events}"
+        )
         progresses = [e[0] for e in _RecordingProgress.events]
         assert progresses == [1.0, 2.0, 3.0, 4.0, 5.0]
         assert all(e[1] == 5.0 for e in _RecordingProgress.events)

--- a/tests/dao_ai/mcp/test_mcp_agent_tool.py
+++ b/tests/dao_ai/mcp/test_mcp_agent_tool.py
@@ -44,7 +44,11 @@ class _StubAgent:
                     "type": "message",
                     "role": "assistant",
                     "content": [
-                        {"type": "output_text", "text": self.reply_text, "annotations": []}
+                        {
+                            "type": "output_text",
+                            "text": self.reply_text,
+                            "annotations": [],
+                        }
                     ],
                 }
             ]
@@ -80,9 +84,7 @@ def _list_tools(mcp: FastMCP) -> list[Any]:
     return asyncio.run(mcp.list_tools())
 
 
-def _call_tool(
-    mcp: FastMCP, name: str, arguments: dict[str, Any]
-) -> Any:
+def _call_tool(mcp: FastMCP, name: str, arguments: dict[str, Any]) -> Any:
     return asyncio.run(mcp.call_tool(name, arguments))
 
 
@@ -262,9 +264,12 @@ def test_invoke_agent_string_input_is_wrapped_and_headers_forwarded() -> None:
     register_agent_as_tool(mcp, config)  # type: ignore[arg-type]
 
     fake_headers = {"x-forwarded-access-token": "abc123", "x-request-id": "r1"}
-    with patch(
-        "dao_ai.mcp.agent_tool.current_request_headers", return_value=fake_headers
-    ), patch("dao_ai.mcp.agent_tool.current_request_id", return_value="r1"):
+    with (
+        patch(
+            "dao_ai.mcp.agent_tool.current_request_headers", return_value=fake_headers
+        ),
+        patch("dao_ai.mcp.agent_tool.current_request_id", return_value="r1"),
+    ):
         result = _call_tool(mcp, "mcp_dao_ai_test", {"input": "hello"})
 
     assert agent.last_request is not None
@@ -295,10 +300,13 @@ def test_invoke_agent_reports_obo_absent_when_no_forwarded_token() -> None:
     config = _StubConfig(agent=_StubAgent())
     register_agent_as_tool(mcp, config)  # type: ignore[arg-type]
 
-    with patch(
-        "dao_ai.mcp.agent_tool.current_request_headers",
-        return_value={"x-request-id": "r2"},
-    ), patch("dao_ai.mcp.agent_tool.current_request_id", return_value="r2"):
+    with (
+        patch(
+            "dao_ai.mcp.agent_tool.current_request_headers",
+            return_value={"x-request-id": "r2"},
+        ),
+        patch("dao_ai.mcp.agent_tool.current_request_id", return_value="r2"),
+    ):
         result = _call_tool(mcp, "mcp_dao_ai_test", {"input": "hi"})
 
     assert result.meta is not None
@@ -346,7 +354,11 @@ class _StubAgentWithTrace(_StubAgent):
                     "type": "message",
                     "role": "assistant",
                     "content": [
-                        {"type": "output_text", "text": self.reply_text, "annotations": []}
+                        {
+                            "type": "output_text",
+                            "text": self.reply_text,
+                            "annotations": [],
+                        }
                     ],
                 }
             ],
@@ -413,8 +425,9 @@ def test_invoke_agent_returns_structured_content_with_trace_id() -> None:
     config = _StubConfig(agent=agent)
     register_agent_as_tool(mcp, config)  # type: ignore[arg-type]
 
-    with patch("dao_ai.mcp.agent_tool.current_request_headers", return_value={}), patch(
-        "dao_ai.mcp.agent_tool.current_request_id", return_value="req-1"
+    with (
+        patch("dao_ai.mcp.agent_tool.current_request_headers", return_value={}),
+        patch("dao_ai.mcp.agent_tool.current_request_id", return_value="req-1"),
     ):
         result = _call_tool(mcp, "mcp_dao_ai_test", {"input": "hi"})
 
@@ -453,10 +466,13 @@ def test_invoke_agent_header_flows_into_custom_inputs_and_echoes() -> None:
     config = _StubConfig(agent=agent)
     register_agent_as_tool(mcp, config)  # type: ignore[arg-type]
 
-    with patch(
-        "dao_ai.mcp.agent_tool.current_request_headers",
-        return_value={"x-databricks-conversation-id": "hdr-999"},
-    ), patch("dao_ai.mcp.agent_tool.current_request_id", return_value="req-c3"):
+    with (
+        patch(
+            "dao_ai.mcp.agent_tool.current_request_headers",
+            return_value={"x-databricks-conversation-id": "hdr-999"},
+        ),
+        patch("dao_ai.mcp.agent_tool.current_request_id", return_value="req-c3"),
+    ):
         result = _call_tool(mcp, "mcp_dao_ai_test", {"input": "hi"})
 
     assert agent.last_request is not None
@@ -506,8 +522,9 @@ def test_invoke_agent_echoes_server_generated_id_when_none_supplied() -> None:
     config = _StubConfig(agent=agent)
     register_agent_as_tool(mcp, config)  # type: ignore[arg-type]
 
-    with patch("dao_ai.mcp.agent_tool.current_request_headers", return_value={}), patch(
-        "dao_ai.mcp.agent_tool.current_request_id", return_value="req-c5"
+    with (
+        patch("dao_ai.mcp.agent_tool.current_request_headers", return_value={}),
+        patch("dao_ai.mcp.agent_tool.current_request_id", return_value="req-c5"),
     ):
         result = _call_tool(mcp, "mcp_dao_ai_test", {"input": "hi"})
 
@@ -532,8 +549,9 @@ def test_invoke_agent_surfaces_error_via_is_error_flag() -> None:
     config = _StubConfig(agent=_FailingAgent())
     register_agent_as_tool(mcp, config)  # type: ignore[arg-type]
 
-    with patch("dao_ai.mcp.agent_tool.current_request_headers", return_value={}), patch(
-        "dao_ai.mcp.agent_tool.current_request_id", return_value="req-err"
+    with (
+        patch("dao_ai.mcp.agent_tool.current_request_headers", return_value={}),
+        patch("dao_ai.mcp.agent_tool.current_request_id", return_value="req-err"),
     ):
         result = _call_tool(mcp, "mcp_dao_ai_test", {"input": "boom"})
 

--- a/tests/dao_ai/mcp/test_server_capabilities.py
+++ b/tests/dao_ai/mcp/test_server_capabilities.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from mcp.server.fastmcp import FastMCP

--- a/tests/dao_ai/test_apply_runtime_trace_destination.py
+++ b/tests/dao_ai/test_apply_runtime_trace_destination.py
@@ -12,7 +12,6 @@ trace server rejects a bare table name with ``Invalid full table name``.
 from __future__ import annotations
 
 import pytest
-
 from mlflow.tracing.provider import _MLFLOW_TRACE_USER_DESTINATION
 from mlflow.tracing.utils import get_active_spans_table_name
 

--- a/tests/dao_ai/test_autolog_config.py
+++ b/tests/dao_ai/test_autolog_config.py
@@ -64,9 +64,7 @@ class TestAutologCallSite:
             and isinstance(node.func.value, ast.Attribute)
             and node.func.value.attr == "langchain"
         ]
-        assert autolog_calls, (
-            f"{module_name} did not call mlflow.langchain.autolog"
-        )
+        assert autolog_calls, f"{module_name} did not call mlflow.langchain.autolog"
         inline_kwargs = [
             kw
             for call in autolog_calls
@@ -75,9 +73,7 @@ class TestAutologCallSite:
             and isinstance(kw.value, ast.Constant)
             and kw.value.value is True
         ]
-        assert inline_kwargs, (
-            f"{module_name} must call autolog(run_tracer_inline=True)"
-        )
+        assert inline_kwargs, f"{module_name} must call autolog(run_tracer_inline=True)"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/dao_ai/test_bundle_code_paths.py
+++ b/tests/dao_ai/test_bundle_code_paths.py
@@ -98,9 +98,7 @@ class TestDeployAppsUploadsCodePaths:
         cfg_path.write_text(_CONFIG)
         return AppConfig.from_file(str(cfg_path))
 
-    def test_upload_planner_walks_and_uploads_each_file(
-        self, tmp_path: Path
-    ) -> None:
+    def test_upload_planner_walks_and_uploads_each_file(self, tmp_path: Path) -> None:
         from unittest.mock import MagicMock
 
         from dao_ai.providers.databricks import DatabricksProvider
@@ -112,8 +110,7 @@ class TestDeployAppsUploadsCodePaths:
         provider._upload_code_paths(config, source_path)
 
         upload_paths = [
-            c.kwargs["path"]
-            for c in provider.w.workspace.upload.call_args_list
+            c.kwargs["path"] for c in provider.w.workspace.upload.call_args_list
         ]
         assert upload_paths == [f"{source_path}/tools/custom_tool.py"]
         # Parent dir created before upload.

--- a/tests/dao_ai/test_bundle_dependency_lock.py
+++ b/tests/dao_ai/test_bundle_dependency_lock.py
@@ -102,7 +102,9 @@ class TestGenerateBundleLock:
         seen: dict[str, bool] = {}
 
         def _run(cmd, cwd=None, capture_output=None, text=None, check=None):
-            seen["stub"] = (Path(cwd) / "src" / "_daoai_lockstub" / "__init__.py").exists()
+            seen["stub"] = (
+                Path(cwd) / "src" / "_daoai_lockstub" / "__init__.py"
+            ).exists()
             (Path(cwd) / "uv.lock").write_text("# stub lock\n")
 
             class _R:
@@ -114,7 +116,7 @@ class TestGenerateBundleLock:
         monkeypatch.setattr(_locking.subprocess, "run", _run)
         pyproject = (
             '[project]\nname = "x"\n'
-            '[tool.hatch.build.targets.wheel]\n'
+            "[tool.hatch.build.targets.wheel]\n"
             'packages = ["src"]\nsources = ["src"]\n'
         )
         _locking.render_portable_lock(pyproject)
@@ -125,7 +127,7 @@ class TestGenerateBundleLock:
 
         (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
         poisoned = (
-            'wheels = [{ url = '
+            "wheels = [{ url = "
             '"https://pypi-proxy.dev.databricks.com/packages/aa/bb/x.whl" }]\n'
         )
         monkeypatch.setattr(
@@ -186,8 +188,7 @@ class TestDevLocalVersion:
     def _write_pyproject(self, tmp_path, version: str) -> "object":
         p = tmp_path / "pyproject.toml"
         p.write_text(
-            f'[project]\nname = "dao-ai"\nversion = "{version}"\n'
-            'description = "x"\n'
+            f'[project]\nname = "dao-ai"\nversion = "{version}"\ndescription = "x"\n'
         )
         return p
 

--- a/tests/dao_ai/test_code_paths.py
+++ b/tests/dao_ai/test_code_paths.py
@@ -47,9 +47,7 @@ _CONFIG_TEMPLATE = textwrap.dedent(
 
 def _write_config(tmp_path: Path, code_paths: list[str]) -> AppConfig:
     block = "\n".join(f"    - {p}" for p in code_paths)
-    (tmp_path / "cfg.yaml").write_text(
-        _CONFIG_TEMPLATE.format(code_paths_block=block)
-    )
+    (tmp_path / "cfg.yaml").write_text(_CONFIG_TEMPLATE.format(code_paths_block=block))
     return AppConfig.from_file(str(tmp_path / "cfg.yaml"))
 
 
@@ -133,9 +131,7 @@ class TestCollectCodePaths:
         (tmp_path / "tools").mkdir()
         (tmp_path / "tools" / "a.py").write_text("x = 1\n")
         (tmp_path / "tools" / "b.py").write_text("x = 1\n")
-        config = _write_config(
-            tmp_path, ["tools/a.py", "tools/b.py", "tools/a.py"]
-        )
+        config = _write_config(tmp_path, ["tools/a.py", "tools/b.py", "tools/a.py"])
 
         collected = cp.collect_code_paths(config)
         assert [Path(p).name for p in collected] == ["a.py", "b.py"]
@@ -261,7 +257,7 @@ class TestDiscoverSrcPackages:
         (tmp_path / "src" / "foo").mkdir(parents=True)
         (tmp_path / "src" / "baz").mkdir()
         (tmp_path / "src" / "foo" / "bar.py").write_text("x = 1\n")  # namespace pkg
-        (tmp_path / "src" / "baz" / "__init__.py").write_text("")   # regular pkg
+        (tmp_path / "src" / "baz" / "__init__.py").write_text("")  # regular pkg
         config = _write_config_no_code_paths(tmp_path)
 
         names = [p.name for p in cp.discover_src_packages(config)]

--- a/tests/dao_ai/test_coerce_filter_values.py
+++ b/tests/dao_ai/test_coerce_filter_values.py
@@ -84,9 +84,7 @@ class TestCoerceBoolean:
         assert coerce_filter_values({"active": "TRUE"}, self.cols) == {"active": True}
 
     def test_false_string(self) -> None:
-        assert coerce_filter_values({"active": "false"}, self.cols) == {
-            "active": False
-        }
+        assert coerce_filter_values({"active": "false"}, self.cols) == {"active": False}
 
     def test_numeric_string(self) -> None:
         assert coerce_filter_values({"active": "1"}, self.cols) == {"active": True}
@@ -138,9 +136,9 @@ class TestCoercePassthroughs:
 
     def test_array_untouched(self) -> None:
         cols = [ColumnInfo(name="tags", type="array")]
-        assert coerce_filter_values(
-            {"tags": ["cordless", "brushless"]}, cols
-        ) == {"tags": ["cordless", "brushless"]}
+        assert coerce_filter_values({"tags": ["cordless", "brushless"]}, cols) == {
+            "tags": ["cordless", "brushless"]
+        }
 
     def test_unknown_column_passes_through(self) -> None:
         cols = [ColumnInfo(name="brand", type="string")]

--- a/tests/dao_ai/test_config_vars.py
+++ b/tests/dao_ai/test_config_vars.py
@@ -1861,9 +1861,7 @@ def test_appconfig_no_registered_model_no_config_time_error():
         """
     )
 
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".yaml", delete=False
-    ) as fh:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as fh:
         fh.write(yaml_text)
         tmp_path = Path(fh.name)
 

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -15,9 +15,9 @@ from dao_ai.config import (
     IndexModel,
     SchemaModel,
     TableModel,
-    UnityCatalogFunctionSqlModel,
     VectorStoreModel,
 )
+from dao_ai.providers.databricks import DatabricksProvider
 
 
 def _stamp_extras_resolvable(mock_config: MagicMock) -> MagicMock:
@@ -64,7 +64,6 @@ def _stamp_extras_resolvable(mock_config: MagicMock) -> MagicMock:
     if sp is None or isinstance(sp, MagicMock):
         mock_config.app.service_principal = None
     return mock_config
-from dao_ai.providers.databricks import DatabricksProvider
 
 
 @pytest.mark.unit
@@ -867,9 +866,7 @@ def test_deploy_agent_routes_to_model_serving_explicitly():
         with patch.object(DatabricksProvider, "deploy_apps_agent") as mock_apps:
             provider = DatabricksProvider()
             _stamp_extras_resolvable(mock_config)
-            provider.deploy_agent(
-                config=mock_config, target=ServingMode.MODEL_SERVING
-            )
+            provider.deploy_agent(config=mock_config, target=ServingMode.MODEL_SERVING)
 
             mock_model_serving.assert_called_once_with(mock_config)
             mock_apps.assert_not_called()
@@ -907,11 +904,25 @@ def test_deploy_agent_routes_mcp(monkeypatch):
     from dao_ai.config import ServingMode
     from dao_ai.providers.databricks import DatabricksProvider
 
-    p = DatabricksProvider.__new__(DatabricksProvider)  # no __init__ / no WorkspaceClient
+    p = DatabricksProvider.__new__(
+        DatabricksProvider
+    )  # no __init__ / no WorkspaceClient
     calls = []
-    monkeypatch.setattr(p, "deploy_model_serving_agent", lambda c: calls.append("ms"), raising=False)
-    monkeypatch.setattr(p, "deploy_apps_agent", lambda c, development=None: calls.append("apps"), raising=False)
-    monkeypatch.setattr(p, "deploy_mcp_agent", lambda c, development=None: calls.append("mcp"), raising=False)
+    monkeypatch.setattr(
+        p, "deploy_model_serving_agent", lambda c: calls.append("ms"), raising=False
+    )
+    monkeypatch.setattr(
+        p,
+        "deploy_apps_agent",
+        lambda c, development=None: calls.append("apps"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        p,
+        "deploy_mcp_agent",
+        lambda c, development=None: calls.append("mcp"),
+        raising=False,
+    )
     p.deploy_agent(config=object(), target=ServingMode.MCP)
     assert calls == ["mcp"]
 
@@ -922,13 +933,17 @@ def test_deploy_mcp_agent_command_and_extras(monkeypatch):
     import dao_ai._extras as _extras
     from dao_ai.providers.databricks import DatabricksProvider
 
-    monkeypatch.setattr(_extras, "resolve_required_extras_or_all", lambda config, target="mcp": set())
+    monkeypatch.setattr(
+        _extras, "resolve_required_extras_or_all", lambda config, target="mcp": set()
+    )
 
     p = DatabricksProvider.__new__(DatabricksProvider)
     captured = {}
 
     def _fake_deploy_app(config, *, app_command, extras, include_chat_ui, development):
-        captured.update(app_command=app_command, extras=extras, include_chat_ui=include_chat_ui)
+        captured.update(
+            app_command=app_command, extras=extras, include_chat_ui=include_chat_ui
+        )
 
     monkeypatch.setattr(p, "_deploy_app", _fake_deploy_app, raising=False)
 
@@ -1347,6 +1362,7 @@ def test_serving_mode_enum_values():
 @pytest.mark.unit
 def test_serving_mode_members():
     from dao_ai.config import ServingMode
+
     assert {t.value for t in ServingMode} == {"model_serving", "apps", "mcp"}
     assert ServingMode("mcp") is ServingMode.MCP
     with pytest.raises(ValueError):

--- a/tests/dao_ai/test_deep_agent_bundle_integration.py
+++ b/tests/dao_ai/test_deep_agent_bundle_integration.py
@@ -93,7 +93,10 @@ class TestBundleShipsSkills:
         ).exists()
 
     def test_local_skill_copied_when_cwd_is_not_config_dir(
-        self, project_root_with_skills: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        project_root_with_skills: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Regression: skills are colocated with the config and must be found at
         bundle time even when the CLI runs from a CWD that is NOT the config's

--- a/tests/dao_ai/test_dependency_constraints.py
+++ b/tests/dao_ai/test_dependency_constraints.py
@@ -97,9 +97,7 @@ class TestUvLockIsProtobuf5Coherent:
         )
 
     def test_protobuf_resolves_below_6(self) -> None:
-        protobufs = [
-            p for p in self._lock_packages() if p["name"] == "protobuf"
-        ]
+        protobufs = [p for p in self._lock_packages() if p["name"] == "protobuf"]
         assert protobufs, "protobuf missing from uv.lock"
         for p in protobufs:
             assert Version(p["version"]) < Version("6"), (

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -97,7 +97,9 @@ class TestNounVerbParsing:
         # --direct is meaningless with model_serving (which always deploys via the
         # SDK); the combo is rejected at parse time rather than silently ignored.
         with pytest.raises(SystemExit):
-            parse_args(["agent", "up", "-c", "c.yaml", "--direct", "--mode", "model_serving"])
+            parse_args(
+                ["agent", "up", "-c", "c.yaml", "--direct", "--mode", "model_serving"]
+            )
 
     def test_up_verb_rejects_direct_with_model_serving_alias(self) -> None:
         # The `ms` alias normalizes to model_serving before the check runs.
@@ -126,9 +128,7 @@ class TestDefaultBundleDir:
     """Default bundle dir: $DAO_AI_BUNDLE_DIR base or `.dao-ai/bundle`, then
     `<kind>/<app>` appended (per-app isolation)."""
 
-    def test_default_base_when_env_unset(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_default_base_when_env_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("DAO_AI_BUNDLE_DIR", raising=False)
         assert cli._default_bundle_dir("agent", "my_app") == Path(
             ".dao-ai/bundle/agent/my_app"
@@ -148,9 +148,7 @@ class TestDefaultBundleDir:
     ) -> None:
         monkeypatch.setenv("DAO_AI_BUNDLE_DIR", "artifacts")
         for kind in ("workflow", "agent", "mcp"):
-            assert cli._default_bundle_dir(kind, "app") == Path(
-                f"artifacts/{kind}/app"
-            )
+            assert cli._default_bundle_dir(kind, "app") == Path(f"artifacts/{kind}/app")
 
     def test_clean_guard_respects_env_base(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -222,9 +220,7 @@ class TestEditSafety:
         monkeypatch.setenv("DAO_AI_BUNDLE_DIR", str(tmp_path / "base"))
         d = self._staged(tmp_path)
         (d / "app.yaml").write_text("edited\n")
-        cli._clean_default_staging_dir(
-            d, is_default=True, overwrite=True, noun="agent"
-        )
+        cli._clean_default_staging_dir(d, is_default=True, overwrite=True, noun="agent")
         assert not d.exists()
 
     def test_missing_marker_treated_as_edited(
@@ -490,7 +486,9 @@ def _app_config(*, trace: bool) -> AppConfig:
 class TestModeChoices:
     def test_deploy_accepts_all_three(self) -> None:
         for m in ("model_serving", "apps", "mcp"):
-            assert parse_args(["agent", "deploy", "-c", "c.yaml", "--mode", m]).mode == m
+            assert (
+                parse_args(["agent", "deploy", "-c", "c.yaml", "--mode", m]).mode == m
+            )
 
     def test_generate_rejects_model_serving(self) -> None:
         with pytest.raises(SystemExit):
@@ -498,13 +496,17 @@ class TestModeChoices:
 
     def test_generate_accepts_apps_and_mcp(self) -> None:
         for m in ("apps", "mcp"):
-            assert parse_args(["agent", "generate", "-c", "c.yaml", "--mode", m]).mode == m
+            assert (
+                parse_args(["agent", "generate", "-c", "c.yaml", "--mode", m]).mode == m
+            )
 
     def test_mode_defaults_to_apps(self) -> None:
         assert parse_args(["agent", "deploy", "-c", "c.yaml"]).mode == "apps"
 
     def test_short_alias_m(self) -> None:
-        assert parse_args(["agent", "deploy", "-c", "c.yaml", "-m", "mcp"]).mode == "mcp"
+        assert (
+            parse_args(["agent", "deploy", "-c", "c.yaml", "-m", "mcp"]).mode == "mcp"
+        )
 
     @pytest.mark.parametrize("alias", ["ms", "model-serving", "model_serving"])
     def test_model_serving_aliases_normalize_on_deploy(self, alias: str) -> None:
@@ -640,7 +642,16 @@ class TestAgentModeWriterSelection:
 
         cfg = self._write_config(tmp_path)
         opts = parse_args(
-            ["agent", "generate", "-c", str(cfg), "-o", str(tmp_path / "out"), "--mode", "mcp"]
+            [
+                "agent",
+                "generate",
+                "-c",
+                str(cfg),
+                "-o",
+                str(tmp_path / "out"),
+                "--mode",
+                "mcp",
+            ]
         )
         cli.handle_agent_command(opts)
 
@@ -694,11 +705,11 @@ class TestAgentModeWriterSelection:
 
         monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
 
-        with patch.object(cli, "_resolve_bundle_dir", side_effect=mock_resolve_bundle_dir):
+        with patch.object(
+            cli, "_resolve_bundle_dir", side_effect=mock_resolve_bundle_dir
+        ):
             with patch.object(cli, "deploy_app_bundle"):
-                opts = parse_args(
-                    ["agent", "deploy", "-c", str(cfg), "--mode", "mcp"]
-                )
+                opts = parse_args(["agent", "deploy", "-c", str(cfg), "--mode", "mcp"])
                 cli.handle_agent_command(opts)
 
         assert "mcp" in resolved_bundle_dirs, (
@@ -746,9 +757,7 @@ class TestDeployRestagesOnConfigDrift:
         monkeypatch.setattr(
             cli, "_resolve_bundle_dir", lambda kind, config, output_dir: (staged, True)
         )
-        monkeypatch.setattr(
-            cli, "_staging_dir_has_local_edits", lambda d: has_edits
-        )
+        monkeypatch.setattr(cli, "_staging_dir_has_local_edits", lambda d: has_edits)
         monkeypatch.setattr(cli, "deploy_app_bundle", lambda *a, **k: None)
         monkeypatch.setattr(AppConfig, "_resolve_all_resources", lambda self: None)
         monkeypatch.setattr(
@@ -795,9 +804,7 @@ class TestDeployRestagesOnConfigDrift:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # Legacy staged dir with no marker -> no recorded fingerprint -> in place.
-        assert (
-            self._run_deploy(tmp_path, monkeypatch, marker_fingerprint=None) is False
-        )
+        assert self._run_deploy(tmp_path, monkeypatch, marker_fingerprint=None) is False
 
     def test_stale_with_edits_deploys_in_place(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -984,9 +991,7 @@ class TestDeployLinks:
             cli._print_app_link("my-app")  # must not raise
         assert "databricksapps" not in capsys.readouterr().out
 
-    def test_endpoint_link_printed(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_endpoint_link_printed(self, capsys: pytest.CaptureFixture[str]) -> None:
         class _Cfg:
             host = "https://ws.cloud.databricks.com/"
 
@@ -1012,9 +1017,7 @@ class TestDeployLinks:
         import subprocess as _sp
 
         summary = {
-            "resources": {
-                "jobs": {"deploy_job": {"url": "https://ws/jobs/42?w=1"}}
-            }
+            "resources": {"jobs": {"deploy_job": {"url": "https://ws/jobs/42?w=1"}}}
         }
 
         class _R:
@@ -1146,7 +1149,9 @@ class TestDeployAutoGenerate:
             import pathlib
 
             pathlib.Path(str(bundle_dir)).mkdir(parents=True, exist_ok=True)
-            (pathlib.Path(str(bundle_dir)) / "databricks.yaml").write_text("bundle: {}\n")
+            (pathlib.Path(str(bundle_dir)) / "databricks.yaml").write_text(
+                "bundle: {}\n"
+            )
 
         monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
         monkeypatch.setattr(
@@ -1205,9 +1210,10 @@ class TestDeployAutoGenerate:
             "dao_ai.config.AppConfig.deploy_agent",
             fake_deploy_agent,
         )
-        with patch.object(cli, "deploy_app_bundle") as dep, patch.object(
-            cli, "_exec_bundle_command"
-        ) as exec_cmd:
+        with (
+            patch.object(cli, "deploy_app_bundle") as dep,
+            patch.object(cli, "_exec_bundle_command") as exec_cmd,
+        ):
             opts = parse_args(["agent", "up", "-c", str(cfg), "--direct"])
             cli.handle_agent_command(opts)
 
@@ -1245,7 +1251,9 @@ class TestDeployAutoGenerate:
         monkeypatch.setattr("dao_ai.config.AppConfig.create_agent", fake_create_agent)
         monkeypatch.setattr("dao_ai.config.AppConfig.deploy_agent", fake_deploy_agent)
         with patch.object(cli, "deploy_app_bundle") as dep:
-            opts = parse_args(["agent", "deploy", "-c", str(cfg), "--mode", "model_serving"])
+            opts = parse_args(
+                ["agent", "deploy", "-c", str(cfg), "--mode", "model_serving"]
+            )
             cli.handle_agent_command(opts)
 
         from dao_ai.config import ServingMode
@@ -1272,7 +1280,9 @@ class TestDeployAutoGenerate:
         """`agent run` on an empty dir must still error (auto-generate is deploy-only)."""
         cfg = self._write_cfg(tmp_path)
         monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
-        opts = parse_args(["agent", "run", "-c", str(cfg), "-o", str(tmp_path / "nope")])
+        opts = parse_args(
+            ["agent", "run", "-c", str(cfg), "-o", str(tmp_path / "nope")]
+        )
         with pytest.raises(SystemExit) as exc:
             cli.handle_agent_command(opts)
         assert exc.value.code == 1
@@ -1290,7 +1300,9 @@ class TestDeployAutoGenerate:
             import pathlib
 
             pathlib.Path(str(bundle_dir)).mkdir(parents=True, exist_ok=True)
-            (pathlib.Path(str(bundle_dir)) / "databricks.yaml").write_text("bundle: {}\n")
+            (pathlib.Path(str(bundle_dir)) / "databricks.yaml").write_text(
+                "bundle: {}\n"
+            )
 
         def track_resolve(self_config: object) -> None:
             resolve_calls.append("called")
@@ -1308,9 +1320,9 @@ class TestDeployAutoGenerate:
             opts = parse_args(["agent", "deploy", "-c", str(cfg), "-o", str(out)])
             cli.handle_agent_command(opts)
 
-        assert resolve_calls == [
-            "called"
-        ], "auto-generate path must call _resolve_all_resources"
+        assert resolve_calls == ["called"], (
+            "auto-generate path must call _resolve_all_resources"
+        )
 
     def test_deploy_inplace_does_not_call_resolve_all_resources(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1335,9 +1347,9 @@ class TestDeployAutoGenerate:
             opts = parse_args(["agent", "deploy", "-c", str(cfg), "-o", str(out)])
             cli.handle_agent_command(opts)
 
-        assert (
-            resolve_calls == []
-        ), "in-place deploy path must NOT call _resolve_all_resources"
+        assert resolve_calls == [], (
+            "in-place deploy path must NOT call _resolve_all_resources"
+        )
 
     def test_up_deploys_and_runs(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1357,7 +1369,9 @@ class TestDeployAutoGenerate:
 
         dep.assert_called_once()
         call_kwargs = dep.call_args.kwargs
-        assert call_kwargs["deploy"] is True, "up must call deploy_app_bundle(deploy=True)"
+        assert call_kwargs["deploy"] is True, (
+            "up must call deploy_app_bundle(deploy=True)"
+        )
         assert call_kwargs["run"] is True, "up must call deploy_app_bundle(run=True)"
 
 
@@ -1411,7 +1425,16 @@ class TestTraceNoun:
 
     def test_trace_link_optional_flags(self) -> None:
         o = parse_args(
-            ["trace", "link", "-c", "c.yaml", "--experiment-id", "9999", "--app-sp", "uuid-1"]
+            [
+                "trace",
+                "link",
+                "-c",
+                "c.yaml",
+                "--experiment-id",
+                "9999",
+                "--app-sp",
+                "uuid-1",
+            ]
         )
         assert o.experiment_id == "9999"
         assert o.app_sp == "uuid-1"
@@ -1424,7 +1447,16 @@ class TestTraceNoun:
 
     def test_trace_grant_optional_flags(self) -> None:
         o = parse_args(
-            ["trace", "grant", "-c", "c.yaml", "--experiment-id", "8888", "--app-sp", "uuid-2"]
+            [
+                "trace",
+                "grant",
+                "-c",
+                "c.yaml",
+                "--experiment-id",
+                "8888",
+                "--app-sp",
+                "uuid-2",
+            ]
         )
         assert o.experiment_id == "8888"
         assert o.app_sp == "uuid-2"

--- a/tests/dao_ai/test_extras.py
+++ b/tests/dao_ai/test_extras.py
@@ -41,7 +41,11 @@ def _app(**kwargs) -> AppModel:
     kwargs.setdefault("name", "my-app")
     kwargs.setdefault(
         "agents",
-        [AgentModel(name="ag", model=InferenceEndpointModel(name="databricks-gpt-oss-120b"))],
+        [
+            AgentModel(
+                name="ag", model=InferenceEndpointModel(name="databricks-gpt-oss-120b")
+            )
+        ],
     )
     return AppModel(**kwargs)
 
@@ -124,7 +128,9 @@ def test_flashrank_columns_only_does_not_trigger() -> None:
 
 @pytest.mark.unit
 def test_flashrank_model_triggers() -> None:
-    retriever = _retriever(rerank=RerankParametersModel(model="ms-marco-MiniLM-L-12-v2"))
+    retriever = _retriever(
+        rerank=RerankParametersModel(model="ms-marco-MiniLM-L-12-v2")
+    )
     assert _extras._retriever_needs_flashrank(retriever) is True
 
 
@@ -164,7 +170,9 @@ def test_memory_checkpointer_only_is_core() -> None:
 
 @pytest.mark.unit
 def test_memory_store_triggers_langmem() -> None:
-    assert _extras._memory_needs_langmem(MemoryModel(store=StoreModel(name="s"))) is True
+    assert (
+        _extras._memory_needs_langmem(MemoryModel(store=StoreModel(name="s"))) is True
+    )
 
 
 @pytest.mark.unit
@@ -175,7 +183,9 @@ def test_memory_none() -> None:
 # ---------------------------------------------------------------------------
 # resolve_required_extras — real AppConfig, target awareness
 # ---------------------------------------------------------------------------
-def _config(*, tools=None, middleware=None, memory=None, datasets=None, app=None) -> AppConfig:
+def _config(
+    *, tools=None, middleware=None, memory=None, datasets=None, app=None
+) -> AppConfig:
     """Build a minimal real AppConfig for the resolver."""
     return AppConfig(
         tools=tools or {},
@@ -242,7 +252,9 @@ def test_deep_agent_orchestration_triggers_deepagents() -> None:
         orchestration=OrchestrationModel(deep_agent=DeepAgentModel()),
     )
     cfg = _config(app=app)
-    assert _extras.resolve_required_extras(cfg, target="model_serving") == {"deepagents"}
+    assert _extras.resolve_required_extras(cfg, target="model_serving") == {
+        "deepagents"
+    }
 
 
 @pytest.mark.unit
@@ -252,7 +264,9 @@ def test_deepagents_middleware_fqn_triggers_deepagents() -> None:
         middleware={"m": MiddlewareModel(name=fqn)},
         app=_app(a2a=A2AModel(enabled=False)),
     )
-    assert _extras.resolve_required_extras(cfg, target="model_serving") == {"deepagents"}
+    assert _extras.resolve_required_extras(cfg, target="model_serving") == {
+        "deepagents"
+    }
 
 
 @pytest.mark.unit
@@ -319,9 +333,7 @@ def test_import_dao_ai_tools_does_not_eagerly_import_optional_packages() -> None
     result = subprocess.run(
         [sys.executable, "-c", code], capture_output=True, text=True, check=True
     )
-    leaked_line = [
-        ln for ln in result.stdout.splitlines() if ln.startswith("LEAKED:")
-    ]
+    leaked_line = [ln for ln in result.stdout.splitlines() if ln.startswith("LEAKED:")]
     assert leaked_line, f"probe produced no LEAKED line; stdout={result.stdout!r}"
     leaked = leaked_line[0].removeprefix("LEAKED:").strip()
     assert leaked == "", (
@@ -366,9 +378,7 @@ class TestExtrasPermutationMatrix:
         cfg = _config(app=_app())  # a2a defaults enabled
         for t in ("apps", "mcp", "pipeline"):
             assert "a2a" in _extras.resolve_required_extras(cfg, target=t), t
-        assert "a2a" not in _extras.resolve_required_extras(
-            cfg, target="model_serving"
-        )
+        assert "a2a" not in _extras.resolve_required_extras(cfg, target="model_serving")
 
     def test_search_plus_rerank_union_all_targets(self) -> None:
         tools = {**self._search_tool(), **self._reranking_retriever_tool()}

--- a/tests/dao_ai/test_filter_messages_agent_own_toolchain.py
+++ b/tests/dao_ai/test_filter_messages_agent_own_toolchain.py
@@ -56,7 +56,9 @@ def test_own_tool_chain_stays_adjacent_no_bridge_between() -> None:
                 f"expected ToolMessage after own AIMessage(tool_calls); "
                 f"got {type(next_msg).__name__}"
             )
-            expected_ids = {tc.get("id") for tc in msg.tool_calls if isinstance(tc, dict)}
+            expected_ids = {
+                tc.get("id") for tc in msg.tool_calls if isinstance(tc, dict)
+            }
             assert next_msg.tool_call_id in expected_ids
 
 
@@ -93,13 +95,14 @@ def test_own_ai_tool_tail_no_bridge_synthetic_result_inserted_instead() -> None:
     assert filtered[-1].name == "__orphan_placeholder__"
     # AND no HumanMessage bridge should have been inserted between the
     # AIMessage and its synthetic ToolMessage.
-    ai_idx = next(i for i, m in enumerate(filtered) if isinstance(m, AIMessage) and m.tool_calls)
+    ai_idx = next(
+        i for i, m in enumerate(filtered) if isinstance(m, AIMessage) and m.tool_calls
+    )
     assert isinstance(filtered[ai_idx + 1], ToolMessage), (
         "synthetic ToolMessage must sit immediately after its parent AIMessage"
     )
     assert not any(
-        isinstance(m, HumanMessage) and m.name == "__filter_bridge__"
-        for m in filtered
+        isinstance(m, HumanMessage) and m.name == "__filter_bridge__" for m in filtered
     ), "no bridge should be inserted for an own tool_call orphan"
 
 
@@ -131,7 +134,11 @@ def test_orphan_tool_call_gets_synthetic_placeholder() -> None:
             content="",
             name="supervisor",
             tool_calls=[
-                {"id": "orphan-call", "name": "search_memory", "args": {"query": "credit"}},
+                {
+                    "id": "orphan-call",
+                    "name": "search_memory",
+                    "args": {"query": "credit"},
+                },
                 {"id": "handoff-call", "name": "handoff_to_credit_limit", "args": {}},
             ],
         ),
@@ -141,8 +148,7 @@ def test_orphan_tool_call_gets_synthetic_placeholder() -> None:
 
     # Find the AIMessage — its tool_calls must all have adjacent ToolMessages.
     ai_index = next(
-        i for i, m in enumerate(filtered)
-        if isinstance(m, AIMessage) and m.tool_calls
+        i for i, m in enumerate(filtered) if isinstance(m, AIMessage) and m.tool_calls
     )
     following = filtered[ai_index + 1 :]
     tool_ids_seen = {m.tool_call_id for m in following if isinstance(m, ToolMessage)}
@@ -154,7 +160,8 @@ def test_orphan_tool_call_gets_synthetic_placeholder() -> None:
 
     # And the synthetic placeholder must be tagged so ops can spot it.
     placeholder = next(
-        m for m in filtered
+        m
+        for m in filtered
         if isinstance(m, ToolMessage) and m.tool_call_id == "orphan-call"
     )
     assert placeholder.name == "__orphan_placeholder__"
@@ -181,7 +188,9 @@ def test_orphan_placeholders_stay_adjacent_to_parent_ai() -> None:
     filtered = filter_messages_for_agent(messages, current_agent_name="supervisor")
 
     # Sequence must be [AIMessage, ToolMessage(a), ToolMessage(b)] with no gaps.
-    ai_idx = next(i for i, m in enumerate(filtered) if isinstance(m, AIMessage) and m.tool_calls)
+    ai_idx = next(
+        i for i, m in enumerate(filtered) if isinstance(m, AIMessage) and m.tool_calls
+    )
     assert isinstance(filtered[ai_idx + 1], ToolMessage)
     assert isinstance(filtered[ai_idx + 2], ToolMessage)
     tool_ids = {filtered[ai_idx + 1].tool_call_id, filtered[ai_idx + 2].tool_call_id}
@@ -197,13 +206,16 @@ def test_no_orphan_no_placeholder() -> None:
         AIMessage(
             content="",
             name="general",
-            tool_calls=[{"id": "own1", "name": "search_memory", "args": {"query": "x"}}],
+            tool_calls=[
+                {"id": "own1", "name": "search_memory", "args": {"query": "x"}}
+            ],
         ),
         ToolMessage(content="[]", tool_call_id="own1"),
     ]
     filtered = filter_messages_for_agent(messages, current_agent_name="general")
     placeholders = [
-        m for m in filtered
+        m
+        for m in filtered
         if isinstance(m, ToolMessage) and m.name == "__orphan_placeholder__"
     ]
     assert placeholders == [], f"unexpected placeholders: {placeholders}"

--- a/tests/dao_ai/test_filter_messages_bridge.py
+++ b/tests/dao_ai/test_filter_messages_bridge.py
@@ -79,9 +79,9 @@ def test_planner_handoff_shape_ends_with_non_ai_tail() -> None:
 
     filtered = filter_messages_for_agent(messages, current_agent_name="general")
 
-    assert not isinstance(
-        filtered[-1], AIMessage
-    ), f"tail must not be AIMessage; got {type(filtered[-1]).__name__}"
+    assert not isinstance(filtered[-1], AIMessage), (
+        f"tail must not be AIMessage; got {type(filtered[-1]).__name__}"
+    )
 
 
 @pytest.mark.unit
@@ -135,12 +135,16 @@ def test_no_bridge_appended_when_tail_is_already_human() -> None:
     ]
     filtered = filter_messages_for_agent(messages, current_agent_name="general")
     # Only original HumanMessages preserved — no extra bridge.
-    assert sum(
-        1 for m in filtered if isinstance(m, HumanMessage) and m.name != "__filter_bridge__"
-    ) == 2
+    assert (
+        sum(
+            1
+            for m in filtered
+            if isinstance(m, HumanMessage) and m.name != "__filter_bridge__"
+        )
+        == 2
+    )
     assert not any(
-        isinstance(m, HumanMessage) and m.name == "__filter_bridge__"
-        for m in filtered
+        isinstance(m, HumanMessage) and m.name == "__filter_bridge__" for m in filtered
     )
 
 
@@ -224,9 +228,7 @@ def test_article_invariant_last_message_is_not_assistant() -> None:
             AIMessage(
                 content="routing note",
                 name="planner",
-                tool_calls=[
-                    {"id": "call1", "name": "handoff_to_x", "args": {}}
-                ],
+                tool_calls=[{"id": "call1", "name": "handoff_to_x", "args": {}}],
             ),
         ],
         # (c) peer AIMessage with tool_calls only (no content) — filter drops entirely
@@ -235,9 +237,7 @@ def test_article_invariant_last_message_is_not_assistant() -> None:
             AIMessage(
                 content="",
                 name="planner",
-                tool_calls=[
-                    {"id": "call1", "name": "handoff_to_x", "args": {}}
-                ],
+                tool_calls=[{"id": "call1", "name": "handoff_to_x", "args": {}}],
             ),
         ],
     ]

--- a/tests/dao_ai/test_genie_agent_middleware.py
+++ b/tests/dao_ai/test_genie_agent_middleware.py
@@ -38,10 +38,14 @@ def _middleware(monkeypatch: Any) -> tuple[GenieAgentMiddleware, dict[str, Any]]
     # Stub OBO client resolution + the per-request model build so we don't hit
     # the network or need a real WorkspaceClient.
     monkeypatch.setattr(
-        GenieRoomModel, "workspace_client_from", lambda self, ctx, *, strict=False: MagicMock()
+        GenieRoomModel,
+        "workspace_client_from",
+        lambda self, ctx, *, strict=False: MagicMock(),
     )
 
-    def _fake_build(self: GenieAgentModel, ws: Any, *, conversation_id: str | None = None) -> Any:
+    def _fake_build(
+        self: GenieAgentModel, ws: Any, *, conversation_id: str | None = None
+    ) -> Any:
         built["conversation_id"] = conversation_id
         return MagicMock(name="GenieAgentChatModel")
 
@@ -59,7 +63,9 @@ def _request(session: SessionState | None) -> MagicMock:
 
 def _handler_returning(conversation_id: str | None):
     def _handler(_req: Any) -> ModelResponse:
-        meta = {CONVERSATION_ID_METADATA_KEY: conversation_id} if conversation_id else {}
+        meta = (
+            {CONVERSATION_ID_METADATA_KEY: conversation_id} if conversation_id else {}
+        )
         return ModelResponse(result=[AIMessage("answer", response_metadata=meta)])
 
     return _handler
@@ -127,10 +133,18 @@ class TestAsync:
 
         async def _ahandler(_req: Any) -> ModelResponse:
             return ModelResponse(
-                result=[AIMessage("a", response_metadata={CONVERSATION_ID_METADATA_KEY: "conv-next"})]
+                result=[
+                    AIMessage(
+                        "a",
+                        response_metadata={CONVERSATION_ID_METADATA_KEY: "conv-next"},
+                    )
+                ]
             )
 
         result = asyncio.run(mw.awrap_model_call(request, _ahandler))
         assert built["conversation_id"] == "conv-prior"
         assert isinstance(result, ExtendedModelResponse)
-        assert result.command.update["session"].genie.get_conversation_id(AGENT_ID) == "conv-next"
+        assert (
+            result.command.update["session"].genie.get_conversation_id(AGENT_ID)
+            == "conv-next"
+        )

--- a/tests/dao_ai/test_genie_agent_model.py
+++ b/tests/dao_ai/test_genie_agent_model.py
@@ -28,14 +28,19 @@ from unittest.mock import MagicMock
 
 import httpx
 import pytest
+from langchain_core.messages import AIMessage, HumanMessage
 
-from dao_ai.config import AgentModel, GenieAgentModel, GenieRoomModel, InferenceEndpointModel
+from dao_ai.config import (
+    AgentModel,
+    GenieAgentModel,
+    GenieRoomModel,
+    InferenceEndpointModel,
+)
 from dao_ai.genie.agent_chat_model import (
     CONVERSATION_ID_METADATA_KEY,
     GenieAgentChatModel,
     GenieAgentError,
 )
-from langchain_core.messages import AIMessage, HumanMessage
 
 AGENT_ID: str = "01f05dd06c421ad6b522bf7a517cf6d2"
 HOST: str = "https://example.cloud.databricks.com"
@@ -59,7 +64,13 @@ def _happy_events(conversation_id: str = "conv-1") -> list[tuple[str, dict[str, 
     return [
         (
             "response.created",
-            {"response": {"id": "resp-1", "conversation_id": conversation_id, "status": "in_progress"}},
+            {
+                "response": {
+                    "id": "resp-1",
+                    "conversation_id": conversation_id,
+                    "status": "in_progress",
+                }
+            },
         ),
         (
             "response.output_item.done",
@@ -69,22 +80,48 @@ def _happy_events(conversation_id: str = "conv-1") -> list[tuple[str, dict[str, 
                     "type": "function_call",
                     "name": "execute_sql",
                     "arguments": json.dumps(
-                        {"title": "Store count", "sql": "SELECT state, COUNT(*) FROM stores GROUP BY state"}
+                        {
+                            "title": "Store count",
+                            "sql": "SELECT state, COUNT(*) FROM stores GROUP BY state",
+                        }
                     ),
                 }
             },
         ),
         (
             "response.output_item.done",
-            {"item": {"id": "out-a", "type": "function_call_output", "output": "| state | count |\n|---|---|\n| CA | 42 |\n"}},
+            {
+                "item": {
+                    "id": "out-a",
+                    "type": "function_call_output",
+                    "output": "| state | count |\n|---|---|\n| CA | 42 |\n",
+                }
+            },
         ),
         (
             "response.output_item.done",
-            {"item": {"id": "msg-a", "type": "message", "content": [{"type": "output_text", "text": "California leads with 42 stores."}]}},
+            {
+                "item": {
+                    "id": "msg-a",
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "California leads with 42 stores.",
+                        }
+                    ],
+                }
+            },
         ),
         (
             "response.completed",
-            {"response": {"id": "resp-1", "conversation_id": conversation_id, "status": "completed"}},
+            {
+                "response": {
+                    "id": "resp-1",
+                    "conversation_id": conversation_id,
+                    "status": "completed",
+                }
+            },
         ),
     ]
 
@@ -162,11 +199,16 @@ class TestStreaming:
         assert result.response_metadata[CONVERSATION_ID_METADATA_KEY] == "conv-1"
         # Request shape: single user turn, no conversation_id on first turn.
         assert record["url"].endswith(f"/api/2.0/genie/agents/{AGENT_ID}/responses")
-        assert record["body"]["input"][0]["content"][0]["text"] == "How many stores by state?"
+        assert (
+            record["body"]["input"][0]["content"][0]["text"]
+            == "How many stores by state?"
+        )
         assert "conversation_id" not in record["body"]
         assert record["auth"] == "Bearer stub-token"
 
-    def test_astream_yields_chunks_in_order(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_astream_yields_chunks_in_order(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         model = _model_with_transport(
             lambda req: httpx.Response(200, content=_sse(_happy_events())),
             monkeypatch,
@@ -181,7 +223,11 @@ class TestStreaming:
         chunks = asyncio.run(_collect())
         joined = "".join(chunks)
         # SQL precedes table precedes narrative.
-        assert joined.index("```sql") < joined.index("| state | count |") < joined.index("California leads")
+        assert (
+            joined.index("```sql")
+            < joined.index("| state | count |")
+            < joined.index("California leads")
+        )
 
     def test_astream_final_chunk_carries_conversation_id(
         self, monkeypatch: pytest.MonkeyPatch
@@ -207,7 +253,9 @@ class TestStreaming:
 
 
 class TestConversationIdField:
-    def test_conversation_id_field_sent_in_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_conversation_id_field_sent_in_body(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         record: dict[str, Any] = {}
         model = _model_with_transport(
             lambda req: httpx.Response(200, content=_sse(_happy_events("conv-2"))),
@@ -221,7 +269,9 @@ class TestConversationIdField:
                 HumanMessage("first"),
                 AIMessage(
                     "prev answer",
-                    response_metadata={CONVERSATION_ID_METADATA_KEY: "ignored-metadata"},
+                    response_metadata={
+                        CONVERSATION_ID_METADATA_KEY: "ignored-metadata"
+                    },
                 ),
                 HumanMessage("follow-up"),
             ]
@@ -230,7 +280,9 @@ class TestConversationIdField:
         # Latest human turn is the one sent.
         assert record["body"]["input"][0]["content"][0]["text"] == "follow-up"
 
-    def test_no_conversation_id_omits_field(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_no_conversation_id_omits_field(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         record: dict[str, Any] = {}
         model = _model_with_transport(
             lambda req: httpx.Response(200, content=_sse(_happy_events())),
@@ -242,7 +294,10 @@ class TestConversationIdField:
         model.invoke(
             [
                 AIMessage(
-                    "prev", response_metadata={CONVERSATION_ID_METADATA_KEY: "should-not-be-used"}
+                    "prev",
+                    response_metadata={
+                        CONVERSATION_ID_METADATA_KEY: "should-not-be-used"
+                    },
                 ),
                 HumanMessage("q"),
             ]
@@ -258,7 +313,9 @@ class TestConversationIdField:
 class TestErrors:
     def test_http_error_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         model = _model_with_transport(
-            lambda req: httpx.Response(404, content=b'{"error_code":"FEATURE_DISABLED"}'),
+            lambda req: httpx.Response(
+                404, content=b'{"error_code":"FEATURE_DISABLED"}'
+            ),
             monkeypatch,
         )
         with pytest.raises(GenieAgentError, match="404"):
@@ -266,10 +323,29 @@ class TestErrors:
 
     def test_response_failed_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         events = [
-            ("response.created", {"response": {"id": "r", "conversation_id": "c", "status": "in_progress"}}),
+            (
+                "response.created",
+                {
+                    "response": {
+                        "id": "r",
+                        "conversation_id": "c",
+                        "status": "in_progress",
+                    }
+                },
+            ),
             (
                 "response.failed",
-                {"response": {"id": "r", "conversation_id": "c", "status": "failed", "error": {"code": "sql_execution_error", "message": "Table not found"}}},
+                {
+                    "response": {
+                        "id": "r",
+                        "conversation_id": "c",
+                        "status": "failed",
+                        "error": {
+                            "code": "sql_execution_error",
+                            "message": "Table not found",
+                        },
+                    }
+                },
             ),
         ]
         model = _model_with_transport(
@@ -308,18 +384,28 @@ class TestConfigModel:
         assert m.name == AGENT_ID
 
     def test_obo_delegates_to_room(self) -> None:
-        m = GenieAgentModel(genie_room=GenieRoomModel(space_id=AGENT_ID, on_behalf_of_user=True))
+        m = GenieAgentModel(
+            genie_room=GenieRoomModel(space_id=AGENT_ID, on_behalf_of_user=True)
+        )
         assert m.on_behalf_of_user is True
 
     def test_parses_through_agent_model_union(self) -> None:
         agent = AgentModel.model_validate(
-            {"name": "genie_specialist", "model": {"genie_room": {"agent_id": AGENT_ID}}, "tools": []}
+            {
+                "name": "genie_specialist",
+                "model": {"genie_room": {"agent_id": AGENT_ID}},
+                "tools": [],
+            }
         )
         assert isinstance(agent.model, GenieAgentModel)
 
     def test_serving_endpoint_still_parses(self) -> None:
         agent = AgentModel.model_validate(
-            {"name": "normal", "model": {"name": "databricks-claude-sonnet-4"}, "tools": []}
+            {
+                "name": "normal",
+                "model": {"name": "databricks-claude-sonnet-4"},
+                "tools": [],
+            }
         )
         assert isinstance(agent.model, InferenceEndpointModel)
 
@@ -354,7 +440,9 @@ class TestConfigModel:
         assert isinstance(agent.model, GenieAgentModel)
         assert agent.model.timeout_seconds == 600
 
-    def test_unresolvable_agent_id_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_unresolvable_agent_id_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # A name-only room (no space_id) with no env fallback cannot resolve
         # an agent_id without a live lookup.
         monkeypatch.delenv("DATABRICKS_GENIE_SPACE_ID", raising=False)
@@ -374,10 +462,16 @@ class TestGenieRoomRegistrationValidator:
 
         cfg = {
             "agents": {
-                "g": {"name": "g", "model": {"genie_room": {"agent_id": AGENT_ID}}, "tools": []}
+                "g": {
+                    "name": "g",
+                    "model": {"genie_room": {"agent_id": AGENT_ID}},
+                    "tools": [],
+                }
             }
         }
-        with pytest.raises(ValueError, match="not registered under resources.genie_rooms"):
+        with pytest.raises(
+            ValueError, match="not registered under resources.genie_rooms"
+        ):
             AppConfig(**cfg)
 
     def test_registered_room_passes(self) -> None:
@@ -386,7 +480,11 @@ class TestGenieRoomRegistrationValidator:
         cfg = {
             "resources": {"genie_rooms": {"retail": {"agent_id": AGENT_ID}}},
             "agents": {
-                "g": {"name": "g", "model": {"genie_room": {"agent_id": AGENT_ID}}, "tools": []}
+                "g": {
+                    "name": "g",
+                    "model": {"genie_room": {"agent_id": AGENT_ID}},
+                    "tools": [],
+                }
             },
         }
         # Should not raise.
@@ -397,7 +495,11 @@ class TestGenieRoomRegistrationValidator:
 
         cfg = {
             "agents": {
-                "x": {"name": "x", "model": {"name": "databricks-claude-sonnet-4"}, "tools": []}
+                "x": {
+                    "name": "x",
+                    "model": {"name": "databricks-claude-sonnet-4"},
+                    "tools": [],
+                }
             }
         }
         # A non-Genie model is never subject to the genie_rooms check.

--- a/tests/dao_ai/test_grant_trace_permissions.py
+++ b/tests/dao_ai/test_grant_trace_permissions.py
@@ -51,9 +51,7 @@ def test_helper_grants_all_documented_privileges() -> None:
     assert body["changes"] == [{"principal": "sp-uuid", "add": ["USE_CATALOG"]}]
     # Schema
     body = calls[1].kwargs["body"]
-    assert (
-        calls[1].args[1] == "/api/2.1/unity-catalog/permissions/schema/cat.sch"
-    )
+    assert calls[1].args[1] == "/api/2.1/unity-catalog/permissions/schema/cat.sch"
     assert body["changes"] == [{"principal": "sp-uuid", "add": ["USE_SCHEMA"]}]
     # Tables
     table_calls = calls[2:]

--- a/tests/dao_ai/test_instructed_pipeline.py
+++ b/tests/dao_ai/test_instructed_pipeline.py
@@ -62,9 +62,7 @@ def instructed_cfg(
     decomposition: DecompositionModel,
     columns: list[ColumnInfo],
 ) -> InstructedRetrieverModel:
-    return InstructedRetrieverModel(
-        columns=columns, decomposition=decomposition
-    )
+    return InstructedRetrieverModel(columns=columns, decomposition=decomposition)
 
 
 def _docs(*ids: str) -> list[Document]:
@@ -120,9 +118,7 @@ class TestDecideMode:
     ) -> None:
         rc = RouterModel(model=llm, default_mode="standard", auto_bypass=True)
         with (
-            patch(
-                "dao_ai.tools.instructed_pipeline._get_cached_llm"
-            ) as mock_llm,
+            patch("dao_ai.tools.instructed_pipeline._get_cached_llm") as mock_llm,
             patch(
                 "dao_ai.tools.instructed_pipeline.route_query",
                 return_value="instructed",
@@ -144,9 +140,7 @@ class TestDecideMode:
     ) -> None:
         rc = RouterModel(model=llm, default_mode="instructed", auto_bypass=False)
         with (
-            patch(
-                "dao_ai.tools.instructed_pipeline._get_cached_llm"
-            ) as mock_llm,
+            patch("dao_ai.tools.instructed_pipeline._get_cached_llm") as mock_llm,
             patch(
                 "dao_ai.tools.instructed_pipeline.route_query",
                 side_effect=RuntimeError("boom"),
@@ -197,12 +191,8 @@ class TestInstructedMode:
             return _docs(f"result_for_{q}")
 
         with (
-            patch(
-                "dao_ai.tools.instructed_pipeline._get_cached_llm"
-            ) as mock_llm,
-            patch(
-                "dao_ai.tools.instructed_pipeline.decompose_query"
-            ) as mock_decompose,
+            patch("dao_ai.tools.instructed_pipeline._get_cached_llm") as mock_llm,
+            patch("dao_ai.tools.instructed_pipeline.decompose_query") as mock_decompose,
         ):
             mock_llm.return_value = MagicMock()
             mock_decompose.return_value = [
@@ -248,12 +238,8 @@ class TestInstructedMode:
             return _docs("ok")
 
         with (
-            patch(
-                "dao_ai.tools.instructed_pipeline._get_cached_llm"
-            ) as mock_llm,
-            patch(
-                "dao_ai.tools.instructed_pipeline.decompose_query"
-            ) as mock_decompose,
+            patch("dao_ai.tools.instructed_pipeline._get_cached_llm") as mock_llm,
+            patch("dao_ai.tools.instructed_pipeline.decompose_query") as mock_decompose,
         ):
             mock_llm.return_value = MagicMock()
             mock_decompose.return_value = [
@@ -289,12 +275,8 @@ class TestInstructedMode:
             return _docs("ok")
 
         with (
-            patch(
-                "dao_ai.tools.instructed_pipeline._get_cached_llm"
-            ) as mock_llm,
-            patch(
-                "dao_ai.tools.instructed_pipeline.decompose_query"
-            ) as mock_decompose,
+            patch("dao_ai.tools.instructed_pipeline._get_cached_llm") as mock_llm,
+            patch("dao_ai.tools.instructed_pipeline.decompose_query") as mock_decompose,
         ):
             mock_llm.return_value = MagicMock()
             mock_decompose.return_value = [
@@ -330,12 +312,8 @@ class TestInstructedMode:
             return _docs("fallback")
 
         with (
-            patch(
-                "dao_ai.tools.instructed_pipeline._get_cached_llm"
-            ) as mock_llm,
-            patch(
-                "dao_ai.tools.instructed_pipeline.decompose_query", return_value=[]
-            ),
+            patch("dao_ai.tools.instructed_pipeline._get_cached_llm") as mock_llm,
+            patch("dao_ai.tools.instructed_pipeline.decompose_query", return_value=[]),
         ):
             mock_llm.return_value = MagicMock()
             docs = execute_instructed_pipeline(
@@ -362,9 +340,7 @@ class TestInstructedMode:
             return _docs("fallback")
 
         with (
-            patch(
-                "dao_ai.tools.instructed_pipeline._get_cached_llm"
-            ) as mock_llm,
+            patch("dao_ai.tools.instructed_pipeline._get_cached_llm") as mock_llm,
             patch(
                 "dao_ai.tools.instructed_pipeline.decompose_query",
                 side_effect=RuntimeError("LLM down"),
@@ -395,15 +371,9 @@ class TestInstructedMode:
             return _docs("x")
 
         with (
-            patch(
-                "dao_ai.tools.instructed_pipeline._get_cached_llm"
-            ) as mock_llm,
-            patch(
-                "dao_ai.tools.instructed_pipeline.decompose_query"
-            ) as mock_decompose,
-            patch(
-                "dao_ai.tools.instructed_pipeline.rrf_merge", return_value=[]
-            ),
+            patch("dao_ai.tools.instructed_pipeline._get_cached_llm") as mock_llm,
+            patch("dao_ai.tools.instructed_pipeline.decompose_query") as mock_decompose,
+            patch("dao_ai.tools.instructed_pipeline.rrf_merge", return_value=[]),
         ):
             mock_llm.return_value = MagicMock()
             mock_decompose.return_value = [
@@ -433,9 +403,7 @@ class TestFlashRankPosition:
             return _docs("a", "b", "c")
 
         fake_ranker = MagicMock(name="Ranker")
-        with patch(
-            "dao_ai.tools.vector_search.rerank_documents"
-        ) as mock_rerank:
+        with patch("dao_ai.tools.vector_search.rerank_documents") as mock_rerank:
             mock_rerank.return_value = _docs("c", "b", "a")
             docs = execute_instructed_pipeline(
                 run_search=run_search,
@@ -460,9 +428,7 @@ class TestFlashRankPosition:
         def run_search(q: str, f: dict[str, Any]) -> list[Document]:
             return _docs("a")
 
-        with patch(
-            "dao_ai.tools.vector_search.rerank_documents"
-        ) as mock_rerank:
+        with patch("dao_ai.tools.vector_search.rerank_documents") as mock_rerank:
             execute_instructed_pipeline(
                 run_search=run_search,
                 query="q",
@@ -516,12 +482,8 @@ class TestInstructionRerank:
             return _docs("a")
 
         with (
-            patch(
-                "dao_ai.tools.instructed_pipeline._get_cached_llm"
-            ) as mock_llm,
-            patch(
-                "dao_ai.tools.instructed_pipeline.decompose_query", return_value=[]
-            ),
+            patch("dao_ai.tools.instructed_pipeline._get_cached_llm") as mock_llm,
+            patch("dao_ai.tools.instructed_pipeline.decompose_query", return_value=[]),
             patch(
                 "dao_ai.tools.instructed_pipeline.instruction_aware_rerank",
                 return_value=_docs("rerank_a"),
@@ -576,15 +538,9 @@ class TestVerifierRetryLoop:
 
         verifier = VerifierModel(model=llm, on_failure="retry", max_retries=3)
         with (
-            patch(
-                "dao_ai.tools.instructed_pipeline._get_cached_llm"
-            ) as mock_llm,
-            patch(
-                "dao_ai.tools.instructed_pipeline.decompose_query", return_value=[]
-            ),
-            patch(
-                "dao_ai.tools.instructed_pipeline.verify_results"
-            ) as mock_verify,
+            patch("dao_ai.tools.instructed_pipeline._get_cached_llm") as mock_llm,
+            patch("dao_ai.tools.instructed_pipeline.decompose_query", return_value=[]),
+            patch("dao_ai.tools.instructed_pipeline.verify_results") as mock_verify,
         ):
             mock_llm.return_value = MagicMock()
             mock_verify.return_value = VerificationResult(passed=True, confidence=0.9)
@@ -606,12 +562,8 @@ class TestVerifierRetryLoop:
         verifier = VerifierModel(model=llm, on_failure="warn", max_retries=3)
         vr = VerificationResult(passed=False, confidence=0.3, feedback="too broad")
         with (
-            patch(
-                "dao_ai.tools.instructed_pipeline._get_cached_llm"
-            ) as mock_llm,
-            patch(
-                "dao_ai.tools.instructed_pipeline.decompose_query", return_value=[]
-            ),
+            patch("dao_ai.tools.instructed_pipeline._get_cached_llm") as mock_llm,
+            patch("dao_ai.tools.instructed_pipeline.decompose_query", return_value=[]),
             patch(
                 "dao_ai.tools.instructed_pipeline.verify_results", return_value=vr
             ) as mock_verify,
@@ -640,17 +592,15 @@ class TestVerifierRetryLoop:
 
         verifier = VerifierModel(model=llm, on_failure="retry", max_retries=3)
         results = [
-            VerificationResult(passed=False, confidence=0.3, feedback="add brand filter"),
+            VerificationResult(
+                passed=False, confidence=0.3, feedback="add brand filter"
+            ),
             VerificationResult(passed=True, confidence=0.9),
         ]
 
         with (
-            patch(
-                "dao_ai.tools.instructed_pipeline._get_cached_llm"
-            ) as mock_llm,
-            patch(
-                "dao_ai.tools.instructed_pipeline.decompose_query"
-            ) as mock_decompose,
+            patch("dao_ai.tools.instructed_pipeline._get_cached_llm") as mock_llm,
+            patch("dao_ai.tools.instructed_pipeline.decompose_query") as mock_decompose,
             patch(
                 "dao_ai.tools.instructed_pipeline.verify_results", side_effect=results
             ) as mock_verify,
@@ -679,12 +629,8 @@ class TestVerifierRetryLoop:
         vr = VerificationResult(passed=False, confidence=0.2, feedback="still bad")
 
         with (
-            patch(
-                "dao_ai.tools.instructed_pipeline._get_cached_llm"
-            ) as mock_llm,
-            patch(
-                "dao_ai.tools.instructed_pipeline.decompose_query"
-            ) as mock_decompose,
+            patch("dao_ai.tools.instructed_pipeline._get_cached_llm") as mock_llm,
+            patch("dao_ai.tools.instructed_pipeline.decompose_query") as mock_decompose,
             patch(
                 "dao_ai.tools.instructed_pipeline.verify_results", return_value=vr
             ) as mock_verify,
@@ -718,9 +664,7 @@ class TestVerifierRetryLoop:
         vr = VerificationResult(passed=False, confidence=0.4)
 
         with (
-            patch(
-                "dao_ai.tools.instructed_pipeline._get_cached_llm"
-            ) as mock_llm,
+            patch("dao_ai.tools.instructed_pipeline._get_cached_llm") as mock_llm,
             patch(
                 "dao_ai.tools.instructed_pipeline.verify_results", return_value=vr
             ) as mock_verify,

--- a/tests/dao_ai/test_instructed_retriever.py
+++ b/tests/dao_ai/test_instructed_retriever.py
@@ -7,13 +7,13 @@ from conftest import add_databricks_resource_attrs
 from langchain_core.documents import Document
 
 from dao_ai.config import (
+    AiSearchRetrieverModel,
     ColumnInfo,
     DecomposedQueries,
     DecompositionModel,
     FilterItem,
     InstructedRetrieverModel,
     LLMModel,
-    AiSearchRetrieverModel,
     SearchQuery,
     VectorStoreModel,
 )

--- a/tests/dao_ai/test_lakebase_app_resources.py
+++ b/tests/dao_ai/test_lakebase_app_resources.py
@@ -543,9 +543,7 @@ def _mock_sdk_client(
 
     fake = MagicMock(spec=_WC)
     fake.postgres = _WC.postgres
-    monkeypatch.setattr(
-        DatabaseModel, "workspace_client", property(lambda self: fake)
-    )
+    monkeypatch.setattr(DatabaseModel, "workspace_client", property(lambda self: fake))
     return _WC.postgres
 
 
@@ -666,9 +664,7 @@ class TestResolveLakebaseDatabasePathPrecedence:
             ],
         )
 
-        result = _resolve_lakebase_database_path(
-            db, "projects/p/branches/main"
-        )
+        result = _resolve_lakebase_database_path(db, "projects/p/branches/main")
         assert result == "projects/p/branches/main/databases/actual-db"
 
     def test_5_sdk_failure_falls_back_to_database_id_default(
@@ -683,9 +679,7 @@ class TestResolveLakebaseDatabasePathPrecedence:
         from dao_ai.config import DatabaseModel
 
         db = DatabaseModel(project="commerce-swarm", branch="production")
-        _mock_sdk_client(
-            monkeypatch, RuntimeError("401 Unauthorized")
-        )
+        _mock_sdk_client(monkeypatch, RuntimeError("401 Unauthorized"))
 
         # loguru: capture WARNING via a dedicated sink.
         from loguru import logger as loguru_logger
@@ -725,9 +719,7 @@ class TestResolveLakebaseDatabasePathPrecedence:
         db = DatabaseModel(project="p", branch="main")
         _mock_sdk_client(monkeypatch, [])
 
-        result = _resolve_lakebase_database_path(
-            db, "projects/p/branches/main"
-        )
+        result = _resolve_lakebase_database_path(db, "projects/p/branches/main")
         assert result == "projects/p/branches/main/databases/databricks-postgres"
 
     def test_2_wins_over_3_explicit_database_id_beats_sdk(
@@ -746,7 +738,5 @@ class TestResolveLakebaseDatabasePathPrecedence:
         )
         _forbid_sdk(monkeypatch)  # Would blow up if the resolver called SDK.
 
-        result = _resolve_lakebase_database_path(
-            db, "projects/p/branches/main"
-        )
+        result = _resolve_lakebase_database_path(db, "projects/p/branches/main")
         assert result == "projects/p/branches/main/databases/user-override-id"

--- a/tests/dao_ai/test_lakebase_backfill.py
+++ b/tests/dao_ai/test_lakebase_backfill.py
@@ -4,7 +4,7 @@ Mocks the DatabaseModel's execute_query + execute_many so tests exercise
 the batching / no-op / SQL-shape behavior without a live database.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -85,8 +85,13 @@ class TestBackfillEmbeddings:
         assert em.call_count == 3
 
     def test_reads_qualified_schema_and_columns_from_config(self) -> None:
-        vs = _vs(schema_name="kb", table="docs", id_column="doc_id",
-                 content_column="body", embedding_column="vec")
+        vs = _vs(
+            schema_name="kb",
+            table="docs",
+            id_column="doc_id",
+            content_column="body",
+            embedding_column="vec",
+        )
         with (
             patch.object(DatabaseModel, "execute_query", return_value=[]) as eq,
             patch.object(DatabaseModel, "execute_many"),

--- a/tests/dao_ai/test_lakebase_provision.py
+++ b/tests/dao_ai/test_lakebase_provision.py
@@ -129,10 +129,10 @@ class TestExecuteQuery:
             "dao_ai.memory.postgres.PostgresPoolManager.get_pool",
             return_value=pool,
         ):
-            rows = _db().execute_query("SELECT id FROM t WHERE id = %s", parameters=(7,))
-        cur.execute.assert_called_once_with(
-            "SELECT id FROM t WHERE id = %s", (7,)
-        )
+            rows = _db().execute_query(
+                "SELECT id FROM t WHERE id = %s", parameters=(7,)
+            )
+        cur.execute.assert_called_once_with("SELECT id FROM t WHERE id = %s", (7,))
         assert rows == [{"id": 7}]
 
 
@@ -225,9 +225,7 @@ class TestProvision:
         # Only lakebase_vector — no lakebase_text without tsvector_column
         assert any("CREATE EXTENSION IF NOT EXISTS lakebase_vector" in s for s in stmts)
         assert not any("lakebase_text" in s for s in stmts)
-        assert any(
-            "CREATE TABLE IF NOT EXISTS public.kb_articles" in s for s in stmts
-        )
+        assert any("CREATE TABLE IF NOT EXISTS public.kb_articles" in s for s in stmts)
         assert any("id text PRIMARY KEY" in s for s in stmts)
         assert any("passage text NOT NULL" in s for s in stmts)
         assert any("embedding vector(1024)" in s for s in stmts)
@@ -309,7 +307,9 @@ class TestProvision:
         ):
             _vs(schema_name="dao_ai_kb").provision(dimension=1024)
         stmts = [c.args[0] for c in cur.execute.call_args_list]
-        assert any("CREATE TABLE IF NOT EXISTS dao_ai_kb.kb_articles" in s for s in stmts)
+        assert any(
+            "CREATE TABLE IF NOT EXISTS dao_ai_kb.kb_articles" in s for s in stmts
+        )
 
     def test_bad_dimension_raises(self) -> None:
         with pytest.raises(ValueError, match="positive int"):

--- a/tests/dao_ai/test_lakebase_search.py
+++ b/tests/dao_ai/test_lakebase_search.py
@@ -16,14 +16,13 @@ from __future__ import annotations
 import json
 from contextlib import contextmanager
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
 
 from dao_ai.config import (
     ColumnInfo,
-    FilterItem,
     FunctionType,
     InferenceEndpointModel,
     LakebaseRetrieverModel,
@@ -32,7 +31,6 @@ from dao_ai.config import (
     SearchParametersModel,
     ToolModel,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -155,9 +153,7 @@ class TestSqlBuilders:
         "metric,expected_op",
         [("cosine", "<=>"), ("l2", "<->"), ("ip", "<#>")],
     )
-    def test_ann_sql_uses_correct_operator(
-        self, metric: str, expected_op: str
-    ) -> None:
+    def test_ann_sql_uses_correct_operator(self, metric: str, expected_op: str) -> None:
         vs = LakebaseVectorStoreModel(**_vs_dict(distance_metric=metric))
         r = self._make(vs)
         stmt, params = r._build_ann_sql({}, k=5)
@@ -219,9 +215,7 @@ class TestSqlBuilders:
         assert '"category" = %s' in rendered
         assert params == ["faq"]
 
-    def test_where_scalar_not(
-        self, vector_store: LakebaseVectorStoreModel
-    ) -> None:
+    def test_where_scalar_not(self, vector_store: LakebaseVectorStoreModel) -> None:
         r = self._make(vector_store)
         clause, params = r._build_where({"category NOT": "faq"})
         rendered = clause.as_string(None)
@@ -233,7 +227,7 @@ class TestSqlBuilders:
     ) -> None:
         r = self._make(vector_store)
         clause, params = r._build_where({"category": ["faq", "howto"]})
-        assert '= ANY(%s)' in clause.as_string(None)
+        assert "= ANY(%s)" in clause.as_string(None)
         assert params == [["faq", "howto"]]
 
     def test_where_not_in_via_list_value(
@@ -678,7 +672,8 @@ class TestFactory:
         assert tool.args_schema is LakebaseSearchInput
 
     def test_factory_column_info_operator_narrowing(
-        self, database_model_dict: dict[str, Any] | None = None,
+        self,
+        database_model_dict: dict[str, Any] | None = None,
     ) -> None:
         """Hand-declared ColumnInfo with a narrower operator list is honored
         end-to-end. Reaches the schema builder as an operator override so

--- a/tests/dao_ai/test_lakebase_search_live.py
+++ b/tests/dao_ai/test_lakebase_search_live.py
@@ -67,18 +67,78 @@ EMBEDDING_DIM = 1024  # matches databricks-gte-large-en
 
 
 SEED_DOCS: list[dict[str, Any]] = [
-    {"id": "d01", "category": "auth",     "priority": 1, "passage": "To reset your password, go to Settings then Security and click 'Reset password'."},
-    {"id": "d02", "category": "auth",     "priority": 2, "passage": "Enable multi-factor authentication (MFA) from your account security page."},
-    {"id": "d03", "category": "billing",  "priority": 3, "passage": "Invoices are issued on the first of each month for the previous billing cycle."},
-    {"id": "d04", "category": "billing",  "priority": 1, "passage": "You can update your payment method under Billing then Payment methods."},
-    {"id": "d05", "category": "shipping", "priority": 2, "passage": "Standard shipping takes 3-5 business days within the continental US."},
-    {"id": "d06", "category": "shipping", "priority": 3, "passage": "International orders may incur customs duties calculated at checkout."},
-    {"id": "d07", "category": "returns",  "priority": 1, "passage": "Returns are accepted within 30 days of delivery with a valid receipt."},
-    {"id": "d08", "category": "returns",  "priority": 2, "passage": "Refunds are processed to the original payment method within 7 business days."},
-    {"id": "d09", "category": "auth",     "priority": 3, "passage": "If you forgot your username, contact support with the email on file."},
-    {"id": "d10", "category": "shipping", "priority": 1, "passage": "Track your package status from the Orders page in your account."},
-    {"id": "d11", "category": "billing",  "priority": 2, "passage": "Late payments incur a 2% monthly finance charge after 30 days overdue."},
-    {"id": "d12", "category": "auth",     "priority": 1, "passage": "Password reset links expire after 24 hours for security reasons."},
+    {
+        "id": "d01",
+        "category": "auth",
+        "priority": 1,
+        "passage": "To reset your password, go to Settings then Security and click 'Reset password'.",
+    },
+    {
+        "id": "d02",
+        "category": "auth",
+        "priority": 2,
+        "passage": "Enable multi-factor authentication (MFA) from your account security page.",
+    },
+    {
+        "id": "d03",
+        "category": "billing",
+        "priority": 3,
+        "passage": "Invoices are issued on the first of each month for the previous billing cycle.",
+    },
+    {
+        "id": "d04",
+        "category": "billing",
+        "priority": 1,
+        "passage": "You can update your payment method under Billing then Payment methods.",
+    },
+    {
+        "id": "d05",
+        "category": "shipping",
+        "priority": 2,
+        "passage": "Standard shipping takes 3-5 business days within the continental US.",
+    },
+    {
+        "id": "d06",
+        "category": "shipping",
+        "priority": 3,
+        "passage": "International orders may incur customs duties calculated at checkout.",
+    },
+    {
+        "id": "d07",
+        "category": "returns",
+        "priority": 1,
+        "passage": "Returns are accepted within 30 days of delivery with a valid receipt.",
+    },
+    {
+        "id": "d08",
+        "category": "returns",
+        "priority": 2,
+        "passage": "Refunds are processed to the original payment method within 7 business days.",
+    },
+    {
+        "id": "d09",
+        "category": "auth",
+        "priority": 3,
+        "passage": "If you forgot your username, contact support with the email on file.",
+    },
+    {
+        "id": "d10",
+        "category": "shipping",
+        "priority": 1,
+        "passage": "Track your package status from the Orders page in your account.",
+    },
+    {
+        "id": "d11",
+        "category": "billing",
+        "priority": 2,
+        "passage": "Late payments incur a 2% monthly finance charge after 30 days overdue.",
+    },
+    {
+        "id": "d12",
+        "category": "auth",
+        "priority": 1,
+        "passage": "Password reset links expire after 24 hours for security reasons.",
+    },
 ]
 
 
@@ -144,9 +204,9 @@ def seeded_table(database: DatabaseModel) -> None:
                 ).format(sql.Identifier(SCHEMA), sql.Identifier(TABLE))
             )
             cur.execute(
-                sql.SQL("SELECT COUNT(*) AS n FROM {}.{} WHERE priority IS NOT NULL").format(
-                    sql.Identifier(SCHEMA), sql.Identifier(TABLE)
-                )
+                sql.SQL(
+                    "SELECT COUNT(*) AS n FROM {}.{} WHERE priority IS NOT NULL"
+                ).format(sql.Identifier(SCHEMA), sql.Identifier(TABLE))
             )
             existing = int(cur.fetchone()["n"])
 
@@ -167,7 +227,13 @@ def seeded_table(database: DatabaseModel) -> None:
                             "passage = EXCLUDED.passage, "
                             "embedding = EXCLUDED.embedding"
                         ).format(sql.Identifier(SCHEMA), sql.Identifier(TABLE)),
-                        (doc["id"], doc["category"], doc["priority"], doc["passage"], vec),
+                        (
+                            doc["id"],
+                            doc["category"],
+                            doc["priority"],
+                            doc["passage"],
+                            vec,
+                        ),
                     )
 
     with pool.connection() as conn:
@@ -312,9 +378,7 @@ class TestFilters:
         assert docs
         assert all(d.metadata["category"] == "billing" for d in docs)
 
-    def test_in_via_list_value(
-        self, vector_store: LakebaseVectorStoreModel
-    ) -> None:
+    def test_in_via_list_value(self, vector_store: LakebaseVectorStoreModel) -> None:
         docs = _retriever(
             vector_store,
             "ANN",
@@ -348,9 +412,7 @@ class TestFilters:
         assert docs
         assert all(d.metadata["priority"] >= 2 for d in docs)
 
-    def test_comparison_less_than(
-        self, vector_store: LakebaseVectorStoreModel
-    ) -> None:
+    def test_comparison_less_than(self, vector_store: LakebaseVectorStoreModel) -> None:
         docs = _retriever(
             vector_store,
             "ANN",
@@ -586,9 +648,7 @@ class TestRerank:
         retriever = LakebaseRetrieverModel(
             vector_store=vector_store,
             rerank=True,  # default FlashRank model
-            search_parameters=SearchParametersModel(
-                query_type="ANN", num_results=10
-            ),
+            search_parameters=SearchParametersModel(query_type="ANN", num_results=10),
         )
         tool = create_lakebase_search_tool(retriever=retriever)
         raw = tool.invoke({"query": "how do I reset my password?"})
@@ -597,19 +657,13 @@ class TestRerank:
         for d in parsed:
             assert "reranker_score" in d["metadata"], d["metadata"]
 
-    def test_top_n_truncates(
-        self, vector_store: LakebaseVectorStoreModel
-    ) -> None:
+    def test_top_n_truncates(self, vector_store: LakebaseVectorStoreModel) -> None:
         from dao_ai.config import RerankParametersModel
 
         retriever = LakebaseRetrieverModel(
             vector_store=vector_store,
-            rerank=RerankParametersModel(
-                model="ms-marco-MiniLM-L-12-v2", top_n=3
-            ),
-            search_parameters=SearchParametersModel(
-                query_type="ANN", num_results=10
-            ),
+            rerank=RerankParametersModel(model="ms-marco-MiniLM-L-12-v2", top_n=3),
+            search_parameters=SearchParametersModel(query_type="ANN", num_results=10),
         )
         tool = create_lakebase_search_tool(retriever=retriever)
         raw = tool.invoke({"query": "password"})
@@ -622,9 +676,7 @@ class TestRerank:
         retriever = LakebaseRetrieverModel(
             vector_store=vector_store,
             rerank=True,
-            search_parameters=SearchParametersModel(
-                query_type="ANN", num_results=10
-            ),
+            search_parameters=SearchParametersModel(query_type="ANN", num_results=10),
         )
         tool = create_lakebase_search_tool(retriever=retriever)
         raw = tool.invoke({"query": "password reset"})
@@ -643,9 +695,7 @@ class TestRerank:
         retriever = LakebaseRetrieverModel(
             vector_store=vector_store,
             rerank=True,
-            search_parameters=SearchParametersModel(
-                query_type="ANN", num_results=10
-            ),
+            search_parameters=SearchParametersModel(query_type="ANN", num_results=10),
         )
         tool = create_lakebase_search_tool(retriever=retriever)
         raw = tool.invoke({"query": "how do I reset my password?"})
@@ -663,9 +713,7 @@ class TestRerank:
         retriever = LakebaseRetrieverModel(
             vector_store=vector_store,
             rerank=True,
-            search_parameters=SearchParametersModel(
-                query_type="BM25", num_results=5
-            ),
+            search_parameters=SearchParametersModel(query_type="BM25", num_results=5),
         )
         tool = create_lakebase_search_tool(retriever=retriever)
         raw = tool.invoke({"query": "password reset"})
@@ -680,9 +728,7 @@ class TestRerank:
         retriever = LakebaseRetrieverModel(
             vector_store=vector_store,
             rerank=True,
-            search_parameters=SearchParametersModel(
-                query_type="HYBRID", num_results=5
-            ),
+            search_parameters=SearchParametersModel(query_type="HYBRID", num_results=5),
         )
         tool = create_lakebase_search_tool(retriever=retriever)
         raw = tool.invoke({"query": "reset my forgotten password"})
@@ -700,9 +746,7 @@ class TestRerank:
         retriever = LakebaseRetrieverModel(
             vector_store=vector_store,
             rerank=True,
-            search_parameters=SearchParametersModel(
-                query_type="ANN", num_results=5
-            ),
+            search_parameters=SearchParametersModel(query_type="ANN", num_results=5),
         )
         tool = create_lakebase_search_tool(retriever=retriever)
         raw = tool.invoke({"query": "password"})

--- a/tests/dao_ai/test_lakebase_search_rerank.py
+++ b/tests/dao_ai/test_lakebase_search_rerank.py
@@ -29,7 +29,6 @@ from dao_ai.config import (
     SearchParametersModel,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -115,18 +114,14 @@ class TestRerankConfig:
         r = LakebaseRetrieverModel(vector_store=vector_store, rerank=False)
         assert r.rerank is False
 
-    def test_rerank_none_default(
-        self, vector_store: LakebaseVectorStoreModel
-    ) -> None:
+    def test_rerank_none_default(self, vector_store: LakebaseVectorStoreModel) -> None:
         r = LakebaseRetrieverModel(vector_store=vector_store)
         assert r.rerank is None
 
     def test_explicit_rerank_params_pass_through(
         self, vector_store: LakebaseVectorStoreModel
     ) -> None:
-        params = RerankParametersModel(
-            model="ms-marco-TinyBERT-L-2-v2", top_n=3
-        )
+        params = RerankParametersModel(model="ms-marco-TinyBERT-L-2-v2", top_n=3)
         r = LakebaseRetrieverModel(vector_store=vector_store, rerank=params)
         assert r.rerank is params
         assert r.rerank.model == "ms-marco-TinyBERT-L-2-v2"
@@ -361,9 +356,7 @@ class TestRerankEndToEnd:
         from dao_ai.retrievers.lakebase import LakebaseRetriever
         from dao_ai.tools import create_lakebase_search_tool
 
-        rows = [
-            {"id": "d1", "passage": "hello", "category": "a", "_distance": 0.1}
-        ]
+        rows = [{"id": "d1", "passage": "hello", "category": "a", "_distance": 0.1}]
         pool = _MockPool(rows)
 
         retriever = LakebaseRetrieverModel(vector_store=vector_store, rerank=True)

--- a/tests/dao_ai/test_link_trace_destination_cli.py
+++ b/tests/dao_ai/test_link_trace_destination_cli.py
@@ -141,9 +141,7 @@ class TestHandleCommand:
         ):
             ac.from_file.return_value = cfg
             handle_link_trace_destination_command(
-                Namespace(
-                    config="cfg.yaml", profile=None, experiment_id=None, var=None
-                )
+                Namespace(config="cfg.yaml", profile=None, experiment_id=None, var=None)
             )
         assert "nothing to link" in capsys.readouterr().err
 
@@ -156,9 +154,7 @@ class TestHandleCommand:
         with (
             patch("dao_ai.cli._apply_profile_context"),
             patch("dao_ai.cli.AppConfig") as ac,
-            patch(
-                "dao_ai.cli._resolve_experiment_id_for_link", return_value=None
-            ),
+            patch("dao_ai.cli._resolve_experiment_id_for_link", return_value=None),
         ):
             ac.from_file.return_value = cfg
             with pytest.raises(SystemExit) as exc:
@@ -181,9 +177,7 @@ class TestHandleCommand:
         with (
             patch("dao_ai.cli._apply_profile_context"),
             patch("dao_ai.cli.AppConfig") as ac,
-            patch(
-                "dao_ai.cli._resolve_experiment_id_for_link", return_value="exp42"
-            ),
+            patch("dao_ai.cli._resolve_experiment_id_for_link", return_value="exp42"),
             patch(
                 "dao_ai.providers.databricks._link_experiment_trace_location"
             ) as link,
@@ -214,9 +208,7 @@ class TestHandleCommand:
         with (
             patch("dao_ai.cli._apply_profile_context"),
             patch("dao_ai.cli.AppConfig") as ac,
-            patch(
-                "dao_ai.cli._resolve_experiment_id_for_link", return_value="exp42"
-            ),
+            patch("dao_ai.cli._resolve_experiment_id_for_link", return_value="exp42"),
             patch(
                 "dao_ai.providers.databricks._link_experiment_trace_location",
                 side_effect=RuntimeError("warehouse timeout"),

--- a/tests/dao_ai/test_mcp_capabilities_client.py
+++ b/tests/dao_ai/test_mcp_capabilities_client.py
@@ -93,13 +93,19 @@ class TestBuildMcpClient:
     def test_classic_path_when_capabilities_none(self) -> None:
         from dao_ai.tools import mcp as mcp_mod
 
-        with patch.object(mcp_mod, "MultiServerMCPClient") as mock_cls, patch.object(
-            mcp_mod, "_build_connection_config", return_value={"url": "x"}
+        with (
+            patch.object(mcp_mod, "MultiServerMCPClient") as mock_cls,
+            patch.object(
+                mcp_mod, "_build_connection_config", return_value={"url": "x"}
+            ),
         ):
             mcp_mod._build_mcp_client(self._make_fn(capabilities=None))
             _, kwargs = mock_cls.call_args
             assert "callbacks" not in kwargs or kwargs.get("callbacks") is None
-            assert "tool_interceptors" not in kwargs or kwargs.get("tool_interceptors") is None
+            assert (
+                "tool_interceptors" not in kwargs
+                or kwargs.get("tool_interceptors") is None
+            )
             assert kwargs["handle_tool_errors"] is False
 
     def test_capabilities_path_attaches_callbacks_and_interceptors(self) -> None:
@@ -111,8 +117,11 @@ class TestBuildMcpClient:
             structured_output=True,
         )
 
-        with patch.object(mcp_mod, "MultiServerMCPClient") as mock_cls, patch.object(
-            mcp_mod, "_build_connection_config", return_value={"url": "x"}
+        with (
+            patch.object(mcp_mod, "MultiServerMCPClient") as mock_cls,
+            patch.object(
+                mcp_mod, "_build_connection_config", return_value={"url": "x"}
+            ),
         ):
             mcp_mod._build_mcp_client(self._make_fn(capabilities=caps))
             args, kwargs = mock_cls.call_args
@@ -130,8 +139,11 @@ class TestBuildMcpClient:
         from dao_ai.tools import mcp as mcp_mod
 
         caps = McpCapabilitiesModel(progress=True, structured_output=False)
-        with patch.object(mcp_mod, "MultiServerMCPClient") as mock_cls, patch.object(
-            mcp_mod, "_build_connection_config", return_value={"url": "x"}
+        with (
+            patch.object(mcp_mod, "MultiServerMCPClient") as mock_cls,
+            patch.object(
+                mcp_mod, "_build_connection_config", return_value={"url": "x"}
+            ),
         ):
             mcp_mod._build_mcp_client(self._make_fn(capabilities=caps))
             _, kwargs = mock_cls.call_args
@@ -142,8 +154,11 @@ class TestBuildMcpClient:
         from dao_ai.tools import mcp as mcp_mod
 
         caps = McpCapabilitiesModel(structured_output=True)
-        with patch.object(mcp_mod, "MultiServerMCPClient") as mock_cls, patch.object(
-            mcp_mod, "_build_connection_config", return_value={"url": "x"}
+        with (
+            patch.object(mcp_mod, "MultiServerMCPClient") as mock_cls,
+            patch.object(
+                mcp_mod, "_build_connection_config", return_value={"url": "x"}
+            ),
         ):
             mcp_mod._build_mcp_client(self._make_fn(capabilities=caps))
             _, kwargs = mock_cls.call_args
@@ -190,8 +205,9 @@ class TestClientRoutingCallsites:
     def test_acreate_tool_wrapper_uses_build_mcp_client(self) -> None:
         """The wrapper produced by acreate_mcp_tools() must route through
         _build_mcp_client on invocation, threading context + capabilities."""
-        from dao_ai.tools import mcp as mcp_mod
         from mcp.types import Tool
+
+        from dao_ai.tools import mcp as mcp_mod
 
         # Skip discovery — return one fake Tool so a wrapper is built.
         fake_tool = Tool(
@@ -204,9 +220,7 @@ class TestClientRoutingCallsites:
         # kwargs so we don't need to track SDK signature changes.
         class _FakeSession:
             async def call_tool(self, name, args, **_kwargs):
-                return CallToolResult(
-                    content=[TextContent(type="text", text="ok")]
-                )
+                return CallToolResult(content=[TextContent(type="text", text="ok")])
 
         class _FakeCtx:
             async def __aenter__(self_inner):
@@ -222,12 +236,14 @@ class TestClientRoutingCallsites:
         fn = self._make_fn(capabilities=caps)
 
         async def _run() -> str:
-            with patch.object(
-                mcp_mod, "_afetch_tools_from_server", return_value=[fake_tool]
-            ), patch.object(
-                mcp_mod, "_build_mcp_client", return_value=fake_client
-            ) as mock_build, patch.object(
-                mcp_mod, "set_resource_attributes"
+            with (
+                patch.object(
+                    mcp_mod, "_afetch_tools_from_server", return_value=[fake_tool]
+                ),
+                patch.object(
+                    mcp_mod, "_build_mcp_client", return_value=fake_client
+                ) as mock_build,
+                patch.object(mcp_mod, "set_resource_attributes"),
             ):
                 tools = await mcp_mod.acreate_mcp_tools(fn)
                 assert len(tools) == 1
@@ -363,9 +379,7 @@ class TestResumeValueMapping:
 class TestStructuredOutputInterceptor:
     def test_resource_link_expanded_to_span_event(self) -> None:
         span = MagicMock()
-        request = MCPToolCallRequest(
-            name="tool_a", args={}, server_name="server_a"
-        )
+        request = MCPToolCallRequest(name="tool_a", args={}, server_name="server_a")
         result = CallToolResult(
             content=[
                 TextContent(type="text", text="hello"),

--- a/tests/dao_ai/test_mcp_stream_forwarding.py
+++ b/tests/dao_ai/test_mcp_stream_forwarding.py
@@ -195,9 +195,7 @@ def test_progress_callback_dispatches_via_callback_manager():
 
     fake_config = {"callbacks": [MagicMock()]}
     with (
-        patch(
-            "dao_ai.tools.mcp_callbacks.ensure_config", return_value=fake_config
-        ),
+        patch("dao_ai.tools.mcp_callbacks.ensure_config", return_value=fake_config),
         patch(
             "dao_ai.tools.mcp_callbacks.adispatch_custom_event",
             new_callable=AsyncMock,

--- a/tests/dao_ai/test_mcp_trace_context.py
+++ b/tests/dao_ai/test_mcp_trace_context.py
@@ -56,9 +56,7 @@ class TestBuildTraceContextMeta:
     def test_traceparent_from_uc_uri_trace_id(self) -> None:
         # UC-backed trace ids arrive as a trace:/cat.schema.prefix/<hex> URI;
         # the OTel-native hex is the final hex run.
-        span = _span(
-            f"trace:/cat.schema.my_prefix/{_TRACE_HEX}", _SPAN_HEX
-        )
+        span = _span(f"trace:/cat.schema.my_prefix/{_TRACE_HEX}", _SPAN_HEX)
         with patch(
             "dao_ai.tools.mcp_trace_context.mlflow.get_current_active_span",
             return_value=span,

--- a/tests/dao_ai/test_memory_extraction_reflector.py
+++ b/tests/dao_ai/test_memory_extraction_reflector.py
@@ -131,4 +131,6 @@ def test_filter_matches_partial_span_for_run_id_variants(_fresh_loggers: None) -
         "Span for run_id 019f... not found (retrying).",
     ]:
         record = _emit("mlflow.utils.autologging_utils", msg)
-        assert _passes_all_filters("mlflow.utils.autologging_utils", record) is False, msg
+        assert _passes_all_filters("mlflow.utils.autologging_utils", record) is False, (
+            msg
+        )

--- a/tests/dao_ai/test_model_call_limit_field.py
+++ b/tests/dao_ai/test_model_call_limit_field.py
@@ -135,7 +135,9 @@ class TestAgentCallLimitWiring:
         assert limit_mws[0].run_limit == 6
 
     @patch("dao_ai.nodes.create_agent")
-    def test_agent_node_no_model_call_limit_when_not_configured(self, mock_create_agent):
+    def test_agent_node_no_model_call_limit_when_not_configured(
+        self, mock_create_agent
+    ):
         from dao_ai.nodes import create_agent_node
 
         mock_compiled_agent = MagicMock()

--- a/tests/dao_ai/test_parallel_fan_out_integration.py
+++ b/tests/dao_ai/test_parallel_fan_out_integration.py
@@ -36,7 +36,6 @@ from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMe
 from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.state import CompiledStateGraph
-from langgraph.types import Command
 
 from dao_ai.config import AgentModel, AppConfig, LLMModel
 from dao_ai.state import AgentState, Context

--- a/tests/dao_ai/test_parallel_handoffs.py
+++ b/tests/dao_ai/test_parallel_handoffs.py
@@ -41,7 +41,6 @@ from dao_ai.config import (
     SwarmModel,
 )
 
-
 # =============================================================================
 # HandoffRouteModel per-entry shape
 # =============================================================================
@@ -168,9 +167,7 @@ class TestSwarmParallelCohortValidators:
             SwarmModel(
                 handoffs={
                     "source": [
-                        HandoffRouteModel(
-                            agents=["source", "worker_b"], join="synth"
-                        ),
+                        HandoffRouteModel(agents=["source", "worker_b"], join="synth"),
                     ]
                 }
             )
@@ -188,20 +185,14 @@ class TestSwarmParallelCohortValidators:
             )
 
     def test_sibling_in_two_cohorts_with_different_joins_rejected(self) -> None:
-        with pytest.raises(
-            ValueError, match="different join targets"
-        ):
+        with pytest.raises(ValueError, match="different join targets"):
             SwarmModel(
                 handoffs={
                     "source_1": [
-                        HandoffRouteModel(
-                            agents=["shared", "worker_a"], join="join_1"
-                        ),
+                        HandoffRouteModel(agents=["shared", "worker_a"], join="join_1"),
                     ],
                     "source_2": [
-                        HandoffRouteModel(
-                            agents=["shared", "worker_b"], join="join_2"
-                        ),
+                        HandoffRouteModel(agents=["shared", "worker_b"], join="join_2"),
                     ],
                 }
             )
@@ -268,7 +259,9 @@ class TestSwarmCohortCycleDetection:
             SwarmModel(
                 handoffs={
                     "source": [
-                        HandoffRouteModel(agents=["worker_a", "worker_b"], join="synth"),
+                        HandoffRouteModel(
+                            agents=["worker_a", "worker_b"], join="synth"
+                        ),
                     ],
                     "synth": ["source"],
                 }
@@ -366,7 +359,11 @@ class TestHandoffsForAgentCohort:
         result = _handoffs_for_agent(agents[0], config)
         tool_names = sorted(t.name for t in result.tools)
         # Two cohort tools (worker_a, synth) + one peer tool (escalation).
-        assert tool_names == ["handoff_to_escalation", "handoff_to_synth", "handoff_to_worker_a"]
+        assert tool_names == [
+            "handoff_to_escalation",
+            "handoff_to_synth",
+            "handoff_to_worker_a",
+        ]
         assert set(result.parallel_targets) == {"worker_a", "synth"}
         assert result.parallel_join == "escalation"
 

--- a/tests/dao_ai/test_pipeline_bundle.py
+++ b/tests/dao_ai/test_pipeline_bundle.py
@@ -97,9 +97,7 @@ class _AppStub:
     ``config.app.pip_requirements``, and (in dev mode, via the extras resolver)
     ``config.app.a2a`` / ``config.app.orchestration``."""
 
-    def __init__(
-        self, name: str, pip_requirements: list[str] | None = None
-    ) -> None:
+    def __init__(self, name: str, pip_requirements: list[str] | None = None) -> None:
         self.name = name
         self.pip_requirements = pip_requirements or []
         # Resolver-touched attributes (dev-mode extras resolution).
@@ -166,7 +164,9 @@ class TestGeneratePipelineDatabricksYaml:
         doc = self._doc(development=False)
         # The dao_ai_dep variable exists and defaults to the version-pinned
         # PyPI spec so a raw ``bundle deploy`` (no CLI override) is reproducible.
-        assert doc["variables"]["dao_ai_dep"]["default"] == f"dao-ai=={dao_ai_version()}"
+        assert (
+            doc["variables"]["dao_ai_dep"]["default"] == f"dao-ai=={dao_ai_version()}"
+        )
         # The serverless environment installs exactly the dao_ai_dep dependency.
         env = doc["resources"]["jobs"]["deploy_job"]["environments"][0]
         assert env["spec"]["dependencies"] == ["${var.dao_ai_dep}"]
@@ -184,7 +184,9 @@ class TestGeneratePipelineDatabricksYaml:
         # bracket) on a local path.
         for dep in deps:
             if dep.endswith(".whl") or "dist/" in dep or dep == "${var.dao_ai_dep}":
-                assert "[" not in dep, f"wheel dep must be glob-safe (no extras): {dep!r}"
+                assert "[" not in dep, (
+                    f"wheel dep must be glob-safe (no extras): {dep!r}"
+                )
         # In development, the extra-feature package pins are present (glob-safe
         # PyPI specs like "a2a-sdk==..."). The stub config exercises no optional
         # features, so at minimum the core pins (e.g. mlflow) appear.
@@ -236,9 +238,7 @@ class TestReferencedAssetPaths:
     def test_volume_backed_ddl_ignored(self) -> None:
         """Volume references live on UC volumes and need no staging."""
         config = self._config(
-            datasets=[
-                DatasetModel(ddl=VolumeModel(name="c.s.v"), data=None)
-            ],
+            datasets=[DatasetModel(ddl=VolumeModel(name="c.s.v"), data=None)],
         )
         assert _referenced_asset_paths(config) == []
 
@@ -326,18 +326,14 @@ class TestWritePipelineBundle:
         "    ddl: {fn}\n"
     )
 
-    def test_stages_config_relative_assets_next_to_config(
-        self, tmp_path: Path
-    ) -> None:
+    def test_stages_config_relative_assets_next_to_config(self, tmp_path: Path) -> None:
         # Assets colocated with the config (config-relative bare paths).
         (tmp_path / "data").mkdir()
         (tmp_path / "functions").mkdir()
         (tmp_path / "data" / "seed.sql").write_text("SELECT 1;")
         (tmp_path / "functions" / "fn.sql").write_text("CREATE FUNCTION f();")
 
-        body = self._ASSET_CONFIG.format(
-            ddl="data/seed.sql", fn="functions/fn.sql"
-        )
+        body = self._ASSET_CONFIG.format(ddl="data/seed.sql", fn="functions/fn.sql")
         config = self._load(tmp_path, body)
         out = tmp_path / "bundle"
         write_pipeline_bundle(config, out)
@@ -457,14 +453,11 @@ class TestWritePipelineBundle:
         write_pipeline_bundle(config, out, overwrite=True)
         assert staged_config.read_text() != "SENTINEL"
 
-
     def test_two_configs_isolated_dirs_no_collision(self, tmp_path: Path) -> None:
         """Two different configs staged into their own dirs each get a
         databricks.yaml whose bundle name matches that config — no bleed-over."""
         cfg_a = _MINIMAL_CONFIG  # app.name: pipeline_test_app
-        cfg_b = _MINIMAL_CONFIG.replace(
-            "name: pipeline_test_app", "name: other_app"
-        )
+        cfg_b = _MINIMAL_CONFIG.replace("name: pipeline_test_app", "name: other_app")
         a = AppConfig.from_file(
             self._write(tmp_path, "a.yaml", cfg_a), initialize=False
         )

--- a/tests/dao_ai/test_reranking.py
+++ b/tests/dao_ai/test_reranking.py
@@ -6,8 +6,8 @@ import pytest
 from conftest import add_databricks_resource_attrs
 
 from dao_ai.config import (
-    RerankParametersModel,
     AiSearchRetrieverModel,
+    RerankParametersModel,
     SchemaModel,
     TableModel,
     VectorStoreModel,
@@ -93,7 +93,9 @@ class TestRetrieverModelWithReranker:
         vector_store = create_mock_vector_store()
 
         rerank_config = RerankParametersModel(model="ms-marco-MiniLM-L-6-v2", top_n=3)
-        retriever = AiSearchRetrieverModel(vector_store=vector_store, rerank=rerank_config)
+        retriever = AiSearchRetrieverModel(
+            vector_store=vector_store, rerank=rerank_config
+        )
 
         assert isinstance(retriever.rerank, RerankParametersModel)
         assert retriever.rerank.model == "ms-marco-MiniLM-L-6-v2"

--- a/tests/dao_ai/test_reranking_integration.py
+++ b/tests/dao_ai/test_reranking_integration.py
@@ -18,9 +18,9 @@ from databricks.sdk import WorkspaceClient
 from langchain_core.messages import ToolMessage
 
 from dao_ai.config import (
+    AiSearchRetrieverModel,
     IndexModel,
     RerankParametersModel,
-    AiSearchRetrieverModel,
     SchemaModel,
     SearchParametersModel,
     TableModel,

--- a/tests/dao_ai/test_retriever_model_hierarchy.py
+++ b/tests/dao_ai/test_retriever_model_hierarchy.py
@@ -29,7 +29,6 @@ from dao_ai.config import (
     SchemaModel,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -112,7 +111,9 @@ class TestDiscriminator:
     def test_unknown_type_rejected(self) -> None:
         adapter = self._adapter()
         with pytest.raises(ValidationError):
-            adapter.validate_python({"type": "not_a_real_retriever", **_ai_search_dict()})
+            adapter.validate_python(
+                {"type": "not_a_real_retriever", **_ai_search_dict()}
+            )
 
     def test_lakebase_shape_without_type_field_dispatches_wrong(self) -> None:
         """If someone writes lakebase shape but forgets `type: lakebase_search`,

--- a/tests/dao_ai/test_trace_location_linkage.py
+++ b/tests/dao_ai/test_trace_location_linkage.py
@@ -40,9 +40,7 @@ class TestLinkExperimentTraceLocation:
         cfg.app = MagicMock()
         cfg.app.trace_location = None
 
-        with patch(
-            "dao_ai.providers.databricks.mlflow.set_experiment"
-        ) as set_exp:
+        with patch("dao_ai.providers.databricks.mlflow.set_experiment") as set_exp:
             link_experiment_trace_location(cfg, "exp1")
         set_exp.assert_not_called()
 
@@ -183,8 +181,9 @@ class TestLinkExperimentTraceLocation:
     def test_already_contains_traces_swallowed_as_fallback(self) -> None:
         """If the tag-check misses but MLflow says 'already contains traces',
         treat as idempotent — the linkage must already be in place."""
-        from dao_ai.providers.databricks import link_experiment_trace_location
         import mlflow
+
+        from dao_ai.providers.databricks import link_experiment_trace_location
 
         cfg = _cfg("cat", "sch")
         exp = _FakeExperiment(tags={})  # tag lookup says "not linked"

--- a/tests/dao_ai/test_vector_search.py
+++ b/tests/dao_ai/test_vector_search.py
@@ -205,7 +205,9 @@ def test_vector_search_input_accepts_null_filters() -> None:
     """LLM may omit filters or pass null when no constraint applies."""
     assert VectorSearchInput.model_validate({"query": "no filters"}).filters is None
     assert (
-        VectorSearchInput.model_validate({"query": "explicit null", "filters": None}).filters
+        VectorSearchInput.model_validate(
+            {"query": "explicit null", "filters": None}
+        ).filters
         is None
     )
 
@@ -354,7 +356,9 @@ def _make_obo_vector_store_mock() -> Mock:
 
 
 @pytest.mark.unit
-def test_create_vector_search_tool_obo_passes_context_to_workspace_client_from() -> None:
+def test_create_vector_search_tool_obo_passes_context_to_workspace_client_from() -> (
+    None
+):
     """When on_behalf_of_user=True and the tool is invoked with a ToolRuntime
     carrying user headers, the factory must call
     vector_store.workspace_client_from(context) with THAT same Context — so
@@ -479,9 +483,14 @@ def _make_ambient_vector_store_mock(*, on_behalf_of_user: bool = False) -> Mock:
     return vs
 
 
-def _fake_wc(*, auth_type: str, host: str = "https://fevm.example.com",
-             client_id: Any = None, client_secret: Any = None,
-             bearer: str | None = None) -> MagicMock:
+def _fake_wc(
+    *,
+    auth_type: str,
+    host: str = "https://fevm.example.com",
+    client_id: Any = None,
+    client_secret: Any = None,
+    bearer: str | None = None,
+) -> MagicMock:
     """Build a WorkspaceClient mock whose .config exposes the auth_type shape
     the databricks-langchain library and _client_args_from_ambient_wc read."""
     wc = MagicMock(name=f"wc[{auth_type}]")
@@ -517,9 +526,11 @@ def _capture_client_args_and_invoke(
     retriever = AiSearchRetrieverModel(vector_store=vs_model)
 
     captured: dict[str, Any] = {}
-    with patch("dao_ai.tools.vector_search.DatabricksVectorSearch") as MockDVS, \
-        patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None), \
-        patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None):
+    with (
+        patch("dao_ai.tools.vector_search.DatabricksVectorSearch") as MockDVS,
+        patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+        patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None),
+    ):
         # Build-time refresh is stubbed out; these tests exercise the
         # query-time auth-mode behavior, not schema hydration.
         vs_model.refresh = MagicMock(return_value=None)
@@ -529,6 +540,7 @@ def _capture_client_args_and_invoke(
             m = MagicMock()
             m.similarity_search.return_value = []
             return m
+
         MockDVS.side_effect = _capture
 
         tool = create_vector_search_tool(retriever=retriever)
@@ -546,7 +558,12 @@ def test_vs_mode1_ambient_app_sp_oauth_m2m(monkeypatch: pytest.MonkeyPatch) -> N
     empty/falsy) — the library reads config.client_id / .client_secret from
     the WorkspaceClient we hand it.
     """
-    for var in ("DATABRICKS_TOKEN", "DATABRICKS_CLIENT_ID", "DATABRICKS_CLIENT_SECRET", "DATABRICKS_HOST"):
+    for var in (
+        "DATABRICKS_TOKEN",
+        "DATABRICKS_CLIENT_ID",
+        "DATABRICKS_CLIENT_SECRET",
+        "DATABRICKS_HOST",
+    ):
         monkeypatch.delenv(var, raising=False)
 
     vs_model = _make_ambient_vector_store_mock()
@@ -573,7 +590,12 @@ def test_vs_mode2_ambient_serverless_user(monkeypatch: pytest.MonkeyPatch) -> No
     default}. The databricks-langchain library does NOT extract creds from
     these, so dao-ai must fill client_args from the runtime bearer.
     """
-    for var in ("DATABRICKS_TOKEN", "DATABRICKS_CLIENT_ID", "DATABRICKS_CLIENT_SECRET", "DATABRICKS_HOST"):
+    for var in (
+        "DATABRICKS_TOKEN",
+        "DATABRICKS_CLIENT_ID",
+        "DATABRICKS_CLIENT_SECRET",
+        "DATABRICKS_HOST",
+    ):
         monkeypatch.delenv(var, raising=False)
 
     vs_model = _make_ambient_vector_store_mock()
@@ -598,7 +620,12 @@ def test_vs_mode2_other_ambient_auth_types(monkeypatch: pytest.MonkeyPatch) -> N
     """Mode #2 variants: oauth-u2m and 'default' behave the same as
     databricks-cli — dao-ai must synthesize client_args from the bearer.
     """
-    for var in ("DATABRICKS_TOKEN", "DATABRICKS_CLIENT_ID", "DATABRICKS_CLIENT_SECRET", "DATABRICKS_HOST"):
+    for var in (
+        "DATABRICKS_TOKEN",
+        "DATABRICKS_CLIENT_ID",
+        "DATABRICKS_CLIENT_SECRET",
+        "DATABRICKS_HOST",
+    ):
         monkeypatch.delenv(var, raising=False)
 
     for auth_type in ("oauth-u2m", "default"):
@@ -620,7 +647,12 @@ def test_vs_mode3_obo_passes_none_client_args(monkeypatch: pytest.MonkeyPatch) -
     client_args=None so the library uses the forwarded-bearer WorkspaceClient
     directly instead of building a separate VectorSearchClient.
     """
-    for var in ("DATABRICKS_TOKEN", "DATABRICKS_CLIENT_ID", "DATABRICKS_CLIENT_SECRET", "DATABRICKS_HOST"):
+    for var in (
+        "DATABRICKS_TOKEN",
+        "DATABRICKS_CLIENT_ID",
+        "DATABRICKS_CLIENT_SECRET",
+        "DATABRICKS_HOST",
+    ):
         monkeypatch.delenv(var, raising=False)
 
     vs_model = _make_ambient_vector_store_mock(on_behalf_of_user=True)
@@ -666,8 +698,12 @@ def test_vs_mode4_explicit_sp_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
 
     vs_model = _make_ambient_vector_store_mock()
-    wc = _fake_wc(auth_type="oauth-m2m", client_id="wc-id", client_secret="wc-secret",
-                  bearer="ambient-should-be-ignored")
+    wc = _fake_wc(
+        auth_type="oauth-m2m",
+        client_id="wc-id",
+        client_secret="wc-secret",
+        bearer="ambient-should-be-ignored",
+    )
     kwargs = _capture_client_args_and_invoke(vs_model, wc)
 
     ca = kwargs.get("client_args") or {}
@@ -680,6 +716,7 @@ def test_vs_mode4_explicit_sp_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 # Direct unit tests of the helper — cheap and precise.
+
 
 @pytest.mark.unit
 def test_client_args_from_ambient_wc_returns_none_for_library_native() -> None:
@@ -744,7 +781,12 @@ def test_vs_mode3b_model_serving_obo(monkeypatch: pytest.MonkeyPatch) -> None:
     """OBO on Model Serving path: WC auth_type is model_serving_user_credentials,
     dao-ai must pass client_args=None so the library's native branch fires.
     """
-    for var in ("DATABRICKS_TOKEN", "DATABRICKS_CLIENT_ID", "DATABRICKS_CLIENT_SECRET", "DATABRICKS_HOST"):
+    for var in (
+        "DATABRICKS_TOKEN",
+        "DATABRICKS_CLIENT_ID",
+        "DATABRICKS_CLIENT_SECRET",
+        "DATABRICKS_HOST",
+    ):
         monkeypatch.delenv(var, raising=False)
 
     vs_model = _make_ambient_vector_store_mock(on_behalf_of_user=True)
@@ -788,8 +830,15 @@ def test_client_args_from_ambient_wc_returns_none_for_basic_auth() -> None:
 
 
 @pytest.mark.unit
-def test_vs_default_auth_type_falls_back_to_bearer(monkeypatch: pytest.MonkeyPatch) -> None:
-    for var in ("DATABRICKS_TOKEN", "DATABRICKS_CLIENT_ID", "DATABRICKS_CLIENT_SECRET", "DATABRICKS_HOST"):
+def test_vs_default_auth_type_falls_back_to_bearer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in (
+        "DATABRICKS_TOKEN",
+        "DATABRICKS_CLIENT_ID",
+        "DATABRICKS_CLIENT_SECRET",
+        "DATABRICKS_HOST",
+    ):
         monkeypatch.delenv(var, raising=False)
 
     vs_model = _make_ambient_vector_store_mock()

--- a/tests/dao_ai/test_vector_search_dynamic_schema.py
+++ b/tests/dao_ai/test_vector_search_dynamic_schema.py
@@ -29,10 +29,10 @@ import pytest
 from pydantic import ValidationError
 
 from dao_ai.config import (
+    AiSearchRetrieverModel,
     ColumnInfo,
     FilterItem,
     IndexModel,
-    AiSearchRetrieverModel,
     SchemaModel,
     VectorSearchEndpoint,
     VectorStoreModel,
@@ -49,7 +49,6 @@ from dao_ai.tools.vector_search import (
     _vector_column_names_from_describe,
     create_vector_search_tool,
 )
-
 
 PRODUCTS_COLUMNS = [
     "product_id",
@@ -231,25 +230,23 @@ class TestFactoryColumnHydration:
         payload = _describe_payload()
 
         original_refresh = VectorStoreModel.refresh
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
-        ), patch.object(
-            VectorStoreModel,
-            "refresh",
-            autospec=True,
-            side_effect=lambda self, **kw: original_refresh(self, details=payload),
-        ) as mocked_refresh:
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None),
+            patch.object(
+                VectorStoreModel,
+                "refresh",
+                autospec=True,
+                side_effect=lambda self, **kw: original_refresh(self, details=payload),
+            ) as mocked_refresh,
+        ):
             retriever = AiSearchRetrieverModel(vector_store=vs)
             tool = create_vector_search_tool(retriever=retriever, name="product_search")
 
         mocked_refresh.assert_called_once()
-        enum = (
-            tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
-                "properties"
-            ]["key"]["enum"]
-        )
+        enum = tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+            "properties"
+        ]["key"]["enum"]
         # Every discovered column is in the enum (permissive operators —
         # types are not fetched from the source table anymore).
         assert "product_name" in enum
@@ -270,24 +267,22 @@ class TestFactoryColumnHydration:
         )
         payload = _describe_payload()
         original_refresh = VectorStoreModel.refresh
-        with patch.object(
-            VectorStoreModel,
-            "refresh",
-            autospec=True,
-            side_effect=lambda self, **kw: original_refresh(self, details=payload),
-        ) as mocked_refresh, patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
+        with (
+            patch.object(
+                VectorStoreModel,
+                "refresh",
+                autospec=True,
+                side_effect=lambda self, **kw: original_refresh(self, details=payload),
+            ) as mocked_refresh,
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None),
         ):
             tool = create_vector_search_tool(retriever=retriever, name="product_search")
 
         mocked_refresh.assert_called_once()
-        enum = (
-            tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
-                "properties"
-            ]["key"]["enum"]
-        )
+        enum = tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+            "properties"
+        ]["key"]["enum"]
         assert "product_id" in enum and "price" in enum
         # Everything outside the declared subset is absent:
         assert "sku" not in enum and "category" not in enum
@@ -303,20 +298,16 @@ class TestFactoryColumnHydration:
             vector_store=vs,
             columns=["product_id", "product_name", "nonexistent_col_xyz"],
         )
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
-        ), patch.object(VectorStoreModel, "refresh", autospec=True):
-            tool = create_vector_search_tool(
-                retriever=retriever, name="product_search"
-            )
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None),
+            patch.object(VectorStoreModel, "refresh", autospec=True),
+        ):
+            tool = create_vector_search_tool(retriever=retriever, name="product_search")
 
-        enum = (
-            tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
-                "properties"
-            ]["key"]["enum"]
-        )
+        enum = tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+            "properties"
+        ]["key"]["enum"]
         assert "product_id" in enum
         assert "product_name" in enum
         # All three declared cols get every operator suffix — no drift
@@ -345,13 +336,15 @@ class TestFactoryColumnHydration:
         fake_index_table.columns = [col]
         wc_spy.tables.get.return_value = fake_index_table
 
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch.object(VectorStoreModel, "refresh", autospec=True), patch.object(
-            VectorStoreModel,
-            "workspace_client_from",
-            autospec=True,
-            return_value=wc_spy,
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch.object(VectorStoreModel, "refresh", autospec=True),
+            patch.object(
+                VectorStoreModel,
+                "workspace_client_from",
+                autospec=True,
+                return_value=wc_spy,
+            ),
         ):
             create_vector_search_tool(retriever=retriever, name="product_search")
 
@@ -371,15 +364,15 @@ class TestFactoryColumnHydration:
         pre-change free-form ``FilterItem`` schema."""
         vs = self._make_vs(with_columns=False)
         retriever = AiSearchRetrieverModel(vector_store=vs)
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch.object(
-            VectorStoreModel,
-            "refresh",
-            autospec=True,
-            side_effect=RuntimeError("describe unauthorized"),
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch.object(
+                VectorStoreModel,
+                "refresh",
+                autospec=True,
+                side_effect=RuntimeError("describe unauthorized"),
+            ),
+            patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None),
         ):
             tool = create_vector_search_tool(retriever=retriever, name="product_search")
 
@@ -397,23 +390,21 @@ class TestFactoryColumnHydration:
         retriever = AiSearchRetrieverModel(
             vector_store=vs, columns=["product_id", "product_name"]
         )
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch.object(
-            VectorStoreModel,
-            "refresh",
-            autospec=True,
-            side_effect=RuntimeError("describe unauthorized"),
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch.object(
+                VectorStoreModel,
+                "refresh",
+                autospec=True,
+                side_effect=RuntimeError("describe unauthorized"),
+            ),
+            patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None),
         ):
             tool = create_vector_search_tool(retriever=retriever, name="product_search")
 
-        enum = (
-            tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
-                "properties"
-            ]["key"]["enum"]
-        )
+        enum = tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+            "properties"
+        ]["key"]["enum"]
         assert "product_id" in enum and "product_name" in enum
 
 
@@ -452,7 +443,9 @@ class TestVectorColumnStripping:
     def test_none_or_missing_details_returns_empty(self) -> None:
         assert _vector_column_names_from_describe(None) == set()
         assert _vector_column_names_from_describe({}) == set()
-        assert _vector_column_names_from_describe({"delta_sync_index_spec": {}}) == set()
+        assert (
+            _vector_column_names_from_describe({"delta_sync_index_spec": {}}) == set()
+        )
 
     def test_direct_access_managed_embedding_vector_names(self) -> None:
         """Direct-Access indexes carry the source list under
@@ -636,9 +629,7 @@ class TestFilterValueShapes:
     """
 
     def _model(self):
-        return _build_vector_search_input_model(
-            ["sku", "price", "is_b2b_only"]
-        )
+        return _build_vector_search_input_model(["sku", "price", "is_b2b_only"])
 
     def test_string_scalar(self) -> None:
         m = self._model()(query="x", filters=[{"key": "sku", "value": "FRZ-001"}])
@@ -658,9 +649,7 @@ class TestFilterValueShapes:
 
     def test_array_in_style(self) -> None:
         # ``value: [a, b, c]`` is the IN-style filter — matches any of.
-        m = self._model()(
-            query="x", filters=[{"key": "sku", "value": ["A", "B", "C"]}]
-        )
+        m = self._model()(query="x", filters=[{"key": "sku", "value": ["A", "B", "C"]}])
         assert m.filters[0].value == ["A", "B", "C"]
 
     def test_null_value_rejected(self) -> None:
@@ -713,7 +702,9 @@ class TestScaleAndSpecialColumnNames:
         # ``Literal[*keys]`` collapses duplicates. The enum should not
         # ship the same key twice.
         M = _build_vector_search_input_model(["a", "a", "b"])
-        enum = M.model_json_schema()["$defs"]["DynamicFilterItem"]["properties"]["key"]["enum"]
+        enum = M.model_json_schema()["$defs"]["DynamicFilterItem"]["properties"]["key"][
+            "enum"
+        ]
         assert enum.count("a") == 1
         assert enum.count("b") == 1
 
@@ -727,10 +718,18 @@ class TestScaleAndSpecialColumnNames:
     def test_single_column_index(self) -> None:
         # Trivial happy path with just one column — all 8 suffixes.
         M = _build_vector_search_input_model(["only"])
-        enum = M.model_json_schema()["$defs"]["DynamicFilterItem"]["properties"]["key"]["enum"]
+        enum = M.model_json_schema()["$defs"]["DynamicFilterItem"]["properties"]["key"][
+            "enum"
+        ]
         assert set(enum) == {
-            "only", "only NOT", "only <", "only <=",
-            "only >", "only >=", "only LIKE", "only NOT LIKE",
+            "only",
+            "only NOT",
+            "only <",
+            "only <=",
+            "only >",
+            "only >=",
+            "only LIKE",
+            "only NOT LIKE",
         }
 
 
@@ -749,19 +748,13 @@ class TestFactoryEntryShapes:
         payload = self._describe()
         original_refresh = VectorStoreModel.refresh
         return (
-            patch(
-                "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-            ),
-            patch(
-                "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
-            ),
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None),
             patch.object(
                 VectorStoreModel,
                 "refresh",
                 autospec=True,
-                side_effect=lambda self, **kw: original_refresh(
-                    self, details=payload
-                ),
+                side_effect=lambda self, **kw: original_refresh(self, details=payload),
             ),
         )
 
@@ -781,9 +774,9 @@ class TestFactoryEntryShapes:
         vs = self._bare_vs()
         with self._patches()[0], self._patches()[1], self._patches()[2]:
             tool = create_vector_search_tool(vector_store=vs, name="via_vs")
-        enum = tool.args_schema.model_json_schema()["$defs"][
-            "DynamicFilterItem"
-        ]["properties"]["key"]["enum"]
+        enum = tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+            "properties"
+        ]["key"]["enum"]
         assert "product_name" in enum
 
     def test_missing_index_raises_at_model_level(self) -> None:
@@ -791,9 +784,7 @@ class TestFactoryEntryShapes:
         # a store without either ``index`` or ``source_table``. Guarantees
         # we can't accidentally build a tool without an index.
         with pytest.raises(ValidationError, match="index"):
-            VectorStoreModel(
-                endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint")
-            )
+            VectorStoreModel(endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"))
 
     def test_neither_retriever_nor_vector_store_raises(self) -> None:
         with pytest.raises(ValueError):
@@ -832,22 +823,20 @@ class TestBackwardCompatibility:
         retriever = AiSearchRetrieverModel(vector_store=vs, columns=PRODUCTS_COLUMNS)
         payload = _describe_payload()
         original_refresh = VectorStoreModel.refresh
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
-        ), patch.object(
-            VectorStoreModel,
-            "refresh",
-            autospec=True,
-            side_effect=lambda self, **kw: original_refresh(self, details=payload),
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None),
+            patch.object(
+                VectorStoreModel,
+                "refresh",
+                autospec=True,
+                side_effect=lambda self, **kw: original_refresh(self, details=payload),
+            ),
         ):
-            tool = create_vector_search_tool(
-                retriever=retriever, name="product_search"
-            )
-        enum = tool.args_schema.model_json_schema()["$defs"][
-            "DynamicFilterItem"
-        ]["properties"]["key"]["enum"]
+            tool = create_vector_search_tool(retriever=retriever, name="product_search")
+        enum = tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+            "properties"
+        ]["key"]["enum"]
         # Regression key not present:
         assert "name NOT LIKE" not in enum
         # Every declared column is present:
@@ -861,15 +850,15 @@ class TestBackwardCompatibility:
         narrows to the declared columns, blocking hallucinated keys."""
         vs = self._bare_vs_no_source()
         retriever = AiSearchRetrieverModel(vector_store=vs, columns=["a", "b"])
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
-        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None),
+            patch.object(VectorStoreModel, "refresh", autospec=True),
+        ):
             tool = create_vector_search_tool(retriever=retriever, name="t")
-        enum = tool.args_schema.model_json_schema()["$defs"][
-            "DynamicFilterItem"
-        ]["properties"]["key"]["enum"]
+        enum = tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+            "properties"
+        ]["key"]["enum"]
         # Every column always gets all 8 operator suffixes.
         assert len(enum) == 16
         assert "a LIKE" in enum and "a >=" in enum and "b NOT" in enum
@@ -913,15 +902,19 @@ class TestMcpAdapterEntryPoint:
         original_refresh = VectorStoreModel.refresh
 
         def _build(args: dict) -> Any:
-            with patch(
-                "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-            ), patch(
-                "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
-            ), patch.object(
-                VectorStoreModel,
-                "refresh",
-                autospec=True,
-                side_effect=lambda self, **kw: original_refresh(self, details=payload),
+            with (
+                patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+                patch(
+                    "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
+                ),
+                patch.object(
+                    VectorStoreModel,
+                    "refresh",
+                    autospec=True,
+                    side_effect=lambda self, **kw: original_refresh(
+                        self, details=payload
+                    ),
+                ),
             ):
                 return create_vector_search_tool(**args)
 
@@ -949,9 +942,7 @@ class TestIndexScopedTypeLookup:
     authoritative source as the columns, never the source table.
     """
 
-    def _wc_with_index_table(
-        self, cols_and_types: list[tuple[str, str]]
-    ) -> MagicMock:
+    def _wc_with_index_table(self, cols_and_types: list[tuple[str, str]]) -> MagicMock:
         wc = MagicMock()
         table = MagicMock()
         fake_cols: list[MagicMock] = []
@@ -980,32 +971,30 @@ class TestIndexScopedTypeLookup:
             endpoint=VectorSearchEndpoint(name="dbdemos_vs_endpoint"),
         )
         retriever = AiSearchRetrieverModel(vector_store=vs)
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns",
-            return_value=[
-                ("product_id", "bigint", None),
-                ("product_name", "string", "Full product name"),
-                ("price", "double", None),
-                ("is_b2b_only", "boolean", None),
-            ],
-        ), patch.object(VectorStoreModel, "refresh", autospec=True):
-            tool = create_vector_search_tool(
-                retriever=retriever, name="product_search"
-            )
-        enum = (
-            tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
-                "properties"
-            ]["key"]["enum"]
-        )
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch(
+                "dao_ai.tools.vector_search._fetch_index_columns",
+                return_value=[
+                    ("product_id", "bigint", None),
+                    ("product_name", "string", "Full product name"),
+                    ("price", "double", None),
+                    ("is_b2b_only", "boolean", None),
+                ],
+            ),
+            patch.object(VectorStoreModel, "refresh", autospec=True),
+        ):
+            tool = create_vector_search_tool(retriever=retriever, name="product_search")
+        enum = tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+            "properties"
+        ]["key"]["enum"]
         # 4 discovered columns × 8 suffixes = 32.
         assert len(enum) == 32
         # All suffixes valid for every column — no type-aware narrowing.
         assert "product_name LIKE" in enum
-        assert "product_name >=" in enum        # string with ordering — allowed now
-        assert "price LIKE" in enum             # numeric with LIKE — allowed now
-        assert "is_b2b_only <" in enum          # bool with ordering — allowed now
+        assert "product_name >=" in enum  # string with ordering — allowed now
+        assert "price LIKE" in enum  # numeric with LIKE — allowed now
+        assert "is_b2b_only <" in enum  # bool with ordering — allowed now
         # Hallucinated column still rejected (this is the regression):
         assert "name NOT LIKE" not in enum
         # Description enrichment (product_name has a UC comment):
@@ -1027,11 +1016,11 @@ class TestIndexScopedTypeLookup:
         )
         retriever = AiSearchRetrieverModel(vector_store=vs)
 
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
-        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None),
+            patch.object(VectorStoreModel, "refresh", autospec=True),
+        ):
             tool = create_vector_search_tool(retriever=retriever, name="t")
 
         schema = tool.args_schema.model_json_schema()
@@ -1193,11 +1182,11 @@ class TestHandDeclaredColumnInfoInFactory:
             ],
         )
         fetch_mock = MagicMock(return_value=None)
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns", fetch_mock
-        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch("dao_ai.tools.vector_search._fetch_index_columns", fetch_mock),
+            patch.object(VectorStoreModel, "refresh", autospec=True),
+        ):
             create_vector_search_tool(retriever=retriever, name="t")
         # The factory must NOT have called _fetch_index_columns in
         # hand-declared mode.
@@ -1216,15 +1205,15 @@ class TestHandDeclaredColumnInfoInFactory:
                 ColumnInfo(name="price", type="number"),  # defaults
             ],
         )
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
-        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None),
+            patch.object(VectorStoreModel, "refresh", autospec=True),
+        ):
             tool = create_vector_search_tool(retriever=retriever, name="t")
-        enum = tool.args_schema.model_json_schema()["$defs"][
-            "DynamicFilterItem"
-        ]["properties"]["key"]["enum"]
+        enum = tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+            "properties"
+        ]["key"]["enum"]
         # brand is hand-locked to 2 ops; price falls to the per-type
         # numeric default (equality + NOT + comparisons, no LIKE).
         assert "brand" in enum and "brand LIKE" in enum
@@ -1240,15 +1229,15 @@ class TestHandDeclaredColumnInfoInFactory:
             vector_store=vs,
             columns=[ColumnInfo(name="brand", type="string")],
         )
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
-        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None),
+            patch.object(VectorStoreModel, "refresh", autospec=True),
+        ):
             tool = create_vector_search_tool(retriever=retriever, name="t")
-        enum = tool.args_schema.model_json_schema()["$defs"][
-            "DynamicFilterItem"
-        ]["properties"]["key"]["enum"]
+        enum = tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+            "properties"
+        ]["key"]["enum"]
         # All 8 suffixes for brand.
         assert len(enum) == 8
 
@@ -1264,11 +1253,11 @@ class TestHandDeclaredColumnInfoInFactory:
                 ),
             ],
         )
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
-        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None),
+            patch.object(VectorStoreModel, "refresh", autospec=True),
+        ):
             tool = create_vector_search_tool(retriever=retriever, name="t")
         assert "Brand — MILWAUKEE, DEWALT, MAKITA" in tool.description
         assert "- brand (STRING)" in tool.description
@@ -1283,15 +1272,15 @@ class TestHandDeclaredColumnInfoInFactory:
                 "sku",
             ],
         )
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
-        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None),
+            patch.object(VectorStoreModel, "refresh", autospec=True),
+        ):
             tool = create_vector_search_tool(retriever=retriever, name="t")
-        enum = tool.args_schema.model_json_schema()["$defs"][
-            "DynamicFilterItem"
-        ]["properties"]["key"]["enum"]
+        enum = tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+            "properties"
+        ]["key"]["enum"]
         # brand → 2 ops; product_id + sku → 8 ops each = 18 total.
         assert len(enum) == 18
         assert "brand LIKE" in enum and "brand NOT" not in enum
@@ -1301,26 +1290,26 @@ class TestHandDeclaredColumnInfoInFactory:
         """Mode B: bare-string columns declared → UC call is still made
         best-effort for description enrichment (types + comments)."""
         vs = self._bare_vs()
-        retriever = AiSearchRetrieverModel(
-            vector_store=vs, columns=["brand", "price"]
-        )
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns",
-            return_value=[
-                ("brand", "STRING", "Brand — Milwaukee, DeWalt, ..."),
-                ("price", "INT64", None),
-            ],
-        ) as fetch_mock, patch.object(VectorStoreModel, "refresh", autospec=True):
+        retriever = AiSearchRetrieverModel(vector_store=vs, columns=["brand", "price"])
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch(
+                "dao_ai.tools.vector_search._fetch_index_columns",
+                return_value=[
+                    ("brand", "STRING", "Brand — Milwaukee, DeWalt, ..."),
+                    ("price", "INT64", None),
+                ],
+            ) as fetch_mock,
+            patch.object(VectorStoreModel, "refresh", autospec=True),
+        ):
             tool = create_vector_search_tool(retriever=retriever, name="t")
         # UC call happened (for description enrichment)
         fetch_mock.assert_called_once()
         # But the enum is built from declared names + all 8 suffixes each
         # — no type-aware narrowing.
-        enum = tool.args_schema.model_json_schema()["$defs"][
-            "DynamicFilterItem"
-        ]["properties"]["key"]["enum"]
+        enum = tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+            "properties"
+        ]["key"]["enum"]
         assert len(enum) == 16
         assert "price LIKE" in enum  # numeric can LIKE — no narrowing
         # Description enrichment came through
@@ -1351,8 +1340,17 @@ class TestIsArrayType:
         assert _is_array_type("ARRAY") is True
 
     def test_scalars_return_false(self) -> None:
-        for t in ("string", "STRING", "int", "bigint", "double", "boolean",
-                  "timestamp", "date", "decimal(10,2)"):
+        for t in (
+            "string",
+            "STRING",
+            "int",
+            "bigint",
+            "double",
+            "boolean",
+            "timestamp",
+            "date",
+            "decimal(10,2)",
+        ):
             assert _is_array_type(t) is False, t
 
     def test_empty_or_none_returns_false(self) -> None:
@@ -1386,21 +1384,28 @@ class TestArrayColumnInFactory:
                 ColumnInfo(name="brand", type="string"),
             ],
         )
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
-        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None),
+            patch.object(VectorStoreModel, "refresh", autospec=True),
+        ):
             tool = create_vector_search_tool(retriever=retriever, name="t")
-        enum = tool.args_schema.model_json_schema()["$defs"][
-            "DynamicFilterItem"
-        ]["properties"]["key"]["enum"]
+        enum = tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+            "properties"
+        ]["key"]["enum"]
         # tags: 1 suffix. brand: 8 suffixes. Total = 9.
         assert len(enum) == 9
         assert "tags" in enum
         # None of the disallowed suffixes appear for the array column:
-        for bad in ("tags NOT", "tags <", "tags <=", "tags >",
-                    "tags >=", "tags LIKE", "tags NOT LIKE"):
+        for bad in (
+            "tags NOT",
+            "tags <",
+            "tags <=",
+            "tags >",
+            "tags >=",
+            "tags LIKE",
+            "tags NOT LIKE",
+        ):
             assert bad not in enum, f"array column got bad suffix: {bad}"
         # brand still gets the standard set:
         assert "brand LIKE" in enum and "brand NOT" in enum
@@ -1414,15 +1419,15 @@ class TestArrayColumnInFactory:
                 ColumnInfo(name="tags", type="array", operators=["", "NOT"]),
             ],
         )
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
-        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None),
+            patch.object(VectorStoreModel, "refresh", autospec=True),
+        ):
             tool = create_vector_search_tool(retriever=retriever, name="t")
-        enum = tool.args_schema.model_json_schema()["$defs"][
-            "DynamicFilterItem"
-        ]["properties"]["key"]["enum"]
+        enum = tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+            "properties"
+        ]["key"]["enum"]
         # User asked for equality + NOT — honored.
         assert set(enum) == {"tags", "tags NOT"}
 
@@ -1431,16 +1436,18 @@ class TestArrayColumnInFactory:
         array column → factory adds equality-only override."""
         vs = self._bare_vs()
         retriever = AiSearchRetrieverModel(vector_store=vs)
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns",
-            return_value=[("tags", "array<string>", "Product tags")],
-        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch(
+                "dao_ai.tools.vector_search._fetch_index_columns",
+                return_value=[("tags", "array<string>", "Product tags")],
+            ),
+            patch.object(VectorStoreModel, "refresh", autospec=True),
+        ):
             tool = create_vector_search_tool(retriever=retriever, name="t")
-        key_schema = tool.args_schema.model_json_schema()["$defs"][
-            "DynamicFilterItem"
-        ]["properties"]["key"]
+        key_schema = tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+            "properties"
+        ]["key"]
         # Pydantic renders a single-value Literal as ``const`` (not ``enum``).
         # Either shape is fine as long as the value is exactly "tags".
         assert key_schema.get("const") == "tags" or key_schema.get("enum") == ["tags"]
@@ -1450,20 +1457,22 @@ class TestArrayColumnInFactory:
         columns keep full 8 suffixes."""
         vs = self._bare_vs()
         retriever = AiSearchRetrieverModel(vector_store=vs)
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns",
-            return_value=[
-                ("tags", "array<string>", None),
-                ("price", "double", None),
-                ("sku", "string", None),
-            ],
-        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch(
+                "dao_ai.tools.vector_search._fetch_index_columns",
+                return_value=[
+                    ("tags", "array<string>", None),
+                    ("price", "double", None),
+                    ("sku", "string", None),
+                ],
+            ),
+            patch.object(VectorStoreModel, "refresh", autospec=True),
+        ):
             tool = create_vector_search_tool(retriever=retriever, name="t")
-        enum = tool.args_schema.model_json_schema()["$defs"][
-            "DynamicFilterItem"
-        ]["properties"]["key"]["enum"]
+        enum = tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+            "properties"
+        ]["key"]["enum"]
         # tags: 1 + price: 8 + sku: 8 = 17.
         assert len(enum) == 17
         assert "tags" in enum
@@ -1480,11 +1489,11 @@ class TestArrayColumnInFactory:
                 ColumnInfo(name="tags", type="array", description="Product tags"),
             ],
         )
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
-        ), patch.object(VectorStoreModel, "refresh", autospec=True):
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None),
+            patch.object(VectorStoreModel, "refresh", autospec=True),
+        ):
             tool = create_vector_search_tool(retriever=retriever, name="t")
         assert "- tags (ARRAY)" in tool.description
         assert "Array columns match via element containment" in tool.description
@@ -1512,9 +1521,7 @@ class TestArrayInColumnsDescription:
     def test_array_hint_detects_uc_style_type_strings(self) -> None:
         # UC Tables API returns type_text like "array<string>"; the
         # description hint should still fire.
-        block = _build_columns_description(
-            ["tags"], {"tags": "array<string>"}, {}
-        )
+        block = _build_columns_description(["tags"], {"tags": "array<string>"}, {})
         assert "Array columns match via element containment" in block
 
 
@@ -1557,17 +1564,17 @@ class TestFactoryToolNameShadowing:
             vector_store=vs,
             columns=["product_id", "sku", "description"],  # last col = 'description'
         )
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch.object(
-            VectorStoreModel, "refresh", autospec=True, return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns",
-            return_value=[
-                ("product_id", "STRING", None),
-                ("sku", "STRING", "SKU column"),
-                ("description", "STRING", "Product description"),
-            ],
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch.object(VectorStoreModel, "refresh", autospec=True, return_value=None),
+            patch(
+                "dao_ai.tools.vector_search._fetch_index_columns",
+                return_value=[
+                    ("product_id", "STRING", None),
+                    ("sku", "STRING", "SKU column"),
+                    ("description", "STRING", "Product description"),
+                ],
+            ),
         ):
             tool = create_vector_search_tool(
                 retriever=retriever, name="product_vector_search_tool"
@@ -1582,16 +1589,16 @@ class TestFactoryToolNameShadowing:
         """
         vs = self._make_vs()
         retriever = AiSearchRetrieverModel(vector_store=vs)  # no declared columns
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch.object(
-            VectorStoreModel, "refresh", autospec=True, return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns",
-            return_value=[
-                ("product_id", "STRING", None),
-                ("description", "STRING", None),  # last col
-            ],
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch.object(VectorStoreModel, "refresh", autospec=True, return_value=None),
+            patch(
+                "dao_ai.tools.vector_search._fetch_index_columns",
+                return_value=[
+                    ("product_id", "STRING", None),
+                    ("description", "STRING", None),  # last col
+                ],
+            ),
         ):
             tool = create_vector_search_tool(retriever=retriever, name="my_tool")
         assert tool.name == "my_tool"
@@ -1610,12 +1617,10 @@ class TestFactoryToolNameShadowing:
                 ColumnInfo(name="brand", type="string"),
             ],
         )
-        with patch(
-            "dao_ai.tools.vector_search._vsc_for_refresh", return_value=None
-        ), patch.object(
-            VectorStoreModel, "refresh", autospec=True, return_value=None
-        ), patch(
-            "dao_ai.tools.vector_search._fetch_index_columns", return_value=None
+        with (
+            patch("dao_ai.tools.vector_search._vsc_for_refresh", return_value=None),
+            patch.object(VectorStoreModel, "refresh", autospec=True, return_value=None),
+            patch("dao_ai.tools.vector_search._fetch_index_columns", return_value=None),
         ):
             tool = create_vector_search_tool(retriever=retriever, name="my_tool")
         assert tool.name == "my_tool"

--- a/tests/dao_ai/test_vector_search_fevm_integration.py
+++ b/tests/dao_ai/test_vector_search_fevm_integration.py
@@ -38,8 +38,8 @@ from langchain_core.messages import ToolCall as LCToolCall
 from langchain_core.messages import ToolMessage
 
 from dao_ai.config import (
-    IndexModel,
     AiSearchRetrieverModel,
+    IndexModel,
     SchemaModel,
     SearchParametersModel,
     VectorSearchEndpoint,
@@ -205,7 +205,7 @@ class TestVectorSearchFevmExplicitAuthMode4:
         headers = wc.config.authenticate() or {}
         bearer = headers.get("Authorization", "")
         assert bearer.startswith("Bearer "), f"can't get bearer: {bearer!r}"
-        token = bearer[len("Bearer "):]
+        token = bearer[len("Bearer ") :]
         monkeypatch.setenv("DATABRICKS_TOKEN", token)
         monkeypatch.setenv("DATABRICKS_HOST", wc.config.host)
         return token
@@ -288,17 +288,24 @@ class TestDynamicSchemaHydration:
         # Live products index columns (see commerce_swarm data DDL):
         # product_id, sku, product_name, brand, category, subcategory,
         # description, price, is_b2b_only.
-        for c in ("product_id", "product_name", "brand", "category", "price", "is_b2b_only"):
+        for c in (
+            "product_id",
+            "product_name",
+            "brand",
+            "category",
+            "price",
+            "is_b2b_only",
+        ):
             assert c in enum, f"missing column {c!r} in {enum}"
         # Every column gets every operator suffix — no type-aware
         # narrowing. Databricks VS rejects invalid combinations at query
         # time (matches upstream databricks-langchain).
         assert "product_name LIKE" in enum
-        assert "product_name >" in enum      # ordering allowed on any col
+        assert "product_name >" in enum  # ordering allowed on any col
         assert "price <=" in enum
-        assert "price LIKE" in enum          # LIKE allowed on any col
+        assert "price LIKE" in enum  # LIKE allowed on any col
         assert "is_b2b_only NOT" in enum
-        assert "is_b2b_only <" in enum       # ordering allowed on any col
+        assert "is_b2b_only <" in enum  # ordering allowed on any col
         # Regression key still absent (LLM cannot emit ``name`` — real
         # column is ``product_name``).
         assert not any(k.startswith("name ") or k == "name" for k in enum), enum

--- a/tests/dao_ai/test_vector_search_hardware_store_fevm.py
+++ b/tests/dao_ai/test_vector_search_hardware_store_fevm.py
@@ -27,8 +27,8 @@ import pytest
 from pydantic import ValidationError
 
 from dao_ai.config import (
-    IndexModel,
     AiSearchRetrieverModel,
+    IndexModel,
     SchemaModel,
     SearchParametersModel,
     VectorSearchEndpoint,
@@ -231,13 +231,11 @@ class TestHardwareStoreDynamicSchema:
         )
         tool = create_vector_search_tool(retriever=retriever, name="hw_search")
 
-        enum = (
-            tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
-                "properties"
-            ]["key"]["enum"]
-        )
+        enum = tool.args_schema.model_json_schema()["$defs"]["DynamicFilterItem"][
+            "properties"
+        ]["key"]["enum"]
         assert "product_name" in enum
         assert "brand_name" in enum
-        assert not any(
-            k.startswith("nonexistent_column_xyz") for k in enum
-        ), f"bogus YAML column leaked into enum: {enum!r}"
+        assert not any(k.startswith("nonexistent_column_xyz") for k in enum), (
+            f"bogus YAML column leaked into enum: {enum!r}"
+        )

--- a/tests/dao_ai/test_vector_search_instructed.py
+++ b/tests/dao_ai/test_vector_search_instructed.py
@@ -12,12 +12,12 @@ from conftest import add_databricks_resource_attrs
 from langchain_core.documents import Document
 
 from dao_ai.config import (
+    AiSearchRetrieverModel,
     ColumnInfo,
     DecompositionModel,
     FilterItem,
     InstructedRetrieverModel,
     LLMModel,
-    AiSearchRetrieverModel,
     RouterModel,
     SearchQuery,
     VectorStoreModel,

--- a/tests/dao_ai/test_vector_store_union.py
+++ b/tests/dao_ai/test_vector_store_union.py
@@ -20,7 +20,6 @@ import pytest
 from dao_ai.config import (
     AiSearchIndexModel,
     AiSearchVectorStoreModel,
-    AppConfig,
     DatabaseModel,
     IndexModel,
     LakebaseVectorStoreModel,


### PR DESCRIPTION
## What

Runs `ruff format` across `src/` and `tests/` and clears the outstanding `ruff check` errors so `make check` / `make format` pass clean.

## Format

- **84 files reformatted** to the configured Black-compatible style (line-length 88, double quotes). No behavior change — whitespace/wrapping only.

## Lint fixes

`ruff check --ignore E501` went from **136 errors → 0**:

- **Databricks notebooks** (`src/dao_ai/pipeline/notebooks/*.py`): added a scoped `per-file-ignores` for **E402** (imports live inside `# COMMAND ----------` cells, not the module top) and **F821** (the Databricks runtime injects `spark`/`dbutils`/`dlt`/`display`). These were 131 false positives; the ignore is scoped to the notebooks dir so the rest of the tree stays strict.
- `providers/databricks.py`: import `ExperimentModel` from `dao_ai.config` (it was an unresolved forward-ref string annotation on `create_experiment`) and drop the now-unnecessary quotes — fixes F821.
- `tools/mcp_callbacks.py`: add `Optional` to the `typing` import (used in a local annotation, never imported) — fixes F821.
- tests: hoist misplaced module-level imports into the top import block (`test_databricks.py`, `genie/test_prompt_history.py`) — fixes E402.

## Verification

- `ruff check --ignore E501 src tests` → **All checks passed!**
- `ruff format --check src tests` → **390 files already formatted** (idempotent)
- All src files compile; touched test files pass (263 passed)
- The 10 pre-existing `test_databricks.py` Mock-harness failures are **unchanged** — identical count on clean `main`, unrelated to formatting (verified via stash-compare)
- `uv.lock` confirmed clean (no internal-mirror pollution)

This pull request and its description were written by Isaac.