### PR TITLE
feat(cli): add mcp utilities noun (tools|inspect|call)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -579,29 +579,67 @@ dao-ai chat -c config/my_config.yaml
 dao-ai chat -c config/my_config.yaml --param catalog=nfleming --param module_id=09
 ```
 
-## List MCP Tools
+## MCP Utilities
 
-Discover and inspect tools available from MCP (Model Context Protocol) servers configured in your application.
+Inspect and test MCP (Model Context Protocol) servers and tools, grouped under
+the `dao-ai mcp` noun. There are two distinct surfaces, told apart by their
+flags:
 
-Use `dao-ai tools` (formerly `dao-ai list-mcp-tools`).
+- `-c/--config` → the MCP tools an agent **config** declares (what your agent sees)
+- `--url`/`--app` → a **live** MCP server (what a running server exposes)
 
-### Basic Usage
+> To **deploy** a dao-ai agent as an MCP server, use `agent --mode mcp`.
+> Deployment is intentionally not part of this noun.
 
-List all MCP tools with full descriptions and schemas:
+| Verb | Purpose |
+|---|---|
+| `dao-ai mcp tools`   | List the MCP tools an agent config declares (with filter status) |
+| `dao-ai mcp inspect` | Connect to a live MCP server and show its health + available tools |
+| `dao-ai mcp call`    | Invoke a single tool on a live MCP server and print the result |
+
+### `mcp tools` — inspect config-declared tools
+
+List all MCP tools declared in a config with full descriptions and schemas:
 
 ```bash
-dao-ai tools -c config/my_config.yaml
+dao-ai mcp tools -c config/my_config.yaml
 
 # With parameter overrides
-dao-ai tools -c config/my_config.yaml --param catalog=main
+dao-ai mcp tools -c config/my_config.yaml --param catalog=main
 ```
 
-### Show Only Filtered Tools
-
-Use `--apply-filters` to see only the tools that will actually be loaded (respecting `include_tools` and `exclude_tools` configuration):
+Use `--apply-filters` to see only the tools that will actually be loaded
+(respecting `include_tools` and `exclude_tools` configuration):
 
 ```bash
-dao-ai tools -c config/my_config.yaml --apply-filters
+dao-ai mcp tools -c config/my_config.yaml --apply-filters
+```
+
+### `mcp inspect` — introspect a live server
+
+Connect to a running MCP server and show its health (best-effort `/healthz`)
+plus the tools it exposes. Target any MCP server with `--url`, or a Databricks
+App (e.g. a dao-ai agent deployed via `agent --mode mcp`) with `--app`:
+
+```bash
+# A deployed dao-ai MCP App, resolved by name via the SDK
+dao-ai mcp inspect --app my-mcp-app -p fevm
+
+# Any MCP server URL
+dao-ai mcp inspect --url https://<host>/api/2.0/mcp/sql -p fevm
+```
+
+### `mcp call` — smoke-test a single tool
+
+Invoke one tool on a live MCP server and print its result — an end-to-end smoke
+test of a deployed server. Arguments are passed as a JSON object via `--args`:
+
+```bash
+dao-ai mcp call ask --app my-mcp-app --args '{"input": "hello"}' -p fevm
+
+dao-ai mcp call execute_sql \
+  --url https://<host>/api/2.0/mcp/sql \
+  --args '{"query": "SELECT 1"}' -p fevm
 ```
 
 ### What It Shows
@@ -830,18 +868,32 @@ dao-ai chat -c config/my_config.yaml [OPTIONS]
 
 Starts an interactive REPL session where you can chat with your agent locally.
 
-### List MCP Tools Options
+### MCP Utilities Options
 
 ```bash
-dao-ai tools -c config/my_config.yaml [OPTIONS]
+dao-ai mcp tools   -c config/my_config.yaml [OPTIONS]
+dao-ai mcp inspect (--url URL | --app NAME) [OPTIONS]
+dao-ai mcp call    TOOL (--url URL | --app NAME) [--args JSON] [OPTIONS]
 ```
+
+**`mcp tools`**
 
 | Option | Description |
 |--------|-------------|
 | `-c, --config FILE` | Path to configuration file (default: `./config/model_config.yaml`) |
 | `--apply-filters` | Only show tools that pass include/exclude filters (hide excluded tools) |
 
-Lists all available MCP tools with full descriptions and readable parameter schemas. Supports filtering to show only included tools.
+Lists all MCP tools declared in a config with full descriptions and readable parameter schemas. Supports filtering to show only included tools.
+
+**`mcp inspect`** / **`mcp call`**
+
+| Option | Description |
+|--------|-------------|
+| `--url URL` | Direct MCP server URL (e.g. `https://<host>/.../mcp`). Mutually exclusive with `--app`. |
+| `--app NAME` | Databricks App name; its `/mcp` endpoint is resolved via the SDK. Mutually exclusive with `--url`. |
+| `--args JSON` | (`call` only) JSON object of tool arguments (default: `{}`). |
+
+`inspect` and `call` connect to a **live** MCP server and require valid auth (a `-p/--profile` or ambient credentials).
 
 ---
 
