### PR TITLE
fix(cli): mcp inspect health/error UX + root-cause messages

### DIFF
--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -2707,6 +2707,31 @@ def _mcp_function_from_args(options: Namespace) -> "McpFunctionModel":
     return McpFunctionModel(url=options.url)
 
 
+def _root_cause(exc: BaseException) -> str:
+    """Return the innermost, user-meaningful message from a wrapped exception.
+
+    MCP connection failures surface as nested TaskGroup ``ExceptionGroup``s
+    wrapping the real error (e.g. ``McpError: Session terminated``). The default
+    ``str(exc)`` yields the useless ``"unhandled errors in a TaskGroup (1
+    sub-exception)"``; this drills through ExceptionGroups and ``__cause__``/
+    ``__context__`` chains to the leaf message.
+    """
+    seen: set[int] = set()
+    cur: BaseException | None = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        group = getattr(cur, "exceptions", None)
+        if group:  # ExceptionGroup / TaskGroup — descend into the first child
+            cur = group[0]
+            continue
+        nxt = cur.__cause__ or cur.__context__
+        if nxt is None:
+            break
+        cur = nxt
+    msg = str(cur).strip() if cur is not None else str(exc).strip()
+    return f"{type(cur).__name__}: {msg}" if msg else type(cur).__name__
+
+
 def _handle_mcp_inspect(options: Namespace) -> None:
     """Connect to a live MCP server and show its health + available tools.
 
@@ -2772,7 +2797,7 @@ def _handle_mcp_inspect(options: Namespace) -> None:
                 "an MCP server.\n   If this is a dao-ai agent App (not an MCP "
                 "server), inspect it via its\n   agent API instead; only "
                 "`agent --mode mcp` deployments expose MCP tools.\n"
-                f"\n   Detail: {e}"
+                f"\n   Detail: {_root_cause(e)}"
             )
             print(f"\n{'=' * 80}\n")
             sys.exit(1)
@@ -2799,7 +2824,7 @@ def _handle_mcp_inspect(options: Namespace) -> None:
     except Exception as e:
         logger.error(f"Failed to inspect MCP server: {e}")
         logger.debug(traceback.format_exc())
-        print(f"\n❌ Error: {e}")
+        print(f"\n❌ Error: {_root_cause(e)}")
         sys.exit(1)
 
 
@@ -2834,7 +2859,7 @@ def _handle_mcp_call(options: Namespace) -> None:
     except Exception as e:
         logger.error(f"Failed to call MCP tool '{options.tool}': {e}")
         logger.debug(traceback.format_exc())
-        print(f"\n❌ Error: {e}")
+        print(f"\n❌ Error: {_root_cause(e)}")
         sys.exit(1)
 
 

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -2727,20 +2727,52 @@ def _handle_mcp_inspect(options: Namespace) -> None:
         print(f"Server: {mcp_url}")
         print(f"{'=' * 80}\n")
 
-        # Health is best-effort: only dao-ai MCP servers expose /healthz.
+        # Health is best-effort. dao-ai apps (agent and MCP-server) expose
+        # /healthz; arbitrary/managed MCP servers may not. The probe reuses the
+        # resolved workspace-client auth headers, since Databricks Apps sit
+        # behind an authenticating proxy. A 200 with an empty body still means
+        # healthy — only a 404 means "no such endpoint".
         health_url = f"{mcp_url.rstrip('/').removesuffix('/mcp')}/healthz"
         try:
             import httpx
 
-            resp = httpx.get(health_url, timeout=10.0)
+            headers = function.workspace_client.config.authenticate() or {}
+            resp = httpx.get(
+                health_url, headers=headers, timeout=10.0, follow_redirects=True
+            )
             if resp.status_code == 200:
-                print(f"   Health: ✓ {resp.json()}")
+                body = resp.text.strip()
+                detail = ""
+                if body:
+                    try:
+                        detail = f" {resp.json()}"
+                    except ValueError:
+                        detail = f" {body[:200]}"
+                print(f"   Health: ✓ 200{detail}")
+            elif resp.status_code == 404:
+                print("   Health: n/a (no /healthz endpoint)")
             else:
                 print(f"   Health: n/a (HTTP {resp.status_code})")
-        except Exception:
-            print("   Health: n/a (no /healthz endpoint)")
+        except Exception as e:
+            print(f"   Health: n/a ({type(e).__name__})")
 
-        tools = list_mcp_tools(function, apply_filters=False)
+        # Tool listing. Only MCP servers expose a tool list; a plain dao-ai
+        # agent App has no /mcp tool-listing route, so surface that as guidance
+        # rather than an opaque hard error.
+        try:
+            tools = list_mcp_tools(function, apply_filters=False)
+        except Exception as e:
+            logger.debug(traceback.format_exc())
+            print(
+                "\n   ⚠️  Could not list tools — this endpoint did not respond as "
+                "an MCP server.\n   If this is a dao-ai agent App (not an MCP "
+                "server), inspect it via its\n   agent API instead; only "
+                "`agent --mode mcp` deployments expose MCP tools.\n"
+                f"\n   Detail: {e}"
+            )
+            print(f"\n{'=' * 80}\n")
+            sys.exit(1)
+
         print(f"\n   Available Tools: {len(tools)}\n")
         for tool in sorted(tools, key=lambda t: t.name):
             print(f"     • {tool.name}")
@@ -2779,8 +2811,10 @@ def _handle_mcp_call(options: Namespace) -> None:
         print(f"\n❌ Error: --args must be a JSON object: {e}", file=sys.stderr)
         sys.exit(1)
     if not isinstance(args, dict):
-        print("\n❌ Error: --args must be a JSON object (e.g. '{\"q\": \"hi\"}')",
-              file=sys.stderr)
+        print(
+            '\n❌ Error: --args must be a JSON object (e.g. \'{"q": "hi"}\')',
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     try:

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -2758,10 +2758,14 @@ def _handle_mcp_inspect(options: Namespace) -> None:
 
         # Tool listing. Only MCP servers expose a tool list; a plain dao-ai
         # agent App has no /mcp tool-listing route, so surface that as guidance
-        # rather than an opaque hard error.
+        # rather than an opaque hard error. Silence the dao_ai.tools.mcp logger
+        # for this call — it logs-and-reraises at ERROR, which would duplicate
+        # the guidance below with a noisy traceback line. Restored in `finally`.
         try:
+            logger.disable("dao_ai.tools.mcp")
             tools = list_mcp_tools(function, apply_filters=False)
         except Exception as e:
+            logger.enable("dao_ai.tools.mcp")
             logger.debug(traceback.format_exc())
             print(
                 "\n   ⚠️  Could not list tools — this endpoint did not respond as "
@@ -2772,6 +2776,8 @@ def _handle_mcp_inspect(options: Namespace) -> None:
             )
             print(f"\n{'=' * 80}\n")
             sys.exit(1)
+        finally:
+            logger.enable("dao_ai.tools.mcp")
 
         print(f"\n   Available Tools: {len(tools)}\n")
         for tool in sorted(tools, key=lambda t: t.name):

--- a/tests/dao_ai/test_mcp_cli.py
+++ b/tests/dao_ai/test_mcp_cli.py
@@ -14,6 +14,7 @@ from dao_ai.cli import (
     _handle_mcp_call,
     _handle_mcp_inspect,
     _mcp_function_from_args,
+    _root_cause,
 )
 from dao_ai.config import McpFunctionModel
 
@@ -175,3 +176,25 @@ class TestHandleMcpInspect:
         assert exc.value.code == 1
         out = capsys.readouterr().out
         assert "did not respond as an MCP server" in out
+
+
+@pytest.mark.unit
+class TestRootCause:
+    """_root_cause drills through ExceptionGroup / cause chains to the leaf."""
+
+    def test_plain_exception(self) -> None:
+        assert _root_cause(ValueError("boom")) == "ValueError: boom"
+
+    def test_unwraps_nested_task_groups(self) -> None:
+        leaf = RuntimeError("Session terminated")
+        inner = ExceptionGroup("unhandled errors in a TaskGroup", [leaf])
+        outer = ExceptionGroup("unhandled errors in a TaskGroup", [inner])
+        wrapper = RuntimeError("Failed to list MCP tools ...")
+        wrapper.__cause__ = outer
+        assert _root_cause(wrapper) == "RuntimeError: Session terminated"
+
+    def test_follows_cause_chain(self) -> None:
+        root = ConnectionError("connection refused")
+        top = RuntimeError("wrapper")
+        top.__cause__ = root
+        assert _root_cause(top) == "ConnectionError: connection refused"

--- a/tests/dao_ai/test_mcp_cli.py
+++ b/tests/dao_ai/test_mcp_cli.py
@@ -6,12 +6,37 @@ network layer mocked.
 """
 
 from argparse import Namespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from dao_ai.cli import _handle_mcp_call, _mcp_function_from_args
