### PR TITLE
fix: dao-ai live-test-matrix bug fixes (trace-link, warehouse env, genie resource names, workflow eval, HITL parser, MCP OBO)

### DIFF
--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -8057,6 +8057,18 @@
           ],
           "title": "Output Mode",
           "type": "string"
+        },
+        "interrupt_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InferenceEndpointModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "LLM used to parse a user's natural-language Human-in-the-Loop interrupt response (approve/reject/edit) into structured decisions. When unset, dao-ai derives it from the router: the supervisor's model, else the swarm default agent's model, else the first declared agent's model. Set this to pin a specific endpoint for interrupt parsing (e.g. a cheaper/faster model). The resolved choice and its source are logged at build time."
         }
       },
       "title": "OrchestrationModel",
@@ -8982,7 +8994,7 @@
               "type": "boolean"
             }
           ],
-          "description": "Model Serving endpoint to call. Accepts either an endpoint name string (sugar) or a full InferenceEndpointModel with temperature / max_tokens / ai_gateway / on_behalf_of_user. For a UC-registered agent endpoint or a Knowledge Assistant this is the endpoint name (e.g., 'ka-customer-reviews', 'hardware_store_dao'). For FMAPI it's the foundation model endpoint name (e.g., 'databricks-claude-sonnet-4').",
+          "description": "Model Serving endpoint to call. Accepts either an endpoint name string (sugar) or a full InferenceEndpointModel with temperature / max_tokens / ai_gateway / on_behalf_of_user. For a UC-registered agent endpoint or a Knowledge Assistant this is the endpoint name (e.g., 'ka-customer-reviews', 'hardware_store_dao'). For FMAPI it's the foundation model endpoint name (e.g., 'databricks-claude-sonnet-4-5').",
           "title": "Endpoint"
         },
         "api": {

--- a/src/dao_ai/apps/a2a/executor.py
+++ b/src/dao_ai/apps/a2a/executor.py
@@ -46,6 +46,8 @@ from dao_ai.hitl import decide_graph_turn
 from dao_ai.state import Context as DaoContext
 
 if TYPE_CHECKING:
+    from langchain_core.language_models import LanguageModelLike
+
     from dao_ai.config import AppConfig, ToolModel
 
 
@@ -76,6 +78,13 @@ class A2AAgentExecutor(AgentExecutor):
     def _tool_models(self) -> list["ToolModel"]:
         """Flattened tool_models across every agent — used by the HITL audit tap."""
         return [tool for agent in self.config.agents.values() for tool in agent.tools]
+
+    @property
+    def _interrupt_model(self) -> Optional["LanguageModelLike"]:
+        """Model used to parse HITL interrupt responses — the configured
+        default agent's model, so the parser matches the deployment instead of
+        a hardcoded endpoint. None when no agents are declared."""
+        return self.config.interrupt_parser_model()
 
     async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
         task_id = context.task_id
@@ -125,6 +134,7 @@ class A2AAgentExecutor(AgentExecutor):
                 custom_inputs=custom_inputs,
                 runtime_config=runtime_config,
                 tool_models=self._tool_models,
+                interrupt_model=self._interrupt_model,
             )
 
             if turn.should_skip_graph:

--- a/src/dao_ai/apps/resources.py
+++ b/src/dao_ai/apps/resources.py
@@ -728,7 +728,7 @@ def generate_app_resources(config: AppConfig) -> list[dict[str, Any]]:
             {
                 "name": "default_llm",
                 "type": "serving-endpoint",
-                "serving_endpoint_name": "databricks-claude-sonnet-4",
+                "serving_endpoint_name": "databricks-claude-sonnet-4-5",
                 "permissions": [{"level": "CAN_QUERY"}]
             },
             ...