@@ -950,7 +1002,7 @@ The deploy-model v2 release removed several commands and renamed others. Use thi
 | `dao-ai create-experiment ...` | `dao-ai trace create ...` |
 | `dao-ai link-trace-destination ...` | `dao-ai trace link ...` |
 | `dao-ai grant-trace-permissions ...` | `dao-ai trace grant ...` |
-| `dao-ai list-mcp-tools ...` | `dao-ai tools ...` |
+| `dao-ai list-mcp-tools ...` | `dao-ai mcp tools ...` |
 | `--deployment-target <mode>` flag | `--mode <mode>` flag |
 | `--deploy` / `--run` one-shot flags on `generate` | Removed — use the `up` verb |
 | `app.deployment_target:` config field | Removed — serving mode is chosen at deploy time via `--mode` (default `apps`) |

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -695,11 +695,11 @@ Getting started:
   dao-ai agent deploy  -c config.yaml -p fevm                   # push the bundle (auto-generates if unstaged); start with `run`
 
 Bring an agent up (generate → deploy → run):
-  dao-ai agent up -c config.yaml -p fevm                        # live agent (Apps, default --mode apps)
+  dao-ai agent up -c config.yaml -p fevm                       # live agent (Apps, default --mode apps)
   dao-ai agent up -c config.yaml --mode model_serving -p fevm  # deploy to a Model Serving endpoint
   dao-ai agent up -c config.yaml -m ms -p fevm                 # same, using the -m ms alias
   dao-ai agent up -c config.yaml --mode mcp -p fevm            # bring up an MCP server
-  dao-ai agent up -c config.yaml --direct -p fevm             # SDK fast-path (no bundle on disk)
+  dao-ai agent up -c config.yaml --direct -p fevm              # SDK fast-path (no bundle on disk)
   dao-ai -p fevm agent up -c config.yaml                       # -p accepted at the top level too
 
 Granular lifecycle (DAB-style primitives):
@@ -723,7 +723,9 @@ Production monitoring:
   dao-ai monitor scorers disable -c config.yaml -p fevm         # stop all monitoring scorers
 
 Inspect & utilities:
-  dao-ai tools      -c config.yaml                 # list MCP tools visible to agents
+  dao-ai mcp tools   -c config.yaml                # MCP tools the agent config sees
+  dao-ai mcp inspect --app my-mcp-app              # live MCP server: health + tool list
+  dao-ai mcp call    <tool> --app my-mcp-app --args '{...}'   # smoke-test one tool
   dao-ai validate   -c config.yaml                 # validate config syntax + semantics
   dao-ai parameters list -c config.yaml            # show declared parameters + resolved values
   dao-ai schema                                    # dump JSON schema for IDE validation
@@ -1136,10 +1138,39 @@ Examples:
         parents=[_GLOBAL],
     )
 
