### PR TITLE
chore(examples): parameterize model endpoints with GA defaults

### DIFF
--- a/examples/01_getting_started/minimal.yaml
+++ b/examples/01_getting_started/minimal.yaml
@@ -11,6 +11,13 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  # Model endpoints are parameterized so the default can be overridden per
+  # environment (e.g. --param llm=databricks-claude-sonnet-5) without editing
+  # the config. Defaults track a current GA Foundation Model API endpoint;
+  # override when a workspace pins a different model.
+  llm:
+    description: Chat/reasoning serving endpoint for the agent.
+    default: databricks-claude-sonnet-4-5
 
 schemas:
   retail_schema: &retail_schema
@@ -20,7 +27,7 @@ schemas:
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4  # Databricks serving endpoint name
+      name: ${var.llm}                              # Databricks serving endpoint (override via --param llm=...)
 
   vector_stores:
     products_vector_store: &products_vector_store

--- a/examples/02_mcp/managed_mcp.yaml
+++ b/examples/02_mcp/managed_mcp.yaml
@@ -11,6 +11,12 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  # Parameterized so the model default is overridable per environment
+  # (e.g. --param llm=databricks-claude-sonnet-5). Default tracks a current GA
+  # Foundation Model API endpoint.
+  llm:
+    description: Chat/reasoning serving endpoint for the MCP agent.
+    default: databricks-claude-sonnet-4-5
 
 variables:
   client_id: &client_id
@@ -42,7 +48,7 @@ resources:
   models:
     default_llm: &default_llm
                                                  # Default LLM configuration
-      name: databricks-claude-3-7-sonnet        # Databricks serving endpoint name
+      name: ${var.llm}                          # serving endpoint (override via --param llm=...)
 
   genie_rooms:
     retail_genie_room: &retail_genie_room

--- a/examples/07_human_in_the_loop/human_in_the_loop_audited.yaml
+++ b/examples/07_human_in_the_loop/human_in_the_loop_audited.yaml
@@ -19,6 +19,14 @@
 #   - HITL + Audit         → interrupt fires, receipt on approve/reject/edit,
 #                            fail-closed on args-hash drift at execution time.
 
+parameters:
+  # Model endpoint is parameterized so the default can be overridden per
+  # environment (e.g. --param llm=databricks-claude-sonnet-5) without editing
+  # the config. Default tracks a current GA Foundation Model API endpoint.
+  llm:
+    description: Chat/reasoning serving endpoint for the audit admin agent.
+    default: databricks-claude-sonnet-4-5
+
 variables:
   client_id: &client_id
     options:
@@ -43,7 +51,7 @@ resources:
 
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}                              # override via --param llm=...
       ai_gateway: true
       temperature: 0.1
       max_tokens: 8192

--- a/examples/15_complete_applications/hardware_store/hardware_store_swarm.yaml
+++ b/examples/15_complete_applications/hardware_store/hardware_store_swarm.yaml
@@ -11,6 +11,15 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  # Model endpoints are parameterized so defaults are overridable per
+  # environment (e.g. --param llm=databricks-claude-sonnet-5) without editing
+  # the config. Defaults track current GA Foundation Model API endpoints.
+  llm:
+    description: Chat/reasoning serving endpoint (agents, tool-calling, judge).
+    default: databricks-claude-sonnet-4-5
+  embedding_model:
+    description: Text embedding serving endpoint for vector search.
+    default: databricks-gte-large-en
 
 # =============================================================================
 # Multi-Agent AI Orchestration Framework Configuration
@@ -41,25 +50,25 @@ resources:
   models:
     # Primary LLM for general tasks
     default_llm:
-      name: databricks-claude-sonnet-4-5  # Databricks serving endpoint name
+      name: ${var.llm}                              # serving endpoint (override via --param llm=...)
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
 
     # LLM optimized for tool calling and function execution
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 8192
 
     # LLM for evaluating and judging responses (guardrails)
     judge_llm: &judge_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.5                              # Higher temperature for diverse judgments
       max_tokens: 8192
 
     # Embedding model for vector search and semantic similarity
     embedding_model: &embedding_model
-      name: databricks-gte-large-en                 # Text embedding model
+      name: ${var.embedding_model}                  # override via --param embedding_model=...
 
   # ---------------------------------------------------------------------------
   # VECTOR STORES


### PR DESCRIPTION
## What

Parameterize model serving endpoints in the four live-test-matrix example configs so the model default is overridable per environment, and refresh the defaults to current GA Foundation Model API endpoints.

- `examples/01_getting_started/minimal.yaml`
- `examples/02_mcp/managed_mcp.yaml`
- `examples/07_human_in_the_loop/human_in_the_loop_audited.yaml`
- `examples/15_complete_applications/hardware_store/hardware_store_swarm.yaml`

## Why

These configs pinned model names as literals — some now deprecated on FMAPI (`databricks-claude-sonnet-4`, `databricks-claude-3-7-sonnet`), so a plain deploy 400s at inference. A literal also can't be overridden via `--param`.

## How

Add first-class `parameters` (`llm`, plus `embedding_model` where applicable) referenced via `${var.*}`, defaulting to current GA endpoints (`databricks-claude-sonnet-4-5`, `databricks-gte-large-en`). This mirrors the existing `catalog`/`schema` param pattern and establishes the going-forward best practice: no stale model pins, and defaults overridable without editing the config, e.g.:

```
uv run dao-ai agent up -c <config> --param llm=databricks-claude-sonnet-5 -p <profile>
```

## Verification

- All four configs resolve to GA defaults and honor `--param` overrides (verified via `AppConfig.from_file`).
- `dao-ai validate` passes on all four (minimal's genie-space warning is a pre-existing example-data issue, unrelated).

## Scope

Limited to the four live-test-matrix configs. ~79 other example configs still hardcode model names (many deprecated) — a follow-up sweep.

This pull request and its description were written by Isaac.