### PR TITLE
fix(workflow): --param overrides + Genie provisioning via new `provided` param scope

### DIFF
--- a/examples/15_complete_applications/loyalty_offer_personalization/loyalty_offer_personalization.yaml
+++ b/examples/15_complete_applications/loyalty_offer_personalization/loyalty_offer_personalization.yaml
@@ -40,8 +40,8 @@ parameters:
     description: SQL Warehouse id used by Genie + provisioning. Override per workspace via --var.
     default: d58e5fb998498840
   genie_space_id:
-    description: Genie space id forwarded from the provision-genie task (taskValue). Leave empty for local runs; the bundle deploy_job fills it in at runtime.
-    default: ""
+    description: Genie space id — provided at run time by the provision-genie task (taskValue). Supply --param to reuse an existing space.
+    provided: true
 
 # =============================================================================
 # VARIABLES (shared secrets for the retail_consumer_goods service principal)

--- a/examples/15_complete_applications/sporting_goods_store/sporting_goods_store.yaml
+++ b/examples/15_complete_applications/sporting_goods_store/sporting_goods_store.yaml
@@ -18,11 +18,11 @@ parameters:
     description: SQL Warehouse id used by Genie + provisioning. Override per workspace via --var.
     default: d58e5fb998498840
   merchandising_genie_space_id:
-    description: Genie space id for the merchandising analytics room, forwarded from the provision-genie task (taskValue). Leave empty for first deploy; the bundle deploy_job fills it in at runtime.
-    default: ""
+    description: Genie space id for the merchandising analytics room — provided at run time by the provision-genie task (taskValue). Supply --param to reuse an existing space.
+    provided: true
   sales_pricing_genie_space_id:
-    description: Genie space id for the sales & pricing analytics room, forwarded from the provision-genie task (taskValue). Leave empty for first deploy; the bundle deploy_job fills it in at runtime.
-    default: ""
+    description: Genie space id for the sales & pricing analytics room — provided at run time by the provision-genie task (taskValue). Supply --param to reuse an existing space.
+    provided: true
 
 # =============================================================================
 # Sporting Goods Store - Merchandiser 360

--- a/examples/16_test_scenarios/genie_provisioning_only.yaml
+++ b/examples/16_test_scenarios/genie_provisioning_only.yaml
@@ -33,8 +33,8 @@ parameters:
     description: SQL warehouse id for Genie space
     default: d58e5fb998498840  # FEVM "Serverless Starter Warehouse"
   genie_space_id:
-    description: Resolved by provision-genie task; empty on first deploy
-    default: ""
+    description: Genie space id — provided at run time by the provision-genie task.
+    provided: true
   genie_parent_path:
     description: Workspace folder for the Genie space
     default: /Users/${workspace.current_user.userName}

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -8100,6 +8100,12 @@
           "default": null,
           "description": "Default value if not provided at load time. Omit to make required.",
           "title": "Default"
+        },
+        "provided": {
+          "default": false,
+          "description": "When true, this parameter's value is supplied DYNAMICALLY at run time rather than at config-load time \u2014 analogous to a build tool's 'provided' dependency scope (furnished by the runtime environment). Most commonly it comes from an upstream job task's taskValues (e.g. a Genie space id created by the workflow's provision-genie task), but the flag is generic and independent of any consumer. At load time an unsupplied `provided` param resolves to an empty string (or its `default`, if given) instead of raising missing-required, so ${var.NAME} references load cleanly before the real value exists. The workflow staging path leaves such refs unresolved (see write_pipeline_bundle) so the run-time step can fill them in; non-workflow deploy paths (apps, mcp, model_serving) have no such step and reject an unsupplied, defaultless `provided` param rather than deploy a broken binding.",
+          "title": "Provided",
+          "type": "boolean"
         }
       },
       "title": "ParameterDeclarationModel",

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -229,6 +229,49 @@ def _strip_parameters_block(rendered_yaml: str) -> str:
     return buf.getvalue()
 
 
