### PR TITLE
refactor(cli)!: rename bundle -o/--output-dir → -s/--staging-dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING — Renamed the bundle staging-dir flag `-o/--output-dir` → `-s/--staging-dir`** on every bundle verb (`generate`/`up`/`deploy`/`run`/`destroy` across the `agent`, `workflow`, and `mcp` nouns). The flag never wrote a one-shot output — it names a persistent, reused staging directory (`deploy`/`run`/`destroy` act on the same dir without regenerating), and every other reference to it already used "bundle"/"staging" vocabulary (`DAO_AI_BUNDLE_DIR`, `_resolve_bundle_dir`). `-o` is now free for genuine output flags (`graph -o FILE`, `trace create -o FORMAT`). No alias is kept — update any scripts using `-o`/`--output-dir` on bundle verbs. The `DAO_AI_BUNDLE_DIR` env var and default `<base>/<kind>/<app>` layout are unchanged.
+
 ## [0.2.4] - 2026-07-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -511,10 +511,10 @@ dao-ai agent up -c config/my_config.yaml -p <profile>
 Or generate first, optionally hand-edit the staged files, then ship exactly what's on disk with the `deploy` verb, and start it with `run`:
 
 ```bash
-dao-ai agent generate -c config/my_config.yaml -o ./my-bundle
+dao-ai agent generate -c config/my_config.yaml -s ./my-bundle
 # (optionally hand-edit ./my-bundle)
-dao-ai agent deploy -c config/my_config.yaml -o ./my-bundle -p <profile>
-dao-ai agent run    -c config/my_config.yaml -o ./my-bundle -p <profile>
+dao-ai agent deploy -c config/my_config.yaml -s ./my-bundle -p <profile>
+dao-ai agent run    -c config/my_config.yaml -s ./my-bundle -p <profile>
 
 # ...or drive the bundle by hand
 cd ./my-bundle

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -144,7 +144,7 @@ dao-ai workflow up|generate|deploy|run|destroy  -c <cfg> [-p <profile>]
 **The granular lifecycle — `generate → deploy → run → destroy`:**
 
 - **`generate`** stages a bundle to disk (`<base>/<noun>/<app>`, where `<base>`
-  is `$DAO_AI_BUNDLE_DIR` or `./.dao-ai/bundle`, or `-o <dir>`) and does nothing
+  is `$DAO_AI_BUNDLE_DIR` or `./.dao-ai/bundle`, or `-s <dir>`) and does nothing
   else — inspect or hand-edit the staged files before shipping.
 - **`deploy`** pushes the bundle. For `agent`/`mcp`, `deploy` is
   `databricks bundle deploy`; when a staged bundle exists it deploys it in place
@@ -167,7 +167,7 @@ with just `dao-ai agent deploy -c <cfg> -p fevm` — no regeneration. To deploy
 **Edit safety.** Re-running `generate` into the **default** staging dir refuses
 to wipe it once it has local hand-edits (detected via the `.dao-ai-generated`
 marker file's mtime), unless you pass `--overwrite`. The error points you at
-`<noun> deploy` to ship the edits instead. A `-o <dir>` is never auto-wiped.
+`<noun> deploy` to ship the edits instead. A `-s <dir>` is never auto-wiped.
 The source-selection flags `--overwrite`, `--development`, and `--no-development`
 are on `up`, `generate`, and `deploy` (for `agent`/`mcp`, `deploy` can
 auto-generate; for `workflow` it acts on the already-staged bundle); `run` and
@@ -251,10 +251,10 @@ When the source config uses `${param.NAME}` / `${var.NAME}` parameters or `${wor
 ### Basic Usage
 
 ```bash
-dao-ai agent generate -c config/retail.yaml -o ./my-bundle
+dao-ai agent generate -c config/retail.yaml -s ./my-bundle
 
 # With parameter overrides baked into the generated bundle
-dao-ai agent generate -c config/retail.yaml -o ./my-bundle --param catalog=prod_catalog
+dao-ai agent generate -c config/retail.yaml -s ./my-bundle --param catalog=prod_catalog
 
 # Generate, deploy, and start the app in one command
 dao-ai agent up -c config/retail.yaml -p fevm
@@ -387,17 +387,17 @@ dao-ai trace create --name /Shared/my-app/dao-ai-fresh -p <profile>
 If the output directory already contains generated files, they are skipped by default. Use `--overwrite` to overwrite:
 
 ```bash
-dao-ai agent generate -c config/retail.yaml -o ./my-bundle --overwrite
+dao-ai agent generate -c config/retail.yaml -s ./my-bundle --overwrite
 ```
 
-Re-running `generate` into the **default** staging dir (no `-o`) refuses to wipe it once it has local hand-edits (detected via the `.dao-ai-generated` marker's mtime) unless you pass `--overwrite`; the error points you at `dao-ai agent deploy` to ship the edits as-is. A `-o <dir>` is never auto-wiped. `--overwrite` is only valid on `generate`.
+Re-running `generate` into the **default** staging dir (no `-s`) refuses to wipe it once it has local hand-edits (detected via the `.dao-ai-generated` marker's mtime) unless you pass `--overwrite`; the error points you at `dao-ai agent deploy` to ship the edits as-is. A `-s <dir>` is never auto-wiped. `--overwrite` is only valid on `generate`.
 
 ### Using a Databricks Profile
 
 If your config references workspace resources (Genie rooms, warehouses, etc.), specify a profile so they can be resolved during generation:
 
 ```bash
-dao-ai agent generate -c config/retail.yaml -o ./my-bundle --profile my-workspace
+dao-ai agent generate -c config/retail.yaml -s ./my-bundle --profile my-workspace
 ```
 
 ### Development Mode
@@ -405,7 +405,7 @@ dao-ai agent generate -c config/retail.yaml -o ./my-bundle --profile my-workspac
 Use `--development` to bundle a local build of dao-ai instead of pulling from PyPI. This is useful when testing unreleased dao-ai changes in a deployed app.
 
 ```bash
-dao-ai agent generate -c config/retail.yaml -o ./my-bundle --development
+dao-ai agent generate -c config/retail.yaml -s ./my-bundle --development
 ```
 
 Development mode changes the generated bundle in several ways:
@@ -509,7 +509,7 @@ app:
 
 ```bash
 # 3. Deploy → link → run → restart.
-dao-ai agent generate -c my_config.yaml -o ./bundle --overwrite
+dao-ai agent generate -c my_config.yaml -s ./bundle --overwrite
 cd ./bundle
 databricks bundle deploy --target dev -p <profile>
 dao-ai trace link -c ../my_config.yaml -p <profile>

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -274,7 +274,7 @@ MCP server bundles use `dao-ai agent generate --mode mcp` (not a separate noun).
 All three generators (`agent`, `mcp`, `workflow`)
 resolve where to write the bundle in this order:
 
-1. `-o/--output-dir <dir>` — used verbatim.
+1. `-s/--staging-dir <dir>` — used verbatim.
 2. `DAO_AI_BUNDLE_DIR` env var — bundles land at `$DAO_AI_BUNDLE_DIR/<kind>/<app>`
    (`<kind>` is `agent`, `mcp`, or `workflow`). Set this for a central location,
    e.g. `export DAO_AI_BUNDLE_DIR=~/.dao-ai/bundle`.
@@ -820,7 +820,7 @@ the bundle only; `deploy` pushes the already-staged bundle (unlike `agent deploy
 | Option | Description | Verbs |
 |--------|-------------|-------|
 | `-c, --config FILE` | Path to the dao-ai configuration file (required) | all |
-| `-o, --output-dir DIR` | Bundle staging dir (default: `$DAO_AI_BUNDLE_DIR/workflow/<app>` or `./.dao-ai/bundle/workflow/<app>`) | all |
+| `-s, --staging-dir DIR` | Bundle staging dir (default: `$DAO_AI_BUNDLE_DIR/workflow/<app>` or `./.dao-ai/bundle/workflow/<app>`) | all |
 | `-p, --profile NAME` | Databricks CLI profile to use | all |
 | `--param KEY=VALUE` / `--var KEY=VALUE` | Config parameter overrides (repeatable) | all |
 | `--cloud {azure,aws,gcp}` | Cloud provider (auto-detected from the workspace URL; required only if detection fails) | all |
@@ -853,7 +853,7 @@ the bundle only; `deploy` pushes it (auto-generating if nothing is staged);
 | Option | Description | Verbs |
 |--------|-------------|-------|
 | `-c, --config FILE` | Path to the dao-ai configuration file (required) | all |
-| `-o, --output-dir DIR` | Output dir (default: `$DAO_AI_BUNDLE_DIR/<kind>/<app>` or `./.dao-ai/bundle/<kind>/<app>`, where `<kind>` is `agent` or `mcp`) | all |
+| `-s, --staging-dir DIR` | Bundle staging dir (default: `$DAO_AI_BUNDLE_DIR/<kind>/<app>` or `./.dao-ai/bundle/<kind>/<app>`, where `<kind>` is `agent` or `mcp`) | all |
 | `-p, --profile NAME` | Databricks profile for config loading and deploy | all |
 | `--param KEY=VALUE` / `--var KEY=VALUE` | Config parameter overrides (repeatable) | all |
 | `--mode {apps,mcp,model_serving}` | Serving target (default: `apps`; `ms`/`model-serving` accepted as aliases). `run`/`destroy` accept `apps`/`mcp` only. | all |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -197,10 +197,10 @@ print(f"Deployed app: {config.app.name}")
 **Path 2 — `dao-ai agent generate` (Asset Bundle you can inspect / edit / check into Git):**
 
 ```bash
-dao-ai agent generate -c config/my_agent.yaml -o ./my-bundle
+dao-ai agent generate -c config/my_agent.yaml -s ./my-bundle
 # Optionally hand-edit ./my-bundle, then ship exactly what's on disk (no regeneration):
-dao-ai agent deploy -c config/my_agent.yaml -o ./my-bundle
-dao-ai agent run    -c config/my_agent.yaml -o ./my-bundle
+dao-ai agent deploy -c config/my_agent.yaml -s ./my-bundle
+dao-ai agent run    -c config/my_agent.yaml -s ./my-bundle
 # ...or drive the bundle manually
 cd my-bundle
 databricks bundle deploy
@@ -762,7 +762,7 @@ app:
 **Deploy flow for Databricks Apps** (bundle path):
 
 ```bash
-dao-ai agent generate -c my_config.yaml -o ./bundle
+dao-ai agent generate -c my_config.yaml -s ./bundle
 cd ./bundle
 databricks bundle deploy --target dev -p <profile>
 dao-ai trace link -c ../my_config.yaml -p <profile>               # explicit link step

--- a/docs/mcp_server.md
+++ b/docs/mcp_server.md
@@ -453,7 +453,7 @@ launches the server via module invocation — no console script required.
 | Flag | Meaning |
 |---|---|
 | `-c / --config` | Path to your dao-ai config YAML. |
-| `-o / --output-dir` | Where to write the bundle. |
+| `-s / --staging-dir` | Where to write the bundle. |
 | `--overwrite` | Overwrite existing files in the output directory. |
 | `--development` | Build the local dao-ai wheel and bundle it under `output/dist/`; the generated pyproject installs from there. Use when dao-ai changes haven't shipped to PyPI yet. |
 | `-p / --profile` | Databricks CLI profile — drives `_resolve_all_resources` so generated bundle paths (e.g. Lakebase database IDs) come from the target workspace. Always pass this when your config references resources resolved at generate time. |

--- a/docs/mcp_server.md
+++ b/docs/mcp_server.md
@@ -49,11 +49,11 @@ pip install 'dao-ai[mcp]'
 dao-ai agent generate \
   --mode mcp \
   -c my_agent.yaml \
-  -o ./my-agent-mcp \
+  -s ./my-agent-mcp \
   -p <profile>
 
 # 3. Deploy + run in one step (or drive databricks bundle by hand, below)
-dao-ai agent up --mode mcp -c my_agent.yaml -o ./my-agent-mcp -p <profile>
+dao-ai agent up --mode mcp -c my_agent.yaml -s ./my-agent-mcp -p <profile>
 
 # 3b. ...or drive the bundle manually
 cd my-agent-mcp

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -784,9 +784,9 @@ def write_bundle(
         raise ValueError(
             f"Refusing to write bundle into the dao-ai source repo "
             f"({resolved_output}). ``generate-agent`` would clobber the "
-            "dao-ai project's ``pyproject.toml``. Pass ``-o <path>`` to "
+            "dao-ai project's ``pyproject.toml``. Pass ``-s <path>`` to "
             "target a fresh directory, e.g. "
-            "``dao-ai generate-agent -c <config> -o ./bundle``."
+            "``dao-ai generate-agent -c <config> -s ./bundle``."
         )
 
     staging_dir.mkdir(parents=True, exist_ok=True)

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -754,7 +754,7 @@ def _write_file(path: Path, content: str, overwrite: bool) -> bool:
 
 def write_bundle(
     config: AppConfig,
-    output_dir: Path,
+    staging_dir: Path,
     overwrite: bool = False,
     development: bool = False,
 ) -> dict[str, str]:
@@ -771,7 +771,7 @@ def write_bundle(
     a ``pyproject.toml`` with ``name = "<app_name>"`` and would silently
     clobber the dao-ai project descriptor if the deployer accidentally ran
     ``generate-agent`` from inside a dao-ai checkout (the default
-    ``--output-dir`` is the CWD).
+    ``--staging-dir`` is the CWD).
 
     Returns the staging registry: ``{relative_posix_path: sha256}`` for the
     files dao-ai *generated* (databricks.yaml, resources/app.yml, pyproject.toml,
@@ -779,7 +779,7 @@ def write_bundle(
     skills, dist wheels) is deliberately excluded so hand-edits to it never trip
     edit-detection. The caller stamps this into ``.dao-ai-manifest.yaml``.
     """
-    resolved_output = output_dir.resolve()
+    resolved_output = staging_dir.resolve()
     if (resolved_output / "src" / "dao_ai" / "config.py").exists():
         raise ValueError(
             f"Refusing to write bundle into the dao-ai source repo "
@@ -789,21 +789,21 @@ def write_bundle(
             "``dao-ai generate-agent -c <config> -o ./bundle``."
         )
 
-    output_dir.mkdir(parents=True, exist_ok=True)
+    staging_dir.mkdir(parents=True, exist_ok=True)
     app_name: str = config.app.app_resource_name
     written: list[str] = []
     skipped: list[str] = []
     # User code (src/ + code_paths + source config) that already existed at the
     # dest and was left untouched — never overwritten, even with --overwrite.
     preserved: list[str] = []
-    # Content hashes of the files dao-ai generated, keyed by output-dir-relative
+    # Content hashes of the files dao-ai generated, keyed by staging-dir-relative
     # POSIX path. Populated only at generated-scaffold write sites (see _track and
     # the uv.lock write); user-code copy sites deliberately omit themselves.
     registry: dict[str, str] = {}
 
     def _register(path: Path) -> None:
         if path.exists():
-            registry[path.relative_to(output_dir).as_posix()] = _sha256_file(path)
+            registry[path.relative_to(staging_dir).as_posix()] = _sha256_file(path)
 
     # Warn loudly when the bundle is being built without `trace_location`:
     # Databricks Apps containers cannot reach the artifact-storage host the
@@ -844,7 +844,7 @@ def write_bundle(
     # Databricks agent template pattern.  No pre-build needed here.
 
     _track(
-        output_dir / "databricks.yaml",
+        staging_dir / "databricks.yaml",
         generate_databricks_yaml(
             config, development=development, config_filename=config_filename
         ),
@@ -853,7 +853,7 @@ def write_bundle(
     # The App + experiment block lives in resources/app.yml so users can drop
     # sibling resources/*.yml files (jobs, pipelines, etc.) into the bundle
     # without conflicting with the regen-owned databricks.yaml.
-    resources_dir = output_dir / "resources"
+    resources_dir = staging_dir / "resources"
     resources_dir.mkdir(parents=True, exist_ok=True)
     _track(
         resources_dir / "app.yml",
@@ -861,7 +861,7 @@ def write_bundle(
     )
 
     if source_config:
-        dest = output_dir / config_filename
+        dest = staging_dir / config_filename
         # Never write over the user's ORIGINAL config (would strip their
         # parameters: block irreversibly). Belt-and-suspenders behind the
         # overlap hard-error in the CLI.
@@ -909,7 +909,7 @@ def write_bundle(
             # under skills/<basename>. The user can still reference the skill
             # via the rendered absolute path in the deployed config.
             rel = Path("skills") / src_dir.name
-        dest = output_dir / rel
+        dest = staging_dir / rel
         # In-place (output overlaps the skill source): never rmtree the user's
         # own skills dir. Belt-and-suspenders behind the overlap hard-error.
         if dest.resolve() == src_dir.resolve():
@@ -943,7 +943,7 @@ def write_bundle(
 
     for src, code_dest in iter_code_path_stagings(config):
         for file_src, file_dest in walk_code_path_files(src, code_dest):
-            out = output_dir / file_dest
+            out = staging_dir / file_dest
             # User code is sacred: never overwrite it (even with --overwrite),
             # and never copy a file onto itself when output overlaps the source.
             if file_src.resolve() == out.resolve():
@@ -963,7 +963,7 @@ def write_bundle(
         for file_src, file_dest in walk_code_path_files(
             pkg_dir, f"{_SRC_DIRNAME}/{pkg_dir.name}"
         ):
-            out = output_dir / file_dest
+            out = staging_dir / file_dest
             if file_src.resolve() == out.resolve():
                 preserved.append(file_dest)
                 continue
@@ -1055,7 +1055,7 @@ def write_bundle(
             logger.info("Using existing dev wheel", wheel=wheel_path.name)
 
         # Copy wheel into bundle's dist/ directory
-        dist_dir = output_dir / "dist"
+        dist_dir = staging_dir / "dist"
         dist_dir.mkdir(parents=True, exist_ok=True)
         dest_wheel = dist_dir / wheel_path.name
         shutil.copy2(wheel_path, dest_wheel)
@@ -1066,7 +1066,7 @@ def write_bundle(
         # requirement is redirected to the bundled local wheel via
         # ``[tool.uv.sources]`` so the generated uv.lock installs THIS code.
         _track(
-            output_dir / "pyproject.toml",
+            staging_dir / "pyproject.toml",
             _PYPROJECT_DEV_TEMPLATE.format(
                 name=app_name,
                 package_name=package_name,
@@ -1081,7 +1081,7 @@ def write_bundle(
         # ABSENT — never overwrite an existing __init__.py (the user may have a
         # real src/<app_name> package, copied by the src/ loop above), even with
         # --overwrite; clobbering it with an empty file would destroy their code.
-        stub_dir = output_dir / "src" / package_name
+        stub_dir = staging_dir / "src" / package_name
         stub_init = stub_dir / "__init__.py"
         if not stub_init.exists():
             stub_dir.mkdir(parents=True, exist_ok=True)
@@ -1093,12 +1093,12 @@ def write_bundle(
         # ``uv sync --locked --no-dev`` from pyproject.toml + uv.lock (no
         # requirements.txt). The lock references the bundled wheel via the
         # ``[tool.uv.sources]`` path and pins the full public-PyPI closure.
-        generate_bundle_lock(output_dir)
+        generate_bundle_lock(staging_dir)
         written.append("uv.lock")
-        _register(output_dir / "uv.lock")
+        _register(staging_dir / "uv.lock")
     else:
         _track(
-            output_dir / "pyproject.toml",
+            staging_dir / "pyproject.toml",
             _PYPROJECT_TEMPLATE.format(
                 name=app_name,
                 package_name=package_name,
@@ -1112,7 +1112,7 @@ def write_bundle(
         # Only scaffold when ABSENT — never overwrite an existing __init__.py
         # (the user may have a real src/<app_name> package, copied above), even
         # with --overwrite; clobbering it with an empty file destroys their code.
-        stub_dir = output_dir / "src" / package_name
+        stub_dir = staging_dir / "src" / package_name
         stub_init = stub_dir / "__init__.py"
         if not stub_init.exists():
             stub_dir.mkdir(parents=True, exist_ok=True)
@@ -1124,17 +1124,17 @@ def write_bundle(
         # ``uv sync --locked --no-dev`` from pyproject.toml + uv.lock (no
         # requirements.txt). The sole ``dao-ai>={ver}`` dep resolves the full
         # public-PyPI closure at lock time; the lock pins it.
-        generate_bundle_lock(output_dir)
+        generate_bundle_lock(staging_dir)
         written.append("uv.lock")
-        _register(output_dir / "uv.lock")
+        _register(staging_dir / "uv.lock")
 
     _track(
-        output_dir / ".gitignore",
+        staging_dir / ".gitignore",
         _GITIGNORE_DEV_CONTENT if development else _GITIGNORE_CONTENT,
     )
-    _track(output_dir / ".python-version", "3.11\n")
+    _track(staging_dir / ".python-version", "3.11\n")
 
-    print(f"\nBundle generated in {output_dir}/\n")
+    print(f"\nBundle generated in {staging_dir}/\n")
     for name in written:
         print(f"  {name:<20s} (created)")
     for name in skipped:
@@ -1149,7 +1149,7 @@ def write_bundle(
         )
 
     print("\nNext steps:")
-    print(f"  cd {output_dir}")
+    print(f"  cd {staging_dir}")
     print("  databricks bundle deploy --target dev")
     if config.app and config.app.trace_location:
         # Idempotent — safe on every deploy — but load-bearing on

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -256,12 +256,12 @@ def _global_parent_parser() -> ArgumentParser:
 
 
 def _add_bundle_common_args(parser: ArgumentParser, *, kind: str) -> None:
-    """Add the flags every bundle verb shares: -c/-o/-p/--dry-run/--param.
+    """Add the flags every bundle verb shares: -c/-s/-p/--dry-run/--param.
 
     Shared across ``generate``/``deploy``/``run``/``destroy`` for all three
     nouns (agent/mcp/workflow) so the config path, staging dir, profile, and
     dry-run switch are spelled identically everywhere. ``kind`` only customizes
-    the ``--output-dir`` help text (``<base>/<kind>/<app>``).
+    the ``--staging-dir`` help text (``<base>/<kind>/<app>``).
     """
     parser.add_argument(
         "-c",
@@ -272,8 +272,8 @@ def _add_bundle_common_args(parser: ArgumentParser, *, kind: str) -> None:
         help="Path to the dao-ai configuration file",
     )
     parser.add_argument(
-        "-o",
-        "--output-dir",
+        "-s",
+        "--staging-dir",
         type=str,
         default=None,
         metavar="DIR",
@@ -3247,7 +3247,7 @@ def run_databricks_command(
     mode: Optional[str] = None,
     development: bool | None = None,
     config_vars: Optional[dict[str, str]] = None,
-    output_dir: Optional[str] = None,
+    staging_dir: Optional[str] = None,
     overwrite: bool = False,
     stage: bool = True,
 ) -> None:
@@ -3273,7 +3273,7 @@ def run_databricks_command(
             ``databricks bundle`` command as ``--var name=value`` so the
             asset-bundle layer's own ``${var.NAME}`` substitution sees the same
             values when the names overlap.
-        output_dir: Directory to stage the bundle into. When ``None`` (default),
+        staging_dir: Directory to stage the bundle into. When ``None`` (default),
             a per-app dir ``.dao-ai/bundle/workflow/<app>`` is used so
             deploying multiple configs never collides on a shared staging dir.
         overwrite: Overwrite copied-in *content* (config, data/functions assets)
@@ -3338,15 +3338,15 @@ def run_databricks_command(
     # resolved config — no source checkout required. `bundle deploy/run/destroy`
     # then run with cwd == the staging dir.
     #
-    # When --output-dir is omitted, derive a PER-APP default under the shared
+    # When --staging-dir is omitted, derive a PER-APP default under the shared
     # `.dao-ai/bundle/workflow/<app>` namespace rather than a single shared dir.
     # The staging dir's contents (bundle name, targets, config) are app-specific,
     # so a shared default would let a second config's deploy fail against the
     # first config's stale databricks.yaml. A per-app default isolates each
     # bundle's DABs state and makes deploying many configs "just work".
-    is_default_dir: bool = output_dir is None
-    if output_dir is not None:
-        staging_dir = Path(output_dir).resolve()
+    is_default_dir: bool = staging_dir is None
+    if staging_dir is not None:
+        staging_dir = Path(staging_dir).resolve()
     elif normalized_name:
         staging_dir = _default_bundle_dir("workflow", app_config.app.name).resolve()
     else:
@@ -3400,7 +3400,7 @@ def run_databricks_command(
             logger.error(
                 f"No staged workflow bundle at {staging_dir}. "
                 f"Run `dao-ai workflow generate -c {config}"
-                f"{f' -o {output_dir}' if output_dir else ''}` first."
+                f"{f' -s {staging_dir}' if staging_dir else ''}` first."
             )
             sys.exit(1)
 
@@ -3594,7 +3594,7 @@ def _link_and_grant_trace(
 def deploy_app_bundle(
     config: AppConfig,
     *,
-    output_dir: Path,
+    staging_dir: Path,
     deploy: bool,
     run: bool,
     destroy: bool,
@@ -3611,7 +3611,7 @@ def deploy_app_bundle(
 
     Args:
         config: loaded AppConfig (for trace_location + app name).
-        output_dir: the staged bundle dir (``bundle`` commands run here).
+        staging_dir: the staged bundle dir (``bundle`` commands run here).
         deploy / run / destroy: which action(s) to perform.
         profile: Databricks CLI profile.
         dry_run: print instead of executing.
@@ -3626,7 +3626,7 @@ def deploy_app_bundle(
             ["bundle", "destroy", "--auto-approve"],
             profile=profile,
             target=target,
-            cwd=output_dir,
+            cwd=staging_dir,
             dry_run=dry_run,
         )
         return
@@ -3636,7 +3636,7 @@ def deploy_app_bundle(
             ["bundle", "deploy"],
             profile=profile,
             target=target,
-            cwd=output_dir,
+            cwd=staging_dir,
             dry_run=dry_run,
         )
         # Between deploy and run: link the trace destination + grant the App SP
@@ -3648,7 +3648,7 @@ def deploy_app_bundle(
             ["bundle", "run", app_name],
             profile=profile,
             target=target,
-            cwd=output_dir,
+            cwd=staging_dir,
             dry_run=dry_run,
         )
 
@@ -3719,7 +3719,7 @@ def _exec_workflow_verb(options: Namespace, command: list[str]) -> None:
         dry_run=options.dry_run,
         mode=getattr(options, "mode", None),
         config_vars=_parse_var_args(options.var),
-        output_dir=options.output_dir,
+        staging_dir=options.staging_dir,
         stage=False,
     )
 
@@ -3735,11 +3735,11 @@ def handle_generate_workflow_command(options: Namespace) -> None:
     mode: Optional[str] = getattr(options, "mode", None)
     development: bool | None = getattr(options, "development", None)
     config_vars: dict[str, str] = _parse_var_args(options.var)
-    output_dir: str | None = getattr(options, "output_dir", None)
+    staging_dir: str | None = getattr(options, "staging_dir", None)
     overwrite: bool = getattr(options, "overwrite", False)
 
     # Generate-only: stage the bundle so the user can inspect it or deploy
-    # manually (`cd <output-dir> && databricks bundle deploy ...`). Use
+    # manually (`cd <staging-dir> && databricks bundle deploy ...`). Use
     # `dao-ai workflow up` to generate → deploy → run in one command.
     logger.info("Staging DAO AI workflow bundle...")
     run_databricks_command(
@@ -3752,7 +3752,7 @@ def handle_generate_workflow_command(options: Namespace) -> None:
         mode=mode,
         development=development,
         config_vars=config_vars,
-        output_dir=output_dir,
+        staging_dir=staging_dir,
         overwrite=overwrite,
     )
 
@@ -3768,7 +3768,7 @@ def _handle_up_workflow_command(options: Namespace) -> None:
     mode: Optional[str] = getattr(options, "mode", None)
     development: bool | None = getattr(options, "development", None)
     config_vars: dict[str, str] = _parse_var_args(options.var)
-    output_dir: str | None = getattr(options, "output_dir", None)
+    staging_dir: str | None = getattr(options, "staging_dir", None)
     overwrite: bool = getattr(options, "overwrite", False)
 
     logger.info("Deploying DAO AI asset bundle...")
@@ -3782,7 +3782,7 @@ def _handle_up_workflow_command(options: Namespace) -> None:
         mode=mode,
         development=development,
         config_vars=config_vars,
-        output_dir=output_dir,
+        staging_dir=staging_dir,
         overwrite=overwrite,
     )
     logger.info("Running DAO AI provisioning workflow...")
@@ -3796,13 +3796,13 @@ def _handle_up_workflow_command(options: Namespace) -> None:
         mode=mode,
         development=development,
         config_vars=config_vars,
-        output_dir=output_dir,
+        staging_dir=staging_dir,
         overwrite=overwrite,
     )
 
 
 def _resolve_bundle_dir(
-    kind: str, config: AppConfig, output_dir: str | None
+    kind: str, config: AppConfig, staging_dir: str | None
 ) -> tuple[Path, bool]:
     """Resolve the staging dir for an App bundle, shared by generate + verbs.
 
@@ -3811,10 +3811,10 @@ def _resolve_bundle_dir(
     ``-o``. Both ``<noun> generate`` and the standalone ``deploy``/``run``/
     ``destroy`` verbs call this so they always agree on the same directory.
     """
-    is_default_dir: bool = output_dir is None
+    is_default_dir: bool = staging_dir is None
     bundle_dir: Path = (
-        Path(output_dir)
-        if output_dir is not None
+        Path(staging_dir)
+        if staging_dir is not None
         else _default_bundle_dir(kind, config.app.name)
     ).resolve()
     return bundle_dir, is_default_dir
@@ -3908,7 +3908,7 @@ def _generate_app_bundle(options: Namespace, *, kind: str, writer, what: str) ->
     # that wasn't supplied and has no default, rather than ship a broken binding.
     config.assert_provided_params_satisfied()
 
-    bundle_dir, is_default_dir = _resolve_bundle_dir(kind, config, options.output_dir)
+    bundle_dir, is_default_dir = _resolve_bundle_dir(kind, config, options.staging_dir)
     _stage_app_bundle(
         config,
         bundle_dir,
@@ -3991,7 +3991,7 @@ def _deploy_run_destroy_app_bundle(
 
     # --- Route 3: bundle path ---
     config = _load_app_config(options, what=what)
-    bundle_dir, is_default_dir = _resolve_bundle_dir(kind, config, options.output_dir)
+    bundle_dir, is_default_dir = _resolve_bundle_dir(kind, config, options.staging_dir)
     is_staged: bool = (bundle_dir / "databricks.yaml").exists()
 
     if not is_staged and not deploy:
@@ -3999,7 +3999,7 @@ def _deploy_run_destroy_app_bundle(
         logger.error(
             f"No staged {kind} bundle at {bundle_dir}. "
             f"Run `dao-ai {kind} generate -c {options.config}"
-            f"{f' -o {options.output_dir}' if options.output_dir else ''}` first."
+            f"{f' -s {options.staging_dir}' if options.staging_dir else ''}` first."
         )
         sys.exit(1)
 
@@ -4067,7 +4067,7 @@ def _deploy_run_destroy_app_bundle(
 
     deploy_app_bundle(
         config,
-        output_dir=bundle_dir,
+        staging_dir=bundle_dir,
         deploy=deploy,
         run=run,
         destroy=destroy,

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -3344,9 +3344,10 @@ def run_databricks_command(
     # so a shared default would let a second config's deploy fail against the
     # first config's stale databricks.yaml. A per-app default isolates each
     # bundle's DABs state and makes deploying many configs "just work".
-    is_default_dir: bool = staging_dir is None
-    if staging_dir is not None:
-        staging_dir = Path(staging_dir).resolve()
+    staging_dir_arg: Optional[str] = staging_dir
+    is_default_dir: bool = staging_dir_arg is None
+    if staging_dir_arg is not None:
+        staging_dir = Path(staging_dir_arg).resolve()
     elif normalized_name:
         staging_dir = _default_bundle_dir("workflow", app_config.app.name).resolve()
     else:
@@ -3400,7 +3401,7 @@ def run_databricks_command(
             logger.error(
                 f"No staged workflow bundle at {staging_dir}. "
                 f"Run `dao-ai workflow generate -c {config}"
-                f"{f' -s {staging_dir}' if staging_dir else ''}` first."
+                f"{f' -s {staging_dir_arg}' if staging_dir_arg else ''}` first."
             )
             sys.exit(1)
 

--- a/src/dao_ai/mcp/generate.py
+++ b/src/dao_ai/mcp/generate.py
@@ -59,19 +59,19 @@ _MCP_APP_COMMAND: list[str] = ["python", "-m", "dao_ai.mcp.server"]
 
 def write_mcp_bundle(
     config: AppConfig,
-    output_dir: Path,
+    staging_dir: Path,
     *,
     overwrite: bool = False,
     development: bool = False,
 ) -> dict[str, str]:
-    """Write an MCP-server deploy bundle into ``output_dir``.
+    """Write an MCP-server deploy bundle into ``staging_dir``.
 
     Requires ``config.app.name`` (used as both the Databricks App name and
     the single MCP tool's name) and encourages ``config.app.description``
     (surfaced as the tool description to MCP clients).
 
     When ``development=True``, builds the local dao-ai wheel and bundles it
-    into ``output_dir/dist/``; the generated requirements.txt then installs
+    into ``staging_dir/dist/``; the generated requirements.txt then installs
     from that wheel instead of pulling ``dao-ai[mcp]`` from PyPI.
 
     Returns the staging registry: ``{relative_posix_path: sha256}`` for the
@@ -93,7 +93,7 @@ def write_mcp_bundle(
             "description. Add `app.description` for a better client UX."
         )
 
-    output_dir.mkdir(parents=True, exist_ok=True)
+    staging_dir.mkdir(parents=True, exist_ok=True)
 
     app_name = _derive_app_name(config)
     tool_name = _slugify(str(config.app.name))
@@ -106,24 +106,24 @@ def write_mcp_bundle(
     skipped: list[str] = []
     # User code (src/ + code_paths + source config) preserved as-is.
     preserved: list[str] = []
-    # Content hashes of the files dao-ai generated, keyed by output-dir-relative
+    # Content hashes of the files dao-ai generated, keyed by staging-dir-relative
     # POSIX path. User-code writes pass register=False so hand-edits to them never
     # trip edit-detection.
     registry: dict[str, str] = {}
 
     def _register(path: Path) -> None:
         if path.exists():
-            registry[path.relative_to(output_dir).as_posix()] = _sha256_file(path)
+            registry[path.relative_to(staging_dir).as_posix()] = _sha256_file(path)
 
     def _write(path: Path, content: str, *, register: bool = True) -> None:
         if path.exists() and not overwrite:
-            skipped.append(str(path.relative_to(output_dir)))
+            skipped.append(str(path.relative_to(staging_dir)))
             if register:
                 _register(path)
             return
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content)
-        written.append(str(path.relative_to(output_dir)))
+        written.append(str(path.relative_to(staging_dir)))
         if register:
             _register(path)
 
@@ -133,7 +133,7 @@ def write_mcp_bundle(
     # ``artifacts:`` block (MCP doesn't build a user wheel — it installs
     # ``dao-ai[mcp]`` from PyPI via requirements.txt).
     _write(
-        output_dir / "databricks.yaml",
+        staging_dir / "databricks.yaml",
         generate_databricks_yaml(
             config,
             development=development,
@@ -144,7 +144,7 @@ def write_mcp_bundle(
         ),
     )
 
-    resources_dir = output_dir / "resources"
+    resources_dir = staging_dir / "resources"
     resources_dir.mkdir(parents=True, exist_ok=True)
     _write(
         resources_dir / "app.yml",
@@ -158,7 +158,7 @@ def write_mcp_bundle(
 
     wheel_filename: str | None = None
     if development:
-        wheel_filename = _bundle_local_wheel(output_dir, written=written)
+        wheel_filename = _bundle_local_wheel(staging_dir, written=written)
 
     # The MCP server always needs the ``mcp`` extra (fastapi/uvicorn); merge in
     # whatever optional-feature extras the config exercises so ``uv sync``
@@ -184,7 +184,7 @@ def write_mcp_bundle(
     extra_deps: str = _format_extra_deps(user_pip_requirements)
 
     _write(
-        output_dir / "pyproject.toml",
+        staging_dir / "pyproject.toml",
         _render_pyproject(
             app_name=app_name,
             wheel_filename=wheel_filename,
@@ -197,23 +197,23 @@ def write_mcp_bundle(
     # pyproject declares ``packages = ["src/<pkg>"]``). User code: not registered
     # so a real package the user drops here can be edited freely.
     package_name = app_name.replace("-", "_")
-    _write(output_dir / "src" / package_name / "__init__.py", "", register=False)
+    _write(staging_dir / "src" / package_name / "__init__.py", "", register=False)
 
     _write(
-        output_dir / ".gitignore",
+        staging_dir / ".gitignore",
         _GITIGNORE_DEV_CONTENT if development else _GITIGNORE_CONTENT,
     )
-    _write(output_dir / ".python-version", "3.11\n")
+    _write(staging_dir / ".python-version", "3.11\n")
 
     # Generate the portable uv.lock (Apps runs ``uv sync --locked --no-dev``
     # from pyproject.toml + uv.lock; no requirements.txt). In dev mode the lock
     # references the bundled wheel via ``[tool.uv.sources]``; published mode
     # locks the full ``dao-ai[mcp]`` public-PyPI closure.
-    generate_bundle_lock(output_dir)
+    generate_bundle_lock(staging_dir)
     written.append("uv.lock")
-    _register(output_dir / "uv.lock")
+    _register(staging_dir / "uv.lock")
 
-    config_dest = output_dir / config_filename
+    config_dest = staging_dir / config_filename
     if source_config_path is not None and (
         config_dest.resolve() == Path(source_config_path).resolve()
     ):
@@ -243,7 +243,7 @@ def write_mcp_bundle(
 
     for src, code_dest in iter_code_path_stagings(config):
         for file_src, file_dest in walk_code_path_files(src, code_dest):
-            out = output_dir / file_dest
+            out = staging_dir / file_dest
             # User code is sacred: never overwrite; never copy onto itself.
             if file_src.resolve() == out.resolve() or out.exists():
                 preserved.append(file_dest)
@@ -258,7 +258,7 @@ def write_mcp_bundle(
         for file_src, file_dest in walk_code_path_files(
             pkg_dir, f"{_SRC_DIRNAME}/{pkg_dir.name}"
         ):
-            out = output_dir / file_dest
+            out = staging_dir / file_dest
             if file_src.resolve() == out.resolve() or out.exists():
                 preserved.append(file_dest)
                 continue
@@ -267,11 +267,11 @@ def write_mcp_bundle(
             written.append(file_dest)
 
     _write(
-        output_dir / "README.md",
+        staging_dir / "README.md",
         _render_readme(config, app_name=app_name, tool_name=tool_name),
     )
 
-    print(f"\nMCP bundle generated in {output_dir}/\n")
+    print(f"\nMCP bundle generated in {staging_dir}/\n")
     for name in written:
         print(f"  {name:<32s} (created)")
     for name in skipped:
@@ -281,7 +281,7 @@ def write_mcp_bundle(
 
     print(f"\nMCP tool exposed: {tool_name}")
     print("\nNext steps:")
-    print(f"  cd {output_dir}")
+    print(f"  cd {staging_dir}")
     print("  databricks bundle deploy --target dev")
     if config.app.trace_location:
         # Idempotent — safe on every deploy — but load-bearing on
@@ -331,8 +331,8 @@ def _render_pyproject(
     )
 
 
-def _bundle_local_wheel(output_dir: Path, *, written: list[str]) -> str:
-    """Build (or reuse) a local dao-ai wheel and copy it under ``output_dir/dist/``."""
+def _bundle_local_wheel(staging_dir: Path, *, written: list[str]) -> str:
+    """Build (or reuse) a local dao-ai wheel and copy it under ``staging_dir/dist/``."""
     project_root = Path(__file__).parents[3]
     source_dir = project_root / "src" / "dao_ai"
 
@@ -368,7 +368,7 @@ def _bundle_local_wheel(output_dir: Path, *, written: list[str]) -> str:
         raise RuntimeError(f"No wheel produced under {dist_src}")
     wheel_path = wheels[-1]
 
-    dist_dst = output_dir / "dist"
+    dist_dst = staging_dir / "dist"
     dist_dst.mkdir(parents=True, exist_ok=True)
     dst_path = dist_dst / wheel_path.name
     shutil.copy2(wheel_path, dst_path)

--- a/src/dao_ai/pipeline/bundle.py
+++ b/src/dao_ai/pipeline/bundle.py
@@ -14,7 +14,7 @@ resolved against the config's own directory (see ``AppConfig.from_file`` /
 under ``config/`` and resolve identically when the notebook reloads the staged
 config::
 
-    <output_dir>/
+    <staging_dir>/
       databricks.yaml          # built programmatically (dict -> yaml.dump)
       notebooks/NN_*.py        # packaged step notebooks
       config/<name>.yaml       # the resolved dao-ai config
@@ -237,13 +237,13 @@ def generate_pipeline_databricks_yaml(config: AppConfig, development: bool) -> s
     return dump_bundle_yaml(bundle)
 
 
-def _materialize_notebooks(output_dir: Path, overwrite: bool) -> list[str]:
-    """Copy the packaged step notebooks into ``<output_dir>/notebooks/``.
+def _materialize_notebooks(staging_dir: Path, overwrite: bool) -> list[str]:
+    """Copy the packaged step notebooks into ``<staging_dir>/notebooks/``.
 
     Only the wired ``NN_*.py`` step notebooks are materialized; the package
     ``__init__.py`` marker is skipped.
     """
-    notebooks_dir = output_dir / "notebooks"
+    notebooks_dir = staging_dir / "notebooks"
     notebooks_dir.mkdir(parents=True, exist_ok=True)
 
     written: list[str] = []
@@ -311,7 +311,7 @@ def _asset_sync_globs(config: AppConfig) -> list[str]:
 
 def _stage_assets(
     config: AppConfig,
-    output_dir: Path,
+    staging_dir: Path,
     overwrite: bool,
 ) -> tuple[list[str], list[str]]:
     """Copy config-referenced data/functions files into the staging bundle.
@@ -320,8 +320,8 @@ def _stage_assets(
     ``data: data/products.snappy.parquet`` in
     ``.../hardware_store/hardware_store.yaml`` means
     ``.../hardware_store/data/products.snappy.parquet``. The config stages to
-    ``<output_dir>/config/<name>.yaml``, so we copy each asset to the same
-    path relative to that staged config (``<output_dir>/config/<rel>``); the
+    ``<staging_dir>/config/<name>.yaml``, so we copy each asset to the same
+    path relative to that staged config (``<staging_dir>/config/<rel>``); the
     provisioning notebook reloads the staged config and its
     :meth:`DatasetModel.resolve_asset_path` resolves the same relative path
     against the staged config's directory, finding the copy.
@@ -337,14 +337,14 @@ def _stage_assets(
         return [], []
 
     src_anchor = Path(source_config).resolve().parent
-    dest_anchor = (output_dir / "config").resolve()
+    dest_anchor = (staging_dir / "config").resolve()
     copied: list[str] = []
     missing: list[str] = []
 
     def _staged_label(dest: Path) -> str:
         """Bundle-relative label for the summary (e.g. ``config/foo/bar.sql``)."""
         try:
-            return str(dest.relative_to(output_dir))
+            return str(dest.relative_to(staging_dir))
         except ValueError:
             return str(dest)
 
@@ -355,7 +355,7 @@ def _stage_assets(
             missing.append(rel)
             continue
         if src == dest:
-            # Staging in place (output_dir is the source tree) — nothing to copy.
+            # Staging in place (staging_dir is the source tree) — nothing to copy.
             continue
         if dest.exists() and not overwrite:
             continue
@@ -368,7 +368,7 @@ def _stage_assets(
 
 def _stage_code_paths(
     config: AppConfig,
-    output_dir: Path,
+    staging_dir: Path,
 ) -> tuple[list[str], list[str]]:
     """Copy ``config.app.code_paths`` files into the staged bundle under ``config/``.
 
@@ -383,13 +383,13 @@ def _stage_code_paths(
     """
     from dao_ai.code_paths import iter_code_path_stagings, walk_code_path_files
 
-    dest_anchor = (output_dir / "config").resolve()
+    dest_anchor = (staging_dir / "config").resolve()
     copied: list[str] = []
     preserved: list[str] = []
     for src, dest in iter_code_path_stagings(config):
         for file_src, file_dest in walk_code_path_files(src, dest):
             file_out = (dest_anchor / file_dest).resolve()
-            label = _bundle_label(file_out, output_dir)
+            label = _bundle_label(file_out, staging_dir)
             if file_src == file_out or file_out.exists():
                 preserved.append(label)
                 continue
@@ -401,7 +401,7 @@ def _stage_code_paths(
 
 def _stage_src_packages(
     config: AppConfig,
-    output_dir: Path,
+    staging_dir: Path,
 ) -> tuple[list[str], list[str]]:
     """Copy colocated ``src/<pkg>`` packages into the staged bundle under ``config/src``.
 
@@ -421,7 +421,7 @@ def _stage_src_packages(
         walk_code_path_files,
     )
 
-    dest_anchor = (output_dir / "config").resolve()
+    dest_anchor = (staging_dir / "config").resolve()
     copied: list[str] = []
     preserved: list[str] = []
     for pkg_dir in discover_src_packages(config):
@@ -429,7 +429,7 @@ def _stage_src_packages(
             pkg_dir, f"{_SRC_DIRNAME}/{pkg_dir.name}"
         ):
             file_out = (dest_anchor / file_dest).resolve()
-            label = _bundle_label(file_out, output_dir)
+            label = _bundle_label(file_out, staging_dir)
             if file_src == file_out or file_out.exists():
                 preserved.append(label)
                 continue
@@ -439,10 +439,10 @@ def _stage_src_packages(
     return copied, preserved
 
 
-def _bundle_label(file_out: Path, output_dir: Path) -> str:
+def _bundle_label(file_out: Path, staging_dir: Path) -> str:
     """Bundle-relative label for the staging summary (best-effort)."""
     try:
-        return str(file_out.relative_to(output_dir))
+        return str(file_out.relative_to(staging_dir))
     except ValueError:
         return str(file_out)
 
@@ -512,14 +512,14 @@ def _staged_config_text(config: AppConfig) -> str | None:
 
 def write_pipeline_bundle(
     config: AppConfig,
-    output_dir: Path,
+    staging_dir: Path,
     overwrite: bool = False,
     development: bool = False,
 ) -> dict[str, str]:
     """Stage a deployable ``deploy_job`` bundle for ``dao-ai generate-workflow``.
 
     Materializes the packaged pipeline assets (``databricks.yaml`` template,
-    step notebooks) plus the resolved dao-ai config into ``output_dir``, so
+    step notebooks) plus the resolved dao-ai config into ``staging_dir``, so
     ``databricks bundle deploy/run`` can be invoked from there with no source
     checkout. dao-ai installs via the serverless env's ``dao_ai_dep`` dependency.
 
@@ -531,7 +531,7 @@ def write_pipeline_bundle(
     Args:
         config: The loaded dao-ai config (via ``AppConfig.from_file`` — the
             source path it records is what asset paths resolve against).
-        output_dir: Directory to stage the bundle into.
+        staging_dir: Directory to stage the bundle into.
         overwrite: Overwrite existing staged files.
         development: When True, stage the current build's dao-ai wheel under
             ``dist/`` so the step notebooks install *this* code rather than the
@@ -549,19 +549,19 @@ def write_pipeline_bundle(
             "Config must have an 'app' section to stage a pipeline bundle."
         )
 
-    output_dir = output_dir.resolve()
-    output_dir.mkdir(parents=True, exist_ok=True)
+    staging_dir = staging_dir.resolve()
+    staging_dir.mkdir(parents=True, exist_ok=True)
 
     written: list[str] = []
     # User code (src/ + code_paths + source config) left untouched.
     preserved_user_code: list[str] = []
     # Content hashes of the files dao-ai generated (databricks.yaml + notebooks),
-    # keyed by output-dir-relative POSIX path. The staged config and assets are
+    # keyed by staging-dir-relative POSIX path. The staged config and assets are
     # user-editable, so they're excluded.
     registry: dict[str, str] = {}
 
     def _register(rel: str) -> None:
-        path = output_dir / rel
+        path = staging_dir / rel
         if path.exists():
             registry[Path(rel).as_posix()] = _sha256_file(path)
 
@@ -577,7 +577,7 @@ def write_pipeline_bundle(
     # 1. databricks.yaml — built programmatically (dict -> YAML). Development
     #    mode adds the `dist/*.whl` sync include so the staged wheel uploads.
     _write_file(
-        output_dir / "databricks.yaml",
+        staging_dir / "databricks.yaml",
         generate_pipeline_databricks_yaml(config, development=development),
         overwrite=True,
     )
@@ -587,7 +587,7 @@ def write_pipeline_bundle(
     # 2. Step notebooks. (No requirements.txt: the serverless environment
     #    installs dao-ai — which pulls its own transitive deps — via the
     #    ``dao_ai_dep`` dependency, mirroring the Apps deploy paths.)
-    notebook_rels = _materialize_notebooks(output_dir, overwrite=True)
+    notebook_rels = _materialize_notebooks(staging_dir, overwrite=True)
     written.extend(notebook_rels)
     for rel in notebook_rels:
         _register(rel)
@@ -598,7 +598,7 @@ def write_pipeline_bundle(
     #    stripped) so the deployed job needs no --var arguments.
     source_config: str | None = config._source_config_path
     config_filename = Path(source_config).name if source_config else "dao_ai.yaml"
-    config_dir = output_dir / "config"
+    config_dir = staging_dir / "config"
     config_dir.mkdir(parents=True, exist_ok=True)
     config_dest = config_dir / config_filename
     if source_config and config_dest.resolve() == Path(source_config).resolve():
@@ -661,7 +661,7 @@ def write_pipeline_bundle(
                 "No local dao-ai wheel found for a --development pipeline "
                 "bundle. Build one first with `uv build --wheel`."
             )
-        dist_dir = output_dir / "dist"
+        dist_dir = staging_dir / "dist"
         dist_dir.mkdir(parents=True, exist_ok=True)
         dest_wheel = dist_dir / wheel_path.name
         for stale in dist_dir.glob("dao_ai-*.whl"):
@@ -675,20 +675,20 @@ def write_pipeline_bundle(
         )
 
     # 6. Config-referenced data/functions asset files.
-    copied, missing = _stage_assets(config, output_dir, overwrite)
+    copied, missing = _stage_assets(config, staging_dir, overwrite)
     written.extend(copied)
 
     # 6b. Custom code (app.code_paths + colocated src/) staged next to the config
     # so the deploy notebook's create_agent/deploy_agent find it. User code is
     # sacred — existing files are preserved, never overwritten.
-    cp_copied, cp_preserved = _stage_code_paths(config, output_dir)
-    src_copied, src_preserved = _stage_src_packages(config, output_dir)
+    cp_copied, cp_preserved = _stage_code_paths(config, staging_dir)
+    src_copied, src_preserved = _stage_src_packages(config, staging_dir)
     written.extend(cp_copied)
     written.extend(src_copied)
     preserved_user_code.extend(cp_preserved)
     preserved_user_code.extend(src_preserved)
 
-    print(f"\nPipeline bundle staged in {output_dir}/\n")
+    print(f"\nPipeline bundle staged in {staging_dir}/\n")
     for name in sorted(written):
         print(f"  {name}")
     for name in sorted(preserved_user_code):

--- a/tests/dao_ai/test_config_vars.py
+++ b/tests/dao_ai/test_config_vars.py
@@ -1883,7 +1883,7 @@ def test_cli_run_databricks_command_forwards_only_declared_vars(
         ["bundle", "deploy"],
         config=str(parameterised_config_path),
         config_vars={"module_id": "09", "catalog": "nfleming", "undeclared_x": "z"},
-        output_dir=str(out),
+        staging_dir=str(out),
         development=False,
         stage=False,
     )

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -524,7 +524,7 @@ class TestPipelineEmitsDevelopmentVar:
         run_databricks_command(
             None,
             config=str(cfg),
-            output_dir=str(tmp_path / "out"),
+            staging_dir=str(tmp_path / "out"),
             # Published mode: the stubbed bundle-write stages no wheel; this
             # test asserts staging + no-exec, not local-wheel resolution.
             development=False,
@@ -563,7 +563,7 @@ class TestPipelineEmitsDevelopmentVar:
         run_databricks_command(
             ["bundle", "deploy"],
             config=str(cfg),
-            output_dir=str(out),
+            staging_dir=str(out),
             development=False,
             stage=False,
         )
@@ -590,7 +590,7 @@ class TestPipelineEmitsDevelopmentVar:
             run_databricks_command(
                 ["bundle", "deploy"],
                 config=str(cfg),
-                output_dir=str(tmp_path / "nonexistent"),
+                staging_dir=str(tmp_path / "nonexistent"),
                 development=False,
                 stage=False,
             )
@@ -642,7 +642,7 @@ class TestConfigVarsForwardedOnlyIfDeclared:
         run_databricks_command(
             ["bundle", "deploy"],
             config=str(cfg),
-            output_dir=str(out),
+            staging_dir=str(out),
             development=False,
             stage=False,
             config_vars=config_vars,
@@ -892,7 +892,7 @@ class TestAgentModeWriterSelection:
                 "generate",
                 "-c",
                 str(cfg),
-                "-o",
+                "-s",
                 str(tmp_path / "out"),
                 "--mode",
                 "mcp",
@@ -922,7 +922,7 @@ class TestAgentModeWriterSelection:
 
         cfg = self._write_config(tmp_path)
         opts = parse_args(
-            ["agent", "generate", "-c", str(cfg), "-o", str(tmp_path / "out")]
+            ["agent", "generate", "-c", str(cfg), "-s", str(tmp_path / "out")]
         )
         cli.handle_agent_command(opts)
 
@@ -939,14 +939,14 @@ class TestAgentModeWriterSelection:
         resolved_bundle_dirs: dict[str, tuple[str, Path]] = {}
 
         def mock_resolve_bundle_dir(
-            kind: str, config: object, output_dir: str | None
+            kind: str, config: object, staging_dir: str | None
         ) -> tuple[Path, bool]:
-            # Record: kind -> (output_dir passed in, resolved path)
+            # Record: kind -> (staging_dir passed in, resolved path)
             mcp_staging = tmp_path / "staged" / kind / "test_app"
             mcp_staging.mkdir(parents=True, exist_ok=True)
             (mcp_staging / "databricks.yaml").write_text("bundle: {}\n")
-            resolved_bundle_dirs[kind] = (output_dir or "default", mcp_staging)
-            return mcp_staging, output_dir is None
+            resolved_bundle_dirs[kind] = (staging_dir or "default", mcp_staging)
+            return mcp_staging, staging_dir is None
 
         monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
 
@@ -1006,7 +1006,7 @@ class TestDeployRestagesOnConfigDrift:
         restaged: dict[str, bool] = {}
         monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
         monkeypatch.setattr(
-            cli, "_resolve_bundle_dir", lambda kind, config, output_dir: (staged, True)
+            cli, "_resolve_bundle_dir", lambda kind, config, staging_dir: (staged, True)
         )
         monkeypatch.setattr(cli, "_staging_dir_has_local_edits", lambda d: has_edits)
         monkeypatch.setattr(cli, "deploy_app_bundle", lambda *a, **k: None)
@@ -1101,7 +1101,7 @@ class TestDeployAppBundle:
         ):
             deploy_app_bundle(
                 cfg,
-                output_dir=tmp_path,
+                staging_dir=tmp_path,
                 deploy=True,
                 run=True,
                 destroy=False,
@@ -1145,7 +1145,7 @@ class TestDeployAppBundle:
         ):
             deploy_app_bundle(
                 cfg,
-                output_dir=tmp_path,
+                staging_dir=tmp_path,
                 deploy=True,
                 run=True,
                 destroy=False,
@@ -1161,7 +1161,7 @@ class TestDeployAppBundle:
         ):
             deploy_app_bundle(
                 cfg,
-                output_dir=tmp_path,
+                staging_dir=tmp_path,
                 deploy=False,
                 run=False,
                 destroy=True,
@@ -1184,7 +1184,7 @@ class TestDeployAppBundle:
         ):
             deploy_app_bundle(
                 cfg,
-                output_dir=tmp_path,
+                staging_dir=tmp_path,
                 deploy=False,
                 run=True,
                 destroy=False,
@@ -1341,12 +1341,12 @@ class TestNounVerbDispatch:
             lambda *a, **k: wrote.setdefault("wrote", True),
         )
         with patch.object(cli, "deploy_app_bundle") as dep:
-            opts = parse_args(["agent", "deploy", "-c", str(cfg), "-o", str(out)])
+            opts = parse_args(["agent", "deploy", "-c", str(cfg), "-s", str(out)])
             cli.handle_agent_command(opts)
 
         assert "wrote" not in wrote, "deploy must not regenerate"
         dep.assert_called_once()
-        assert dep.call_args.kwargs["output_dir"] == out
+        assert dep.call_args.kwargs["staging_dir"] == out
         assert (out / "sentinel").read_text() == "keep\n"
 
     def test_deploy_verb_errors_when_not_staged(
@@ -1361,7 +1361,7 @@ class TestNounVerbDispatch:
         )
         monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
         opts = parse_args(
-            ["agent", "deploy", "-c", str(cfg), "-o", str(tmp_path / "nope")]
+            ["agent", "deploy", "-c", str(cfg), "-s", str(tmp_path / "nope")]
         )
         with pytest.raises(SystemExit) as exc:
             cli.handle_agent_command(opts)
@@ -1410,7 +1410,7 @@ class TestDeployAutoGenerate:
             fake_writer,
         )
         with patch.object(cli, "deploy_app_bundle") as dep:
-            opts = parse_args(["agent", "deploy", "-c", str(cfg), "-o", str(out)])
+            opts = parse_args(["agent", "deploy", "-c", str(cfg), "-s", str(out)])
             cli.handle_agent_command(opts)
 
         assert wrote.get("called"), "writer must be called to auto-generate the bundle"
@@ -1434,7 +1434,7 @@ class TestDeployAutoGenerate:
             lambda *a, **k: wrote.setdefault("called", True),
         )
         with patch.object(cli, "deploy_app_bundle") as dep:
-            opts = parse_args(["agent", "deploy", "-c", str(cfg), "-o", str(out)])
+            opts = parse_args(["agent", "deploy", "-c", str(cfg), "-s", str(out)])
             cli.handle_agent_command(opts)
 
         assert not wrote, "deploy must NOT regenerate when already staged"
@@ -1596,7 +1596,7 @@ class TestDeployAutoGenerate:
         cfg = self._write_cfg(tmp_path)
         monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
         opts = parse_args(
-            ["agent", "run", "-c", str(cfg), "-o", str(tmp_path / "nope")]
+            ["agent", "run", "-c", str(cfg), "-s", str(tmp_path / "nope")]
         )
         with pytest.raises(SystemExit) as exc:
             cli.handle_agent_command(opts)
@@ -1632,7 +1632,7 @@ class TestDeployAutoGenerate:
             track_resolve,
         )
         with patch.object(cli, "deploy_app_bundle"):
-            opts = parse_args(["agent", "deploy", "-c", str(cfg), "-o", str(out)])
+            opts = parse_args(["agent", "deploy", "-c", str(cfg), "-s", str(out)])
             cli.handle_agent_command(opts)
 
         assert resolve_calls == ["called"], (
@@ -1659,7 +1659,7 @@ class TestDeployAutoGenerate:
             track_resolve,
         )
         with patch.object(cli, "deploy_app_bundle"):
-            opts = parse_args(["agent", "deploy", "-c", str(cfg), "-o", str(out)])
+            opts = parse_args(["agent", "deploy", "-c", str(cfg), "-s", str(out)])
             cli.handle_agent_command(opts)
 
         assert resolve_calls == [], (
@@ -1678,7 +1678,7 @@ class TestDeployAutoGenerate:
         monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
         with patch.object(cli, "deploy_app_bundle") as dep:
             opts = parse_args(
-                ["agent", "up", "-c", str(cfg), "-o", str(out), "--mode", "apps"]
+                ["agent", "up", "-c", str(cfg), "-s", str(out), "--mode", "apps"]
             )
             cli.handle_agent_command(opts)
 

--- a/tests/dao_ai/test_generate_safety.py
+++ b/tests/dao_ai/test_generate_safety.py
@@ -136,7 +136,7 @@ class TestUserCodeSacred:
         assert (out / "src" / "safe_app" / "__init__.py").read_text() == ""
 
     def test_in_place_copy_is_noop_not_error(self, tmp_path: Path) -> None:
-        # output_dir == config dir would normally be blocked by the CLI guard,
+        # staging_dir == config dir would normally be blocked by the CLI guard,
         # but write_bundle itself must not raise SameFileError on in-place files.
         cfg = _config_with_src(tmp_path)
         # Deploy into the config dir directly (bypassing the CLI guard).


### PR DESCRIPTION
## What

Rename the bundle staging-directory flag `-o/--output-dir` → `-s/--staging-dir` on every bundle verb (`generate`/`up`/`deploy`/`run`/`destroy` across the `agent`, `workflow`, and `mcp` nouns), and rename the internal `output_dir` Python parameter to `staging_dir` throughout.

## Why

The flag never wrote a one-shot *output* — it names a **persistent, reused staging directory** that `deploy`/`run`/`destroy` act on without regenerating (edit-tracked via `.dao-ai-manifest.yaml`). The old name was a semantic mismatch:

- `-o` conventionally means "output file" and is already reused for genuine outputs (`graph -o FILE`, `trace create -o FORMAT`).
- Every other reference to this concept already used **bundle/staging** vocabulary — the env var `DAO_AI_BUNDLE_DIR`, the helpers `_default_bundle_dir` / `_resolve_bundle_dir`, and the flag's own help text ("Directory for the bundle **staging dir**"). `--output-dir` was the odd one out.

## Scope

- **Hard rename, no alias** — `-o/--output-dir` is removed on bundle verbs.
- **Full internal rename** — `output_dir` → `staging_dir` in `cli.py`, `apps/bundle.py`, `pipeline/bundle.py`, `mcp/generate.py` (params, docstrings, comments, `options.staging_dir` reads).
- **Unchanged (intentional):** `graph -o FILE`, `trace create -o FORMAT`, `DAO_AI_BUNDLE_DIR`, `_default_bundle_dir` helpers, and `config.py` (no `make schema` needed).

## Breaking change

Scripts using `-o`/`--output-dir` on bundle verbs must switch to `-s`/`--staging-dir`.

## Verification

- `--help` shows `-s DIR, --staging-dir DIR`; `-o` gone from bundle verbs ✅
- old `-o` on bundle verbs now rejected (`unrecognized arguments: -o`) ✅
- `agent generate -s /tmp/stg-test --dry-run` stages the full bundle into the given dir ✅
- `agent deploy -s /tmp/stg-test --dry-run` reuses the dir (exit 0) ✅
- **305/305** tests pass across `test_development_flag_cli.py`, `test_config_vars.py`, `test_generate_safety.py` ✅
- grep clean — only the intentional `graph`/`trace` `-o` and the historical CHANGELOG note remain ✅

This pull request and its description were written by Isaac.