### PR TITLE
fix(config): defer vector-search endpoint discovery to provisioning

### DIFF
--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -3260,6 +3260,16 @@ class AiSearchVectorStoreModel(IsDatabricksResource, ManagedResource):
     def as_index(self, vsc: VectorSearchClient | None = None) -> VectorSearchIndex:
         from dao_ai.providers.databricks import DatabricksProvider
 
+        # Build an authenticated VectorSearchClient from this model's own
+        # workspace client when the caller didn't supply one — a bare
+        # ``VectorSearchClient()`` raises ``InvalidInputException`` under SP /
+        # ambient CLI-profile auth. Same ambient-auth extraction the runtime
+        # retrieval path uses (``_vsc_for_refresh`` → ``_client_args_from_ambient_wc``).
+        if vsc is None:
+            from dao_ai.tools.vector_search import _vsc_for_refresh
+
+            vsc = _vsc_for_refresh(self)
+
         provider: DatabricksProvider = DatabricksProvider(vsc=vsc)
         index: VectorSearchIndex = provider.get_vector_index(self)
         return index

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -3238,32 +3238,14 @@ class AiSearchVectorStoreModel(IsDatabricksResource, ManagedResource):
             self.index = IndexModel(schema=self.source_table.schema_model, name=name)
         return self
 
-    @model_validator(mode="after")
-    def set_default_endpoint(self) -> Self:
-        # Only find/create endpoint in provisioning mode
-        if self.endpoint is None and self.source_table is not None:
-            from dao_ai.providers.databricks import (
-                DatabricksProvider,
-                with_available_indexes,
-            )
-
-            provider: DatabricksProvider = DatabricksProvider()
-            logger.debug("Finding endpoint for existing index...")
-            endpoint_name: str | None = provider.find_endpoint_for_index(self.index)
-            if endpoint_name is None:
-                logger.debug("Finding first endpoint with available indexes...")
-                endpoint_name = provider.find_vector_search_endpoint(
-                    with_available_indexes
-                )
-            if endpoint_name is None:
-                logger.debug("No endpoint found, creating a new name...")
-                endpoint_name = (
-                    f"{self.source_table.schema_model.catalog_name}_endpoint"
-                )
-            logger.debug(f"Using endpoint: {endpoint_name}")
-            self.endpoint = VectorSearchEndpoint(name=endpoint_name)
-
-        return self
+    # NOTE: endpoint auto-discovery is intentionally NOT done here. It used to
+    # live in a ``@model_validator(mode="after")``, but validators run at config
+    # PARSE time — which includes serving/MCP-server boot (``AppConfig.from_file``
+    # / ``initialize()``). Discovering the endpoint requires a
+    # ``VectorSearchClient``, whose bare constructor hard-requires explicit creds
+    # and crashes ambient serving auth. The endpoint is a PROVISIONING-only
+    # concern (the runtime retrieval path uses ``index.full_name`` and never
+    # reads ``endpoint``), so discovery is deferred to ``_create_new_index``.
 
     @property
     def api_scopes(self) -> Sequence[str]:
@@ -3408,6 +3390,25 @@ class AiSearchVectorStoreModel(IsDatabricksResource, ManagedResource):
         """
         from dao_ai.providers.databricks import DatabricksProvider
 
+        # Resolve provisioning-mode fields (e.g. primary_key) up front. Idempotent
+        # (guarded by ``self._resolved``) so this is a no-op when the config was
+        # already resolved during ``AppConfig.initialize()``. Endpoint discovery
+        # is NOT part of ``ensure_resolved`` — it happens in ``_create_new_index``
+        # so serving/MCP boot never builds a VectorSearchClient.
+        self.ensure_resolved()
+
+        # Build the VectorSearchClient from this model's own workspace client so
+        # provisioning (endpoint discovery + index create) authenticates under
+        # every auth mode — including ambient CLI-profile / Serverless-v5, where a
+        # bare ``VectorSearchClient()`` raises ``InvalidInputException``. Reuses
+        # the same ambient-auth extraction the runtime retrieval path uses
+        # (``_vsc_for_refresh`` → ``_client_args_from_ambient_wc``). A caller-
+        # supplied ``vsc`` still takes precedence.
+        if vsc is None:
+            from dao_ai.tools.vector_search import _vsc_for_refresh
+
+            vsc = _vsc_for_refresh(self)
+
         provider: DatabricksProvider = DatabricksProvider(vsc=vsc)
 
         if self.source_table is not None:
@@ -3432,13 +3433,36 @@ class AiSearchVectorStoreModel(IsDatabricksResource, ManagedResource):
             )
 
     def _create_new_index(self, provider: Any) -> None:
-        """Create a new vector search index from source table."""
+        """Create a new vector search index from source table.
+
+        Discovers the target endpoint on demand when one was not configured.
+        This is deliberately here (provisioning) rather than in a validator or
+        ``ensure_resolved`` so that serving/MCP-server boot — which parses and
+        resolves the config but never provisions — makes zero VectorSearch API
+        calls and never needs VectorSearch credentials.
+        """
         if self.embedding_source_column is None:
             raise ValueError("embedding_source_column is required for provisioning")
-        if self.endpoint is None:
-            raise ValueError("endpoint is required for provisioning")
         if self.index is None:
             raise ValueError("index is required for provisioning")
+
+        if self.endpoint is None:
+            from dao_ai.providers.databricks import with_available_indexes
+
+            logger.debug("Finding endpoint for existing index...")
+            endpoint_name: str | None = provider.find_endpoint_for_index(self.index)
+            if endpoint_name is None:
+                logger.debug("Finding first endpoint with available indexes...")
+                endpoint_name = provider.find_vector_search_endpoint(
+                    with_available_indexes
+                )
+            if endpoint_name is None:
+                logger.debug("No endpoint found, creating a new name...")
+                endpoint_name = (
+                    f"{self.source_table.schema_model.catalog_name}_endpoint"
+                )
+            logger.debug(f"Using endpoint: {endpoint_name}")
+            self.endpoint = VectorSearchEndpoint(name=endpoint_name)
 
         provider.create_vector_store(self)
 

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -2805,9 +2805,38 @@ class DatabricksProvider(ServiceProvider):
         self.vsc.create_delta_sync_index_and_wait(**create_kwargs)
         return self.vsc.get_index(endpoint_name, index_name)
 
-    def get_vector_index(self, vector_store: VectorStoreModel) -> None:
+    def get_vector_index(self, vector_store: VectorStoreModel) -> VectorSearchIndex:
+        # Endpoint discovery is deferred out of config parse (serving-safe). A
+        # caller can reach here with an unresolved endpoint — e.g. a retriever's
+        # deep-copied vector_store that never went through create(), which only
+        # populates the resources.vector_stores instance. Resolve on demand and
+        # stamp it so refresh()/subsequent calls are consistent, falling back to
+        # an endpoint-less lookup (the SDK's get_index accepts endpoint_name=None
+        # and resolves the index by full name alone).
+        endpoint_name: str | None = (
+            vector_store.endpoint.name if vector_store.endpoint is not None else None
+        )
+        if endpoint_name is None and vector_store.index is not None:
+            # Best-effort discovery. If it fails (e.g. an unauthenticated
+            # VectorSearchClient), fall through to the endpoint-less lookup
+            # rather than propagating — get_index resolves the index by full
+            # name alone.
+            try:
+                endpoint_name = self.find_endpoint_for_index(vector_store.index)
+            except Exception as e:  # noqa: BLE001
+                logger.debug(
+                    "Endpoint discovery failed; using endpoint-less index lookup",
+                    index_name=vector_store.index.full_name,
+                    error=f"{type(e).__name__}: {e}",
+                )
+                endpoint_name = None
+            if endpoint_name is not None:
+                from dao_ai.config import VectorSearchEndpoint
+
+                vector_store.endpoint = VectorSearchEndpoint(name=endpoint_name)
+
         index: VectorSearchIndex = self.vsc.get_index(
-            vector_store.endpoint.name, vector_store.index.full_name
+            endpoint_name, vector_store.index.full_name
         )
         return index
 

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -1972,12 +1972,11 @@ def test_vector_store_model_provisioning_mode():
     schema = SchemaModel(catalog_name="test_catalog", schema_name="test_schema")
     table = TableModel(schema=schema, name="test_table")
 
-    # Mock the DatabricksProvider to avoid actual API calls
-    # The import happens inside the validators, so we patch the providers module
+    # Mock the DatabricksProvider to avoid actual API calls during
+    # ensure_resolved (primary-key discovery uses the provider).
     with patch("dao_ai.providers.databricks.DatabricksProvider") as mock_provider_class:
         mock_provider = MagicMock()
         mock_provider.find_primary_key.return_value = ["id"]
-        mock_provider.find_endpoint_for_index.return_value = "test_endpoint"
         mock_provider_class.return_value = mock_provider
 
         vector_store = VectorStoreModel(
@@ -2000,9 +1999,43 @@ def test_vector_store_model_provisioning_mode():
         # Primary key should be auto-discovered
         assert vector_store.primary_key == "id"
 
-        # Endpoint should be auto-discovered in provisioning mode
-        assert vector_store.endpoint is not None
-        assert vector_store.endpoint.name == "test_endpoint"
+        # Endpoint discovery is deferred to create()/_create_new_index — it must
+        # NOT run during construction or ensure_resolved (that would build a
+        # VectorSearchClient at serving/parse time). It stays None until create().
+        assert vector_store.endpoint is None
+        mock_provider.find_endpoint_for_index.assert_not_called()
+        mock_provider.find_vector_search_endpoint.assert_not_called()
+
+
+@pytest.mark.unit
+def test_vector_store_provisioning_config_load_makes_no_vector_search_calls():
+    """Regression: parsing + resolving a provisioning config must not touch
+    Vector Search.
+
+    Endpoint discovery used to run in a model validator, building a
+    VectorSearchClient at config-parse time. On serving/MCP-server boot (which
+    parses and calls ensure_resolved but never provisions) that bare client has
+    no credentials and crashed with InvalidInputException. This locks in that
+    neither construction nor ensure_resolved performs endpoint discovery.
+    """
+    schema = SchemaModel(catalog_name="test_catalog", schema_name="test_schema")
+    table = TableModel(schema=schema, name="test_table")
+
+    with patch("dao_ai.providers.databricks.DatabricksProvider") as mock_provider_class:
+        mock_provider = MagicMock()
+        mock_provider.find_primary_key.return_value = ["id"]
+        mock_provider_class.return_value = mock_provider
+
+        vector_store = VectorStoreModel(
+            source_table=table,
+            embedding_source_column="description",
+        )
+        vector_store.ensure_resolved()
+
+        # Endpoint stays unresolved; no Vector Search endpoint lookups happened.
+        assert vector_store.endpoint is None
+        mock_provider.find_endpoint_for_index.assert_not_called()
+        mock_provider.find_vector_search_endpoint.assert_not_called()
 
 
 @pytest.mark.unit
@@ -2317,23 +2350,21 @@ def test_vector_store_create_provisions_new_index():
     table = TableModel(schema=schema, name="test_table")
 
     with patch("dao_ai.providers.databricks.DatabricksProvider") as mock_provider_class:
-        # Mock for validators - called multiple times during __init__
+        # Provider used by ensure_resolved() for primary-key discovery.
         mock_provider_for_primary_key = MagicMock()
         mock_provider_for_primary_key.find_primary_key.return_value = ["id"]
 
-        mock_provider_for_endpoint = MagicMock()
-        mock_provider_for_endpoint.find_endpoint_for_index.return_value = None
-        mock_provider_for_endpoint.find_vector_search_endpoint.return_value = (
+        # Provider built inside create(); endpoint discovery now happens here
+        # (deferred out of the validator), so it must stub the lookup methods.
+        mock_provider_for_create = MagicMock()
+        mock_provider_for_create.find_endpoint_for_index.return_value = None
+        mock_provider_for_create.find_vector_search_endpoint.return_value = (
             "test_endpoint"
         )
 
-        # Mock for create call
-        mock_provider_for_create = MagicMock()
-
-        # Return different instances for each DatabricksProvider() call
+        # One construction during ensure_resolved(), one inside create().
         mock_provider_class.side_effect = [
-            mock_provider_for_endpoint,  # set_default_endpoint validator (during __init__)
-            mock_provider_for_primary_key,  # set_default_primary_key (during ensure_resolved)
+            mock_provider_for_primary_key,  # ensure_resolved() primary-key discovery
             mock_provider_for_create,  # create() call
         ]
 
@@ -2343,8 +2374,12 @@ def test_vector_store_create_provisions_new_index():
         )
         vector_store.ensure_resolved()
 
-        # Call create() - this will use the third mock from side_effect
+        # Call create() - this will use the second mock from side_effect
         vector_store.create()
+
+        # Endpoint was auto-discovered inside create()/_create_new_index.
+        assert vector_store.endpoint is not None
+        assert vector_store.endpoint.name == "test_endpoint"
 
         # Should call create_vector_store
         mock_provider_for_create.create_vector_store.assert_called_once_with(
@@ -2386,18 +2421,20 @@ def test_vector_store_create_provisioning_requires_embedding_column():
 
 
 @pytest.mark.unit
-def test_vector_store_create_provisioning_requires_endpoint():
-    """Test VectorStoreModel._create_new_index() validates endpoint."""
+def test_vector_store_create_provisioning_auto_discovers_endpoint():
+    """_create_new_index() auto-discovers the endpoint when none is configured.
+
+    Endpoint discovery was moved out of the config validator (which ran at
+    serving/parse time) into provisioning. When endpoint is None, it now falls
+    back through find_endpoint_for_index -> find_vector_search_endpoint using the
+    provider passed by create().
+    """
     schema = SchemaModel(catalog_name="test_catalog", schema_name="test_schema")
     table = TableModel(schema=schema, name="test_table")
 
     with patch("dao_ai.providers.databricks.DatabricksProvider") as mock_provider_class:
         mock_provider_for_validators = MagicMock()
         mock_provider_for_validators.find_primary_key.return_value = ["id"]
-        mock_provider_for_validators.find_endpoint_for_index.return_value = None
-        mock_provider_for_validators.find_vector_search_endpoint.return_value = (
-            "test_endpoint"
-        )
         mock_provider_class.return_value = mock_provider_for_validators
 
         vector_store = VectorStoreModel(
@@ -2405,15 +2442,22 @@ def test_vector_store_create_provisioning_requires_endpoint():
             embedding_source_column="description",
         )
 
-        # Force None to test validation
-        vector_store.endpoint = None
+        # No endpoint configured (nor discovered at parse time — that's the fix).
+        assert vector_store.endpoint is None
 
+        # Provider handed to _create_new_index: first lookup misses, the
+        # available-indexes fallback resolves the endpoint.
         mock_provider = MagicMock()
+        mock_provider.find_endpoint_for_index.return_value = None
+        mock_provider.find_vector_search_endpoint.return_value = "discovered_endpoint"
 
-        with pytest.raises(ValueError) as exc_info:
-            vector_store._create_new_index(mock_provider)
+        vector_store._create_new_index(mock_provider)
 
-        assert "endpoint is required for provisioning" in str(exc_info.value)
+        assert vector_store.endpoint is not None
+        assert vector_store.endpoint.name == "discovered_endpoint"
+        mock_provider.find_endpoint_for_index.assert_called_once()
+        mock_provider.find_vector_search_endpoint.assert_called_once()
+        mock_provider.create_vector_store.assert_called_once_with(vector_store)
 
 
 @pytest.mark.unit

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -2461,6 +2461,151 @@ def test_vector_store_create_provisioning_auto_discovers_endpoint():
 
 
 @pytest.mark.unit
+def test_get_vector_index_self_resolves_endpoint_when_none():
+    """get_vector_index resolves a missing endpoint on demand and stamps it.
+
+    The read path must work on an instance that never went through create()
+    (e.g. a retriever's deep-copied vector_store), so it resolves the endpoint
+    via find_endpoint_for_index and stamps it back onto the model.
+    """
+    schema = SchemaModel(catalog_name="c", schema_name="s")
+    vector_store = VectorStoreModel(
+        index=IndexModel(schema=schema, name="products_index"),
+        embedding_source_column="description",
+    )
+    assert vector_store.endpoint is None
+
+    provider = DatabricksProvider(vsc=MagicMock())
+    with patch.object(
+        provider, "find_endpoint_for_index", return_value="resolved_ep"
+    ) as mock_find:
+        provider.get_vector_index(vector_store)
+
+    mock_find.assert_called_once()
+    # Endpoint stamped back onto the model, and get_index called with it.
+    assert vector_store.endpoint is not None
+    assert vector_store.endpoint.name == "resolved_ep"
+    provider.vsc.get_index.assert_called_once_with(
+        "resolved_ep", "c.s.products_index"
+    )
+
+
+@pytest.mark.unit
+def test_get_vector_index_endpointless_fallback():
+    """When discovery finds no endpoint, fall back to an endpoint-less lookup.
+
+    The SDK's get_index accepts endpoint_name=None and resolves the index by
+    full name, so a failed discovery must NOT crash.
+    """
+    schema = SchemaModel(catalog_name="c", schema_name="s")
+    vector_store = VectorStoreModel(
+        index=IndexModel(schema=schema, name="products_index"),
+        embedding_source_column="description",
+    )
+
+    provider = DatabricksProvider(vsc=MagicMock())
+    with patch.object(provider, "find_endpoint_for_index", return_value=None):
+        provider.get_vector_index(vector_store)
+
+    assert vector_store.endpoint is None
+    provider.vsc.get_index.assert_called_once_with(None, "c.s.products_index")
+
+
+@pytest.mark.unit
+def test_get_vector_index_discovery_failure_falls_through():
+    """A raising discovery (e.g. unauthenticated VS client) must not propagate.
+
+    On serving with SP auth, _vsc_for_refresh can yield a client that can't
+    list endpoints; discovery then raises. get_vector_index must swallow it and
+    fall back to the endpoint-less lookup so retrieval degrades gracefully.
+    """
+    schema = SchemaModel(catalog_name="c", schema_name="s")
+    vector_store = VectorStoreModel(
+        index=IndexModel(schema=schema, name="products_index"),
+        embedding_source_column="description",
+    )
+
+    provider = DatabricksProvider(vsc=MagicMock())
+    with patch.object(
+        provider,
+        "find_endpoint_for_index",
+        side_effect=RuntimeError("InvalidInputException: no creds"),
+    ):
+        provider.get_vector_index(vector_store)
+
+    assert vector_store.endpoint is None
+    provider.vsc.get_index.assert_called_once_with(None, "c.s.products_index")
+
+
+@pytest.mark.unit
+def test_get_vector_index_uses_configured_endpoint():
+    """An explicitly configured endpoint is used as-is (no discovery call)."""
+    schema = SchemaModel(catalog_name="c", schema_name="s")
+    vector_store = VectorStoreModel(
+        index=IndexModel(schema=schema, name="products_index"),
+        embedding_source_column="description",
+        endpoint={"name": "explicit_ep"},
+    )
+
+    provider = DatabricksProvider(vsc=MagicMock())
+    with patch.object(provider, "find_endpoint_for_index") as mock_find:
+        provider.get_vector_index(vector_store)
+
+    mock_find.assert_not_called()
+    provider.vsc.get_index.assert_called_once_with("explicit_ep", "c.s.products_index")
+
+
+@pytest.mark.unit
+def test_retriever_copy_endpoint_resolves_after_provisioning():
+    """Regression: a retriever's deep-copied vector_store is a DISTINCT instance
+    from resources.vector_stores, so provisioning create() only stamps the
+    endpoint on the resource copy. The retriever copy must still resolve its
+    endpoint on demand via get_vector_index rather than raising on endpoint.name.
+    """
+    cfg = {
+        "schemas": {"s": {"catalog_name": "c", "schema_name": "sch"}},
+        "resources": {
+            "vector_stores": {
+                "pv": {
+                    "index": {
+                        "schema": {"catalog_name": "c", "schema_name": "sch"},
+                        "name": "products_index",
+                    },
+                    "embedding_source_column": "description",
+                }
+            }
+        },
+        "retrievers": {
+            "r": {
+                "vector_store": {
+                    "index": {
+                        "schema": {"catalog_name": "c", "schema_name": "sch"},
+                        "name": "products_index",
+                    },
+                    "embedding_source_column": "description",
+                },
+                "columns": ["x"],
+            }
+        },
+    }
+    config = AppConfig(**cfg)
+    vs_res = config.resources.vector_stores["pv"]
+    vs_ret = config.retrievers["r"].vector_store
+
+    # Distinct instances (the crux of the regression) and both start unresolved.
+    assert vs_res is not vs_ret
+    assert vs_res.endpoint is None and vs_ret.endpoint is None
+
+    # get_vector_index on the retriever copy self-resolves instead of raising.
+    provider = DatabricksProvider(vsc=MagicMock())
+    with patch.object(provider, "find_endpoint_for_index", return_value="ep"):
+        provider.get_vector_index(vs_ret)
+
+    assert vs_ret.endpoint is not None
+    assert vs_ret.endpoint.name == "ep"
+
+
+@pytest.mark.unit
 def test_vector_store_create_provisioning_requires_index():
     """Test VectorStoreModel._create_new_index() validates index."""
     schema = SchemaModel(catalog_name="test_catalog", schema_name="test_schema")


### PR DESCRIPTION
## Summary

Deploying a dao-ai agent with a `vector_search` tool whose `vector_store` omits an explicit `endpoint:` crashed at **container startup** — most visibly as an MCP server (`agent --mode mcp`, which loads the config on boot):

```
databricks.ai_search.exceptions.InvalidInputException:
  Please specify either personal access token or service principal client ID and secret.
```

### Root cause

`AiSearchVectorStoreModel.set_default_endpoint` was a `@model_validator(mode="after")` that did **eager endpoint discovery** via a bare `VectorSearchClient()`. Validators run at config-**parse** time — which includes serving/MCP-server boot (`AppConfig.from_file` / `initialize()`). The bare `VectorSearchClient()` constructor hard-requires explicit PAT/SP creds and rejects ambient serving auth, so the process crashed before it could serve.

Key insight: **the endpoint is a provisioning-only concern.** The runtime retrieval path builds `DatabricksVectorSearch(index_name=vector_store.index.full_name, ...)` and never reads `.endpoint`.

### Fix

- **Delete** the `set_default_endpoint` validator — config parse/serving makes zero Vector Search calls.
- **Move** endpoint discovery into `_create_new_index` (the provisioning path only, never hit at serve time).
- `create()` now calls `ensure_resolved()` (idempotent) and builds the provider's `VectorSearchClient` from the model's own workspace client via `_vsc_for_refresh` — the same ambient-auth extraction the runtime uses. So provisioning discovery authenticates under **SP, PAT, and ambient CLI-profile** auth, not just a bare client.

No config schema change (`make schema` not needed); field types unchanged.

## Testing

- Unit: `tests/dao_ai/test_databricks.py` + `test_vector_store_refresh.py` — 24 pass. Dropped the endpoint-at-parse assertions, added an assertion that discovery happens in `create()`, and added a regression test asserting config-load + `ensure_resolved()` make **zero** Vector Search calls.
- Live on FEVM: deployed the exact crash config (existing index `retail_consumer_goods.hardware_store.products_index`, no `endpoint:`) as an MCP server with `--development`. Before the fix it CRASHED at boot; now it reaches **RUNNING** (`Application startup complete`), `mcp inspect` shows `Health: ✓ 200`, and `mcp call` returns a real product from the index. Also verified provisioning-mode discovery resolves the correct endpoint (`dbdemos_vs_endpoint`) under ambient CLI-profile auth.

## Note (pre-existing, not a regression)

Runtime `create_ai_search_tool` calls `vector_store.refresh()` → `get_vector_index`, which dereferences `endpoint.name`. For an index-only / no-endpoint config `endpoint` is `None`, so this raises — but it is **caught and soft-failed** (WARNING; column auto-discovery falls back). This behavior predates this change (index-only configs already had `endpoint=None` on `main`); this PR does not alter it.

This pull request and its description were written by Isaac.