-    # List MCP tools command
-    list_mcp_parser: ArgumentParser = subparsers.add_parser(
+    # MCP noun: `dao-ai mcp <tools|inspect|call>` — MCP inspection/test utilities.
+    # NOTE: MCP *deployment* is NOT here — it lives on `agent --mode mcp`. This
+    # noun groups read-only/test utilities only.
+    mcp_parser: ArgumentParser = subparsers.add_parser(
+        "mcp",
+        help="Inspect and test MCP servers and tools (tools | inspect | call)",
+        description="""
+Inspect and test Model Context Protocol (MCP) servers and tools.
+
+Two distinct surfaces, told apart by their flags:
+  -c/--config  → the MCP tools an agent CONFIG declares (what your agent sees)
+  --url/--app  → a LIVE MCP server (what a running server exposes)
+
+To DEPLOY a dao-ai agent as an MCP server, use `agent --mode mcp` — deployment
+is intentionally not part of this noun.
+        """,
+        epilog="""
+Examples:
+  dao-ai mcp tools   -c config.yaml                # MCP tools the agent config sees
+  dao-ai mcp tools   -c config.yaml --apply-filters
+  dao-ai mcp inspect --app my-mcp-app -p fevm      # live server: health + tool list
+  dao-ai mcp inspect --url https://host/.../mcp
+  dao-ai mcp call    ask --app my-mcp-app --args '{"input":"hi"}' -p fevm
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_GLOBAL],
+    )
+    mcp_verbs = mcp_parser.add_subparsers(dest="subcommand", required=True)
+
+    # mcp tools (was: top-level `tools`)
+    mcp_tools_parser: ArgumentParser = mcp_verbs.add_parser(
         "tools",
-        help="List MCP tools visible to agents in a configuration",
+        help="List the MCP tools an agent config declares (with filter status)",
         description="""
 List the MCP tools declared in a dao-ai config. Shows each tool's name,
 description, parameter schema, and include/exclude filter status. Useful for
@@ -1150,14 +1181,14 @@ excluded tools). Without it, all available tools are shown with filter status.
         """,
         epilog="""
 Examples:
-  dao-ai tools -c config.yaml                     # list all tools + filter status
-  dao-ai tools -c config.yaml --apply-filters     # only show tools that pass filters
-  dao-ai tools -c config.yaml -p fevm             # use a specific Databricks profile
+  dao-ai mcp tools -c config.yaml                 # list all tools + filter status
+  dao-ai mcp tools -c config.yaml --apply-filters # only show tools that pass filters
+  dao-ai mcp tools -c config.yaml -p fevm         # use a specific Databricks profile
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         parents=[_GLOBAL],
     )
