### PR TITLE
fix(config): emit the relationship marker Genie requires on join_specs

### DIFF
--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -1579,6 +1579,35 @@ class GenieRelationshipType(str, Enum):
     MANY_TO_MANY = "MANY_TO_MANY"
 
 
+_RELATIONSHIP_MARKER_PREFIX = "FROM_RELATIONSHIP_TYPE_"
+_RELATIONSHIP_MARKER_RE = re.compile(r"--rt=([A-Z_]+)--")
+
+
+def _relationship_marker(relationship_type: Any) -> str:
+    """Encode a join's cardinality the way Genie's export proto expects.
+
+    ``instructions.join_specs[].sql`` must carry exactly two elements: the
+    join condition, then this marker. Posting the condition on its own is
+    rejected with ``Failed to parse export proto: <condition> (of class
+    java.lang.String)``, so an undeclared cardinality still has to say so.
+    """
+    value = getattr(relationship_type, "value", relationship_type) or "UNSPECIFIED"
+    return f"--rt={_RELATIONSHIP_MARKER_PREFIX}{value}--"
+
+
+def _relationship_type_from_marker(marker: str) -> "GenieRelationshipType | None":
+    """Decode a ``--rt=…--`` marker, or ``None`` if it carries no cardinality."""
+    match = _RELATIONSHIP_MARKER_RE.search(marker or "")
+    if not match:
+        return None
+    try:
+        return GenieRelationshipType(
+            match.group(1).removeprefix(_RELATIONSHIP_MARKER_PREFIX)
+        )
+    except ValueError:
+        return None
+
+
 class GenieJoinSpec(BaseModel):
     """A trusted join relationship between two Genie data sources."""
 
@@ -2277,14 +2306,18 @@ class GenieRoomModel(IsDatabricksResource, ManagedResource):
             join_payload: list[dict[str, Any]] = []
             for spec in self.join_specs:
                 left: dict[str, str] = {"identifier": spec.left.full_name}
+                if spec.left_alias:
+                    left["alias"] = spec.left_alias
                 right: dict[str, str] = {"identifier": spec.right.full_name}
+                if spec.right_alias:
+                    right["alias"] = spec.right_alias
                 entry: dict[str, Any] = {
                     "id": _stable_id(
                         "join_spec", spec.left.full_name, spec.right.full_name, spec.sql
                     ),
                     "left": left,
                     "right": right,
-                    "sql": [spec.sql],
+                    "sql": [spec.sql, _relationship_marker(spec.relationship_type)],
                 }
                 if spec.comment:
                     entry["comment"] = [spec.comment]
@@ -2565,14 +2598,21 @@ class GenieRoomModel(IsDatabricksResource, ManagedResource):
 
     @staticmethod
     def _join_spec_from_payload(entry: dict[str, Any]) -> "GenieJoinSpec":
-        sql_text: str = _unwrap_text(entry.get("sql")) or ""
-        relationship_type: GenieRelationshipType | None = None
+        sql_parts: list[str] = entry.get("sql") or []
+        if isinstance(sql_parts, str):
+            sql_parts = [sql_parts]
+        sql_text: str = sql_parts[0] if sql_parts else ""
+        # Current export format keeps the cardinality marker in its own
+        # element; spaces written by older builds append it to the condition.
+        relationship_type: GenieRelationshipType | None = (
+            _relationship_type_from_marker(sql_parts[-1])
+            if len(sql_parts) > 1
+            else None
+        )
         rt_match = re.search(r"\s*--rt=([A-Z_]+)--\s*$", sql_text)
         if rt_match:
-            try:
-                relationship_type = GenieRelationshipType(rt_match.group(1))
-            except ValueError:
-                relationship_type = None
+            if relationship_type is None:
+                relationship_type = _relationship_type_from_marker(rt_match.group(0))
             sql_text = sql_text[: rt_match.start()].rstrip()
         left = entry.get("left") or {}
         right = entry.get("right") or {}

--- a/tests/dao_ai/test_genie_provisioning.py
+++ b/tests/dao_ai/test_genie_provisioning.py
@@ -180,19 +180,61 @@ class TestBuildSerializedSpace:
         assert mv["identifier"] == "cat.sch.daily_sales_mv"
         assert mv["description"] == ["Daily sales."]
 