+from dao_ai.cli import (
+    _handle_mcp_call,
+    _handle_mcp_inspect,
+    _mcp_function_from_args,
+)
 from dao_ai.config import McpFunctionModel
+
+
+def _mock_function(mcp_url: str = "https://host/mcp") -> MagicMock:
+    """A stand-in McpFunctionModel: exposes mcp_url + workspace_client auth."""
+    fn = MagicMock()
+    fn.mcp_url = mcp_url
+    fn.workspace_client.config.authenticate.return_value = {"Authorization": "Bearer x"}
+    return fn
+
+
+def _mock_health(status_code: int, body: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = body
+    if body:
+        import json as _json
+
+        resp.json.return_value = _json.loads(body)
+    else:
+        resp.json.side_effect = ValueError("no json")
+    return resp
 
 
 @pytest.mark.unit
@@ -80,3 +105,73 @@ class TestHandleMcpCall:
             _handle_mcp_call(opts)
         assert exc.value.code == 1
         assert "must be a JSON object" in capsys.readouterr().err
+
+
+@pytest.mark.unit
+class TestHandleMcpInspect:
+    """_handle_mcp_inspect: health probe + tool listing, with both mocked."""
+
+    def _opts(self) -> Namespace:
+        return Namespace(url="https://host/mcp", app=None, profile=None)
+
+    def test_healthy_server_lists_tools(self, capsys: pytest.CaptureFixture) -> None:
+        tool = MagicMock()
+        tool.name = "agent_tool"
+        tool.description = "desc"
+        tool.input_schema = {}
+        with (
+            patch("dao_ai.cli._mcp_function_from_args", return_value=_mock_function()),
+            patch("httpx.get", return_value=_mock_health(200, '{"ok": true}')),
+            patch("dao_ai.tools.mcp.list_mcp_tools", return_value=[tool]),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                _handle_mcp_inspect(self._opts())
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "Health: ✓ 200" in out
+        assert "agent_tool" in out
+
+    def test_empty_body_health_is_ok(self, capsys: pytest.CaptureFixture) -> None:
+        # 200 with an empty body must NOT be reported as "no /healthz endpoint".
+        with (
+            patch("dao_ai.cli._mcp_function_from_args", return_value=_mock_function()),
+            patch("httpx.get", return_value=_mock_health(200, "")),
+            patch("dao_ai.tools.mcp.list_mcp_tools", return_value=[]),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                _handle_mcp_inspect(self._opts())
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "Health: ✓ 200" in out
+        assert "no /healthz endpoint" not in out
+
+    def test_health_404_reports_no_endpoint(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        with (
+            patch("dao_ai.cli._mcp_function_from_args", return_value=_mock_function()),
+            patch("httpx.get", return_value=_mock_health(404)),
+            patch("dao_ai.tools.mcp.list_mcp_tools", return_value=[]),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                _handle_mcp_inspect(self._opts())
+        assert exc.value.code == 0
+        assert "no /healthz endpoint" in capsys.readouterr().out
+
+    def test_non_mcp_server_gives_guidance_not_crash(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        # Tool listing fails (e.g. a plain agent App) -> friendly guidance, exit 1.
+        with (
+            patch("dao_ai.cli._mcp_function_from_args", return_value=_mock_function()),
+            patch("httpx.get", return_value=_mock_health(200, "")),
+            patch(
+                "dao_ai.tools.mcp.list_mcp_tools",
+                side_effect=RuntimeError("TaskGroup error"),
+            ),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                _handle_mcp_inspect(self._opts())
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "did not respond as an MCP server" in out


### PR DESCRIPTION
## Summary

Three UX fixes to the `dao-ai mcp` utilities noun (`inspect` / `call`), all found while live-testing against deployed dao-ai Apps on FEVM. No behavior change to `mcp tools`.

## Fixes

1. **Health probe false-negative** (`mcp inspect`). The probe did `httpx.get(health_url)` with no auth and then `resp.json()`. dao-ai `/healthz` returns **200 with an empty body**, so `resp.json()` raised and the broad `except` misreported it as `Health: n/a (no /healthz endpoint)` — even though the endpoint was healthy. Now the probe sends the resolved workspace-client auth headers, treats a 200 (empty or JSON body) as healthy, and only reports "no /healthz endpoint" on a real 404.

2. **Opaque failure on non-MCP endpoints** (`mcp inspect`). Inspecting a plain dao-ai agent App (which has no `/mcp` tool-listing route) dumped a raw `unhandled errors in a TaskGroup` and a scary `❌ Error`. Now it prints clear guidance ("this endpoint did not respond as an MCP server … only `agent --mode mcp` deployments expose MCP tools") and exits 1. The duplicate `dao_ai.tools.mcp` ERROR log line (log-and-reraise) is silenced for this one call and restored in `finally`.

3. **Meaningless error text** (`mcp inspect` + `mcp call`). MCP connection failures arrive as nested `TaskGroup` `ExceptionGroup`s, so `str(exc)` yielded `unhandled errors in a TaskGroup (1 sub-exception)`. Added `_root_cause()` to drill through `ExceptionGroup`s and `__cause__`/`__context__` chains to the leaf; errors now read e.g. `McpError: Session terminated`.

## Before / after (`mcp inspect --app <agent-app>`)

Before:
```
   Health: n/a (no /healthz endpoint)
<ERROR log line>
   Detail: Failed to list MCP tools ...: unhandled errors in a TaskGroup (1 sub-exception)
```
After:
```
   Health: ✓ 200

   ⚠️  Could not list tools — this endpoint did not respond as an MCP server.
   ...
   Detail: McpError: Session terminated
```

## Testing

- `tests/dao_ai/test_mcp_cli.py`: added `TestHandleMcpInspect` (healthy server, empty-body 200, 404, non-MCP guidance) and `TestRootCause` (plain / nested TaskGroup / cause-chain). 12 tests pass; 0 new lint.
- Verified live on FEVM against both a deployed dao-ai MCP server (`agent --mode mcp`, lists its tool, `Health: ✓ 200`) and a deployed dao-ai agent App (clean guidance, root-cause detail).

This pull request and its description were written by Isaac.