-    list_mcp_parser.add_argument(
+    mcp_tools_parser.add_argument(
         "-c",
         "--config",
         type=str,
@@ -1166,10 +1197,85 @@ Examples:
         metavar="FILE",
         help="Path to the model configuration file (default: ./config/model_config.yaml)",
     )
-    list_mcp_parser.add_argument(
+    mcp_tools_parser.add_argument(
         "--apply-filters",
         action="store_true",
         help="Only show tools that pass include/exclude filters (hide excluded tools)",
+    )
+
+    # mcp inspect — connect to a live MCP server and list its health + tools
+    mcp_inspect_parser: ArgumentParser = mcp_verbs.add_parser(
+        "inspect",
+        help="Connect to a live MCP server and show its health + available tools",
+        description="""
+Connect to a live MCP server and show its health (best-effort /healthz) plus
+the tools it exposes. Point at any MCP server with --url, or at a Databricks App
+with --app (e.g. a dao-ai agent deployed via `agent --mode mcp`).
+        """,
+        epilog="""
+Examples:
+  dao-ai mcp inspect --app my-mcp-app -p fevm
+  dao-ai mcp inspect --url https://host/api/2.0/mcp/sql -p fevm
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_GLOBAL],
+    )
+    _mcp_target_group = mcp_inspect_parser.add_mutually_exclusive_group(required=True)
+    _mcp_target_group.add_argument(
+        "--url",
+        type=str,
+        metavar="URL",
+        help="Direct MCP server URL (e.g. https://host/.../mcp).",
+    )
+    _mcp_target_group.add_argument(
+        "--app",
+        type=str,
+        metavar="NAME",
+        help="Databricks App name; its /mcp endpoint is resolved via the SDK.",
+    )
+
+    # mcp call — invoke a single tool on a live MCP server
+    mcp_call_parser: ArgumentParser = mcp_verbs.add_parser(
+        "call",
+        help="Invoke a single tool on a live MCP server and print the result",
+        description="""
+Invoke a single tool on a live MCP server and print its result. Smoke-tests a
+deployed MCP server end to end. Target the server with --url or --app.
+        """,
+        epilog="""
+Examples:
+  dao-ai mcp call ask --app my-mcp-app --args '{"input":"hello"}' -p fevm
+  dao-ai mcp call execute_sql --url https://host/api/2.0/mcp/sql \\
+      --args '{"query":"SELECT 1"}' -p fevm
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_GLOBAL],
+    )
+    mcp_call_parser.add_argument(
+        "tool",
+        type=str,
+        metavar="TOOL",
+        help="Name of the tool to invoke.",
+    )
+    _mcp_call_target_group = mcp_call_parser.add_mutually_exclusive_group(required=True)
+    _mcp_call_target_group.add_argument(
+        "--url",
+        type=str,
+        metavar="URL",
+        help="Direct MCP server URL (e.g. https://host/.../mcp).",
+    )
+    _mcp_call_target_group.add_argument(
+        "--app",
+        type=str,
+        metavar="NAME",
+        help="Databricks App name; its /mcp endpoint is resolved via the SDK.",
+    )
+    mcp_call_parser.add_argument(
+        "--args",
+        type=str,
+        default="{}",
+        metavar="JSON",
+        help="JSON object of tool arguments (default: '{}').",
     )
 
     # Monitor command
@@ -1385,7 +1491,7 @@ Examples:
     for sub in (
         validation_parser,
         graph_parser,
-        list_mcp_parser,
+        mcp_tools_parser,
         monitor_scorers_parser,
         monitor_logs_parser,
         chat_parser,
@@ -2379,12 +2485,12 @@ def _format_schema_pretty(schema: dict[str, Any], indent: int = 0) -> str:
     return "\n".join(lines)
 
 
-def handle_list_mcp_tools_command(options: Namespace) -> None:
+def _handle_mcp_tools(options: Namespace) -> None:
     """
-    List available MCP tools from configuration.
+    List available MCP tools from configuration (``dao-ai mcp tools``).
 
-    Shows all MCP servers and their available tools, indicating which
-    are included/excluded based on filter configuration.
+    Shows all MCP servers declared in the config and their available tools,
+    indicating which are included/excluded based on filter configuration.
     """
     _apply_profile_context(options.profile)
     logger.debug(f"Listing MCP tools from configuration: {options.config}")
@@ -2581,6 +2687,126 @@ def handle_list_mcp_tools_command(options: Namespace) -> None:
         logger.debug(traceback.format_exc())
         print(f"\n❌ Error: {e}")
         sys.exit(1)
+
+
+def _mcp_function_from_args(options: Namespace) -> "McpFunctionModel":
+    """Build an in-memory McpFunctionModel from ``--url`` or ``--app``.
+
+    Used by the live-server verbs (``mcp inspect`` / ``mcp call``). The model's
+    ``mcp_url`` property resolves an ``--app`` name to its ``/mcp`` endpoint via
+    the SDK, and its inherited auth chain (OBO → SP → PAT → ambient) is reused
+    for the connection.
+    """
+    from dao_ai.config import DatabricksAppModel, McpFunctionModel
+
+    if getattr(options, "app", None):
+        return McpFunctionModel(app=DatabricksAppModel(name=options.app))
+    return McpFunctionModel(url=options.url)
+
+
+def _handle_mcp_inspect(options: Namespace) -> None:
+    """Connect to a live MCP server and show its health + available tools.
+
+    Accepts either ``--url`` (any MCP server) or ``--app`` (a Databricks App,
+    e.g. a dao-ai agent deployed with ``agent --mode mcp``). Health is
+    best-effort — arbitrary MCP servers need not expose ``/healthz``.
+    """
+    _apply_profile_context(options.profile)
+
+    try:
+        from dao_ai.tools.mcp import list_mcp_tools
+
+        function = _mcp_function_from_args(options)
+        mcp_url: str = function.mcp_url
+
+        print(f"\n{'=' * 80}")
+        print("MCP SERVER INSPECTION")
+        print(f"Server: {mcp_url}")
+        print(f"{'=' * 80}\n")
+
+        # Health is best-effort: only dao-ai MCP servers expose /healthz.
+        health_url = f"{mcp_url.rstrip('/').removesuffix('/mcp')}/healthz"
+        try:
+            import httpx
+
+            resp = httpx.get(health_url, timeout=10.0)
+            if resp.status_code == 200:
+                print(f"   Health: ✓ {resp.json()}")
+            else:
+                print(f"   Health: n/a (HTTP {resp.status_code})")
+        except Exception:
+            print("   Health: n/a (no /healthz endpoint)")
+
+        tools = list_mcp_tools(function, apply_filters=False)
+        print(f"\n   Available Tools: {len(tools)}\n")
+        for tool in sorted(tools, key=lambda t: t.name):
+            print(f"     • {tool.name}")
+            if tool.description:
+                print(f"       Description: {tool.description}")
+            if tool.input_schema:
+                print("       Parameters:")
+                pretty_schema = _format_schema_pretty(tool.input_schema, indent=0)
+                if pretty_schema:
+                    for line in pretty_schema.split("\n"):
+                        print(f"         {line}")
+                else:
+                    print("         (none)")
+
+        print(f"\n{'=' * 80}\n")
+        sys.exit(0)
+
+    except Exception as e:
+        logger.error(f"Failed to inspect MCP server: {e}")
+        logger.debug(traceback.format_exc())
+        print(f"\n❌ Error: {e}")
+        sys.exit(1)
+
+
+def _handle_mcp_call(options: Namespace) -> None:
+    """Invoke a single tool on a live MCP server and print the result.
+
+    Accepts either ``--url`` or ``--app`` plus a ``TOOL`` name and a JSON
+    ``--args`` object. Smoke-tests a deployed MCP server end to end.
+    """
+    _apply_profile_context(options.profile)
+
+    try:
+        args: dict[str, Any] = json.loads(options.args)
+    except json.JSONDecodeError as e:
+        print(f"\n❌ Error: --args must be a JSON object: {e}", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(args, dict):
+        print("\n❌ Error: --args must be a JSON object (e.g. '{\"q\": \"hi\"}')",
+              file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        from dao_ai.tools.mcp import call_mcp_tool
+
+        function = _mcp_function_from_args(options)
+        result: str = call_mcp_tool(function, options.tool, args)
+        print(result)
+        sys.exit(0)
+
+    except Exception as e:
+        logger.error(f"Failed to call MCP tool '{options.tool}': {e}")
+        logger.debug(traceback.format_exc())
+        print(f"\n❌ Error: {e}")
+        sys.exit(1)
+
+
+def handle_mcp_command(options: Namespace) -> None:
+    """Dispatch ``dao-ai mcp <tools|inspect|call>`` to its handler."""
+    match options.subcommand:
+        case "tools":
+            _handle_mcp_tools(options)
+        case "inspect":
+            _handle_mcp_inspect(options)
+        case "call":
+            _handle_mcp_call(options)
+        case _:
+            logger.error(f"Unknown mcp sub-command: {options.subcommand}")
+            sys.exit(1)
 
 
 def handle_version_command(options: Namespace) -> None:
@@ -3761,8 +3987,8 @@ def main() -> None:
             handle_monitor_command(options)
         case "chat":
             handle_chat_command(options)
-        case "tools":
-            handle_list_mcp_tools_command(options)
+        case "mcp":
+            handle_mcp_command(options)
         case "parameters" | "vars":
             handle_vars_command(options)
         case _:

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -12,12 +12,15 @@ import traceback
 from argparse import ArgumentParser, Namespace
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Optional, Sequence
 
 from dotenv import find_dotenv, load_dotenv
 from loguru import logger
 
 from dao_ai.config import AppConfig
+
+if TYPE_CHECKING:
+    from dao_ai.config import McpFunctionModel
 from dao_ai.config_vars import ConfigVariableError, resolve_parameters
 from dao_ai.graph import create_dao_ai_graph
 from dao_ai.logging import configure_logging

--- a/src/dao_ai/tools/mcp.py
+++ b/src/dao_ai/tools/mcp.py
@@ -899,3 +899,67 @@ def create_mcp_tools(
         return tool_wrapper
 
     return [_create_tool_wrapper(tool) for tool in mcp_tools]
+
+
+async def acall_mcp_tool(
+    function: McpFunctionModel,
+    tool_name: str,
+    args: dict[str, Any],
+) -> str:
+    """
+    Async version: invoke a single tool on an MCP server and return its text.
+
+    Goes through the same low-level session path the agent uses at runtime
+    (``_call_tool_with_capabilities``), so a one-shot call exercises the real
+    invocation code path — including per-call capabilities and W3C trace
+    context propagation — rather than building the full LangChain tool set.
+
+    Args:
+        function: The MCP function model configuration (source + auth).
+        tool_name: Name of the tool to invoke.
+        args: Arguments to pass to the tool.
+
+    Returns:
+        The concatenated text content of the tool result.
+
+    Raises:
+        RuntimeError: If connection to the MCP server fails.
+    """
+    logger.debug(
+        "Calling MCP tool", tool_name=tool_name, mcp_url=function.mcp_url, args=args
+    )
+
+    client: MultiServerMCPClient = _build_mcp_client(function)
+    async with client.session("mcp_function") as session:
+        result: CallToolResult = await _call_tool_with_capabilities(
+            function,
+            session,
+            tool_name,
+            args,
+            _resolve_meta(function.meta),
+        )
+        return _extract_text_content(result)
+
+
+def call_mcp_tool(
+    function: McpFunctionModel,
+    tool_name: str,
+    args: dict[str, Any],
+) -> str:
+    """
+    Sync wrapper: invoke a single tool on an MCP server and return its text.
+
+    For async contexts, use acall_mcp_tool() directly.
+
+    Args:
+        function: The MCP function model configuration (source + auth).
+        tool_name: Name of the tool to invoke.
+        args: Arguments to pass to the tool.
+
+    Returns:
+        The concatenated text content of the tool result.
+
+    Raises:
+        RuntimeError: If connection to the MCP server fails.
+    """
+    return asyncio.run(acall_mcp_tool(function, tool_name, args))

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -1378,11 +1378,18 @@ class TestDeployAutoGenerate:
 
 @pytest.mark.unit
 class TestToolsCommandRenamed:
-    """list-mcp-tools renamed to tools."""
+    """MCP tool listing now lives under `mcp tools`; older names are rejected."""
 
-    def test_tools_renamed(self) -> None:
-        """tools command parses successfully with the new name."""
-        assert parse_args(["tools", "-c", "c.yaml"]).command == "tools"
+    def test_mcp_tools_parses(self) -> None:
+        """`mcp tools` parses to (command=mcp, subcommand=tools)."""
+        o = parse_args(["mcp", "tools", "-c", "c.yaml"])
+        assert o.command == "mcp"
+        assert o.subcommand == "tools"
+
+    def test_top_level_tools_rejected(self) -> None:
+        """The interim top-level `tools` name is rejected (moved to `mcp tools`)."""
+        with pytest.raises(SystemExit):
+            parse_args(["tools", "-c", "c.yaml"])
 
     def test_list_mcp_tools_rejected(self) -> None:
         """Old list-mcp-tools name is rejected by the parser."""

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -115,6 +115,7 @@ class TestNounVerbParsing:
             ["generate-workflow", "-c", "c.yaml"],
             ["generate-bundle", "-c", "c.yaml"],
             ["pipeline", "-c", "c.yaml"],
+            ["tools", "-c", "c.yaml"],  # moved to `mcp tools`
         ],
     )
     def test_removed_commands_rejected(self, argv: list[str]) -> None:
@@ -1527,6 +1528,113 @@ class TestTraceNounDispatch:
     ) -> None:
         called = self._invoke(monkeypatch, ["trace", "grant", "-c", "c.yaml"])
         assert called == {"grant": 1}
+
+
+@pytest.mark.unit
+class TestMcpNoun:
+    """``dao-ai mcp tools|inspect|call`` — utilities noun; top-level `tools` is gone."""
+
+    def test_mcp_tools_parses(self) -> None:
+        o = parse_args(["mcp", "tools", "-c", "c.yaml"])
+        assert o.command == "mcp"
+        assert o.subcommand == "tools"
+        assert o.config == "c.yaml"
+        assert o.apply_filters is False
+
+    def test_mcp_tools_apply_filters(self) -> None:
+        o = parse_args(["mcp", "tools", "-c", "c.yaml", "--apply-filters"])
+        assert o.apply_filters is True
+
+    def test_mcp_tools_var_flag(self) -> None:
+        o = parse_args(["mcp", "tools", "-c", "c.yaml", "--var", "k=v"])
+        assert o.var == ["k=v"]
+
+    def test_mcp_inspect_url(self) -> None:
+        o = parse_args(["mcp", "inspect", "--url", "https://x/mcp"])
+        assert o.command == "mcp"
+        assert o.subcommand == "inspect"
+        assert o.url == "https://x/mcp"
+        assert o.app is None
+
+    def test_mcp_inspect_app(self) -> None:
+        o = parse_args(["mcp", "inspect", "--app", "my-app"])
+        assert o.app == "my-app"
+        assert o.url is None
+
+    def test_mcp_inspect_requires_target(self) -> None:
+        # --url/--app are a required mutually-exclusive group.
+        with pytest.raises(SystemExit):
+            parse_args(["mcp", "inspect"])
+
+    def test_mcp_inspect_rejects_both_targets(self) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(["mcp", "inspect", "--url", "https://x/mcp", "--app", "a"])
+
+    def test_mcp_call_parses(self) -> None:
+        o = parse_args(
+            ["mcp", "call", "mytool", "--url", "https://x/mcp", "--args", '{"a":1}']
+        )
+        assert o.command == "mcp"
+        assert o.subcommand == "call"
+        assert o.tool == "mytool"
+        assert o.url == "https://x/mcp"
+        assert o.args == '{"a":1}'
+
+    def test_mcp_call_args_default(self) -> None:
+        o = parse_args(["mcp", "call", "mytool", "--app", "a"])
+        assert o.args == "{}"
+
+    def test_mcp_call_requires_target(self) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(["mcp", "call", "mytool"])
+
+    def test_bare_mcp_requires_verb(self) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(["mcp"])
+
+
+@pytest.mark.unit
+class TestMcpNounDispatch:
+    """main() routes ``mcp <verb>`` to the correct handler via handle_mcp_command."""
+
+    def _invoke(
+        self, monkeypatch: pytest.MonkeyPatch, argv: list[str]
+    ) -> dict[str, int]:
+        called: dict[str, int] = {}
+        monkeypatch.setattr(
+            cli,
+            "_handle_mcp_tools",
+            lambda o: called.update(tools=called.get("tools", 0) + 1),
+        )
+        monkeypatch.setattr(
+            cli,
+            "_handle_mcp_inspect",
+            lambda o: called.update(inspect=called.get("inspect", 0) + 1),
+        )
+        monkeypatch.setattr(
+            cli,
+            "_handle_mcp_call",
+            lambda o: called.update(call=called.get("call", 0) + 1),
+        )
+        monkeypatch.setattr(cli, "setup_logging", lambda v: None)
+        monkeypatch.setattr("sys.argv", ["dao-ai"] + argv)
+        cli.main()
+        return called
+
+    def test_mcp_tools_routes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert self._invoke(monkeypatch, ["mcp", "tools", "-c", "c.yaml"]) == {
+            "tools": 1
+        }
+
+    def test_mcp_inspect_routes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert self._invoke(monkeypatch, ["mcp", "inspect", "--app", "a"]) == {
+            "inspect": 1
+        }
+
+    def test_mcp_call_routes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert self._invoke(monkeypatch, ["mcp", "call", "t", "--app", "a"]) == {
+            "call": 1
+        }
 
 
 @pytest.mark.unit

--- a/tests/dao_ai/test_mcp_cli.py
+++ b/tests/dao_ai/test_mcp_cli.py
@@ -1,0 +1,82 @@
+"""Handler-level tests for the ``dao-ai mcp`` noun.
+
+Parse-level coverage lives in test_development_flag_cli.py (TestMcpNoun /
+TestMcpNounDispatch). These tests exercise the handler bodies with the MCP
+network layer mocked.
+"""
+
+from argparse import Namespace
+from unittest.mock import patch
+
+import pytest
+
+from dao_ai.cli import _handle_mcp_call, _mcp_function_from_args
+from dao_ai.config import McpFunctionModel
+
+
+@pytest.mark.unit
+class TestMcpFunctionFromArgs:
+    """_mcp_function_from_args builds a McpFunctionModel from --url or --app."""
+
+    def test_url_builds_url_model(self) -> None:
+        opts = Namespace(url="https://host/mcp", app=None)
+        fn = _mcp_function_from_args(opts)
+        assert isinstance(fn, McpFunctionModel)
+        assert str(fn.url) == "https://host/mcp"
+        assert fn.app is None
+
+    def test_app_builds_app_model(self) -> None:
+        opts = Namespace(url=None, app="my-mcp-app")
+        fn = _mcp_function_from_args(opts)
+        assert isinstance(fn, McpFunctionModel)
+        assert fn.app is not None
+        assert fn.app.name == "my-mcp-app"
+
+
+@pytest.mark.unit
+class TestHandleMcpCall:
+    """_handle_mcp_call parses --args, invokes call_mcp_tool, prints the result."""
+
+    def test_returns_result_and_exits_zero(self, capsys: pytest.CaptureFixture) -> None:
+        opts = Namespace(
+            url="https://host/mcp",
+            app=None,
+            tool="ask",
+            args='{"input": "hi"}',
+            profile=None,
+        )
+        with patch("dao_ai.tools.mcp.call_mcp_tool", return_value="pong") as mock_call:
+            with pytest.raises(SystemExit) as exc:
+                _handle_mcp_call(opts)
+        assert exc.value.code == 0
+        mock_call.assert_called_once()
+        # tool name + parsed args are forwarded
+        assert mock_call.call_args.args[1] == "ask"
+        assert mock_call.call_args.args[2] == {"input": "hi"}
+        assert "pong" in capsys.readouterr().out
+
+    def test_malformed_json_exits_one(self, capsys: pytest.CaptureFixture) -> None:
+        opts = Namespace(
+            url="https://host/mcp",
+            app=None,
+            tool="ask",
+            args="{not json}",
+            profile=None,
+        )
+        with pytest.raises(SystemExit) as exc:
+            _handle_mcp_call(opts)
+        assert exc.value.code == 1
+        assert "must be a JSON object" in capsys.readouterr().err
+
+    def test_non_object_json_exits_one(self, capsys: pytest.CaptureFixture) -> None:
+        opts = Namespace(
+            url="https://host/mcp",
+            app=None,
+            tool="ask",
+            args="[1, 2, 3]",
+            profile=None,
+        )
+        with pytest.raises(SystemExit) as exc:
+            _handle_mcp_call(opts)
+        assert exc.value.code == 1
+        assert "must be a JSON object" in capsys.readouterr().err

--- a/tests/dao_ai/test_mcp_filtering_integration.py
+++ b/tests/dao_ai/test_mcp_filtering_integration.py
@@ -1069,3 +1069,32 @@ class TestMCPMetaInjection:
 
         mock_session.call_tool.assert_called_once()
         assert mock_session.call_tool.call_args.kwargs.get("meta") is None
+
+
+class TestCallMcpTool:
+    """Tests for the single-tool invocation helper call_mcp_tool."""
+
+    @patch("dao_ai.tools.mcp.MultiServerMCPClient")
+    def test_call_mcp_tool_returns_text(self, mock_client_class, mock_mcp_tools):
+        """call_mcp_tool invokes the named tool and returns its text content."""
+        from mcp.types import CallToolResult, TextContent
+
+        from dao_ai.tools.mcp import call_mcp_tool
+
+        mock_client = _setup_mock_client(mock_client_class, mock_mcp_tools)
+        mock_session = mock_client.session.return_value.__aenter__.return_value
+        mock_session.call_tool = AsyncMock(
+            return_value=CallToolResult(
+                content=[TextContent(type="text", text="hello world")]
+            )
+        )
+
+        function = McpFunctionModel(type="mcp", url="http://test.com/mcp")
+        result = call_mcp_tool(function, "query_sales", {"q": "hi"})
+
+        assert result == "hello world"
+        mock_session.call_tool.assert_called_once()
+        # The tool name and args are forwarded to the session.
+        call_args = mock_session.call_tool.call_args
+        assert call_args.args[0] == "query_sales"
+        assert call_args.args[1] == {"q": "hi"}


### PR DESCRIPTION
## Summary

Groups MCP inspection/test utilities under a clear top-level `mcp` noun. Previously `dao-ai tools` was a lone leaf command for discovering the MCP tools an agent config declares; since then dao-ai gained the ability to deploy itself as an MCP server (`agent --mode mcp`), but there was no CLI way to introspect or smoke-test a *deployed* server. This noun makes the two MCP roles obvious.

| Verb | Purpose |
|---|---|
| `dao-ai mcp tools -c config.yaml` | List the MCP tools an agent **config** declares (with filter status). Moved from top-level `tools`. |
| `dao-ai mcp inspect --url\|--app` | Connect to a **live** MCP server, show best-effort `/healthz` + tool list. |
| `dao-ai mcp call TOOL --url\|--app --args '{...}'` | Invoke one tool on a live server and print the result (smoke test). |

Learnable rule surfaced in the help: **`-c` = what my agent sees; `--url`/`--app` = what a running server exposes.**

## Scope / non-goals

- **Deployment stays on `agent --mode mcp`.** This noun is utilities-only and does NOT reintroduce lifecycle verbs — the `mcp` deployment noun was intentionally removed in `7f90dfe` (2026-07-25) and folded into `agent --mode mcp`. The `mcp` help epilog says so explicitly.
- 0.2.x is unreleased, so the interim top-level `tools` command is removed outright — no deprecated alias.

## Implementation

- `src/dao_ai/tools/mcp.py`: new `acall_mcp_tool` / `call_mcp_tool` — a thin wrapper over the same low-level primitives the agent runtime uses (`_build_mcp_client` + `_call_tool_with_capabilities` + `_extract_text_content`), so a smoke test exercises the real invocation path.
- `src/dao_ai/cli.py`: renamed `handle_list_mcp_tools_command` → `_handle_mcp_tools`; added `_mcp_function_from_args`, `_handle_mcp_inspect`, `_handle_mcp_call`, `handle_mcp_command`; manual noun+verb parser modeled on `trace`/`monitor`; `case "mcp"` dispatch. `--app` resolves the App's `/mcp` endpoint via `McpFunctionModel.mcp_url` (SDK `apps.get`), reusing the existing OBO→SP→PAT→ambient auth chain.
- `docs/cli-reference.md`: "List MCP Tools" → "MCP Utilities".

## Testing

- 240 tests pass (`test_development_flag_cli`, `test_mcp_cli`, `test_mcp_filtering_integration`); 0 new lint errors.
- Live on FEVM: `mcp tools` matches the old `tools` output; `mcp inspect --url <managed SQL MCP>` listed 3 tools with schemas (health n/a best-effort); `mcp call execute_sql_read_only` ran `SELECT 1` → SUCCEEDED with a real result; `--app` name→URL resolution confirmed.

## Notes

- `make schema` not needed — no config-model fields change (`McpFunctionModel` is only constructed in code).

This pull request and its description were written by Isaac.