-    def test_join_spec_encodes_relationship_type_in_sql(
+    def test_join_spec_sql_carries_condition_then_relationship_marker(
         self, fully_configured_room: GenieRoomModel
     ):
-        # As of serialized_space v2, the build path emits left/right
-        # identifiers + sql + comment but no longer encodes
-        # relationship_type. The parser (_join_spec_from_payload) still
-        # tolerates a trailing ``--rt=...--`` marker in case the live
-        # space carries one, but the build side no longer produces it.
+        # Genie's export proto wants exactly two elements in ``sql``: the
+        # join condition, then a ``--rt=FROM_RELATIONSHIP_TYPE_…--`` marker.
+        # Sending the condition alone is rejected with "Failed to parse
+        # export proto: <condition> (of class java.lang.String)".
         payload = fully_configured_room._build_serialized_space()
         join = payload["instructions"]["join_specs"][0]
         assert join["left"]["identifier"] == "cat.sch.orders"
         assert join["right"]["identifier"] == "cat.sch.products"
-        assert join["sql"][0] == "orders.product_id = products.product_id"
+        assert join["sql"] == [
+            "orders.product_id = products.product_id",
+            "--rt=FROM_RELATIONSHIP_TYPE_MANY_TO_ONE--",
+        ]
+
+    def test_join_spec_without_relationship_type_marks_it_unspecified(
+        self, schema: SchemaModel, warehouse: WarehouseModel
+    ):
+        # The marker is mandatory even when the config declares no
+        # cardinality, so an undeclared relationship still has to post one.
+        room = GenieRoomModel(
+            name="X",
+            warehouse=warehouse,
+            join_specs=[
+                GenieJoinSpec(
+                    left=TableModel(schema=schema, name="orders"),
+                    right=TableModel(schema=schema, name="products"),
+                    sql="orders.product_id = products.product_id",
+                )
+            ],
+        )
+        join = room._build_serialized_space()["instructions"]["join_specs"][0]
+        assert join["sql"][1] == "--rt=FROM_RELATIONSHIP_TYPE_UNSPECIFIED--"
+
+    def test_join_spec_emits_declared_aliases(
+        self, schema: SchemaModel, warehouse: WarehouseModel
+    ):
+        room = GenieRoomModel(
+            name="X",
+            warehouse=warehouse,
+            join_specs=[
+                GenieJoinSpec(
+                    left=TableModel(schema=schema, name="orders"),
+                    left_alias="o",
+                    right=TableModel(schema=schema, name="products"),
+                    right_alias="p",
+                    sql="`o`.`product_id` = `p`.`product_id`",
+                    relationship_type=GenieRelationshipType.MANY_TO_ONE,
+                )
+            ],
+        )
+        join = room._build_serialized_space()["instructions"]["join_specs"][0]
+        assert join["left"]["alias"] == "o"
+        assert join["right"]["alias"] == "p"
 
     def test_sql_function_uses_full_uc_identifier(
         self, fully_configured_room: GenieRoomModel
@@ -577,11 +619,10 @@ class TestRefresh:
             "Always join orders to products via product_id."
         ]
         assert fresh.example_sqls[0].usage_guidance == "Use when asked about ranking."
-        # NOTE: relationship_type is not round-tripped through the current
-        # build/refresh cycle (the build side stopped emitting the
-        # ``--rt=…--`` suffix). Asserting only the SQL body here keeps
-        # the rest of the section coverage honest.
         assert fresh.join_specs[0].sql == "orders.product_id = products.product_id"
+        assert (
+            fresh.join_specs[0].relationship_type == GenieRelationshipType.MANY_TO_ONE
+        )
         assert fresh.sql_filters[0].display_name == "Active products"
         assert fresh.benchmarks[0].question == "How many orders were placed yesterday?"
 
@@ -651,22 +692,51 @@ class TestRefresh:
         assert room.table_sources[0].table.full_name == "cat.sch.products"
         assert room.text_instructions == ["hi"]
 
-    @pytest.mark.xfail(
-        reason=(
-            "relationship_type is intentionally not round-tripped through "
-            "the current build/refresh cycle. The parser "
-            "(_join_spec_from_payload) still understands a trailing "
-            "``--rt=…--`` marker for compatibility with live spaces that "
-            "carry it, but the build side no longer emits the marker. "
-            "Restore round-tripping by re-emitting the suffix in "
-            "_build_serialized_space if relationship_type semantics "
-            "matter on the live space."
-        ),
-        strict=False,
-    )
+    def test_join_spec_parses_marker_from_the_second_sql_element(self):
+        entry = {
+            "id": "abc",
+            "left": {"identifier": "cat.sch.orders", "alias": "o"},
+            "right": {"identifier": "cat.sch.products"},
+            "sql": [
+                "`o`.`product_id` = `products`.`product_id`",
+                "--rt=FROM_RELATIONSHIP_TYPE_ONE_TO_MANY--",
+            ],
+        }
+        spec = GenieRoomModel._join_spec_from_payload(entry)
+        assert spec.sql == "`o`.`product_id` = `products`.`product_id`"
+        assert spec.relationship_type == GenieRelationshipType.ONE_TO_MANY
+        assert spec.left_alias == "o"
+
+    def test_unspecified_marker_parses_back_to_no_relationship_type(self):
+        entry = {
+            "id": "abc",
+            "left": {"identifier": "cat.sch.orders"},
+            "right": {"identifier": "cat.sch.products"},
+            "sql": [
+                "orders.product_id = products.product_id",
+                "--rt=FROM_RELATIONSHIP_TYPE_UNSPECIFIED--",
+            ],
+        }
+        spec = GenieRoomModel._join_spec_from_payload(entry)
+        assert spec.relationship_type is None
+        assert spec.sql == "orders.product_id = products.product_id"
+
+    def test_join_spec_parses_legacy_inline_marker(self):
+        # Spaces provisioned by older builds carry the marker appended to
+        # the condition itself; keep decoding those.
+        entry = {
+            "id": "abc",
+            "left": {"identifier": "cat.sch.orders"},
+            "right": {"identifier": "cat.sch.products"},
+            "sql": ["orders.product_id = products.product_id --rt=MANY_TO_ONE--"],
+        }
+        spec = GenieRoomModel._join_spec_from_payload(entry)
+        assert spec.sql == "orders.product_id = products.product_id"
+        assert spec.relationship_type == GenieRelationshipType.MANY_TO_ONE
+
     def test_refresh_relationship_type_round_trip(self):
         # Build a join with each relationship type, refresh, assert the
-        # suffix encoding decodes back to the enum value.
+        # marker encoding decodes back to the enum value.
         for rt in GenieRelationshipType:
             schema = SchemaModel(catalog_name="cat", schema_name="sch")
             orig = GenieRoomModel(


### PR DESCRIPTION
## What

`instructions.join_specs[].sql` in a space's `serialized_space` must carry exactly two elements: the join condition, then a `--rt=FROM_RELATIONSHIP_TYPE_…--` cardinality marker. The build path posted the condition on its own, so any room declaring `join_specs` failed to provision. `create_space` and `update_space` reject it alike.

The message names the condition rather than the missing marker, which makes it read like a SQL syntax problem:

```
Failed to parse export proto: orders.o_custkey = customer.c_custkey (of class java.lang.String)
```

## Repro

Against any workspace with the `samples` catalog:

```python
orders = TableModel(name="samples.tpch.orders")
customer = TableModel(name="samples.tpch.customer")

room = GenieRoomModel(
    name="join_specs repro",
    warehouse=WarehouseModel(warehouse_id=WAREHOUSE_ID),
    parent_path=PARENT,
    table_sources=[
        GenieTableSource(table=orders, description="TPCH orders."),
        GenieTableSource(table=customer, description="TPCH customers."),
    ],
    join_specs=[
        GenieJoinSpec(
            left=orders,
            right=customer,
            sql="orders.o_custkey = customer.c_custkey",
            relationship_type=GenieRelationshipType.MANY_TO_ONE,
        )
    ],
)
room.create(w=WorkspaceClient())
```

Before, the room never provisions:

```
posted sql: ['orders.o_custkey = customer.c_custkey']
rejected: Failed to parse export proto: orders.o_custkey = customer.c_custkey (of class java.lang.String)
```

After:

```
posted sql: ['orders.o_custkey = customer.c_custkey', '--rt=FROM_RELATIONSHIP_TYPE_MANY_TO_ONE--']
create_space accepted
```

## Changes

- `_build_serialized_space` emits `[condition, marker]`. The marker is mandatory even with no declared cardinality, so an unset `relationship_type` posts `FROM_RELATIONSHIP_TYPE_UNSPECIFIED` and parses back to `None`.
- `left_alias` / `right_alias` are emitted again. The parser already read them back, so they round-trip now instead of being silently dropped.
- `_join_spec_from_payload` reads the marker from its own element and still understands the legacy inline `--rt=…--` suffix on spaces older builds wrote.

The API accepts `FROM_RELATIONSHIP_TYPE_` + `{ONE_TO_ONE, ONE_TO_MANY, MANY_TO_ONE, MANY_TO_MANY, UNSPECIFIED}`; the bare enum names previous builds appended are rejected.

## Verification

Unit: 34 tests in `tests/dao_ai/test_genie_provisioning.py`, including the previously `xfail`ed `test_refresh_relationship_type_round_trip`.

Live workspace: `create_space` and `update_space` both accept the payload, `refresh()` returns condition, `relationship_type`, aliases and comment unchanged, and re-provisioning an unchanged config stays a no-op. Payload shape cross-checked against [Use the Genie Agents API](https://docs.databricks.com/aws/en/genie/conversation-api).