--- a/src/dao_ai/apps/resources.py
+++ b/src/dao_ai/apps/resources.py
@@ -314,17 +314,22 @@ def _extract_table_resources(
     SELECT permission, which automatically grants USE CATALOG and USE SCHEMA.
     """
     resources: list[dict[str, Any]] = []
+    # Dict keys (e.g. genie-derived ``tbl_<long_table>`` or
+    # ``<room>_<full_name>``) can exceed the Databricks Apps 2–30 char
+    # resource-name limit; sanitize + uniquify so bundle deploy doesn't 400.
+    used_names: set[str] = set()
     for key, table in tables.items():
         if table.on_behalf_of_user:
             continue
+        name: str = _unique_resource_name(key, used_names)
         resource: dict[str, Any] = {
-            "name": key,
+            "name": name,
             "type": "table",
             "table_name": table.full_name,
             "permissions": [{"level": p} for p in DEFAULT_PERMISSIONS["table"]],
         }
         resources.append(resource)
-        logger.debug(f"Extracted table resource: {key} -> {table.full_name}")
+        logger.debug(f"Extracted table resource: {name} -> {table.full_name}")
     return resources
 
 
@@ -391,17 +396,20 @@ def _extract_function_resources(
     ``user_api_scopes``).
     """
     resources: list[dict[str, Any]] = []
+    # See _extract_table_resources: keys can exceed the 2–30 char limit.
+    used_names: set[str] = set()
     for key, func in functions.items():
         if func.on_behalf_of_user:
             continue
+        name: str = _unique_resource_name(key, used_names)
         resource: dict[str, Any] = {
-            "name": key,
+            "name": name,
             "type": "function",
             "function_name": func.full_name,
             "permissions": [{"level": p} for p in DEFAULT_PERMISSIONS["function"]],
         }
         resources.append(resource)
-        logger.debug(f"Extracted function resource: {key} -> {func.full_name}")
+        logger.debug(f"Extracted function resource: {name} -> {func.full_name}")
     return resources
 
 
@@ -902,6 +910,27 @@ def _sanitize_resource_name(name: str) -> str:
         sanitized = sanitized[:30]
 
     return sanitized
+
+
+def _unique_resource_name(base_name: str, used: set[str]) -> str:
+    """Sanitize ``base_name`` to the Databricks Apps 2–30 char rule and make
+    it unique against ``used`` (mutated in place with the returned name).
+
+    Truncation to 30 chars can collide two long names that share a prefix, so
+    on collision a numeric suffix is appended within the length budget.
+    """
+    sanitized = _sanitize_resource_name(base_name)
+    if sanitized not in used:
+        used.add(sanitized)
+        return sanitized
+    counter = 1
+    while True:
+        suffix = f"_{counter}"
+        candidate = sanitized[: 30 - len(suffix)] + suffix
+        if candidate not in used:
+            used.add(candidate)
+            return candidate
+        counter += 1
 
 
 def generate_sdk_resources(

--- a/src/dao_ai/apps/resources.py
+++ b/src/dao_ai/apps/resources.py
@@ -63,6 +63,7 @@ from dao_ai.config import (
     GenieRoomModel,
     InferenceEndpointModel,
     IsDatabricksResource,
+    McpFunctionModel,
     SecretVariableModel,
     TableModel,
     TraceLocationModel,
@@ -849,6 +850,32 @@ def generate_user_api_scopes(config: AppConfig) -> list[str]:
     for table in config.resources.tables.values():
         if table.on_behalf_of_user:
             obo_resources.append(table)
+
+    # RESOURCELESS MCP tools carry OBO on the function because there is no
+    # resource object to declare it on: the workspace-wide Genie MCP server
+    # (``genie: true``), the serverless DBSQL MCP server (``sql: true``), and a
+    # direct ``url`` server all front no registerable resource. Their OBO
+    # ``mcp.*`` scope can only come from the tool function, so scan those here.
+    #
+    # An MCP tool that references a *declarable* resource (genie_room,
+    # vector_search, connection, app, functions) is deliberately NOT scanned:
+    # OBO for those belongs on the registered resource in ``config.resources.*``
+    # (matching the fail-fast single-source-of-truth model used elsewhere), and
+    # is already collected by the resource loops above. Honoring OBO on the tool
+    # in that case would silently paper over a misplaced flag.
+    for tool in config.tools.values():
+        function = tool.function
+        if not isinstance(function, McpFunctionModel):
+            continue
+        if not function.on_behalf_of_user:
+            continue
+        is_resourceless: bool = (
+            function.genie is True
+            or function.sql is True
+            or function.url is not None
+        )
+        if is_resourceless:
+            obo_resources.append(function)
 
     # Collect api_scopes from all OBO resources and map to user_api_scopes
     for resource in obo_resources:

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -1108,7 +1108,7 @@ Notes:
         help=(
             "Service principal client_id (UUID) of the Databricks App runtime "
             "identity to grant experiment CAN_EDIT and UC OTEL table SELECT+MODIFY. "
-            "When omitted, auto-resolved via ``apps.get(config.app.name)`` — pass "
+            "When omitted, auto-resolved via ``apps.get(config.app.app_resource_name)`` — pass "
             "explicitly to override or to grant a non-default principal. "
             "Set ``app.manage_permissions: false`` in the config to skip grants "
             "entirely (admin-provisioned scenarios)."
@@ -1143,7 +1143,7 @@ Experiment resolution order matches ``dao-ai trace link``:
 
 App SP resolution:
   1. ``--app-sp`` flag (explicit)
-  2. ``apps.get(config.app.name).service_principal_client_id``
+  2. ``apps.get(config.app.app_resource_name).service_principal_client_id``
 
 No-op when ``config.app.trace_location`` is not set.
         """,
@@ -1178,7 +1178,7 @@ Examples:
         metavar="CLIENT_ID",
         help=(
             "Service principal client_id (UUID) to grant. When omitted, "
-            "auto-resolved via ``apps.get(config.app.name)``."
+            "auto-resolved via ``apps.get(config.app.app_resource_name)``."
         ),
     )
     _add_var_argument(trace_grant_parser)
@@ -2242,7 +2242,7 @@ def _grant_trace_writes_to_app_sp(
 
     Resolution order for the App SP:
       1. ``sp_override`` (``--app-sp`` flag).
-      2. ``apps.get(config.app.name).service_principal_client_id``.
+      2. ``apps.get(config.app.app_resource_name).service_principal_client_id``.
 
     Both grant calls WARN-and-continue on failure inside the provider
     helpers, so a deployer without GRANT rights sees diagnostics but the
@@ -2259,16 +2259,20 @@ def _grant_trace_writes_to_app_sp(
         return
 
     sp_id: Optional[str] = sp_override
+    # The deployed Databricks App is named ``app_resource_name`` (lowercased,
+    # underscores → hyphens), NOT the raw ``app.name``. ``apps.get`` must use
+    # that form or it raises NotFound and the grant is silently skipped.
+    app_name: str = config.app.app_resource_name
     if not sp_id:
         try:
             from databricks.sdk import WorkspaceClient
 
             w = WorkspaceClient()
-            app = w.apps.get(name=config.app.name)
+            app = w.apps.get(name=app_name)
             sp_id = app.service_principal_client_id or app.service_principal_id
         except Exception as e:  # noqa: BLE001
             print(
-                f"Could not resolve App SP via apps.get({config.app.name!r}): "
+                f"Could not resolve App SP via apps.get({app_name!r}): "
                 f"{type(e).__name__}: {e}. "
                 "Deploy the app first (``databricks bundle deploy``) or pass "
                 "``--app-sp <CLIENT_ID>`` explicitly.",
@@ -2278,7 +2282,7 @@ def _grant_trace_writes_to_app_sp(
 
     if not sp_id:
         print(
-            f"App {config.app.name!r} has no service_principal_client_id — "
+            f"App {app_name!r} has no service_principal_client_id — "
             "pass ``--app-sp <CLIENT_ID>`` explicitly.",
             file=sys.stderr,
         )

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -9644,10 +9644,31 @@ class AppModel(BaseModel):
             )
 
         if self.trace_location is not None:
-            self.environment_vars.setdefault(
-                "MLFLOW_TRACING_SQL_WAREHOUSE_ID",
-                self.trace_location.warehouse_id,
-            )
+            # ``warehouse_id`` is None here when the warehouse is given by NAME
+            # — name→id resolution is deferred to WarehouseModel.ensure_resolved()
+            # (a live API call we must not force at config-load, or offline
+            # ``generate`` breaks). Injecting None poisons environment_vars: the
+            # schema re-validation inside the Model Serving pyfunc rejects a None
+            # value. Only set the var when the id is already concrete; a
+            # name-based warehouse therefore requires pinning ``warehouse_id``
+            # for Model Serving trace routing (Apps/local resolve it at runtime).
+            warehouse_id: Optional[str] = self.trace_location.warehouse_id
+            if warehouse_id:
+                self.environment_vars.setdefault(
+                    "MLFLOW_TRACING_SQL_WAREHOUSE_ID",
+                    warehouse_id,
+                )
+            else:
+                # Expected for a name-based warehouse (id resolves later);
+                # fine for Apps/local, but Model Serving needs the id in the
+                # endpoint env for trace routing. Log so a missing-MS-traces
+                # investigation isn't left guessing.
+                logger.debug(
+                    "trace_location warehouse id not yet resolved at "
+                    "config-load; skipping MLFLOW_TRACING_SQL_WAREHOUSE_ID "
+                    "env injection. Pin trace_location.warehouse_id (not "
+                    "name) for Model Serving trace routing.",
+                )
         return self
 
     @model_validator(mode="after")

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -6920,7 +6920,7 @@ class ServingEndpointToolModel(BaseFunctionModel):
             "For a UC-registered agent endpoint or a Knowledge Assistant "
             "this is the endpoint name (e.g., 'ka-customer-reviews', "
             "'hardware_store_dao'). For FMAPI it's the foundation model "
-            "endpoint name (e.g., 'databricks-claude-sonnet-4')."
+            "endpoint name (e.g., 'databricks-claude-sonnet-4-5')."
         ),
     )
     api: Optional[Literal["responses", "completions"]] = Field(
@@ -7819,7 +7819,7 @@ class AgentModel(BaseModel):
 
             model: *retail_genie_room          # bare room  → GenieAgentModel
             model: {genie_room: *room, timeout_seconds: 600}  # explicit wrapper
-            model: {name: databricks-claude-sonnet-4}         # LLM (untouched)
+            model: {name: databricks-claude-sonnet-4-5}       # LLM (untouched)
 
         Coercion is by shape, not by smart-union guessing:
 
@@ -8600,6 +8600,18 @@ class OrchestrationModel(BaseModel):
             "app via ``orchestration.output_mode: full_history`` when cross-"
             "agent tool context is required and the worker-side message-"
             "assembly path is known to be clean."
+        ),
+    )
+    interrupt_model: Optional[InferenceEndpointModel] = Field(
+        default=None,
+        description=(
+            "LLM used to parse a user's natural-language Human-in-the-Loop "
+            "interrupt response (approve/reject/edit) into structured "
+            "decisions. When unset, dao-ai derives it from the router: the "
+            "supervisor's model, else the swarm default agent's model, else "
+            "the first declared agent's model. Set this to pin a specific "
+            "endpoint for interrupt parsing (e.g. a cheaper/faster model). "
+            "The resolved choice and its source are logged at build time."
         ),
     )
 
@@ -11303,6 +11315,71 @@ class AppConfig(BaseModel):
         app: ChatModel = create_agent(graph)
         return app
 
+    def interrupt_parser_model(self) -> Optional[LanguageModelLike]:
+        """Chat model used to parse a user's natural-language HITL interrupt
+        response (approve/reject/edit) into structured decisions.
+
+        Resolution order (first match wins), so the parser matches the
+        deployment's model rather than a hardcoded (possibly deprecated)
+        endpoint:
+
+          1. explicit ``orchestration.interrupt_model``
+          2. supervisor router model (``orchestration.supervisor.model``)
+          3. swarm default agent's model
+          4. first declared agent's model
+          5. None → ``handle_interrupt_response`` falls back to its own GA default
+
+        The resolved endpoint and its source are logged so operators can see
+        which model is parsing interrupts and why.
+        """
+        orch = self.app.orchestration if self.app else None
+
+        # 1. Explicit override.
+        if orch is not None and orch.interrupt_model is not None:
+            logger.info(
+                "HITL interrupt parser model resolved",
+                source="orchestration.interrupt_model",
+                endpoint=orch.interrupt_model.name,
+            )
+            return orch.interrupt_model.as_chat_model()
+
+        # 2. Supervisor router model.
+        if orch is not None and orch.supervisor is not None:
+            logger.info(
+                "HITL interrupt parser model resolved",
+                source="orchestration.supervisor.model",
+                endpoint=orch.supervisor.model.name,
+            )
+            return orch.supervisor.model.as_chat_model()
+
+        agents: list[AgentModel] = list(self.agents.values())
+        if not agents:
+            logger.info(
+                "HITL interrupt parser model unresolved — no agents declared; "
+                "handle_interrupt_response will use its GA fallback",
+                source="fallback",
+            )
+            return None
+
+        # 3. Swarm default agent, else 4. first declared agent.
+        default_agent: AgentModel = agents[0]
+        source: str = "agents[0].model"
+        if orch is not None and orch.swarm and isinstance(
+            orch.swarm.default_agent, AgentModel
+        ):
+            default_agent = orch.swarm.default_agent
+            source = "orchestration.swarm.default_agent.model"
+        # ``model`` is InferenceEndpointModel | GenieAgentModel; only the former
+        # exposes ``name``. Genie-backed agents have no endpoint name.
+        endpoint = getattr(default_agent.model, "name", "<genie-agent>")
+        logger.info(
+            "HITL interrupt parser model resolved",
+            source=source,
+            agent=default_agent.name,
+            endpoint=endpoint,
+        )
+        return default_agent.model.as_chat_model()
+
     def as_responses_agent(self) -> ResponsesAgent:
         from dao_ai.models import create_responses_agent
 
@@ -11313,6 +11390,7 @@ class AppConfig(BaseModel):
         app: ResponsesAgent = create_responses_agent(
             graph,
             tool_models=tool_models,
+            interrupt_model=self.interrupt_parser_model(),
         )
 
         background = self.app.background if self.app else None

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -284,6 +284,20 @@ class CompositeVariableModel(BaseModel, HasValue):
             value = value_of(v)
             if value is not None:
                 return value
+        # All declared sources (secret scopes, env vars, ...) resolved to None,
+        # so we fall back to default_value. This is a common silent-misconfig
+        # trap: e.g. a `--direct` deploy where the container's env/scope isn't
+        # populated falls back to a stale hardcoded default (a dead genie
+        # space_id). Warn when a non-None default is actually used so the
+        # fallback is visible instead of failing mysteriously downstream.
+        if self.default_value is not None:
+            logger.warning(
+                "Composite variable resolved to its default_value — all "
+                "declared sources (scope/env) returned None. Using default; "
+                "verify the intended source is populated in this environment.",
+                default_value=self.default_value,
+                option_kinds=[type(v).__name__ for v in self.options],
+            )
         return self.default_value
 
 
@@ -6205,13 +6219,32 @@ class McpFunctionModel(BaseFunctionModel, IsDatabricksResource):
     def api_scopes(self) -> Sequence[str]:
         """API scopes for an MCP connection.
 
-        OBO emission derives ``mcp.*`` companion scopes from the underlying
-        platform scope (see apps/resources.py:API_SCOPE_TO_USER_SCOPES), so
-        the resource itself just declares ``serving.serving-endpoints``.
+        Sub-type aware: each managed-MCP endpoint kind declares the native
+        platform scope for the resource it fronts, and OBO emission derives the
+        ``mcp.*`` companion scope from it (see
+        apps/resources.py:API_SCOPE_TO_USER_SCOPES). Without this an OBO MCP
+        tool contributes no usable user-API scope and OBO calls to the endpoint
+        are under-scoped.
+
+        Mapping (mirrors :meth:`mcp_url`):
+          - genie_room / genie      → ``dashboards.genie``      (→ genie, mcp.genie)
+          - sql / functions         → ``sql.warehouses``        (→ sql, mcp.functions)
+          - vector_search           → ``vectorsearch.vector-search-indexes``
+                                                                (→ vector-search, mcp.vectorsearch)
+          - connection              → ``catalog.connections``   (→ catalog.connections, mcp.external)
+          - url / app (opaque)      → ``serving.serving-endpoints`` (best-effort default)
         """
-        return [
-            "serving.serving-endpoints",
-        ]
+        if self.genie_room is not None or self.genie:
+            return ["dashboards.genie"]
+        if self.sql or self.functions is not None:
+            return ["sql.warehouses"]
+        if self.vector_search is not None:
+            return ["vectorsearch.vector-search-indexes"]
+        if self.connection is not None:
+            return ["catalog.connections"]
+        # Direct url / Databricks App MCP: endpoint kind is opaque here, so fall
+        # back to the generic serving scope.
+        return ["serving.serving-endpoints"]
 
     def as_resources(self) -> Sequence[DatabricksResource]:
         """MCP functions don't declare static resources."""

--- a/src/dao_ai/hitl.py
+++ b/src/dao_ai/hitl.py
@@ -18,14 +18,14 @@ from typing import TYPE_CHECKING, Any, Optional, Sequence
 
 from langchain_community.adapters.openai import convert_openai_messages
 from langchain_core.messages import BaseMessage
-
-if TYPE_CHECKING:
-    from langchain_core.language_models import LanguageModelLike
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.types import Command
 from loguru import logger
 
 from dao_ai.config import AuditModel, BaseFunctionModel, ToolModel
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import LanguageModelLike
 
 
 @dataclass

--- a/src/dao_ai/hitl.py
+++ b/src/dao_ai/hitl.py
@@ -14,10 +14,13 @@ to duplicate ~75 lines of decision logic each; they now share
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Optional, Sequence
 
 from langchain_community.adapters.openai import convert_openai_messages
 from langchain_core.messages import BaseMessage
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import LanguageModelLike
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.types import Command
 from loguru import logger
@@ -71,6 +74,7 @@ async def decide_graph_turn(
     runtime_config: dict[str, Any],
     session_input: Optional[dict[str, Any]] = None,
     tool_models: Optional[Sequence[ToolModel]] = None,
+    interrupt_model: Optional[LanguageModelLike] = None,
 ) -> GraphTurn:
     """Decide how to drive the next graph turn for a single request.
 
@@ -145,7 +149,7 @@ async def decide_graph_turn(
             parsed: dict[str, Any] = handle_interrupt_response(
                 snapshot=snapshot,
                 messages=message_objects,
-                model=None,
+                model=interrupt_model,
             )
             if not parsed.get("is_valid", False):
                 validation = parsed.get(

--- a/src/dao_ai/memory/extraction.py
+++ b/src/dao_ai/memory/extraction.py
@@ -17,7 +17,7 @@ Usage::
     from dao_ai.memory.extraction import create_extraction_manager
 
     manager, executor = create_extraction_manager(
-        model="databricks-claude-sonnet-4",
+        model="databricks-claude-sonnet-4-5",
         store=store,
         namespace=("memory", "{user_id}"),
         schemas=["user_profile", "preference"],

--- a/src/dao_ai/models.py
+++ b/src/dao_ai/models.py
@@ -892,8 +892,11 @@ def handle_interrupt_response(
     )
 
     if not model:
+        # Last-resort fallback when no model is threaded from config (e.g.
+        # callers outside the agent path). Prefer passing the deployment's
+        # configured model via the ``model`` arg — see LanggraphResponsesAgent.
         model = ChatDatabricks(
-            endpoint="databricks-claude-sonnet-4",
+            endpoint="databricks-claude-sonnet-4-5",
             temperature=0,
         )
 
@@ -1010,9 +1013,15 @@ class LanggraphResponsesAgent(ResponsesAgent):
         self,
         graph: CompiledStateGraph,
         tool_models: Sequence[ToolModel] | None = None,
+        interrupt_model: Optional[LanguageModelLike] = None,
     ) -> None:
         self.graph = graph
         self._tool_models: Sequence[ToolModel] = tuple(tool_models or ())
+        # LLM used to parse a user's natural-language HITL interrupt response.
+        # Threaded from the agent's configured model so the parser matches the
+        # deployment's model instead of a hardcoded (and potentially deprecated)
+        # endpoint. None falls back to handle_interrupt_response's default.
+        self._interrupt_model: Optional[LanguageModelLike] = interrupt_model
 
         # Stage-1 diagnostic (MS-trace-persistence investigation): log the
         # trace-relevant env-var snapshot at endpoint boot. This is the
@@ -1116,6 +1125,7 @@ class LanggraphResponsesAgent(ResponsesAgent):
                 runtime_config=custom_inputs,
                 session_input=session_input,
                 tool_models=self._tool_models,
+                interrupt_model=self._interrupt_model,
             )
 
             if turn.should_skip_graph:
@@ -1400,6 +1410,7 @@ class LanggraphResponsesAgent(ResponsesAgent):
                 runtime_config=custom_inputs,
                 session_input=session_input,
                 tool_models=self._tool_models,
+                interrupt_model=self._interrupt_model,
             )
 
             if turn.should_skip_graph:
@@ -2027,6 +2038,7 @@ def create_agent(graph: CompiledStateGraph) -> ChatAgent:
 def create_responses_agent(
     graph: CompiledStateGraph,
     tool_models: Sequence[ToolModel] | None = None,
+    interrupt_model: Optional[LanguageModelLike] = None,
 ) -> ResponsesAgent:
     """
     Create an MLflow-compatible ResponsesAgent from a LangGraph state machine.
@@ -2047,6 +2059,7 @@ def create_responses_agent(
     return LanggraphResponsesAgent(
         graph,
         tool_models=tool_models,
+        interrupt_model=interrupt_model,
     )
 
 

--- a/src/dao_ai/pipeline/bundle.py
+++ b/src/dao_ai/pipeline/bundle.py
@@ -90,7 +90,7 @@ _PIPELINE_TASKS: tuple[tuple[str, str, tuple[str, ...], dict[str, str]], ...] = 
         "run-evaluation",
         "08_run_evaluation.py",
         ("deploy-agents", "generate-evaluation-data"),
-        {},
+        {"mode": "${var.mode}"},
     ),
 )
 

--- a/src/dao_ai/pipeline/notebooks/08_run_evaluation.py
+++ b/src/dao_ai/pipeline/notebooks/08_run_evaluation.py
@@ -108,57 +108,98 @@ print(f"Custom inputs (source={_custom_inputs_source}): {custom_inputs}")
 
 # COMMAND ----------
 
-# DBTITLE 1,Resolve UC Model Version
+# DBTITLE 1,Build Shared Agent — source derived from serving mode
+#
+# The eval source is driven by the same ``mode`` the deploy task used, not a
+# free-standing knob — only ``model_serving`` logs/registers an MLflow model
+# (see 06_deploy_agent.py), so only it can be evaluated from the UC registry:
+#
+#   - model_serving → "registry": load the deployed UC artifact via
+#     ``mlflow.pyfunc.load_model`` — the most honest eval (test what shipped).
+#   - apps / mcp    → "config":   build the agent in-process from the YAML via
+#     ``AppConfig.as_responses_agent()``. These modes register no model, so
+#     there is no artifact to load; the app itself also builds from config at
+#     runtime, so this evaluates equivalent code.
+#
+# ``apps + registry`` / ``mcp + registry`` are unrepresentable here by design —
+# that invalid combination was the source of RESOURCE_DOES_NOT_EXIST failures
+# when eval defaulted to the registry regardless of deploy mode.
+#
+# Both paths reach the same LanggraphResponsesAgent with the same async
+# singletons (Lakebase checkpointer, langgraph saver). autolog with
+# run_tracer_inline matches the Apps handler (src/dao_ai/apps/handlers.py:52)
+# so child spans (LLM, tool, retriever) are complete on the config path too.
 import mlflow
-from mlflow import MlflowClient
-from mlflow.entities.model_registry.model_version import ModelVersion
 
-from dao_ai.models import get_latest_model_version
+from dao_ai.config import ServingMode
 
 mlflow.set_registry_uri("databricks-uc")
-# Match the Apps handler (src/dao_ai/apps/handlers.py:52) so config-mode runs
-# produce complete child spans (LLM, tool, retriever). Idempotent for the
-# registry path where pyfunc-load already wires it.
 mlflow.langchain.autolog(run_tracer_inline=True)
-mlflow_client: MlflowClient = MlflowClient()
-
-registered_model_name: str = config.app.registered_model.full_name
-latest_version: int = get_latest_model_version(registered_model_name)
-model_uri: str = f"models:/{registered_model_name}/{latest_version}"
-model_version: ModelVersion = mlflow_client.get_model_version(
-    registered_model_name, str(latest_version)
-)
-
-print(f"Registered model: {registered_model_name}")
-print(f"Latest version:   {latest_version}")
-print(f"Model ID:         {model_version.model_id}")
-
-# COMMAND ----------
-
-# DBTITLE 1,Build Shared Agent — UC Registry (default) or Local Config
-#
-# Two supported eval sources:
-#   - "registry" loads the actual UC-registered artifact via mlflow.pyfunc.load_model.
-#     Most honest eval (you test what's deployed). Requires a successful deploy first.
-#   - "config" builds in-process from the local YAML via AppConfig.as_responses_agent().
-#     Fast iteration on the YAML without redeploying.
-#
-# Both paths reach the same LanggraphResponsesAgent code with the same async
-# singletons (Lakebase checkpointer, langgraph saver). The persistent-loop
-# predict_fn below pins those singletons to a single loop for the whole run.
-from typing import Literal
 
 dbutils.widgets.dropdown(
-    name="agent-source", defaultValue="registry", choices=["registry", "config"]
+    name="mode", choices=["", "model_serving", "apps", "mcp"], defaultValue=""
 )
-agent_source: Literal["registry", "config"] = dbutils.widgets.get("agent-source")  # type: ignore[assignment]
+mode_str: str = dbutils.widgets.get("mode") or ServingMode.APPS.value
+mode: ServingMode = ServingMode(mode_str)
 
-if agent_source == "registry":
+# Downstream cells need three values regardless of source:
+#   experiment_id — where the eval run + traces land
+#   version_label — run-name suffix
+#   eval_model_id — mlflow.genai.evaluate model_id (None on the config path;
+#                   there is no logged model version to attribute to)
+mlflow_client: "MlflowClient"  # noqa: F821 - set in both branches below
+experiment_id: str
+version_label: str
+eval_model_id: str | None
+
+if mode == ServingMode.MODEL_SERVING:
+    from mlflow import MlflowClient
+    from mlflow.entities.model_registry.model_version import ModelVersion
+
+    from dao_ai.models import get_latest_model_version
+
+    registered_model_name: str = config.app.registered_model.full_name
+    latest_version: int = get_latest_model_version(registered_model_name)
+    model_uri: str = f"models:/{registered_model_name}/{latest_version}"
+    mlflow_client = MlflowClient()
+    model_version: ModelVersion = mlflow_client.get_model_version(
+        registered_model_name, str(latest_version)
+    )
+    print(f"Registered model: {registered_model_name}")
+    print(f"Latest version:   {latest_version}")
+    print(f"Model ID:         {model_version.model_id}")
     app: Any = mlflow.pyfunc.load_model(model_uri)
+    agent_source = "registry"
+    experiment_id = mlflow_client.get_run(model_version.run_id).info.experiment_id
+    version_label = f"v{latest_version}"
+    eval_model_id = model_version.model_id
 else:
-    app = config.as_responses_agent()
+    from mlflow import MlflowClient
 
-print(f"Agent source: {agent_source}")
+    app = config.as_responses_agent()
+    agent_source = "config"
+    mlflow_client = MlflowClient()
+    # No registered model on the apps/mcp path — resolve the experiment the
+    # app writes to: its configured MLflow experiment if set, else the
+    # deploy-time bundle experiment ``/Users/<current-user>/<app_resource_name>``.
+    # ``set_experiment`` is get-or-create, so the eval run + traces always have
+    # a home even on the first apps deploy.
+    resolved: str | None = (
+        config.app.experiment.resolved_id
+        if config.app.experiment is not None
+        else None
+    )
+    if resolved:
+        experiment_id = resolved
+    else:
+        current_user: str = spark.sql("SELECT current_user()").collect()[0][0]
+        experiment_name: str = f"/Users/{current_user}/{config.app.app_resource_name}"
+        experiment_id = mlflow.set_experiment(experiment_name).experiment_id
+    version_label = "config"
+    eval_model_id = None
+
+print(f"Serving mode: {mode.value} → agent source: {agent_source}")
+print(f"Experiment ID:    {experiment_id}")
 
 # COMMAND ----------
 
@@ -250,35 +291,36 @@ from mlflow.models.evaluation import EvaluationResult
 scorers = build_scorers(config.evaluation)
 print(f"Scorers: {[getattr(s, 'name', type(s).__name__) for s in scorers]}")
 
-model_run = mlflow_client.get_run(model_version.run_id)
-mlflow.set_experiment(experiment_id=model_run.info.experiment_id)
+mlflow.set_experiment(experiment_id=experiment_id)
 
 eval_dataset = create_or_get_eval_dataset(
     name=f"{payload_table}_dataset",
-    experiment_id=model_run.info.experiment_id,
+    experiment_id=experiment_id,
     source_df=eval_df,
     replace=evaluation.replace,
 )
 
-experiment = mlflow.get_experiment(model_run.info.experiment_id)
+experiment = mlflow.get_experiment(experiment_id)
 print(f"Dataset name:      {eval_dataset.name}")
 print(f"Dataset ID:        {eval_dataset.dataset_id}")
 print(f"Dataset records:   {len(eval_dataset.to_df())} rows")
 print(f"Experiment name:   {experiment.name}")
-print(f"Experiment ID:     {model_run.info.experiment_id}")
+print(f"Experiment ID:     {experiment_id}")
 
 run_tags: dict[str, str] = {k: str(v) for k, v in (config.app.tags or {}).items()}
 run_tags["run_type"] = "evaluation"
-run_name: str = f"{config.app.name}_evaluation_v{latest_version}_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+run_name: str = f"{config.app.name}_evaluation_{version_label}_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
 
 print(f"Starting evaluation: {len(eval_df)} rows, {len(scorers)} scorers")
 
 with mlflow.start_run(run_name=run_name, tags=run_tags) as run:
     try:
+        # model_id is None on the apps/mcp (config) path — there is no logged
+        # model version to attribute the eval to; genai.evaluate accepts None.
         eval_results: EvaluationResult | None = mlflow.genai.evaluate(
             data=eval_dataset,
             predict_fn=predict_fn,
-            model_id=model_version.model_id,
+            model_id=eval_model_id,
             scorers=scorers,
         )
         print(f"Evaluation completed. Run ID: {run.info.run_id}")

--- a/tests/dao_ai/test_app_resource_name_sanitize.py
+++ b/tests/dao_ai/test_app_resource_name_sanitize.py
@@ -1,0 +1,84 @@
+"""Regression tests (F5) for Databricks Apps resource-name sanitization.
+
+Dict keys for genie-derived tables/functions can exceed the Apps 2–30 char
+resource-name rule (e.g. ``tbl_3978880469080159_trace_unified`` = 34 chars, or
+``<room>_<catalog>_<schema>_<table>`` from the primary genie validator). Those
+keys are emitted verbatim as the resource ``name`` and made ``databricks bundle
+deploy`` fail with 400 INVALID_PARAMETER_VALUE. Both emit points must sanitize +
+uniquify the name.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dao_ai.apps.resources import (
+    _extract_function_resources,
+    _extract_table_resources,
+    _unique_resource_name,
+)
+from dao_ai.config import FunctionModel, TableModel
+
+
+@pytest.mark.unit
+class TestUniqueResourceName:
+    def test_long_name_truncated_to_30(self) -> None:
+        # The exact matrix failure key (34 chars).
+        name = _unique_resource_name(
+            "tbl_3978880469080159_trace_unified", set()
+        )
+        assert 2 <= len(name) <= 30
+
+    def test_short_name_unchanged(self) -> None:
+        used: set[str] = set()
+        assert _unique_resource_name("tbl_products", used) == "tbl_products"
+
+    def test_collision_gets_distinct_suffix_within_budget(self) -> None:
+        used: set[str] = set()
+        base = "tbl_" + ("segment_" * 6)  # > 30 chars, shared prefix
+        a = _unique_resource_name(base, used)
+        b = _unique_resource_name(base + "_other", used)
+        assert a != b
+        assert len(a) <= 30 and len(b) <= 30
+
+    def test_dots_and_hyphens_normalized(self) -> None:
+        name = _unique_resource_name("cat.sch-tbl", set())
+        assert "." not in name and "-" not in name
+
+
+@pytest.mark.unit
+class TestExtractResourcesSanitizeNames:
+    def test_table_resource_name_within_limit(self) -> None:
+        tables = {
+            # 34-char key — the matrix repro.
+            "tbl_3978880469080159_trace_unified": TableModel(
+                name="cat.sch.3978880469080159_trace_unified"
+            ),
+            "tbl_products": TableModel(name="cat.sch.products"),
+        }
+        resources = _extract_table_resources(tables)
+        names = [r["name"] for r in resources]
+        assert all(2 <= len(n) <= 30 for n in names)
+        # table_name (the actual UC target) is preserved untouched.
+        assert any(
+            r["table_name"] == "cat.sch.3978880469080159_trace_unified"
+            for r in resources
+        )
+
+    def test_function_resource_name_within_limit(self) -> None:
+        functions = {
+            "fn_a_very_long_function_name_exceeding_limit": FunctionModel(
+                name="cat.sch.a_very_long_function_name_exceeding_limit"
+            ),
+        }
+        resources = _extract_function_resources(functions)
+        assert all(2 <= len(r["name"]) <= 30 for r in resources)
+
+    def test_two_long_table_keys_stay_distinct(self) -> None:
+        tables = {
+            "tbl_" + ("x_prefix_" * 5) + "alpha": TableModel(name="cat.sch.alpha"),
+            "tbl_" + ("x_prefix_" * 5) + "beta": TableModel(name="cat.sch.beta"),
+        }
+        names = [r["name"] for r in _extract_table_resources(tables)]
+        assert len(names) == len(set(names))  # no collision
+        assert all(len(n) <= 30 for n in names)

--- a/tests/dao_ai/test_apps_obo_partition.py
+++ b/tests/dao_ai/test_apps_obo_partition.py
@@ -43,9 +43,11 @@ from dao_ai.config import (
     GenieRoomModel,
     IndexModel,
     LLMModel,
+    McpFunctionModel,
     ResourcesModel,
     SchemaModel,
     TableModel,
+    ToolModel,
     VectorStoreModel,
     VolumeModel,
     WarehouseModel,
@@ -383,3 +385,90 @@ class TestSportingGoodsConfigPartition:
             assert name in names_in_resources, (
                 f"non-OBO resource '{name}' missing from app.yaml resources"
             )
+
+
+@pytest.mark.unit
+class TestMcpFunctionApiScopes:
+    """McpFunctionModel.api_scopes must be sub-type aware so OBO MCP tools map
+    to the correct ``mcp.*`` companion scope."""
+
+    def test_genie_room_scope(self) -> None:
+        fn = McpFunctionModel(genie_room=GenieRoomModel(name="g", space_id="01fABC"))
+        assert list(fn.api_scopes) == ["dashboards.genie"]
+
+    def test_genie_all_scope(self) -> None:
+        assert list(McpFunctionModel(genie=True).api_scopes) == ["dashboards.genie"]
+
+    def test_sql_scope(self) -> None:
+        assert list(McpFunctionModel(sql=True).api_scopes) == ["sql.warehouses"]
+
+    def test_functions_scope(self) -> None:
+        fn = McpFunctionModel(functions=SchemaModel(catalog_name="c", schema_name="s"))
+        assert list(fn.api_scopes) == ["sql.warehouses"]
+
+    def test_vector_search_scope(self) -> None:
+        fn = McpFunctionModel(
+            vector_search=VectorStoreModel(index=IndexModel(name="c.s.idx"))
+        )
+        assert list(fn.api_scopes) == ["vectorsearch.vector-search-indexes"]
+
+    def test_connection_scope(self) -> None:
+        fn = McpFunctionModel(connection=ConnectionModel(name="conn"))
+        assert list(fn.api_scopes) == ["catalog.connections"]
+
+    def test_opaque_url_falls_back_to_serving(self) -> None:
+        fn = McpFunctionModel(url="https://host/mcp")
+        assert list(fn.api_scopes) == ["serving.serving-endpoints"]
+
+
+@pytest.mark.unit
+class TestMcpToolObOUserScopes:
+    """generate_user_api_scopes collects OBO scopes ONLY from *resourceless* MCP
+    tool functions (workspace-wide genie / serverless sql / direct url) — those
+    front no registerable resource, so the tool is the only place OBO can be
+    expressed. An MCP tool that references a declarable resource must carry OBO
+    on the registered resource (single source of truth), so an OBO flag on such
+    a tool is NOT honored here."""
+
+    def _agent_cfg(self, tool: ToolModel, name: str) -> AppConfig:
+        agent = AgentModel(
+            name="a", model=LLMModel(name="databricks-gpt-5-4-mini"), tools=[tool]
+        )
+        return AppConfig(
+            resources=ResourcesModel(),
+            tools={tool.name: tool},
+            agents={"a": agent},
+            app=AppModel(name=name, agents=[agent]),
+        )
+
+    def test_resourceless_genie_true_obo_emits_scopes(self) -> None:
+        # genie: true (workspace-wide) has no resource object to declare OBO on,
+        # so the tool-level flag is the only source — it MUST emit.
+        fn = McpFunctionModel(genie=True, on_behalf_of_user=True)
+        cfg = self._agent_cfg(ToolModel(name="genie_all", function=fn), "rl-genie")
+        scopes = generate_user_api_scopes(cfg)
+        assert "genie" in scopes and "mcp.genie" in scopes
+
+    def test_resourceless_sql_true_obo_emits_scopes(self) -> None:
+        fn = McpFunctionModel(sql=True, on_behalf_of_user=True)
+        cfg = self._agent_cfg(ToolModel(name="sql_mcp", function=fn), "rl-sql")
+        scopes = generate_user_api_scopes(cfg)
+        assert "sql" in scopes and "mcp.functions" in scopes
+
+    def test_obo_on_tool_referencing_resource_is_not_honored(self) -> None:
+        # OBO placed on a tool that references a declarable genie_room must NOT
+        # emit here — it belongs on the registered resource. (The resource is
+        # not registered in this config, so nothing should surface.)
+        fn = McpFunctionModel(
+            genie_room=GenieRoomModel(name="g", space_id="01fABC"),
+            on_behalf_of_user=True,
+        )
+        cfg = self._agent_cfg(ToolModel(name="genie_mcp", function=fn), "tool-obo")
+        scopes = generate_user_api_scopes(cfg)
+        assert "genie" not in scopes and "mcp.genie" not in scopes
+
+    def test_non_obo_resourceless_emits_nothing(self) -> None:
+        fn = McpFunctionModel(genie=True, on_behalf_of_user=False)
+        cfg = self._agent_cfg(ToolModel(name="genie_all", function=fn), "rl-nonobo")
+        scopes = generate_user_api_scopes(cfg)
+        assert "genie" not in scopes and "mcp.genie" not in scopes

--- a/tests/dao_ai/test_composite_default_warning.py
+++ b/tests/dao_ai/test_composite_default_warning.py
@@ -1,0 +1,63 @@
+"""F6b: CompositeVariableModel must WARN when it falls back to default_value.
+
+An env/scope-backed value silently resolving to its hardcoded ``default_value``
+(e.g. in a ``--direct`` deploy where the container's env/scope isn't populated)
+is a silent-misconfig trap — it's how a stale genie ``space_id`` sailed through.
+The warning makes that fallback visible; a resolved source or an absent default
+must stay quiet.
+"""
+
+from __future__ import annotations
+
+import pytest
+from loguru import logger
+
+from dao_ai.config import (
+    CompositeVariableModel,
+    EnvironmentVariableModel,
+)
+
+_MISSING_ENV = "DAO_AI_TEST_DEFINITELY_UNSET_VAR"
+
+
+def _capture(fn) -> list[str]:
+    """Run ``fn`` with a temporary WARNING sink; return captured messages."""
+    msgs: list[str] = []
+    sink_id = logger.add(lambda m: msgs.append(m), level="WARNING")
+    try:
+        fn()
+    finally:
+        logger.remove(sink_id)
+    return msgs
+
+
+@pytest.mark.unit
+class TestCompositeDefaultWarning:
+    def test_warns_when_falling_back_to_default(self, monkeypatch) -> None:
+        monkeypatch.delenv(_MISSING_ENV, raising=False)
+        comp = CompositeVariableModel(
+            options=[EnvironmentVariableModel(env=_MISSING_ENV)],
+            default_value="01fSTALE",
+        )
+        msgs = _capture(lambda: comp.as_value())
+        assert comp.as_value() == "01fSTALE"
+        assert any("default_value" in m for m in msgs), msgs
+
+    def test_no_warn_when_source_resolves(self, monkeypatch) -> None:
+        monkeypatch.setenv("DAO_AI_TEST_SET_VAR", "live-value")
+        comp = CompositeVariableModel(
+            options=[EnvironmentVariableModel(env="DAO_AI_TEST_SET_VAR")],
+            default_value="fallback",
+        )
+        msgs = _capture(lambda: comp.as_value())
+        assert comp.as_value() == "live-value"
+        assert not msgs, f"unexpected warnings: {msgs}"
+
+    def test_no_warn_when_no_default(self, monkeypatch) -> None:
+        monkeypatch.delenv(_MISSING_ENV, raising=False)
+        comp = CompositeVariableModel(
+            options=[EnvironmentVariableModel(env=_MISSING_ENV)],
+        )
+        msgs = _capture(lambda: comp.as_value())
+        assert comp.as_value() is None
+        assert not msgs, f"unexpected warnings: {msgs}"

--- a/tests/dao_ai/test_interrupt_parser_model.py
+++ b/tests/dao_ai/test_interrupt_parser_model.py
@@ -1,0 +1,79 @@
+"""Resolution-order tests for ``AppConfig.interrupt_parser_model`` (F8).
+
+The HITL interrupt parser must use a model derived from the deployment's
+config — explicit override, else supervisor, else swarm default agent, else
+first agent — and return None (GA fallback) only when no agents are declared.
+Each resolved path is logged with its source.
+
+These exercise the resolver in isolation via a lightweight stand-in for
+AppConfig (real AppConfig instantiation drags in many required fields); the
+resolver only touches ``self.orchestration`` and ``self.agents``. Pydantic
+forbids instance attribute injection, so ``as_chat_model`` is patched at the
+class level to echo the model's endpoint name — letting each test assert
+*which* model was selected.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dao_ai.config import (
+    AgentModel,
+    AppConfig,
+    LLMModel,
+    OrchestrationModel,
+    SupervisorModel,
+    SwarmModel,
+)
+
+
+def _agent(name: str, endpoint: str) -> AgentModel:
+    return AgentModel(name=name, model=LLMModel(name=endpoint), prompt="p")
+
+
+def _resolve(orchestration, agents) -> object:
+    """Call the unbound resolver against a stand-in exposing just the two
+    attrs it reads. ``as_chat_model`` is patched to return the endpoint name
+    so the caller can assert which model won."""
+    stub = MagicMock()
+    stub.app.orchestration = orchestration
+    stub.agents = {a.name: a for a in agents}
+    # AgentModel has no as_chat_model of its own — the model is reached via
+    # ``agent.model.as_chat_model()`` (an InferenceEndpointModel/LLMModel).
+    with patch.object(LLMModel, "as_chat_model", lambda self: f"chat:{self.name}"):
+        return AppConfig.interrupt_parser_model(stub)
+
+
+@pytest.mark.unit
+class TestInterruptParserModelResolution:
+    def test_explicit_override_wins(self) -> None:
+        orch = OrchestrationModel(
+            supervisor=SupervisorModel(model=LLMModel(name="router")),
+            interrupt_model=LLMModel(name="pinned-parser"),
+        )
+        assert _resolve(orch, [_agent("a", "agent-model")]) == "chat:pinned-parser"
+
+    def test_supervisor_model_used_when_no_override(self) -> None:
+        orch = OrchestrationModel(supervisor=SupervisorModel(model=LLMModel(name="router-model")))
+        assert _resolve(orch, [_agent("a", "agent-model")]) == "chat:router-model"
+
+    def test_swarm_default_agent_model(self) -> None:
+        first = _agent("first", "first-model")
+        chosen = _agent("chosen", "chosen-model")
+        orch = OrchestrationModel(swarm=SwarmModel(default_agent=chosen))
+        assert _resolve(orch, [first, chosen]) == "chat:chosen-model"
+
+    def test_first_agent_when_swarm_default_is_name_string(self) -> None:
+        first = _agent("first", "first-model")
+        other = _agent("other", "other-model")
+        orch = OrchestrationModel(swarm=SwarmModel(default_agent="other"))
+        assert _resolve(orch, [first, other]) == "chat:first-model"
+
+    def test_first_agent_when_no_orchestration(self) -> None:
+        assert _resolve(None, [_agent("first", "first-model")]) == "chat:first-model"
+
+    def test_none_when_no_agents(self) -> None:
+        orch = OrchestrationModel(swarm=SwarmModel())
+        assert _resolve(orch, []) is None

--- a/tests/dao_ai/test_link_trace_destination_cli.py
+++ b/tests/dao_ai/test_link_trace_destination_cli.py
@@ -228,3 +228,65 @@ class TestHandleCommand:
         err = capsys.readouterr().err
         assert "warehouse timeout" in err
         assert "exp42" in err
+
+
+@pytest.mark.unit
+class TestGrantTraceWritesAppSpName:
+    """Regression: the App SP must be resolved by the *deployed* app name
+    (``app_resource_name``, hyphenated), not the raw ``app.name`` (underscored).
+
+    Passing the raw name to ``apps.get`` raises NotFound and the grant is
+    silently skipped, so traces never persist despite ``trace_location`` set.
+    """
+
+    def _cfg(self) -> MagicMock:
+        cfg = _cfg_with_trace(app_name="my_app")
+        # app_resource_name is a real property on AppModel: lower + _ -> -.
+        cfg.app.app_resource_name = "my-app"
+        cfg.app.manage_permissions = True
+        return cfg
+
+    def test_apps_get_uses_hyphenated_resource_name(self) -> None:
+        from dao_ai.cli import _grant_trace_writes_to_app_sp
+
+        cfg = self._cfg()
+        with (
+            patch("databricks.sdk.WorkspaceClient") as wc,
+            patch(
+                "dao_ai.providers.databricks."
+                "_grant_experiment_permissions_to_principal"
+            ),
+            patch(
+                "dao_ai.providers.databricks."
+                "_grant_uc_trace_table_permissions_to_principal"
+            ),
+            patch("dao_ai.providers.databricks._resolve_trace_table_prefix"),
+        ):
+            app = MagicMock()
+            app.service_principal_client_id = "sp-123"
+            wc.return_value.apps.get.return_value = app
+
+            _grant_trace_writes_to_app_sp(cfg, "exp42", sp_override=None)
+
+            # The lookup must use the hyphenated deployed name, never the raw
+            # underscored config name.
+            wc.return_value.apps.get.assert_called_once_with(name="my-app")
+
+    def test_override_skips_apps_get(self) -> None:
+        from dao_ai.cli import _grant_trace_writes_to_app_sp
+
+        cfg = self._cfg()
+        with (
+            patch("databricks.sdk.WorkspaceClient") as wc,
+            patch(
+                "dao_ai.providers.databricks."
+                "_grant_experiment_permissions_to_principal"
+            ),
+            patch(
+                "dao_ai.providers.databricks."
+                "_grant_uc_trace_table_permissions_to_principal"
+            ),
+            patch("dao_ai.providers.databricks._resolve_trace_table_prefix"),
+        ):
+            _grant_trace_writes_to_app_sp(cfg, "exp42", sp_override="sp-explicit")
+            wc.return_value.apps.get.assert_not_called()

--- a/tests/dao_ai/test_llm_interrupt_handling.py
+++ b/tests/dao_ai/test_llm_interrupt_handling.py
@@ -422,3 +422,77 @@ class TestHandleInterruptResponse:
         assert "validation_message" in result
         assert len(result["decisions"]) == 0
         assert "No user message found" in result["validation_message"]
+
+
+class TestInterruptParserModelSource:
+    """Regression (F8): the parser must use the threaded (configured) model
+    and only fall back to a non-deprecated GA endpoint when none is provided.
+    """
+
+    def _snapshot(self):
+        snapshot = MagicMock(spec=StateSnapshot)
+        interrupt = MagicMock(spec=Interrupt)
+        interrupt.value = {
+            "action_requests": [{"name": "send_email", "args": {}}],
+            "review_configs": [
+                {
+                    "action_name": "send_email",
+                    "allowed_decisions": ["approve", "reject"],
+                }
+            ],
+        }
+        snapshot.interrupts = (interrupt,)
+        return snapshot
+
+    @patch("dao_ai.models.ChatDatabricks")
+    def test_threaded_model_is_used_and_no_chatdatabricks_constructed(
+        self, mock_chat
+    ):
+        """When a model is passed, the parser must NOT construct its own
+        ChatDatabricks (which would ignore the deployment's configured model).
+        """
+
+        class MockDecisions(BaseModel):
+            is_valid: bool = True
+            validation_message: str | None = None
+            decision_1: str = "approve"
+
+        threaded = MagicMock()
+        structured = MagicMock()
+        structured.invoke.return_value = MockDecisions()
+        threaded.with_structured_output.return_value = structured
+
+        handle_interrupt_response(
+            snapshot=self._snapshot(),
+            messages=[HumanMessage(content="approve it")],
+            model=threaded,
+        )
+
+        threaded.with_structured_output.assert_called_once()
+        mock_chat.assert_not_called()
+
+    @patch("dao_ai.models.ChatDatabricks")
+    def test_fallback_uses_non_deprecated_ga_model(self, mock_chat):
+        """With no model threaded, the last-resort fallback must not pin the
+        deprecated ``databricks-claude-sonnet-4`` endpoint.
+        """
+
+        class MockDecisions(BaseModel):
+            is_valid: bool = True
+            validation_message: str | None = None
+            decision_1: str = "approve"
+
+        structured = MagicMock()
+        structured.invoke.return_value = MockDecisions()
+        mock_chat.return_value.with_structured_output.return_value = structured
+
+        handle_interrupt_response(
+            snapshot=self._snapshot(),
+            messages=[HumanMessage(content="approve it")],
+            model=None,
+        )
+
+        mock_chat.assert_called_once()
+        endpoint = mock_chat.call_args.kwargs.get("endpoint")
+        assert endpoint == "databricks-claude-sonnet-4-5"
+        assert endpoint != "databricks-claude-sonnet-4"

--- a/tests/dao_ai/test_pipeline_bundle.py
+++ b/tests/dao_ai/test_pipeline_bundle.py
@@ -148,6 +148,12 @@ class TestGeneratePipelineDatabricksYaml:
         params = by_key["deploy-agents"]["notebook_task"]["base_parameters"]
         assert params["mode"] == "${var.mode}"
         assert params["development"] == "${var.development}"
+        # run-evaluation also forwards mode so it can pick the eval source
+        # (registry for model_serving, config for apps/mcp). Without this the
+        # eval task defaults to the registry and fails on apps-mode deploys,
+        # which register no model.
+        eval_params = by_key["run-evaluation"]["notebook_task"]["base_parameters"]
+        assert eval_params["mode"] == "${var.mode}"
 
     def test_development_includes_wheel_in_sync(self) -> None:
         assert "dist/*.whl" in self._doc(development=True)["sync"]["include"]

--- a/tests/dao_ai/test_trace_location.py
+++ b/tests/dao_ai/test_trace_location.py
@@ -56,3 +56,65 @@ def test_resolved_table_prefix_when_unset(loc_no_prefix: TraceLocationModel) -> 
 def test_catalog_and_schema_names(loc_no_prefix: TraceLocationModel) -> None:
     assert loc_no_prefix.catalog_name == "cat"
     assert loc_no_prefix.schema_name == "sch"
+
+
+# =============================================================================
+# F1: MLFLOW_TRACING_SQL_WAREHOUSE_ID env-var injection guard
+# =============================================================================
+# set_databricks_env_vars must never inject a None warehouse id. A warehouse
+# given by NAME resolves lazily (ensure_resolved → live API), so warehouse_id
+# is None at config-load; injecting it poisons environment_vars and the Model
+# Serving pyfunc's schema re-validation rejects the None. An id-based warehouse
+# resolves immediately and must still be injected.
+
+from dao_ai.config import AppConfig  # noqa: E402
+
+_BASE = """\
+resources:
+  warehouses:
+    w: &w
+{warehouse}
+  models:
+    m: &m
+      name: databricks-claude-sonnet-4-5
+schemas:
+  s: &s
+    catalog_name: cat
+    schema_name: sch
+agents:
+  a: &a
+    name: agent_one
+    model: *m
+    prompt: hi
+app:
+  name: trace_wh_test
+  registered_model:
+    schema: *s
+    name: trace_wh_test
+  trace_location:
+    schema: *s
+    warehouse: *w
+  agents: [*a]
+"""
+
+
+def _env(tmp_path, warehouse: str) -> dict:
+    p = tmp_path / "c.yaml"
+    p.write_text(_BASE.format(warehouse=warehouse))
+    cfg = AppConfig.from_file(str(p), initialize=False)
+    return cfg.app.environment_vars
+
+
+@pytest.mark.unit
+def test_name_based_warehouse_does_not_inject_none(tmp_path) -> None:
+    """A NAME-based warehouse must NOT put MLFLOW_TRACING_SQL_WAREHOUSE_ID in
+    the env at load time (it would be None). The key is simply absent."""
+    env = _env(tmp_path, '      name: "Serverless Starter Warehouse"')
+    assert "MLFLOW_TRACING_SQL_WAREHOUSE_ID" not in env
+
+
+@pytest.mark.unit
+def test_id_based_warehouse_injects_id(tmp_path) -> None:
+    """An ID-based warehouse resolves immediately and IS injected."""
+    env = _env(tmp_path, "      warehouse_id: d58e5fb998498840")
+    assert env.get("MLFLOW_TRACING_SQL_WAREHOUSE_ID") == "d58e5fb998498840"


### PR DESCRIPTION
Six independent fixes surfaced by a full live-test-matrix run of the dao-ai CLI (agent/mcp/workflow × apps/model_serving × direct/bundle). Each is a self-contained commit with regression tests; all 112 new/related tests pass together on this branch.

## Fixes

**F3 — `fix(trace)`: resolve App SP by `app_resource_name`, not raw `app.name`** (`4d2383a`)
Auto trace-link (in `agent up`/`deploy` apps, and `trace link`/`trace grant`) called `apps.get(config.app.name)` (underscores) but the deployed app is hyphenated → NotFound → grant silently skipped → spans never persisted despite `trace_location` set. Use `config.app.app_resource_name`.

**F1 — `fix(trace)`: don't inject a None `MLFLOW_TRACING_SQL_WAREHOUSE_ID`** (`65c11f8`)
A name-based `trace_location.warehouse` resolves lazily, so `set_databricks_env_vars` injected `None` into `environment_vars`; the Model Serving pyfunc re-validates and rejects it (8 pydantic errors). Guard: only inject when the id is concrete; debug-log the skip.

**F5 — `fix(apps)`: sanitize app-resource names to the 2–30 char limit** (`891268c`)
Genie-derived table/function resource keys (`tbl_<long>`, `<room>_<full_name>`) were emitted verbatim as resource names, exceeding the Databricks Apps 2–30 char rule → bundle deploy 400. Sanitize + uniquify at both emit sites.

**F4 — `fix(workflow)`: derive eval source from serving mode** (`139efd3`)
`run-evaluation` loaded a UC-registered model unconditionally; apps/mcp deploys register none → RESOURCE_DOES_NOT_EXIST. Drive eval source off `${var.mode}`: model_serving→registry, apps/mcp→config (build in-process). Live-verified: `workflow up -m apps` completes all 8 tasks; the 25 eval traces are complete (1 root, 0 orphans, 0 exception spans, tool spans present).

**F8 — `fix(hitl)`: parse interrupt responses with the configured model** (`b76a19a`)
The HITL interrupt parser hardcoded `ChatDatabricks("databricks-claude-sonnet-4")` (deprecated) — HITL resume 400s regardless of config. Thread the deployment's model via a resolver (explicit `orchestration.interrupt_model` → supervisor → swarm-default → first agent → GA fallback), logged with its source.

**F6 — `fix(obo)`: OBO scopes for resourceless MCP tools; default-fallback warning** (`56c83be`)
Workspace-wide-genie / serverless-sql MCP tools (`genie: true`/`sql: true`) with OBO emitted no user-API scope (front no registerable resource). Make `McpFunctionModel.api_scopes` sub-type aware and scan `config.tools` for OBO — resourceless-only (a tool referencing a declarable resource must carry OBO on the registered resource). Plus a warning when a composite `{scope/env, default}` variable silently falls back to its default.

## Testing
- 112 unit tests across the touched areas pass together on this branch; each fix's regression tests were verified to fail with the bug reintroduced.
- F3/F4 additionally validated live on FEVM (apps deploy + workflow run + MLflow trace audit).
- Pre-existing unrelated failures on `main` (test_databricks.py, one test_mcp_function_model.py) are not touched.

## Not included (deliberate)
- `workflow up` still exits 0 on job-task failure (surfacing that is a separate, potentially-breaking change).
- MCP-server crash-cascade kept fail-fast (per decision).
- Generalized tool-resource discovery across all tool types: researched, left as a follow-up.
- Example model parameterization / deprecated-model refresh ships separately in #235.

This pull request and its description were written by Isaac.