+def _retain_only_parameters(rendered_yaml: str, keep: set[str]) -> str:
+    """Keep only ``keep`` names under the top-level ``parameters:`` block; drop
+    the rest (and the whole block if nothing remains). Preserves anchors,
+    comments, and key order via the same ruamel round-trip as
+    :func:`_strip_parameters_block`.
+
+    Used by the workflow staging path when a Genie room's ``space_id`` is bound
+    to a deferred ``${var.X}`` reference: the deferred params' declarations must
+    survive into the staged config so ``06_deploy_agent`` can probe them against
+    the provisioning task's taskValues (``AppConfig.from_file`` loops
+    ``for name in declarations``). All other declarations are dropped, matching
+    :func:`_strip_parameters_block`.
+    """
+    if not keep:
+        return _strip_parameters_block(rendered_yaml)
+
+    rt = YAML(typ="rt")
+    rt.preserve_quotes = True
+    rt.width = 4096
+
+    try:
+        data = rt.load(rendered_yaml)
+    except Exception as exc:
+        logger.warning(f"ruamel parse failed; emitting rendered YAML unchanged: {exc}")
+        return rendered_yaml
+
+    from collections.abc import MutableMapping
+
+    if not isinstance(data, MutableMapping):
+        return rendered_yaml
+
+    params = data.get("parameters")
+    if isinstance(params, MutableMapping):
+        for name in [k for k in params if k not in keep]:
+            del params[name]
+        if not params:
+            data.pop("parameters", None)
+
+    buf = io.StringIO()
+    rt.dump(data, buf)
+    return buf.getvalue()
+
+
 def _convert_single_resource(resource: dict[str, Any]) -> dict[str, Any] | None:
     """Convert a single flat app.yaml resource dict to bundle nested format."""
     resource_type: str = resource.get("type", "")

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -4206,6 +4206,7 @@ def handle_vars_command(options: Namespace) -> None:
         header = (
             f"{'NAME':<{name_w}}  "
             f"{'REQUIRED':<8}  "
+            f"{'PROVIDED':<8}  "
             f"{'DEFAULT':<{default_w}}  "
             f"{'RESOLVED':<{value_w}}  "
             f"{'SOURCE':<{source_w}}  "
@@ -4218,6 +4219,7 @@ def handle_vars_command(options: Namespace) -> None:
             print(
                 f"{p.name:<{name_w}}  "
                 f"{('yes' if p.required else 'no'):<8}  "
+                f"{('yes' if p.provided else 'no'):<8}  "
                 f"{(p.default or '-'):<{default_w}}  "
                 f"{(p.value if p.value is not None else '-'):<{value_w}}  "
                 f"{p.source:<{source_w}}  "

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -3884,6 +3884,9 @@ def _generate_app_bundle(options: Namespace, *, kind: str, writer, what: str) ->
 
     # Resolve resources so Genie room tables and warehouses can be discovered.
     config._resolve_all_resources()
+    # apps/mcp has no provisioning step — fail loudly on any `provisioned` param
+    # that wasn't supplied and has no default, rather than ship a broken binding.
+    config.assert_provided_params_satisfied()
 
     bundle_dir, is_default_dir = _resolve_bundle_dir(kind, config, options.output_dir)
     _stage_app_bundle(
@@ -3939,6 +3942,10 @@ def _deploy_run_destroy_app_bundle(
         # current config first (mirrors the workflow deploy notebook + the former
         # `dao-ai deploy` handler). Without this, deploy_model_serving_agent
         # deploys a stale-or-nonexistent model version.
+        config._resolve_all_resources()
+        # model_serving has no provisioning step — fail loudly on any unsatisfied
+        # `provisioned` param (see docstring).
+        config.assert_provided_params_satisfied()
         config.create_agent(development=development)
         config.deploy_agent(target=ServingMode.MODEL_SERVING, development=development)
         return
@@ -3949,6 +3956,10 @@ def _deploy_run_destroy_app_bundle(
 
         config = _load_app_config(options, what=what)
         development = resolve_use_local_source(getattr(options, "development", None))
+        config._resolve_all_resources()
+        # apps/mcp (SDK direct) has no provisioning step — fail loudly on any
+        # unsatisfied `provisioned` param (see docstring).
+        config.assert_provided_params_satisfied()
         # Apps/MCP deploy directly from config + wheel (no MLflow model to
         # register — matches the former `if target != APPS: create_agent()`
         # gate). model_serving is handled by Route 1 above, so mode is apps|mcp here.
@@ -4015,6 +4026,9 @@ def _deploy_run_destroy_app_bundle(
                 )
             # Resolve resources so Genie room tables and warehouses can be discovered.
             config._resolve_all_resources()
+            # apps/mcp has no provisioning step — fail loudly on any unsatisfied
+            # `provisioned` param (see docstring).
+            config.assert_provided_params_satisfied()
             writer: Callable[..., dict[str, str]] = _mode_writer(mode)
             _stage_app_bundle(
                 config,

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -429,9 +429,14 @@ def _add_noun_verb_parsers(
             f"Bring the {noun} up: generate (if needed), deploy, and start it.\n\n"
             "For bundle modes (apps, mcp): stages the bundle when unstaged, runs\n"
             "`databricks bundle deploy`, links the trace destination, then runs\n"
-            "`databricks bundle run <app>`. Use `--direct` to skip the bundle\n"
-            "entirely and deploy via the SDK (apps/mcp only).\n\n"
-            "For --mode model_serving: registers then deploys the endpoint\n"
+            "`databricks bundle run <app>`."
+            + (
+                ""
+                if is_workflow
+                else " Use `--direct` to skip the bundle\n"
+                "entirely and deploy via the SDK (apps/mcp only)."
+            )
+            + "\n\nFor --mode model_serving: registers then deploys the endpoint\n"
             "(serving once READY; `run` is n/a for endpoints)."
         ),
         parents=parents,
@@ -441,15 +446,19 @@ def _add_noun_verb_parsers(
     if is_workflow:
         _add_workflow_target_args(up_parser)
     _add_mode_argument(up_parser, choices=["model_serving", "apps", "mcp"])
-    up_parser.add_argument(
-        "--direct",
-        action="store_true",
-        default=False,
-        help=(
-            "Deploy via the SDK directly (no DAB bundle on disk) — fast "
-            "iteration path for --mode apps|mcp. Inherently starts the app."
-        ),
-    )
+    # --direct (SDK, no DAB on disk) is agent-only: the workflow noun's whole
+    # purpose is running the provisioning JOB, which requires the DAB — there is
+    # no meaningful bundle-less path, so --direct would be a silent no-op.
+    if not is_workflow:
+        up_parser.add_argument(
+            "--direct",
+            action="store_true",
+            default=False,
+            help=(
+                "Deploy via the SDK directly (no DAB bundle on disk) — fast "
+                "iteration path for --mode apps|mcp. Inherently starts the app."
+            ),
+        )
 
     # --- generate: pure staging verb (no deploy/run) -------------------------
     generate_parser: ArgumentParser = verbs.add_parser(

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -1604,27 +1604,47 @@ Examples:
         aliases=["vars"],
         help="Inspect declared parameters in a configuration",
         description="""
-Inspect the declared parameters: block in a DAO AI config file.
+Inspect the declared `parameters:` block in a DAO AI config file.
 
-Shows each declared parameter, whether it is required, its declared default,
-and the value that would be substituted into the YAML for the current
-combination of --param overrides and process environment variables.
+Actions (the action word is optional; 'list' is the default):
+  list          Print every declared parameter as a table — required?, provided?,
+                default, resolved value, and where the value came from (--param,
+                env, default, provided, or MISSING).
+  get <name>    Print ONE parameter's resolved value to stdout (bare, no table),
+                so it is easy to capture in a shell:
+                  CATALOG=$(dao-ai parameters get catalog -c config.yaml)
+
+Resolution for each parameter: --param/--var  >  env var  >  declared default  >
+'provided' placeholder (empty, furnished at run time)  >  MISSING (required, unset).
 
 Use this to discover what knobs a config exposes before deploying or running it.
         """,
         epilog="""
 Examples:
-  dao-ai parameters list -c config/model_config.yaml
+  dao-ai parameters -c config/model_config.yaml            # 'list' is the default
   dao-ai parameters list -c config/retail.yaml --param catalog=nfleming
-  dao-ai vars list -c config/model_config.yaml             # legacy alias
+  dao-ai parameters get catalog -c config/retail.yaml      # print one resolved value
+  dao-ai vars -c config/model_config.yaml                  # legacy alias ('vars' == 'parameters')
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         parents=[_GLOBAL],
     )
     vars_parser.add_argument(
         "action",
-        choices=["list"],
-        help="Parameters action: 'list' prints declared parameters and resolved values.",
+        nargs="?",
+        default="list",
+        choices=["list", "get"],
+        help=(
+            "What to do (default: list). 'list' = table of all parameters; "
+            "'get <name>' = print one parameter's resolved value to stdout."
+        ),
+    )
+    vars_parser.add_argument(
+        "name",
+        nargs="?",
+        default=None,
+        metavar="NAME",
+        help="Parameter name to read. Required with 'get'; ignored by 'list'.",
     )
     vars_parser.add_argument(
         "-c",
@@ -1632,7 +1652,7 @@ Examples:
         type=str,
         required=True,
         metavar="FILE",
-        help="Path to the model configuration file to inspect.",
+        help="Path to the dao-ai config file whose parameters: block to inspect.",
     )
 
     # Add --param/--var to the non-bundle subcommands (bundle verbs get it from
@@ -4184,6 +4204,43 @@ def handle_vars_command(options: Namespace) -> None:
     except Exception as e:
         logger.error(f"Invalid 'parameters:' declaration in {options.config}: {e}")
         sys.exit(1)
+
+    if options.action == "get":
+        name: str | None = getattr(options, "name", None)
+        if not name:
+            logger.error(
+                "parameters get requires a NAME, e.g. "
+                "`dao-ai parameters get catalog -c <file>`."
+            )
+            sys.exit(2)
+        if name not in declarations:
+            declared = ", ".join(sorted(declarations)) or "(none)"
+            logger.error(
+                f"Parameter {name!r} is not declared in {options.config}. "
+                f"Declared parameters: {declared}."
+            )
+            sys.exit(1)
+        resolved = {p.name: p for p in resolve_parameters(declarations, cli_vars=cli_vars)}
+        param = resolved[name]
+        if param.value is None:
+            # Nothing to emit — exit non-zero so scripts don't capture "".
+            # Tailor the guidance to WHY it is unresolved.
+            if param.provided:
+                logger.error(
+                    f"Parameter {name!r} is declared `provided: true` — its value is "
+                    "furnished at run time (e.g. by a workflow provisioning task), so "
+                    "it has no value at inspection time. Pass --param "
+                    f"{name}=<value> to see a concrete value here."
+                )
+            else:
+                logger.error(
+                    f"Parameter {name!r} is required but unset. Supply it with "
+                    f"--param {name}=<value>, set its env var, or give it a default."
+                )
+            sys.exit(1)
+        # Bare value to stdout so it is capture-friendly: X=$(dao-ai parameters get X -c f)
+        print(param.value)
+        sys.exit(0)
 
     if options.action == "list":
         resolved = resolve_parameters(declarations, cli_vars=cli_vars)

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -3904,7 +3904,7 @@ def _generate_app_bundle(options: Namespace, *, kind: str, writer, what: str) ->
 
     # Resolve resources so Genie room tables and warehouses can be discovered.
     config._resolve_all_resources()
-    # apps/mcp has no provisioning step — fail loudly on any `provisioned` param
+    # apps/mcp has no provisioning step — fail loudly on any `provided` param
     # that wasn't supplied and has no default, rather than ship a broken binding.
     config.assert_provided_params_satisfied()
 
@@ -3964,7 +3964,7 @@ def _deploy_run_destroy_app_bundle(
         # deploys a stale-or-nonexistent model version.
         config._resolve_all_resources()
         # model_serving has no provisioning step — fail loudly on any unsatisfied
-        # `provisioned` param (see docstring).
+        # `provided` param (see docstring).
         config.assert_provided_params_satisfied()
         config.create_agent(development=development)
         config.deploy_agent(target=ServingMode.MODEL_SERVING, development=development)
@@ -3978,7 +3978,7 @@ def _deploy_run_destroy_app_bundle(
         development = resolve_use_local_source(getattr(options, "development", None))
         config._resolve_all_resources()
         # apps/mcp (SDK direct) has no provisioning step — fail loudly on any
-        # unsatisfied `provisioned` param (see docstring).
+        # unsatisfied `provided` param (see docstring).
         config.assert_provided_params_satisfied()
         # Apps/MCP deploy directly from config + wheel (no MLflow model to
         # register — matches the former `if target != APPS: create_agent()`
@@ -4047,7 +4047,7 @@ def _deploy_run_destroy_app_bundle(
             # Resolve resources so Genie room tables and warehouses can be discovered.
             config._resolve_all_resources()
             # apps/mcp has no provisioning step — fail loudly on any unsatisfied
-            # `provisioned` param (see docstring).
+            # `provided` param (see docstring).
             config.assert_provided_params_satisfied()
             writer: Callable[..., dict[str, str]] = _mode_writer(mode)
             _stage_app_bundle(
@@ -4220,8 +4220,10 @@ def handle_vars_command(options: Namespace) -> None:
                 f"Declared parameters: {declared}."
             )
             sys.exit(1)
-        resolved = {p.name: p for p in resolve_parameters(declarations, cli_vars=cli_vars)}
-        param = resolved[name]
+        resolved_by_name = {
+            p.name: p for p in resolve_parameters(declarations, cli_vars=cli_vars)
+        }
+        param = resolved_by_name[name]
         if param.value is None:
             # Nothing to emit — exit non-zero so scripts don't capture "".
             # Tailor the guidance to WHY it is unresolved.

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -3117,6 +3117,29 @@ def setup_logging(verbosity: int) -> None:
     configure_logging(level=level)
 
 
+def _declared_bundle_variables(bundle_dir: Path) -> set[str]:
+    """Names declared under ``variables:`` in a staged ``databricks.yaml``.
+
+    Used to decide which dao-ai ``--param`` overrides are safe to forward to
+    ``databricks bundle`` as ``--var``: only names the bundle actually declares.
+    Reading the staged file (rather than a hardcoded list) keeps the filter in
+    step with whatever :func:`generate_pipeline_databricks_yaml` emits. Returns an
+    empty set if the file is missing or unparseable — forward nothing rather than
+    risk an undeclared-variable failure.
+    """
+    import yaml
+
+    databricks_yaml: Path = bundle_dir / "databricks.yaml"
+    if not databricks_yaml.exists():
+        return set()
+    try:
+        doc: Any = yaml.safe_load(databricks_yaml.read_text())
+    except (yaml.YAMLError, OSError):
+        return set()
+    variables: Any = (doc or {}).get("variables") if isinstance(doc, dict) else None
+    return set(variables) if isinstance(variables, dict) else set()
+
+
 def _exec_bundle_command(
     command: list[str],
     *,
@@ -3393,11 +3416,16 @@ def run_databricks_command(
     if config_rel_to_notebooks:
         extra_vars.append(f'--var="config_path={config_rel_to_notebooks}"')
 
-    # Forward dao-ai parameter overrides to the asset-bundle layer too, so
-    # ${var.NAME} references inside databricks.yaml resolve from the same
-    # input values when the names overlap.
+    # Forward dao-ai parameter overrides to the asset-bundle layer ONLY for names
+    # that databricks.yaml actually declares as bundle variables. dao-ai params are
+    # already baked into the staged config (${var.NAME} substituted), so a param
+    # the bundle doesn't declare needs no --var — and passing one the bundle hasn't
+    # declared makes ``databricks bundle`` hard-fail ("variable X has not been
+    # defined"). Filtering to the overlap is what the original intent described.
+    declared_bundle_vars: set[str] = _declared_bundle_variables(staging_dir)
     for key, value in (config_vars or {}).items():
-        extra_vars.append(f'--var="{key}={value}"')
+        if key in declared_bundle_vars:
+            extra_vars.append(f'--var="{key}={value}"')
 
     # Add mode variable for notebooks.
     # Priority: CLI arg > default (model_serving)

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -10699,6 +10699,14 @@ class AppConfig(BaseModel):
     _rendered_yaml: str | None = None
     _substitution_vars: dict[str, str] | None = None
     _raw_yaml_dict: dict[str, Any] | None = None
+    # The ${workspace.*}-resolved but ${param/var}-UNsubstituted source text, the
+    # parsed parameter declarations, and the operator-supplied param names (CLI
+    # --param/--var only — NOT taskValues/env/defaults). The workflow staging path
+    # reuses these to re-render with a `defer` set (preserve unprovided Genie-room
+    # space_id refs) without re-reading the source file. See write_pipeline_bundle.
+    _workspace_resolved_yaml: str | None = None
+    _declarations: dict[str, Any] | None = None
+    _operator_supplied_params: set[str] | None = None
     _initialized: bool = False
 
     @model_validator(mode="after")
@@ -10899,6 +10907,14 @@ class AppConfig(BaseModel):
         config._source_config_path = path
         config._rendered_yaml = rendered_text
         config._substitution_vars = dict(merged_params) if merged_params else None
+        # Preserve inputs the workflow staging path needs to re-render with a
+        # `defer` set (unprovided Genie-room space_id refs). operator_supplied is
+        # the CLI --param/--var subset only, distinct from merged_params (which
+        # also folds in taskValues) — the defer decision keys off what the
+        # operator explicitly passed, not resolved values/defaults.
+        config._workspace_resolved_yaml = workspace_resolved_text
+        config._declarations = declarations
+        config._operator_supplied_params = set(params.keys()) if params else set()
 
         # Stamp each provisioning model with the config's own directory so its
         # relative ``ddl``/``data`` paths resolve against the config location

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -10705,7 +10705,7 @@ class AppConfig(BaseModel):
     # reuses these to re-render with a `defer` set (preserve unprovided Genie-room
     # space_id refs) without re-reading the source file. See write_pipeline_bundle.
     _workspace_resolved_yaml: str | None = None
-    _declarations: dict[str, Any] | None = None
+    _declarations: dict[str, ParameterDeclarationModel] | None = None
     _operator_supplied_params: set[str] | None = None
     _initialized: bool = False
 
@@ -11029,9 +11029,7 @@ class AppConfig(BaseModel):
         unsatisfied: list[str] = [
             name
             for name, decl in declarations.items()
-            if getattr(decl, "provided", False)
-            and decl.default is None
-            and name not in supplied
+            if decl.provided and decl.default is None and name not in supplied
         ]
         if unsatisfied:
             joined = ", ".join(sorted(unsatisfied))

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -11007,6 +11007,42 @@ class AppConfig(BaseModel):
 
         _walk(self)
 
+    def assert_provided_params_satisfied(self) -> None:
+        """Guard non-workflow deploy paths against unsatisfied ``provided`` params.
+
+        A parameter declared ``provided: true`` is furnished dynamically at run
+        time (like a build tool's 'provided' dependency scope) — in dao-ai today
+        that is the ``workflow`` job's provisioning tasks forwarding values via
+        taskValues (e.g. a Genie space id), but the flag is generic and
+        independent of any consumer. The apps / mcp / model_serving deploy paths
+        have NO such run-time step, so a ``provided`` param that was neither
+        supplied by the operator (``--param``/``--var``) nor given a ``default``
+        fallback resolves to an empty placeholder and would silently deploy a
+        broken binding. Fail loudly instead.
+
+        No-op on the workflow path (which never calls this — it defers such params
+        for its run-time step). Params with a ``default`` or an operator value are
+        satisfied and pass. Independent of genie / any specific field.
+        """
+        declarations = self._declarations or {}
+        supplied: set[str] = self._operator_supplied_params or set()
+        unsatisfied: list[str] = [
+            name
+            for name, decl in declarations.items()
+            if getattr(decl, "provided", False)
+            and decl.default is None
+            and name not in supplied
+        ]
+        if unsatisfied:
+            joined = ", ".join(sorted(unsatisfied))
+            raise ValueError(
+                f"Parameter(s) declared `provided: true` have no value on a "
+                f"non-workflow deploy path: {joined}. These paths cannot furnish "
+                "values at run time. Supply each one (e.g. --param "
+                f"{sorted(unsatisfied)[0]}=<value>), give it a `default`, or run "
+                "`dao-ai workflow up` to provision it."
+            )
+
     def initialize(self) -> None:
         if self._initialized:
             return

--- a/src/dao_ai/config_vars.py
+++ b/src/dao_ai/config_vars.py
@@ -165,6 +165,25 @@ class ParameterDeclarationModel(BaseModel):
         default=None,
         description="Default value if not provided at load time. Omit to make required.",
     )
+    provided: bool = Field(
+        default=False,
+        description=(
+            "When true, this parameter's value is supplied DYNAMICALLY at run "
+            "time rather than at config-load time — analogous to a build tool's "
+            "'provided' dependency scope (furnished by the runtime environment). "
+            "Most commonly it comes from an upstream job task's taskValues (e.g. "
+            "a Genie space id created by the workflow's provision-genie task), "
+            "but the flag is generic and independent of any consumer. At load "
+            "time an unsupplied `provided` param resolves to an empty string "
+            "(or its `default`, if given) instead of raising missing-required, "
+            "so ${var.NAME} references load cleanly before the real value "
+            "exists. The workflow staging path leaves such refs unresolved (see "
+            "write_pipeline_bundle) so the run-time step can fill them in; "
+            "non-workflow deploy paths (apps, mcp, model_serving) have no such "
+            "step and reject an unsupplied, defaultless `provided` param rather "
+            "than deploy a broken binding."
+        ),
+    )
 
 
 class ConfigVariableError(ValueError):
@@ -296,6 +315,14 @@ def substitute_params(
             return decl.default
         if inline_default is not None:
             return inline_default
+        # A `provided` param whose value wasn't supplied and has no default is
+        # furnished dynamically at run time (e.g. from a provisioning task's
+        # taskValues), so at load time it resolves to an empty placeholder rather
+        # than a missing-required error. The empty string is not a sentinel — it
+        # is simply "no value yet"; downstream logic keys off the `provided`
+        # flag, never off the value being empty.
+        if decl is not None and decl.provided:
+            return ""
         # Only count declared references as "missing required". Undeclared
         # references are reported separately via `undeclared` so we never
         # double-count them in the error message.

--- a/src/dao_ai/config_vars.py
+++ b/src/dao_ai/config_vars.py
@@ -253,6 +253,7 @@ class ResolvedParameter(BaseModel):
     required: bool
     default: Optional[str]
     description: Optional[str]
+    provided: bool = False
 
 
 def substitute_params(
@@ -367,6 +368,10 @@ def resolve_parameters(
         elif decl.default is not None:
             value = decl.default
             source = "default"
+        elif decl.provided:
+            # Furnished dynamically at run time (e.g. a provisioning task's
+            # taskValues), not at load time — not missing.
+            source = "provided"
         else:
             source = "MISSING"
 
@@ -375,9 +380,12 @@ def resolve_parameters(
                 name=name,
                 value=value,
                 source=source,
-                required=decl.default is None,
+                # A `provided` param is never load-time required (it's supplied
+                # at run time); a plain param with no default is required.
+                required=decl.default is None and not decl.provided,
                 default=decl.default,
                 description=decl.description,
+                provided=decl.provided,
             )
         )
     return results

--- a/src/dao_ai/config_vars.py
+++ b/src/dao_ai/config_vars.py
@@ -242,6 +242,7 @@ def substitute_params(
     declarations: Optional[Mapping[str, ParameterDeclarationModel]] = None,
     cli_vars: Optional[Mapping[str, str]] = None,
     env: Optional[Mapping[str, str]] = None,
+    defer: Optional[set[str]] = None,
     source: str = "<string>",
 ) -> str:
     """Render ``${param.NAME}`` and ``${var.NAME}`` references to literal values.
@@ -251,10 +252,19 @@ def substitute_params(
     Raises :class:`ConfigVariableError` when references are undeclared
     (when ``declarations`` is provided) or when required references cannot
     be resolved.
+
+    ``defer`` names are left in place as their literal ``${var.NAME}`` reference
+    and never counted as missing — even when they have no value and no default.
+    Used only by the workflow staging path (see
+    :func:`dao_ai.pipeline.bundle.write_pipeline_bundle`) to preserve a Genie
+    room's ``space_id: ${var.X}`` binding so the provisioning notebook can detect
+    it via :func:`is_parameter` and create/forward the space at run time. Inert
+    (no behavior change) when ``None``.
     """
     decls: Mapping[str, ParameterDeclarationModel] = declarations or {}
     overrides: Mapping[str, str] = cli_vars or {}
     env_map: Mapping[str, str] = env if env is not None else os.environ
+    deferred: set[str] = defer or set()
 
     comment_spans: list[tuple[int, int]] = _yaml_comment_spans(text)
     references: set[str] = find_param_references(text)
@@ -271,6 +281,11 @@ def substitute_params(
             return match.group(0)
         name: str = match.group("name")
         inline_default: Optional[str] = match.group("default")
+        # Deferred names survive as their literal ${var.NAME} reference (the
+        # workflow provisioning path resolves them at run time) and are never
+        # counted missing, even with no value/default.
+        if name in deferred:
+            return match.group(0)
         if name in overrides:
             return str(overrides[name])
         env_name: str = _env_key(name)

--- a/src/dao_ai/pipeline/bundle.py
+++ b/src/dao_ai/pipeline/bundle.py
@@ -44,7 +44,7 @@ from dao_ai.apps.bundle import (
     _write_file,
     dump_bundle_yaml,
 )
-from dao_ai.config import AppConfig, is_parameter, parameter_name
+from dao_ai.config import AppConfig
 from dao_ai.config_vars import ParameterDeclarationModel, substitute_params
 from dao_ai.utils import dao_ai_version, normalize_name
 
@@ -447,41 +447,39 @@ def _bundle_label(file_out: Path, output_dir: Path) -> str:
         return str(file_out)
 
 
-def _deferred_genie_space_params(config: AppConfig) -> set[str]:
-    """Genie-room ``space_id`` param names to LEAVE unresolved in the staged config.
+def _deferred_provided_params(config: AppConfig) -> set[str]:
+    """Parameter names to LEAVE unresolved (``${var.X}``) in the staged config.
 
-    A Genie room whose ``space_id`` is a ``${var.X}`` reference is a provisioning
-    candidate: ``05_provision_genie`` detects it via ``is_parameter(raw_space_id)``,
-    creates/reuses the space, and forwards the id via taskValues keyed by ``X``.
-    For that to work the staged config must keep the ``${var.X}`` reference (and
-    its declaration) rather than bake it.
+    A parameter declared ``provided: true`` gets its value dynamically at run
+    time — e.g. ``05_provision_genie`` creates a Genie space and forwards its id
+    via taskValues keyed by the param name, which ``06_deploy_agent`` then injects
+    via ``AppConfig.from_file(task_values=...)``. For that to work the staged
+    config must keep the ``${var.X}`` reference (and its declaration) rather than
+    bake it.
 
-    We defer a param only when the operator did NOT supply it on the CLI
-    (``--param``/``--var``). An operator-supplied id means "reuse this space", so
-    it bakes to a literal and ``05`` skips provisioning — no deferral. Names come
-    from ``room.raw_space_id`` (the pre-substitution value), so a ``default: ""``
-    still defers-and-provisions when unprovided.
+    A param is deferred only when the operator did NOT supply it on the CLI
+    (``--param``/``--var``): an operator-supplied value means "use this" — it bakes
+    to a literal and no run-time fill-in happens. Keying off the declaration flag
+    (not genie-room ``space_id`` inference) keeps this general: any ``provided``
+    param is deferred, whatever consumes it.
     """
-    rooms = getattr(config.resources, "genie_rooms", None) if config.resources else None
-    if not rooms:
+    declarations = config._declarations or {}
+    if not declarations:
         return set()
     supplied: set[str] = config._operator_supplied_params or set()
-    deferred: set[str] = set()
-    for room in rooms.values():
-        raw = getattr(room, "raw_space_id", None)
-        if is_parameter(raw):
-            name = parameter_name(raw)
-            if name is not None and name not in supplied:
-                deferred.add(name)
-    return deferred
+    return {
+        name
+        for name, decl in declarations.items()
+        if getattr(decl, "provided", False) and name not in supplied
+    }
 
 
 def _staged_config_text(config: AppConfig) -> str | None:
     """The dao-ai config text to stage for a workflow bundle.
 
     Default: the fully-substituted rendered YAML with the ``parameters:`` block
-    stripped (deployed job needs no ``--var``). When the config has Genie-room
-    ``space_id`` params to defer (see :func:`_deferred_genie_space_params`),
+    stripped (deployed job needs no ``--var``). When the config has
+    ``provided: true`` params to defer (see :func:`_deferred_provided_params`),
     re-render the pre-substitution source leaving those refs in place and retain
     ONLY their declarations, so ``05_provision_genie`` can provision and
     ``06_deploy_agent`` can inject the forwarded id. Returns None if the config
@@ -491,7 +489,7 @@ def _staged_config_text(config: AppConfig) -> str | None:
     if rendered is None:
         return None
 
-    defer: set[str] = _deferred_genie_space_params(config)
+    defer: set[str] = _deferred_provided_params(config)
     if not defer:
         return _strip_parameters_block(rendered)
 

--- a/src/dao_ai/pipeline/bundle.py
+++ b/src/dao_ai/pipeline/bundle.py
@@ -470,7 +470,7 @@ def _deferred_provided_params(config: AppConfig) -> set[str]:
     return {
         name
         for name, decl in declarations.items()
-        if getattr(decl, "provided", False) and name not in supplied
+        if decl.provided and name not in supplied
     }
 
 

--- a/src/dao_ai/pipeline/bundle.py
+++ b/src/dao_ai/pipeline/bundle.py
@@ -38,12 +38,14 @@ from typing import Any
 from loguru import logger
 
 from dao_ai.apps.bundle import (
+    _retain_only_parameters,
     _sha256_file,
     _strip_parameters_block,
     _write_file,
     dump_bundle_yaml,
 )
-from dao_ai.config import AppConfig
+from dao_ai.config import AppConfig, is_parameter, parameter_name
+from dao_ai.config_vars import ParameterDeclarationModel, substitute_params
 from dao_ai.utils import dao_ai_version, normalize_name
 
 # Package location of the step notebooks shipped in the wheel.
@@ -445,6 +447,71 @@ def _bundle_label(file_out: Path, output_dir: Path) -> str:
         return str(file_out)
 
 
+def _deferred_genie_space_params(config: AppConfig) -> set[str]:
+    """Genie-room ``space_id`` param names to LEAVE unresolved in the staged config.
+
+    A Genie room whose ``space_id`` is a ``${var.X}`` reference is a provisioning
+    candidate: ``05_provision_genie`` detects it via ``is_parameter(raw_space_id)``,
+    creates/reuses the space, and forwards the id via taskValues keyed by ``X``.
+    For that to work the staged config must keep the ``${var.X}`` reference (and
+    its declaration) rather than bake it.
+
+    We defer a param only when the operator did NOT supply it on the CLI
+    (``--param``/``--var``). An operator-supplied id means "reuse this space", so
+    it bakes to a literal and ``05`` skips provisioning — no deferral. Names come
+    from ``room.raw_space_id`` (the pre-substitution value), so a ``default: ""``
+    still defers-and-provisions when unprovided.
+    """
+    rooms = getattr(config.resources, "genie_rooms", None) if config.resources else None
+    if not rooms:
+        return set()
+    supplied: set[str] = config._operator_supplied_params or set()
+    deferred: set[str] = set()
+    for room in rooms.values():
+        raw = getattr(room, "raw_space_id", None)
+        if is_parameter(raw):
+            name = parameter_name(raw)
+            if name is not None and name not in supplied:
+                deferred.add(name)
+    return deferred
+
+
+def _staged_config_text(config: AppConfig) -> str | None:
+    """The dao-ai config text to stage for a workflow bundle.
+
+    Default: the fully-substituted rendered YAML with the ``parameters:`` block
+    stripped (deployed job needs no ``--var``). When the config has Genie-room
+    ``space_id`` params to defer (see :func:`_deferred_genie_space_params`),
+    re-render the pre-substitution source leaving those refs in place and retain
+    ONLY their declarations, so ``05_provision_genie`` can provision and
+    ``06_deploy_agent`` can inject the forwarded id. Returns None if the config
+    was not loaded via ``AppConfig.from_file`` (no rendered text available).
+    """
+    rendered: str | None = config._rendered_yaml
+    if rendered is None:
+        return None
+
+    defer: set[str] = _deferred_genie_space_params(config)
+    if not defer:
+        return _strip_parameters_block(rendered)
+
+    # Re-render from the pre-substitution source with the deferred names left in
+    # place, then keep only the deferred declarations. Falls back to the plain
+    # rendered text if the config lacks the stashed pre-substitution inputs.
+    source_text: str | None = config._workspace_resolved_yaml
+    if source_text is None:
+        return _strip_parameters_block(rendered)
+    declarations: dict[str, ParameterDeclarationModel] = config._declarations or {}
+    deferred_render: str = substitute_params(
+        source_text,
+        declarations=declarations,
+        cli_vars=config._substitution_vars or None,
+        defer=defer,
+        source=config._source_config_path or "<config>",
+    )
+    return _retain_only_parameters(deferred_render, keep=defer)
+
+
 def write_pipeline_bundle(
     config: AppConfig,
     output_dir: Path,
@@ -543,9 +610,9 @@ def write_pipeline_bundle(
     elif config_dest.exists() and not overwrite:
         logger.info(f"Skipping {config_filename} (exists; use --overwrite)")
     else:
-        rendered: str | None = config._rendered_yaml
-        if rendered is not None:
-            config_dest.write_text(_strip_parameters_block(rendered))
+        staged_text: str | None = _staged_config_text(config)
+        if staged_text is not None:
+            config_dest.write_text(staged_text)
         elif source_config:
             shutil.copy2(source_config, config_dest)
         else:

--- a/tests/dao_ai/test_config.py
+++ b/tests/dao_ai/test_config.py
@@ -675,3 +675,69 @@ class TestUnresolvedClientIdWarning:
             mock_ws.return_value = MagicMock()
             db.workspace_client
         mock_warning.assert_not_called()
+
+
+@pytest.mark.unit
+class TestAssertProvidedParamsSatisfied:
+    """Non-workflow deploy paths reject an unsatisfied `provided: true` param."""
+
+    _BASE = """
+parameters:
+  gsid:
+    provided: true
+{extra}
+resources:
+  models:
+    m: &m
+      name: databricks-claude-sonnet-4-5
+  genie_rooms:
+    room: &room
+      name: r
+      space_id: ${{var.gsid}}
+tools:
+  gt: &gt
+    name: genie
+    function:
+      type: genie
+      name: q
+      description: d
+      genie_room: *room
+agents:
+  a: &a
+    name: aa
+    description: aa
+    model: *m
+    tools: [*gt]
+    prompt: hi
+app:
+  name: provided_guardrail_test
+  agents: [*a]
+"""
+
+    def _cfg(self, tmp_path, extra: str = "", **from_file_kwargs):
+        p = tmp_path / "c.yaml"
+        p.write_text(self._BASE.format(extra=extra))
+        return AppConfig.from_file(str(p), initialize=False, **from_file_kwargs)
+
+    def test_unsatisfied_provided_param_raises(self, tmp_path) -> None:
+        cfg = self._cfg(tmp_path)  # provided, no default, not supplied
+        with pytest.raises(ValueError, match="provided"):
+            cfg.assert_provided_params_satisfied()
+
+    def test_operator_supplied_passes(self, tmp_path) -> None:
+        cfg = self._cfg(tmp_path, params={"gsid": "01fREAL"})
+        cfg.assert_provided_params_satisfied()  # no raise
+
+    def test_default_fallback_passes(self, tmp_path) -> None:
+        cfg = self._cfg(tmp_path, extra="    default: fallback")
+        cfg.assert_provided_params_satisfied()  # no raise
+
+    def test_no_provided_params_is_noop(self, tmp_path) -> None:
+        text = (
+            "resources:\n  models:\n    m: &m\n      name: databricks-claude-sonnet-4-5\n"
+            "agents:\n  a: &a\n    name: aa\n    description: aa\n    model: *m\n    prompt: hi\n"
+            "app:\n  name: no_provided\n  agents: [*a]\n"
+        )
+        p = tmp_path / "np.yaml"
+        p.write_text(text)
+        AppConfig.from_file(str(p), initialize=False).assert_provided_params_satisfied()

--- a/tests/dao_ai/test_config_vars.py
+++ b/tests/dao_ai/test_config_vars.py
@@ -274,6 +274,37 @@ def test_defer_only_affects_named_refs() -> None:
 
 
 @pytest.mark.unit
+def test_provisioned_param_resolves_empty_when_unset() -> None:
+    """provisioned:true, no value, no default -> resolves to '' (not missing)."""
+    decls = {"gsid": ParameterDeclarationModel(provided=True)}
+    assert substitute_params("s: ${var.gsid}", declarations=decls) == "s: "
+
+
+@pytest.mark.unit
+def test_provisioned_param_uses_default_when_present() -> None:
+    """A default is an optional fallback for a provisioned param."""
+    decls = {"gsid": ParameterDeclarationModel(provided=True, default="fb")}
+    assert substitute_params("s: ${var.gsid}", declarations=decls) == "s: fb"
+
+
+@pytest.mark.unit
+def test_provisioned_param_uses_supplied_value() -> None:
+    decls = {"gsid": ParameterDeclarationModel(provided=True)}
+    assert (
+        substitute_params("s: ${var.gsid}", declarations=decls, cli_vars={"gsid": "R"})
+        == "s: R"
+    )
+
+
+@pytest.mark.unit
+def test_non_provisioned_no_default_still_raises() -> None:
+    """A plain required param (not provisioned) still raises when unset."""
+    decls = {"gsid": ParameterDeclarationModel()}
+    with pytest.raises(ConfigVariableError):
+        substitute_params("s: ${var.gsid}", declarations=decls)
+
+
+@pytest.mark.unit
 def test_retain_only_parameters_keeps_whitelist() -> None:
     from dao_ai.apps.bundle import _retain_only_parameters
 

--- a/tests/dao_ai/test_config_vars.py
+++ b/tests/dao_ai/test_config_vars.py
@@ -413,7 +413,35 @@ def test_resolve_parameters_reports_sources_correctly() -> None:
     assert by_name["from_default"].value == "d"
     assert by_name["missing"].source == "MISSING"
     assert by_name["missing"].value is None
-    assert by_name["missing"].required is True
+
+
+@pytest.mark.unit
+def test_resolve_parameters_reports_provided() -> None:
+    """A `provided` param (no value) reports source='provided', not MISSING, and
+    is not load-time required; an operator value still wins."""
+    decls = {
+        "runtime": ParameterDeclarationModel(provided=True),
+        "runtime_supplied": ParameterDeclarationModel(provided=True),
+        "runtime_default": ParameterDeclarationModel(provided=True, default="fb"),
+    }
+    by_name = {
+        p.name: p
+        for p in resolve_parameters(
+            decls, cli_vars={"runtime_supplied": "given"}, env={}
+        )
+    }
+    # Unsupplied provided param: not missing, not required, flagged provided.
+    assert by_name["runtime"].source == "provided"
+    assert by_name["runtime"].value is None
+    assert by_name["runtime"].required is False
+    assert by_name["runtime"].provided is True
+    # Operator value wins over the provided placeholder.
+    assert by_name["runtime_supplied"].source == "--param"
+    assert by_name["runtime_supplied"].value == "given"
+    # A default fallback wins over the provided placeholder too.
+    assert by_name["runtime_default"].source == "default"
+    assert by_name["runtime_default"].value == "fb"
+    assert by_name["runtime_default"].provided is True
 
 
 class _FakeUser:

--- a/tests/dao_ai/test_config_vars.py
+++ b/tests/dao_ai/test_config_vars.py
@@ -222,6 +222,92 @@ def test_pattern_does_not_match_unprefixed_or_spaced_tokens() -> None:
 
 
 @pytest.mark.unit
+def test_defer_leaves_ref_literal_and_not_missing() -> None:
+    """A deferred name survives as its ${var.X} literal and is never 'missing',
+    even declared with no default and no value (workflow provisioning path)."""
+    decls = {"genie_space_id": ParameterDeclarationModel(default="")}
+    rendered = substitute_params(
+        'space_id: "${var.genie_space_id}"',
+        declarations=decls,
+        defer={"genie_space_id"},
+    )
+    assert rendered == 'space_id: "${var.genie_space_id}"'
+
+
+@pytest.mark.unit
+def test_defer_no_default_no_value_does_not_raise() -> None:
+    """Deferred + declared with NO default + no value must NOT raise missing."""
+    decls = {"genie_space_id": ParameterDeclarationModel()}
+    rendered = substitute_params(
+        "id: ${var.genie_space_id}",
+        declarations=decls,
+        defer={"genie_space_id"},
+    )
+    assert rendered == "id: ${var.genie_space_id}"
+
+
+@pytest.mark.unit
+def test_defer_is_inert_when_none() -> None:
+    """defer=None must not change behavior for existing callers."""
+    decls = {"catalog": ParameterDeclarationModel(default="main")}
+    assert substitute_params("c: ${var.catalog}", declarations=decls) == "c: main"
+    assert (
+        substitute_params("c: ${var.catalog}", declarations=decls, defer=None)
+        == "c: main"
+    )
+
+
+@pytest.mark.unit
+def test_defer_only_affects_named_refs() -> None:
+    """Non-deferred refs still bake; only the deferred name is left literal."""
+    decls = {
+        "catalog": ParameterDeclarationModel(default="main"),
+        "genie_space_id": ParameterDeclarationModel(default=""),
+    }
+    rendered = substitute_params(
+        "cat: ${var.catalog}\nid: ${var.genie_space_id}",
+        declarations=decls,
+        defer={"genie_space_id"},
+    )
+    assert "cat: main" in rendered
+    assert "id: ${var.genie_space_id}" in rendered
+
+
+@pytest.mark.unit
+def test_retain_only_parameters_keeps_whitelist() -> None:
+    from dao_ai.apps.bundle import _retain_only_parameters
+
+    doc = (
+        "parameters:\n  a:\n    default: x\n  genie_space_id:\n    default: \"\"\n"
+        "resources:\n  r: 1\n"
+    )
+    out = _retain_only_parameters(doc, keep={"genie_space_id"})
+    assert "genie_space_id:" in out
+    # 'a' is dropped from the parameters block (but the resources key stays).
+    assert "  a:\n" not in out
+    assert "resources:" in out
+
+
+@pytest.mark.unit
+def test_retain_only_parameters_empty_keep_strips_block() -> None:
+    from dao_ai.apps.bundle import _retain_only_parameters, _strip_parameters_block
+
+    doc = "parameters:\n  a:\n    default: x\nresources:\n  r: 1\n"
+    # Empty keep behaves like a full strip.
+    assert _retain_only_parameters(doc, keep=set()) == _strip_parameters_block(doc)
+
+
+@pytest.mark.unit
+def test_retain_only_parameters_drops_block_when_none_kept() -> None:
+    from dao_ai.apps.bundle import _retain_only_parameters
+
+    doc = "parameters:\n  a:\n    default: x\nresources:\n  r: 1\n"
+    out = _retain_only_parameters(doc, keep={"not_present"})
+    assert "parameters:" not in out
+    assert "resources:" in out
+
+
+@pytest.mark.unit
 def test_var_prefix_alias_is_equivalent_to_param() -> None:
     """${var.NAME} and ${param.NAME} resolve identically."""
     decls = {"foo": ParameterDeclarationModel(default="d")}
@@ -1689,24 +1775,31 @@ def test_cli_var_flag_appears_in_subparser_help(
 
 
 @pytest.mark.unit
-def test_cli_run_databricks_command_forwards_vars_to_databricks_cli(
-    parameterised_config_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_cli_run_databricks_command_forwards_only_declared_vars(
+    parameterised_config_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """--var foo=bar must be appended to the underlying `databricks bundle …`."""
+    """A dao-ai --param is forwarded to `databricks bundle` as --var ONLY when the
+    staged databricks.yaml declares a matching bundle variable.
+
+    dao-ai config params are baked into the staged config; forwarding a param the
+    bundle doesn't declare makes `databricks bundle` hard-fail ("variable X has
+    not been defined"). So `module_id` (declared here) forwards; `undeclared_x`
+    (not a bundle var) must be dropped. Regression guard for the crash-fix.
+    """
     from dao_ai import cli
 
     captured: dict[str, list[str]] = {}
 
-    def _fake_run_command(cmd_args: list[str], **_: object) -> None:
-        captured["cmd"] = cmd_args
+    # Pre-staged bundle dir whose databricks.yaml declares module_id + catalog as
+    # bundle variables (but NOT undeclared_x). stage=False → use it in place.
+    out = tmp_path / "staged"
+    out.mkdir()
+    (out / "databricks.yaml").write_text(
+        "variables:\n  module_id:\n    description: d\n  catalog:\n    description: d\n"
+    )
 
     monkeypatch.setattr(cli, "_apply_profile_context", lambda profile: None)
     monkeypatch.setattr(cli, "detect_cloud_provider", lambda profile: "aws")
-    # Stub the staging-bundle write so the test exercises only the command
-    # assembly (the real write is covered by the pipeline bundle tests).
-    import dao_ai.pipeline.bundle as _pb
-
-    monkeypatch.setattr(_pb, "write_pipeline_bundle", lambda *a, **k: None)
 
     class _FakeStdout:
         def readline(self) -> str:
@@ -1730,16 +1823,17 @@ def test_cli_run_databricks_command_forwards_vars_to_databricks_cli(
     cli.run_databricks_command(
         ["bundle", "deploy"],
         config=str(parameterised_config_path),
-        config_vars={"module_id": "09", "catalog": "nfleming"},
-        # Published mode: the stubbed bundle-write stages no wheel, and this
-        # test only asserts --var forwarding, not local-wheel staging.
+        config_vars={"module_id": "09", "catalog": "nfleming", "undeclared_x": "z"},
+        output_dir=str(out),
         development=False,
+        stage=False,
     )
 
     cmd = captured["cmd"]
     cmd_str = " ".join(cmd)
     assert '--var="module_id=09"' in cmd_str
     assert '--var="catalog=nfleming"' in cmd_str
+    assert "undeclared_x" not in cmd_str
 
 
 @pytest.mark.unit

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -1515,6 +1515,70 @@ class TestDeployAutoGenerate:
         assert deploy_agent_calls[0]["target"] == ServingMode.MODEL_SERVING
         dep.assert_not_called()
 
+    def _write_cfg_with_provided(self, tmp_path: Path) -> Path:
+        """A config whose genie room binds space_id to an unsupplied `provided` param."""
+        cfg = tmp_path / "prov.yaml"
+        cfg.write_text(
+            "parameters:\n"
+            "  gsid:\n    provided: true\n"
+            "resources:\n"
+            "  models:\n    m: &m\n      name: databricks-gpt-5-4-mini\n"
+            "  genie_rooms:\n"
+            "    room: &room\n      name: r\n      space_id: ${var.gsid}\n"
+            "tools:\n"
+            "  gt: &gt\n    name: genie\n    function:\n      type: genie\n"
+            "      name: q\n      description: d\n      genie_room: *room\n"
+            "agents:\n"
+            "  a: &a\n    name: aa\n    description: aa\n    model: *m\n"
+            "    tools: [*gt]\n    prompt: hi\n"
+            "app:\n  name: prov_guardrail_app\n  agents: [*a]\n"
+        )
+        return cfg
+
+    @pytest.mark.parametrize("argv_tail", [["--mode", "model_serving"], ["--direct"]])
+    def test_unsatisfied_provided_param_blocks_sdk_deploy(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, argv_tail: list[str]
+    ) -> None:
+        """model_serving + --direct deploys must hard-error (guardrail) on an
+        unsupplied `provided` param BEFORE calling create_agent/deploy_agent."""
+        cfg = self._write_cfg_with_provided(tmp_path)
+
+        called: list[str] = []
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(AppConfig, "_resolve_all_resources", lambda self: None)
+        monkeypatch.setattr(
+            "dao_ai.config.AppConfig.create_agent",
+            lambda self, development=None: called.append("create"),
+        )
+        monkeypatch.setattr(
+            "dao_ai.config.AppConfig.deploy_agent",
+            lambda self, target=None, development=None: called.append("deploy"),
+        )
+
+        opts = parse_args(["agent", "up", "-c", str(cfg), *argv_tail])
+        with pytest.raises(ValueError, match="provided"):
+            cli.handle_agent_command(opts)
+        assert called == [], "guardrail must fire before create/deploy"
+
+    def test_supplied_provided_param_allows_sdk_deploy(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Supplying the `provided` param via --param satisfies the guardrail."""
+        cfg = self._write_cfg_with_provided(tmp_path)
+
+        called: list[str] = []
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(AppConfig, "_resolve_all_resources", lambda self: None)
+        monkeypatch.setattr(
+            "dao_ai.config.AppConfig.deploy_agent",
+            lambda self, target=None, development=None: called.append("deploy"),
+        )
+        opts = parse_args(
+            ["agent", "up", "-c", str(cfg), "--direct", "--param", "gsid=01fREAL"]
+        )
+        cli.handle_agent_command(opts)
+        assert called == ["deploy"]
+
     def test_direct_flag_parses_on_up(self) -> None:
         """`--direct` is accepted on the `up` verb (moved from deploy)."""
         opts = parse_args(["agent", "up", "-c", "c.yaml", "--direct"])

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -591,6 +591,108 @@ class TestPipelineEmitsDevelopmentVar:
 
 
 @pytest.mark.unit
+class TestConfigVarsForwardedOnlyIfDeclared:
+    """Regression: a dao-ai --param is forwarded to `databricks bundle` as --var
+    ONLY when the staged databricks.yaml declares a matching bundle variable.
+
+    A dao-ai config parameter (e.g. genie_space_id) is baked into the staged
+    config, not declared as a bundle variable — forwarding it made
+    `databricks bundle deploy` hard-fail "variable X has not been defined".
+    """
+
+    _CFG = (
+        "resources:\n  models:\n    m: &m\n      name: databricks-gpt-5-4-mini\n"
+        "agents:\n  g: &g\n    name: g\n    description: d\n    model: *m\n"
+        "    prompt: p\n"
+        "app:\n  name: stage_only_app\n  agents:\n    - *g\n"
+    )
+
+    def _run_and_capture(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        declared_vars: list[str],
+        config_vars: dict[str, str],
+    ) -> list[str]:
+        cfg = tmp_path / "c.yaml"
+        cfg.write_text(self._CFG)
+        out = tmp_path / "out"
+        out.mkdir()
+        # Pre-staged bundle whose databricks.yaml declares `declared_vars`.
+        variables_block = "".join(f"  {name}:\n    description: d\n" for name in declared_vars)
+        (out / "databricks.yaml").write_text(f"variables:\n{variables_block}")
+
+        captured: dict[str, list[str]] = {}
+
+        def _fake_exec(command, *, extra_vars=None, **kwargs):
+            captured["extra_vars"] = extra_vars or []
+
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(cli, "detect_cloud_provider", lambda p: "aws")
+        monkeypatch.setattr(cli, "_exec_bundle_command", _fake_exec)
+
+        run_databricks_command(
+            ["bundle", "deploy"],
+            config=str(cfg),
+            output_dir=str(out),
+            development=False,
+            stage=False,
+            config_vars=config_vars,
+        )
+        return captured["extra_vars"]
+
+    def test_undeclared_param_not_forwarded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        extra = self._run_and_capture(
+            tmp_path,
+            monkeypatch,
+            declared_vars=["config_path", "mode", "development", "dao_ai_dep"],
+            config_vars={"genie_space_id": "01f153"},
+        )
+        joined = " ".join(extra)
+        assert "genie_space_id" not in joined, (
+            "an undeclared dao-ai param must NOT be forwarded as a bundle --var"
+        )
+
+    def test_declared_param_is_forwarded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        extra = self._run_and_capture(
+            tmp_path,
+            monkeypatch,
+            declared_vars=["config_path", "mode", "development", "dao_ai_dep", "catalog"],
+            config_vars={"catalog": "main", "genie_space_id": "01f153"},
+        )
+        joined = " ".join(extra)
+        assert '--var="catalog=main"' in joined, "a declared overlap must be forwarded"
+        assert "genie_space_id" not in joined, "the undeclared one is still dropped"
+
+
+@pytest.mark.unit
+class TestDeclaredBundleVariables:
+    """_declared_bundle_variables reads the staged databricks.yaml safely."""
+
+    def test_reads_declared_names(self, tmp_path: Path) -> None:
+        (tmp_path / "databricks.yaml").write_text(
+            "variables:\n  a:\n    description: x\n  b:\n    default: y\n"
+        )
+        assert cli._declared_bundle_variables(tmp_path) == {"a", "b"}
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert cli._declared_bundle_variables(tmp_path) == set()
+
+    def test_no_variables_block_returns_empty(self, tmp_path: Path) -> None:
+        (tmp_path / "databricks.yaml").write_text("bundle:\n  name: x\n")
+        assert cli._declared_bundle_variables(tmp_path) == set()
+
+    def test_malformed_yaml_returns_empty(self, tmp_path: Path) -> None:
+        (tmp_path / "databricks.yaml").write_text("variables: [not, a, mapping\n")
+        assert cli._declared_bundle_variables(tmp_path) == set()
+
+
+@pytest.mark.unit
 class TestGenerateIsStageOnly:
     """``generate`` is now a pure staging verb — ``--deploy``/``--run``/``--destroy``
     are rejected by the parser (use ``up`` for orchestration).

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -110,6 +110,13 @@ class TestNounVerbParsing:
         opts = parse_args(["agent", "up", "-c", "c.yaml", "--direct"])
         assert opts.direct is True
 
+    def test_workflow_up_rejects_direct(self) -> None:
+        # --direct is agent-only: workflow up runs the provisioning DAB job, which
+        # requires the bundle, so a bundle-less SDK path is meaningless. The flag
+        # is not registered on the workflow noun (was a silent no-op before).
+        with pytest.raises(SystemExit):
+            parse_args(["workflow", "up", "-c", "c.yaml", "--direct"])
+
     def test_up_verb_rejects_direct_with_model_serving(self) -> None:
         # --direct is meaningless with model_serving (which always deploys via the
         # SDK); the combo is rejected at parse time rather than silently ignored.

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -1941,3 +1941,34 @@ class TestGlobalProfileVerbose:
     def test_verbose_after_workflow_subcommand(self) -> None:
         o = parse_args(["workflow", "deploy", "-c", "c.yaml", "-v"])
         assert o.verbose >= 1
+
+
+@pytest.mark.unit
+class TestParametersSubcommand:
+    """`dao-ai parameters` (alias `vars`): action defaults to list; get takes a name."""
+
+    def test_bare_defaults_to_list(self) -> None:
+        o = parse_args(["parameters", "-c", "c.yaml"])
+        assert o.action == "list"
+        assert o.name is None
+
+    def test_explicit_list_backcompat(self) -> None:
+        o = parse_args(["parameters", "list", "-c", "c.yaml"])
+        assert o.action == "list"
+
+    def test_vars_alias_bare(self) -> None:
+        o = parse_args(["vars", "-c", "c.yaml"])
+        assert o.action == "list"
+
+    def test_get_with_name(self) -> None:
+        o = parse_args(["parameters", "get", "catalog", "-c", "c.yaml"])
+        assert o.action == "get"
+        assert o.name == "catalog"
+
+    def test_invalid_action_rejected(self) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(["parameters", "bogus", "-c", "c.yaml"])
+
+    def test_config_still_required(self) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(["parameters", "list"])

--- a/tests/dao_ai/test_pipeline_bundle.py
+++ b/tests/dao_ai/test_pipeline_bundle.py
@@ -484,3 +484,85 @@ def test_materialize_notebooks_skips_init(tmp_path: Path) -> None:
     written = _materialize_notebooks(tmp_path, overwrite=True)
     assert all("__init__" not in w for w in written)
     assert len(written) == 8
+
+
+@pytest.mark.unit
+class TestGenieProvisioningStaging:
+    """Workflow staging must PRESERVE a Genie room's ``space_id: ${var.X}`` binding
+    (+ its declaration) when the operator did NOT supply X, so
+    05_provision_genie can provision and 06_deploy_agent can inject the id.
+    A supplied X bakes to a literal (reuse). Non-genie params always bake."""
+
+    _CFG = (
+        "parameters:\n"
+        "  catalog:\n    default: main\n"
+        "  genie_space_id:\n    description: provisioned by workflow\n    default: \"\"\n"
+        "schemas:\n  s: &s\n    catalog_name: ${var.catalog}\n    schema_name: dao_ai\n"
+        "resources:\n"
+        "  warehouses:\n    wh: &wh\n      name: Serverless Starter Warehouse\n"
+        "  genie_rooms:\n"
+        "    room: &room\n"
+        "      name: test room\n"
+        "      space_id: \"${var.genie_space_id}\"\n"
+        "      warehouse: *wh\n"
+        "  llms:\n    m: &m\n      name: databricks-test-llm\n"
+        "agents:\n  a: &a\n    name: a\n    description: a\n    model: *m\n    prompt: hi\n"
+        "app:\n  name: prov_test\n  agents:\n    - *a\n"
+    )
+
+    def _cfg(self, tmp_path: Path) -> Path:
+        p = tmp_path / "prov.yaml"
+        p.write_text(self._CFG)
+        return p
+
+    def _staged_text(self, tmp_path: Path, out_name: str, **from_file_kwargs) -> str:
+        cfg = AppConfig.from_file(str(self._cfg(tmp_path)), initialize=False, **from_file_kwargs)
+        out = tmp_path / out_name
+        write_pipeline_bundle(cfg, out)
+        return (out / "config" / "prov.yaml").read_text()
+
+    def test_unprovided_genie_param_ref_survives_staging(self, tmp_path: Path) -> None:
+        staged = self._staged_text(tmp_path, "omit")
+        # The ${var.genie_space_id} ref is preserved, and its declaration retained.
+        assert "${var.genie_space_id}" in staged
+        assert "genie_space_id:" in staged
+        # Non-genie params are baked; their decls stripped.
+        assert "${var.catalog}" not in staged
+        assert "catalog_name: main" in staged
+        assert "catalog:" not in staged.split("resources:")[0]
+
+    def test_supplied_genie_param_is_baked_no_provision(self, tmp_path: Path) -> None:
+        staged = self._staged_text(
+            tmp_path, "passid", params={"genie_space_id": "01fEXISTING"}
+        )
+        # Operator supplied it → baked to a literal, declaration stripped (reuse).
+        assert "${var.genie_space_id}" not in staged
+        assert "01fEXISTING" in staged
+        assert "parameters:" not in staged
+
+    def test_staged_provision_config_round_trips(self, tmp_path: Path) -> None:
+        """The staged (deferred) config reloads so 05's gate fires and 06 injects."""
+        from dao_ai.config import is_parameter, parameter_name, value_of
+
+        cfg = AppConfig.from_file(str(self._cfg(tmp_path)), initialize=False)
+        out = tmp_path / "rt"
+        write_pipeline_bundle(cfg, out)
+        staged_path = str(out / "config" / "prov.yaml")
+
+        # 05 gate
+        reloaded = AppConfig.from_file(staged_path, initialize=False)
+        room = list(reloaded.resources.genie_rooms.values())[0]
+        assert is_parameter(room.raw_space_id) is True
+        assert parameter_name(room.raw_space_id) == "genie_space_id"
+        assert not value_of(room.space_id)
+
+        # 06 injection via taskValues
+        class _FakeTV:
+            def get(self, taskKey, key, default="", debugValue=""):
+                return "PROVISIONED_123" if key == "genie_space_id" else default
+
+        injected = AppConfig.from_file(
+            staged_path, task_values=_FakeTV(), task_key="provision-genie", initialize=False
+        )
+        room2 = list(injected.resources.genie_rooms.values())[0]
+        assert value_of(room2.space_id) == "PROVISIONED_123"

--- a/tests/dao_ai/test_pipeline_bundle.py
+++ b/tests/dao_ai/test_pipeline_bundle.py
@@ -496,7 +496,7 @@ class TestGenieProvisioningStaging:
     _CFG = (
         "parameters:\n"
         "  catalog:\n    default: main\n"
-        "  genie_space_id:\n    description: provisioned by workflow\n    default: \"\"\n"
+        "  genie_space_id:\n    description: provisioned by workflow\n    provided: true\n"
         "schemas:\n  s: &s\n    catalog_name: ${var.catalog}\n    schema_name: dao_ai\n"
         "resources:\n"
         "  warehouses:\n    wh: &wh\n      name: Serverless Starter Warehouse\n"


### PR DESCRIPTION
## Summary

Fixes `dao-ai workflow --param`/`--var` overrides and revives the (long-dormant) workflow Genie **provisioning** handshake, then generalizes the underlying mechanism into a first-class `provided: true` parameter scope. All verified end-to-end on FEVM.

Started from one symptom — "`--param` doesn't work for `dao-ai workflow`" — which turned out to be **two independent bugs plus a dormant feature**.

## Commits

1. **`fix(cli): only forward declared bundle variables to databricks bundle`**
   `workflow up --param genie_space_id=X` died with `Error: variable genie_space_id has not been defined`. `run_databricks_command` forwarded *every* `--param` to `databricks bundle` as `--var`, but dao-ai config params aren't declared bundle variables. Now only names the staged `databricks.yaml` declares are forwarded (`_declared_bundle_variables`).

2. **`fix(pipeline): preserve unprovided Genie space_id refs through workflow staging`**
   Workflow staging baked `${var.genie_space_id}` → literal and stripped the `parameters:` block, so `05_provision_genie`'s `is_parameter(raw_space_id)` gate never fired and `06_deploy_agent` had nothing to inject. Staging now **defers** an unprovided `${var.X}` used by a provisioning step (keeps the ref + its declaration); a supplied value still bakes for reuse. Workflow-only — apps/model_serving baking is untouched.

3. **`fix(cli): remove --direct from the workflow noun (was a silent no-op)`**
   `--direct` (skip the DAB, deploy via SDK) can't apply to the workflow noun, whose purpose is running the provisioning job. It was silently ignored; now rejected at parse time. Still valid on `agent`.

4. **`feat(config): add \`provided: true\` param scope`**
   Explicit parameter attribute for values furnished dynamically at run time (analogous to a build tool's "provided" dependency scope), replacing the `default: ""` idiom. Generic and consumer-independent — Genie provisioning is just the first user. An unsupplied `provided` param resolves to empty (not missing-required); a `default` is an optional fallback; `--param` still wins. Workflow staging defers `provided` params; non-workflow paths (apps/mcp/model_serving) hard-error via `AppConfig.assert_provided_params_satisfied()` rather than deploy a broken binding. Migrates the shipped provisioning configs; `make schema` regenerated.

5. **`feat(cli): surface \`provided\` params in \`dao-ai vars list\``**
   `provided` params were mis-reported as `MISSING`/required. Now report `source="provided"`, `required=False`, and a new `PROVIDED` column.

6. **`feat(cli): improve \`parameters\`/\`vars\` UX`**
   `action` is optional (defaults to `list`), so `dao-ai parameters -c cfg` just works. Adds `get <name>` (bare resolved value to stdout, script-friendly) with targeted errors. Clearer help explaining actions, resolution order, and the `vars` alias.

## Live verification (FEVM)

Full end-to-end matrix via `workflow up --development --overwrite`, all **TERMINATED SUCCESS**:

| Config | `--param`? | `provision-genie` | Behavior |
|---|---|---|---|
| `provided: true` | no | `{genie_space_id: <id>}` | provisions + forwards id via taskValue |
| `provided: true` | yes | `{}` | supplied id baked → reuse |
| non-provided (default) | no | `{}` | default baked → reuse |
| non-provided | yes | `{}` | param baked → reuse |

Idempotent: exactly 1 Genie space after all runs (no orphans). Guardrail confirmed firing on the agent/apps path for an unsupplied `provided` param.

## Tests

New unit coverage for the declared-var filter, substitute `defer` + `provided` semantics, `_retain_only_parameters`, staging defer/retain round-trip, the guardrail, `vars list` provided reporting, and the `parameters get`/optional-action parsing. Full affected suites green.

This pull request and its description were written by Isaac.