### PR TITLE
chore(examples): parameterize resources + refresh deprecated models across example configs

### DIFF
--- a/examples/01_getting_started/ai_gateway.yaml
+++ b/examples/01_getting_started/ai_gateway.yaml
@@ -25,6 +25,15 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  # Model endpoints are parameterized so defaults are overridable per
+  # environment (e.g. --param llm=databricks-claude-sonnet-5) without editing
+  # the config. Defaults track current GA Foundation Model API endpoints.
+  llm:
+    description: Chat/reasoning serving endpoint (AI Gateway routed).
+    default: databricks-claude-opus-4-6
+  fallback_llm:
+    description: Fallback chat serving endpoint.
+    default: databricks-claude-sonnet-5
 
 schemas:
   retail_schema: &retail_schema
@@ -35,14 +44,14 @@ resources:
   models:
     # New path — Foundation Model served via AI Gateway.
     gateway_llm: &gateway_llm
-      name: databricks-claude-opus-4-6
+      name: ${var.llm}
       ai_gateway: true
       temperature: 0.1
       max_tokens: 1024
 
     # Legacy path — same workspace, no flag, unchanged behavior.
     legacy_llm: &legacy_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.fallback_llm}
       temperature: 0.1
       max_tokens: 1024
 
@@ -50,12 +59,12 @@ resources:
     # Both ChatOpenAI and ChatDatabricks are LangChain Runnables, so
     # with_fallbacks composes them without further configuration.
     resilient_llm: &resilient_llm
-      name: databricks-claude-opus-4-6
+      name: ${var.llm}
       ai_gateway: true
       temperature: 0.1
       max_tokens: 1024
       fallbacks:
-      - databricks-claude-sonnet-4
+      - ${var.fallback_llm}
 
 agents:
   gateway_agent: &gateway_agent

--- a/examples/02_mcp/custom_mcp.yaml
+++ b/examples/02_mcp/custom_mcp.yaml
@@ -11,6 +11,9 @@ parameters:
   schema:
     description: Schema within the catalog
     default: retail_consumer_goods
+  llm:
+    description: Chat/reasoning serving endpoint for the agent.
+    default: databricks-claude-sonnet-5
 
 variables:
   client_id: &client_id
@@ -42,7 +45,7 @@ resources:
   models:
     default_llm: &default_llm
                                                  # Default LLM configuration
-      name: databricks-claude-3-7-sonnet        # Databricks serving endpoint name
+      name: ${var.llm}                          # Databricks serving endpoint name
 
 tools:
   jira_mcp: &jira_mcp

--- a/examples/02_mcp/external_mcp.yaml
+++ b/examples/02_mcp/external_mcp.yaml
@@ -11,6 +11,9 @@ parameters:
   schema:
     description: Schema within the catalog
     default: retail_ai
+  llm:
+    description: Chat/reasoning serving endpoint for the agent.
+    default: databricks-claude-sonnet-5
 
 schemas:
   retail_schema: &retail_schema
@@ -22,7 +25,7 @@ resources:
   models:
     default_llm: &default_llm
                                                  # Default LLM configuration
-      name: databricks-claude-sonnet-4           # Databricks serving endpoint name
+      name: ${var.llm}                           # Databricks serving endpoint name
   connections:
     github_connection: &github_connection
                                                  # UC Connection for GitHub

--- a/examples/02_mcp/filtered_mcp.yaml
+++ b/examples/02_mcp/filtered_mcp.yaml
@@ -10,6 +10,9 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  llm:
+    description: Chat/reasoning serving endpoint for the agents.
+    default: databricks-claude-sonnet-5
 
 #
 # Example: Filtering MCP Server Tools
@@ -70,7 +73,7 @@ schemas:
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.1
 
 # =============================================================================
@@ -321,7 +324,7 @@ app:
     - *functions_agent                    # Functions agent
   orchestration:                          # Agent orchestration configuration
     swarm:                                # Supervisor orchestration pattern
-      default_agent: *general_agent       # Default agent for routing
+      default_agent: *safe_sql_agent      # Default agent for routing
 
 # =============================================================================
 # USAGE NOTES

--- a/examples/02_mcp/mcp_meta_test.yaml
+++ b/examples/02_mcp/mcp_meta_test.yaml
@@ -14,15 +14,29 @@
 #   DAO_AI_CATALOG        - UC catalog for MLflow model registration (default: main)
 #   DAO_AI_SCHEMA         - UC schema for MLflow model registration (default: default)
 
+# =============================================================================
+# PARAMETERS
+# =============================================================================
+parameters:
+  catalog:
+    description: Unity Catalog catalog name
+    default: retail_consumer_goods
+  schema:
+    description: Schema within the catalog
+    default: dao_ai_mcp_meta_test
+  llm:
+    description: Chat/reasoning serving endpoint for the agent.
+    default: databricks-claude-sonnet-5
+
 schemas:
   registry_schema: &registry_schema
-    catalog_name: retail_consumer_goods
-    schema_name: dao_ai_mcp_meta_test
+    catalog_name: ${var.catalog}
+    schema_name: ${var.schema}
 
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
 
 tools:
   # Feature 1: workspace-wide Genie MCP (the new `genie: true` field)

--- a/examples/03_reranking/instruction_aware_reranking.yaml
+++ b/examples/03_reranking/instruction_aware_reranking.yaml
@@ -11,6 +11,15 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  llm:
+    description: Chat/reasoning serving endpoint for agent reasoning
+    default: databricks-claude-sonnet-5
+  reranker_llm:
+    description: Fast serving endpoint used for query decomposition and instruction-aware reranking
+    default: databricks-meta-llama-3-1-8b-instruct
+  embedding_model:
+    description: Embedding serving endpoint for vector search
+    default: databricks-gte-large-en
 
 # ==============================================================================
 # INSTRUCTED RETRIEVAL + INSTRUCTION-AWARE RERANKING EXAMPLE
@@ -30,7 +39,7 @@ resources:
   models:
     # Primary LLM for agent reasoning
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 8192
 
@@ -39,10 +48,10 @@ resources:
     reranker_llm: &reranker_llm
       #name: databricks-meta-llama-3-1-8b-instruct
       #name: databricks-gpt-5-4-mini
-      name: databricks-meta-llama-3-1-8b-instruct
+      name: ${var.reranker_llm}
 
     embedding_model: &embedding_model
-      name: databricks-gte-large-en
+      name: ${var.embedding_model}
 
   vector_stores:
     products_vector_store: &products_vector_store

--- a/examples/03_reranking/vector_search_with_reranking.yaml
+++ b/examples/03_reranking/vector_search_with_reranking.yaml
@@ -11,6 +11,12 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  llm:
+    description: Chat/reasoning serving endpoint for general tasks
+    default: databricks-claude-sonnet-5
+  embedding_model:
+    description: Embedding serving endpoint for vector search
+    default: databricks-gte-large-en
 
 schemas:
   retail_schema: &retail_schema
@@ -21,12 +27,12 @@ resources:
   models:
     # Primary LLM for general tasks
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4             # Databricks serving endpoint name
+      name: ${var.llm}                              # Databricks serving endpoint name
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
 
     embedding_model: &embedding_model
-      name: databricks-gte-large-en                 # Text embedding model
+      name: ${var.embedding_model}                  # Text embedding model
 
   vector_stores:
     # Product information vector store for similarity search

--- a/examples/04_genie/cache_threshold_optimization.yaml
+++ b/examples/04_genie/cache_threshold_optimization.yaml
@@ -10,6 +10,18 @@ parameters:
   schema:
     description: Schema within the catalog
     default: quick_serve_restaurant
+  llm:
+    description: Judge serving endpoint for semantic equivalence evaluation
+    default: databricks-gpt-5-4-mini
+  embedding_model:
+    description: Embedding serving endpoint for generating embeddings
+    default: databricks-gte-large-en
+  warehouse_id:
+    description: SQL Warehouse id used by the context-aware cache
+    default: 148ccb90800933a1
+  lakebase_project:
+    description: Lakebase project name for the context-aware cache database
+    default: retail-consumer-goods
 
 #
 # Example configuration for context-aware cache threshold optimization.
@@ -39,22 +51,22 @@ resources:
     # Judge model for semantic equivalence evaluation
     # Used when expected_match is not provided for an entry
     judge_model: &judge_model
-      name: databricks-gpt-5-4-mini
+      name: ${var.llm}
       temperature: 0.0  # Low temperature for consistent judgments
       max_tokens: 10    # Only need "MATCH" or "NO_MATCH"
 
     # Embedding model for generating embeddings
     embedding_model: &embedding_model
-      name: databricks-gte-large-en
+      name: ${var.embedding_model}
 
   warehouses:
     shared_endpoint_warehouse: &shared_endpoint_warehouse
       name: "Shared Endpoint Warehouse"
-      warehouse_id: 148ccb90800933a1
+      warehouse_id: ${var.warehouse_id}
 
   databases:
     context_aware_cache_db: &context_aware_cache_db
-      project: "retail-consumer-goods"
+      project: ${var.lakebase_project}
 
 
 # =============================================================================

--- a/examples/04_genie/genie_basic.yaml
+++ b/examples/04_genie/genie_basic.yaml
@@ -12,6 +12,9 @@ parameters:
   schema:
     description: Schema within the catalog
     default: quick_serve_restaurant
+  llm:
+    description: Chat/reasoning serving endpoint for general tasks
+    default: databricks-claude-sonnet-5
 
 schemas:
 
@@ -23,7 +26,7 @@ resources:
   models:
     # Primary LLM for general tasks
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
       on_behalf_of_user: false

--- a/examples/04_genie/genie_context_aware_cache.yaml
+++ b/examples/04_genie/genie_context_aware_cache.yaml
@@ -10,6 +10,18 @@ parameters:
   schema:
     description: Schema within the catalog
     default: quick_serve_restaurant
+  llm:
+    description: Chat/reasoning serving endpoint for general tasks
+    default: databricks-claude-sonnet-5
+  embedding_model:
+    description: Embedding serving endpoint for context-aware similarity search
+    default: databricks-gte-large-en
+  warehouse_id:
+    description: SQL Warehouse id used by the Genie cache to re-execute cached SQL
+    default: 148ccb90800933a1
+  lakebase_project:
+    description: Lakebase project name for the context-aware cache database
+    default: retail-consumer-goods
 
 #
 # Example configuration for Genie with two-tier caching:
@@ -30,14 +42,14 @@ resources:
   models:
     # Primary LLM for general tasks
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
       on_behalf_of_user: false
 
     # Embedding model for context-aware similarity search
     embedding_model: &embedding_model
-      name: databricks-gte-large-en                 # Text embedding model
+      name: ${var.embedding_model}                  # Text embedding model
       on_behalf_of_user: false
 
   warehouses:
@@ -45,13 +57,13 @@ resources:
     shared_endpoint_warehouse: &shared_endpoint_warehouse
       name: "Shared Endpoint Warehouse"             # Human-readable name
       description: "A warehouse for shared endpoints"  # Description
-      warehouse_id: 148ccb90800933a1                # Databricks warehouse ID
+      warehouse_id: ${var.warehouse_id}             # Databricks warehouse ID
       on_behalf_of_user: false
 
   databases:
     # Lakebase (PostgreSQL) database for context-aware cache storage
     context_aware_cache_db: &context_aware_cache_db
-      project: "retail-consumer-goods"              # Autoscaling Lakebase project name
+      project: ${var.lakebase_project}              # Autoscaling Lakebase project name
       description: "PostgreSQL database for context-aware cache"
 
   genie_rooms:

--- a/examples/04_genie/genie_in_memory_context_aware_cache.yaml
+++ b/examples/04_genie/genie_in_memory_context_aware_cache.yaml
@@ -10,6 +10,12 @@ parameters:
   schema:
     description: Schema within the catalog
     default: quick_serve_restaurant
+  llm:
+    description: Chat/reasoning serving endpoint for general tasks
+    default: databricks-claude-sonnet-5
+  embedding_model:
+    description: Embedding serving endpoint for context-aware similarity search
+    default: databricks-gte-large-en
   warehouse_id:
     description: SQL Warehouse id used by the Genie cache to re-execute cached SQL.
     default: 148ccb90800933a1
@@ -42,14 +48,14 @@ resources:
   models:
     # Primary LLM for general tasks
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
       on_behalf_of_user: false
 
     # Embedding model for context-aware similarity search
     embedding_model: &embedding_model
-      name: databricks-gte-large-en                 # Text embedding model
+      name: ${var.embedding_model}                  # Text embedding model
       on_behalf_of_user: false
 
   warehouses:

--- a/examples/04_genie/genie_lru_cache.yaml
+++ b/examples/04_genie/genie_lru_cache.yaml
@@ -12,6 +12,12 @@ parameters:
   schema:
     description: Schema within the catalog
     default: quick_serve_restaurant
+  llm:
+    description: Chat/reasoning serving endpoint for agent models
+    default: databricks-claude-sonnet-5
+  warehouse_id:
+    description: Databricks SQL warehouse ID
+    default: 148ccb90800933a1
 
 schemas:
 
@@ -23,7 +29,7 @@ resources:
   models:
     # Primary LLM for general tasks
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
       on_behalf_of_user: false
@@ -33,7 +39,7 @@ resources:
     shared_endpoint_warehouse: &shared_endpoint_warehouse
       name: "Shared Endpoint Warehouse"             # Human-readable name
       description: "A warehouse for shared endpoints"  # Description
-      warehouse_id: 148ccb90800933a1                # Databricks warehouse ID
+      warehouse_id: ${var.warehouse_id}                # Databricks warehouse ID
       on_behalf_of_user: false
 
   genie_rooms:

--- a/examples/04_genie/genie_with_context_management.yaml
+++ b/examples/04_genie/genie_with_context_management.yaml
@@ -12,16 +12,30 @@
 # Uses the aws-field-eng Databricks CLI profile:
 #   export DATABRICKS_CONFIG_PROFILE=aws-field-eng
 
+# =============================================================================
+# PARAMETERS
+# =============================================================================
+parameters:
+  llm:
+    description: Chat/reasoning serving endpoint for agent models
+    default: databricks-claude-sonnet-4-5
+  summarization_llm:
+    description: Serving endpoint used for conversation summarization
+    default: databricks-gpt-5-4-mini
+  genie_space_id:
+    description: Databricks Genie space ID
+    default: 01f124c2690f1dcb93a15057c2a74339
+
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 8192
       on_behalf_of_user: false
 
     summarization_llm: &summarization_llm
-      name: databricks-gpt-5-4-mini
+      name: ${var.summarization_llm}
       temperature: 0.1
       max_tokens: 1024
 
@@ -29,7 +43,7 @@ resources:
     genie_room: &genie_room
       name: "Sales and Pricing Analytics - Sporting Goods"
       description: "Genie room for sales performance analysis, pricing strategy, margin analytics, promotional effectiveness, and revenue tracking across stores and channels"
-      space_id: 01f124c2690f1dcb93a15057c2a74339
+      space_id: ${var.genie_space_id}
 
 tools:
   genie_tool: &genie_tool

--- a/examples/04_genie/genie_with_conversation_id.yaml
+++ b/examples/04_genie/genie_with_conversation_id.yaml
@@ -1,26 +1,49 @@
 # yaml-language-server: $schema=../../../schemas/model_config_schema.json
 
 
+# =============================================================================
+# PARAMETERS
+# =============================================================================
+parameters:
+  catalog:
+    description: Unity Catalog catalog name
+    default: retail_consumer_goods
+  schema:
+    description: Schema within the catalog
+    default: quick_serve_restaurant
+  registered_model_catalog:
+    description: Unity Catalog catalog where the model is registered
+    default: nfleming
+  registered_model_schema:
+    description: Schema where the model is registered
+    default: retail_ai
+  llm:
+    description: Chat/reasoning serving endpoint for agent models
+    default: databricks-claude-sonnet-5
+  fallback_llm:
+    description: Fallback chat serving endpoint
+    default: databricks-claude-sonnet-5
+
 schemas:
   retail_schema: &retail_schema
-    catalog_name: nfleming                    # Unity Catalog name
-    schema_name: retail_ai                    # Schema within the catalog
+    catalog_name: ${var.registered_model_catalog}                    # Unity Catalog name
+    schema_name: ${var.registered_model_schema}                    # Schema within the catalog
 
   quick_serve_retaurant_schema: &quick_serve_retaurant_schema
-    catalog_name: retail_consumer_goods                    # Unity Catalog name
-    schema_name: quick_serve_restaurant                    # Schema within the catalog
+    catalog_name: ${var.catalog}                    # Unity Catalog name
+    schema_name: ${var.schema}                    # Schema within the catalog
 
 resources:
   models:
     # Primary LLM for general tasks
     default_llm: &default_llm
-      name: databricks-claude-3-7-sonnet # Databricks serving endpoint name
+      name: ${var.llm} # Databricks serving endpoint name
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
       on_behalf_of_user: false
       fallbacks:                                  # Fallback LLMs in case of issues
-      - databricks-claude-sonnet-4
-      - databricks-claude-sonnet-4
+      - ${var.fallback_llm}
+      - ${var.fallback_llm}
 
   databases:
     # PostgreSQL database for agent memory and checkpoints

--- a/examples/05_memory/conversation_summarization.yaml
+++ b/examples/05_memory/conversation_summarization.yaml
@@ -11,6 +11,18 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  llm:
+    description: Chat/reasoning serving endpoint for agent models
+    default: databricks-claude-sonnet-5
+  summarization_llm:
+    description: Serving endpoint used for conversation summarization
+    default: databricks-meta-llama-3-1-8b-instruct
+  embedding_model:
+    description: Embedding serving endpoint for semantic memory
+    default: databricks-gte-large-en
+  lakebase_project:
+    description: Lakebase (PostgreSQL) project name
+    default: retail-consumer-goods
 
 # =============================================================================
 # Conversation Summarization Example
@@ -46,19 +58,19 @@ resources:
   models:
     # Primary LLM for conversation
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.7                             # Moderate temperature for natural conversation
       max_tokens: 4096
 
     # Fast LLM for summarization (use smaller/faster model for efficiency)
     summarization_llm: &summarization_llm
-      name: databricks-meta-llama-3-1-8b-instruct
+      name: ${var.summarization_llm}
       temperature: 0.1                             # Low temperature for consistent summaries
       max_tokens: 512
 
     # Embedding model for semantic memory (optional, for store)
     embedding_model: &embedding_model
-      name: databricks-gte-large-en
+      name: ${var.embedding_model}
       on_behalf_of_user: False
 
   # ---------------------------------------------------------------------------
@@ -68,7 +80,7 @@ resources:
   # This enables conversation state to be saved and restored across sessions
   databases:
     lakehouse_database: &lakehouse_database
-      project: "retail-consumer-goods"
+      project: ${var.lakebase_project}
       description: "PostgreSQL database for conversation checkpoints and memory"
 
 # =============================================================================
@@ -145,7 +157,7 @@ app:
   orchestration:
     memory: *memory
     swarm:
-      default_agent: *main_agent
+      default_agent: *conversational_agent
 
   # ---------------------------------------------------------------------------
   # CHAT HISTORY / SUMMARIZATION CONFIGURATION

--- a/examples/05_memory/in_memory_basic.yaml
+++ b/examples/05_memory/in_memory_basic.yaml
@@ -17,12 +17,20 @@
 # - Not suitable for production long-term conversations
 
 # =============================================================================
+# PARAMETERS
+# =============================================================================
+parameters:
+  llm:
+    description: Chat/reasoning serving endpoint for agent models
+    default: databricks-claude-sonnet-5
+
+# =============================================================================
 # RESOURCES
 # =============================================================================
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.7
       max_tokens: 4096
 

--- a/examples/05_memory/lakebase_persistence.yaml
+++ b/examples/05_memory/lakebase_persistence.yaml
@@ -11,6 +11,12 @@ parameters:
   schema:
     description: Schema within the catalog
     default: default
+  llm:
+    description: Chat/reasoning serving endpoint for agent models
+    default: databricks-claude-sonnet-5
+  lakebase_project:
+    description: Lakebase (PostgreSQL) project name
+    default: my-lakebase-project
 
 # =============================================================================
 # Lakebase Persistence Example
@@ -44,13 +50,13 @@ schemas:
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.7
       max_tokens: 4096
 
     # Optional: Separate model for summarization (more cost-effective)
     summary_llm:
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 512
 
@@ -59,7 +65,7 @@ resources:
   # ---------------------------------------------------------------------------
   databases:
     lakebase_db: &lakebase_db
-      project: "my-lakebase-project"         # Autoscaling Lakebase project name
+      project: ${var.lakebase_project}         # Autoscaling Lakebase project name
       description: "Databricks Lakebase for conversation persistence"
 
 # =============================================================================

--- a/examples/05_memory/postgres_persistence.yaml
+++ b/examples/05_memory/postgres_persistence.yaml
@@ -11,6 +11,9 @@ parameters:
   schema:
     description: Schema within the catalog
     default: default
+  llm:
+    description: Chat/reasoning serving endpoint used by the agents
+    default: databricks-claude-sonnet-5
 
 # =============================================================================
 # PostgreSQL Persistence Example
@@ -43,12 +46,12 @@ schemas:
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.7
       max_tokens: 4096
 
     summary_llm:
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 512
 

--- a/examples/06_on_behalf_of_user/obo_basic.yaml
+++ b/examples/06_on_behalf_of_user/obo_basic.yaml
@@ -11,6 +11,9 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  llm:
+    description: Chat/reasoning serving endpoint used by the agents
+    default: databricks-claude-sonnet-5
 
 # =============================================================================
 # On-Behalf-Of (OBO) User Authentication Example
@@ -44,7 +47,7 @@ schemas:
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.7
       max_tokens: 4096
       # Enable OBO for LLM requests

--- a/examples/07_human_in_the_loop/human_in_the_loop.yaml
+++ b/examples/07_human_in_the_loop/human_in_the_loop.yaml
@@ -26,6 +26,20 @@
   # - Composite: { type: composite, options: [${VAR1}, ${VAR2}, default] }
   # - Primitives: Just use the value directly
 
+parameters:
+  catalog:
+    description: Unity Catalog catalog name
+    default: nfleming
+  schema:
+    description: Schema within the catalog
+    default: retail_ai
+  llm:
+    description: Chat/reasoning serving endpoint used by the agents
+    default: databricks-claude-sonnet-5
+  lakebase_project:
+    description: Lakebase project backing the HITL checkpointer and store
+    default: retail-consumer-goods
+
 variables:
   client_id: &client_id
     options:
@@ -40,19 +54,19 @@ variables:
 
 schemas:
   retail_schema: &retail_schema
-    catalog_name: nfleming                    
-    schema_name: retail_ai                    
+    catalog_name: ${var.catalog}
+    schema_name: ${var.schema}
 
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4 
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 8192
 
   databases:
     lakebase_db: &lakebase_db
-      project: retail-consumer-goods
+      project: ${var.lakebase_project}
       client_id: *client_id
       client_secret: *client_secret
 
@@ -164,7 +178,7 @@ app:
   
   orchestration:
     swarm:
-      default_agent: *main_agent
+      default_agent: *admin_agent
 
     memory: *memory  # CRITICAL: Memory with checkpointer required for HITL
   

--- a/examples/07_human_in_the_loop/human_in_the_loop_audited.yaml
+++ b/examples/07_human_in_the_loop/human_in_the_loop_audited.yaml
@@ -20,12 +20,21 @@
 #                            fail-closed on args-hash drift at execution time.
 
 parameters:
+  catalog:
+    description: Unity Catalog catalog name
+    default: retail_consumer_goods
+  schema:
+    description: Schema within the catalog
+    default: audit_demo
   # Model endpoint is parameterized so the default can be overridden per
   # environment (e.g. --param llm=databricks-claude-sonnet-5) without editing
   # the config. Default tracks a current GA Foundation Model API endpoint.
   llm:
     description: Chat/reasoning serving endpoint for the audit admin agent.
     default: databricks-claude-sonnet-4-5
+  lakebase_project:
+    description: Lakebase project hosting the HITL checkpointer and audit receipts
+    default: retail-consumer-goods-audit
 
 variables:
   client_id: &client_id
@@ -41,8 +50,8 @@ variables:
 
 schemas:
   audit_schema: &audit_schema
-    catalog_name: retail_consumer_goods
-    schema_name: audit_demo
+    catalog_name: ${var.catalog}
+    schema_name: ${var.schema}
 
 resources:
   warehouses:
@@ -59,7 +68,7 @@ resources:
   databases:
     # Single Lakebase — hosts the HITL checkpointer AND the audit receipts.
     audit_db: &audit_db
-      project: retail-consumer-goods-audit
+      project: ${var.lakebase_project}
       autoscaling_min_cu: 0
       autoscaling_max_cu: 4
       client_id: *client_id

--- a/examples/08_guardrails/guardrails_basic.yaml
+++ b/examples/08_guardrails/guardrails_basic.yaml
@@ -11,6 +11,9 @@ parameters:
   schema:
     description: Schema within the catalog
     default: retail_ai
+  llm:
+    description: Chat/reasoning serving endpoint used by the agents and guardrail judges
+    default: databricks-claude-sonnet-5
 
 # =============================================================================
 # Guardrails Configuration Example
@@ -53,14 +56,14 @@ resources:
     #   - databricks-claude-sonnet-4 (more likely to make mistakes)
     #   - Higher temperature values (increases variability)
     default_llm: &default_llm
-      name: databricks-claude-3-7-sonnet
+      name: ${var.llm}
       temperature: 0.7
       max_tokens: 4096
 
     # LLM optimized for judging/evaluating responses
     # Often uses higher temperature for diverse evaluation
     judge_llm: &judge_llm
-      name: databricks-claude-3-7-sonnet
+      name: ${var.llm}
       temperature: 0.3                        # Lower temp for consistent evaluation
       max_tokens: 2048
 
@@ -214,14 +217,14 @@ middleware:
   veracity_middleware: &veracity_middleware
     name: dao_ai.middleware.create_veracity_guardrail_middleware
     args:
-      model: "databricks:/databricks-claude-3-7-sonnet"
+      model: "databricks:/${var.llm}"
       num_retries: 2
 
   # Relevance check - ensures responses address the user's actual query.
   relevance_middleware: &relevance_middleware
     name: dao_ai.middleware.create_relevance_guardrail_middleware
     args:
-      model: "databricks:/databricks-claude-3-7-sonnet"
+      model: "databricks:/${var.llm}"
       num_retries: 2
 
   # Tone check - validates tone against a preset profile.
@@ -229,14 +232,14 @@ middleware:
   tone_middleware:
     name: dao_ai.middleware.create_tone_guardrail_middleware
     args:
-      model: "databricks:/databricks-claude-3-7-sonnet"
+      model: "databricks:/${var.llm}"
       tone: professional
 
   # Conciseness check - hybrid deterministic length + LLM verbosity check.
   conciseness_middleware: &conciseness_middleware
     name: dao_ai.middleware.create_conciseness_guardrail_middleware
     args:
-      model: "databricks:/databricks-claude-3-7-sonnet"
+      model: "databricks:/${var.llm}"
       max_length: 2000
       min_length: 50
       check_verbosity: true

--- a/examples/09_structured_output/structured_output.yaml
+++ b/examples/09_structured_output/structured_output.yaml
@@ -11,6 +11,9 @@ parameters:
   schema:
     description: Schema within the catalog
     default: retail_ai
+  llm:
+    description: Chat/reasoning serving endpoint used by the agent
+    default: databricks-claude-sonnet-5
 
 # Simple Structured Output Example
 # This agent extracts contact information and returns it as JSON
@@ -23,7 +26,7 @@ schemas:
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.0
 
 agents:

--- a/examples/11_prompt_engineering/prompt_registry.yaml
+++ b/examples/11_prompt_engineering/prompt_registry.yaml
@@ -11,6 +11,18 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  llm:
+    description: Chat/reasoning serving endpoint for tool-calling agents
+    default: databricks-claude-sonnet-5
+  fallback_llm:
+    description: Fallback chat serving endpoint if the primary LLM fails
+    default: databricks-claude-sonnet-5
+  judge_llm:
+    description: Serving endpoint used for evaluation/judging (guardrails)
+    default: databricks-claude-sonnet-5
+  embedding_model:
+    description: Embedding serving endpoint for vector search
+    default: databricks-gte-large-en
 
 # =============================================================================
 # Multi-Agent AI Orchestration Framework Configuration
@@ -55,22 +67,22 @@ resources:
 
     # LLM optimized for tool calling and function execution
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-3-7-sonnet
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 8192
       fallbacks:                                     # Fallback models if primary fails
-      - databricks-claude-sonnet-4
+      - ${var.fallback_llm}
 
 
     # LLM for evaluating and judging responses (guardrails)
     judge_llm: &judge_llm
-      name: databricks-claude-3-7-sonnet
+      name: ${var.judge_llm}
       temperature: 0.5                              # Higher temperature for diverse judgments
       max_tokens: 8192
 
     # Embedding model for vector search and semantic similarity
     embedding_model: &embedding_model
-      name: databricks-gte-large-en                 # Text embedding model
+      name: ${var.embedding_model}                 # Text embedding model
 
   # ---------------------------------------------------------------------------
   # VECTOR STORES

--- a/examples/12_middleware/context_management.yaml
+++ b/examples/12_middleware/context_management.yaml
@@ -10,6 +10,9 @@ parameters:
   schema:
     description: Schema within the catalog
     default: quick_serve_restaurant
+  llm:
+    description: Chat/reasoning serving endpoint for the agents
+    default: databricks-claude-sonnet-5
 
 #
 # Example: Context Editing Middleware
@@ -38,7 +41,7 @@ schemas:
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 4096
 

--- a/examples/12_middleware/logging_middleware.yaml
+++ b/examples/12_middleware/logging_middleware.yaml
@@ -10,6 +10,9 @@ parameters:
   schema:
     description: Schema within the catalog
     default: quick_serve_restaurant
+  llm:
+    description: Chat/reasoning serving endpoint used by the agents and supervisor
+    default: databricks-claude-sonnet-5
 
 #
 # Example: Logging Middleware
@@ -25,7 +28,7 @@ schemas:
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 4096
 

--- a/examples/13_orchestration/supervisor_pattern.yaml
+++ b/examples/13_orchestration/supervisor_pattern.yaml
@@ -11,6 +11,14 @@
 # Use case: When you need centralized routing with specialized agents
 
 # =============================================================================
+# PARAMETERS
+# =============================================================================
+parameters:
+  llm:
+    description: Chat/reasoning serving endpoint used by the agents and supervisor
+    default: databricks-claude-sonnet-5
+
+# =============================================================================
 # VARIABLES
 # =============================================================================
 variables:
@@ -23,7 +31,7 @@ variables:
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 4096
 

--- a/examples/13_orchestration/swarm_pattern.yaml
+++ b/examples/13_orchestration/swarm_pattern.yaml
@@ -10,6 +10,14 @@
 # Use case: When agents need to collaborate and hand off fluidly
 
 # =============================================================================
+# PARAMETERS
+# =============================================================================
+parameters:
+  llm:
+    description: Chat/reasoning serving endpoint for the swarm agents
+    default: databricks-claude-sonnet-5
+
+# =============================================================================
 # VARIABLES
 # =============================================================================
 variables:
@@ -22,7 +30,7 @@ variables:
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 4096
 

--- a/examples/15_complete_applications/brick_store/brick_store.yaml
+++ b/examples/15_complete_applications/brick_store/brick_store.yaml
@@ -11,6 +11,24 @@ parameters:
   schema:
     description: Schema within the catalog
     default: store_ops
+  llm:
+    description: Primary chat/reasoning + tool-calling serving endpoint for the agents
+    default: databricks-claude-sonnet-4-5
+  fast_llm:
+    description: Fast serving endpoint for supervisor routing, decomposition, and lightweight calls
+    default: databricks-gpt-5-4-mini
+  embedding_model:
+    description: Embedding serving endpoint for vector search and memory
+    default: databricks-gte-large-en
+  genie_space_id:
+    description: Genie space id for the Brick Store Operations Genie room
+    default: 01f14b11e9dd164483458833e7aa840e
+  warehouse_id:
+    description: SQL warehouse id for Genie and caching workloads
+    default: 4b9b953939869799
+  lakebase_project:
+    description: Lakebase Postgres project name for agent memory
+    default: retail-consumer-goods
   genie_parent_path:
     description: Workspace folder for the Genie space (path under /Users/<user>/)
     default: "/Users/${workspace.current_user.userName}/genie"
@@ -80,39 +98,39 @@ resources:
   # ---------------------------------------------------------------------------
   models:
     fast_llm: &fast_llm
-      name: databricks-gpt-5-4-mini
+      name: ${var.fast_llm}
       temperature: 0.1
       max_tokens: 4096
       on_behalf_of_user: true
 
     supervisor_llm: &supervisor_llm
-      name: databricks-gpt-5-4-mini
+      name: ${var.fast_llm}
       temperature: 0.1
       max_tokens: 1024
       on_behalf_of_user: true
 
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 4096
       on_behalf_of_user: true
       fallbacks:
-      - databricks-claude-sonnet-4-5
+      - ${var.llm}
 
     judge_llm: &judge_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.5
       max_tokens: 8192
       on_behalf_of_user: true
 
     decomposition_llm: &decomposition_llm
-      name: databricks-gpt-5-4-mini
+      name: ${var.fast_llm}
       temperature: 0.0
       max_tokens: 1024
       on_behalf_of_user: true
 
     embedding_model: &embedding_model
-      name: databricks-gte-large-en
+      name: ${var.embedding_model}
       on_behalf_of_user: true
 
   # ---------------------------------------------------------------------------
@@ -178,7 +196,7 @@ resources:
     brickstore_warehouse: &brickstore_warehouse
       name: "Shared Unity Catalog Serverless"
       description: "Shared serverless warehouse for brick_store demo workloads"
-      warehouse_id: 4b9b953939869799
+      warehouse_id: ${var.warehouse_id}
       on_behalf_of_user: true
 
   # ---------------------------------------------------------------------------
@@ -194,7 +212,7 @@ resources:
       # space_id is populated by GenieRoomModel.create() during initial
       # provisioning. With it set, subsequent deploys reference the existing
       # space (update mode) instead of creating a new one.
-      space_id: 01f14b11e9dd164483458833e7aa840e
+      space_id: ${var.genie_space_id}
       on_behalf_of_user: true
       parent_path: "${var.genie_parent_path}"
       warehouse: *brickstore_warehouse
@@ -328,7 +346,7 @@ resources:
   databases:
     retail_database: &retail_database
       name: "retail-consumer-goods"
-      project: "retail-consumer-goods"
+      project: "${var.lakebase_project}"
       description: "Lakebase Postgres for agent memory checkpoints and namespaced store"
       client_id: *client_id
       client_secret: *client_secret

--- a/examples/15_complete_applications/commerce/commerce_supervisor.yaml
+++ b/examples/15_complete_applications/commerce/commerce_supervisor.yaml
@@ -42,6 +42,15 @@ parameters:
   warehouse_id:
     description: SQL warehouse ID used for UC trace_location export
     default: d58e5fb998498840
+  llm:
+    description: Chat/reasoning serving endpoint for all agents (routed via AI Gateway)
+    default: databricks-claude-sonnet-4-6
+  embedding_model:
+    description: Text embedding serving endpoint for Vector Search + memory recall
+    default: databricks-gte-large-en
+  lakebase_project:
+    description: Lakebase (Postgres) project name for memory, checkpointer, and idempotency log
+    default: commerce-swarm
 
 # =============================================================================
 # VARIABLES — credentials sourced from the shared retail_consumer_goods scope
@@ -86,42 +95,42 @@ resources:
 
     # Fast / cheap LLM for triage, routing, simple lookups, UCP execution
     fast_llm: &fast_llm
-      name: databricks-claude-sonnet-4-6
+      name: ${var.llm}
       ai_gateway: true
       temperature: 0.1
       max_tokens: 8192
 
     # Reasoning-heavy LLM for recommendation (history + memory synthesis)
     reasoning_llm: &reasoning_llm
-      name: databricks-claude-sonnet-4-6
+      name: ${var.llm}
       ai_gateway: true
       temperature: 0.2
       max_tokens: 8192
 
     # Tool-calling LLM (alias to fast_llm — Claude Sonnet 4.6 has strong tool-call fidelity)
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-sonnet-4-6
+      name: ${var.llm}
       ai_gateway: true
       temperature: 0.1
       max_tokens: 8192
 
     # Background memory extraction — uses fast_llm to avoid competing with foreground
     extraction_llm: &extraction_llm
-      name: databricks-claude-sonnet-4-6
+      name: ${var.llm}
       ai_gateway: true
       temperature: 0.1
       max_tokens: 4096
 
     # Judge LLM for evaluation runs
     judge_llm: &judge_llm
-      name: databricks-claude-sonnet-4-6
+      name: ${var.llm}
       ai_gateway: true
       temperature: 0.5
       max_tokens: 8192
 
     # Embedding model for Vector Search + memory store semantic recall
     embedding_model: &embedding_model
-      name: databricks-gte-large-en
+      name: ${var.embedding_model}
       on_behalf_of_user: false
 
   # ---------------------------------------------------------------------------
@@ -237,7 +246,7 @@ resources:
 
     commerce_supervisor_db: &commerce_supervisor_db
       name: "Commerce Swarm Lakebase"
-      project: "commerce-swarm"
+      project: ${var.lakebase_project}
       branch: "production"
       description: "Lakebase Postgres for agent memory, checkpointer, and UCP idempotency log"
       client_id: *client_id

--- a/examples/15_complete_applications/commerce/commerce_swarm.yaml
+++ b/examples/15_complete_applications/commerce/commerce_swarm.yaml
@@ -32,6 +32,15 @@ parameters:
   warehouse_id:
     description: SQL warehouse ID used for UC trace_location export
     default: d58e5fb998498840
+  llm:
+    description: Chat/reasoning serving endpoint for all agents (routed via AI Gateway)
+    default: databricks-claude-sonnet-4-6
+  embedding_model:
+    description: Text embedding serving endpoint for Vector Search + memory recall
+    default: databricks-gte-large-en
+  lakebase_project:
+    description: Lakebase (Postgres) project name for memory, checkpointer, and idempotency log
+    default: commerce-swarm
 
 # =============================================================================
 # VARIABLES — credentials sourced from the shared retail_consumer_goods scope
@@ -76,42 +85,42 @@ resources:
 
     # Fast / cheap LLM for triage, routing, simple lookups, UCP execution
     fast_llm: &fast_llm
-      name: databricks-claude-sonnet-4-6
+      name: ${var.llm}
       ai_gateway: true
       temperature: 0.1
       max_tokens: 8192
 
     # Reasoning-heavy LLM for recommendation (history + memory synthesis)
     reasoning_llm: &reasoning_llm
-      name: databricks-claude-sonnet-4-6
+      name: ${var.llm}
       ai_gateway: true
       temperature: 0.2
       max_tokens: 8192
 
     # Tool-calling LLM (alias to fast_llm — Claude Sonnet 4.6 has strong tool-call fidelity)
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-sonnet-4-6
+      name: ${var.llm}
       ai_gateway: true
       temperature: 0.1
       max_tokens: 8192
 
     # Background memory extraction — uses fast_llm to avoid competing with foreground
     extraction_llm: &extraction_llm
-      name: databricks-claude-sonnet-4-6
+      name: ${var.llm}
       ai_gateway: true
       temperature: 0.1
       max_tokens: 4096
 
     # Judge LLM for evaluation runs
     judge_llm: &judge_llm
-      name: databricks-claude-sonnet-4-6
+      name: ${var.llm}
       ai_gateway: true
       temperature: 0.5
       max_tokens: 8192
 
     # Embedding model for Vector Search + memory store semantic recall
     embedding_model: &embedding_model
-      name: databricks-gte-large-en
+      name: ${var.embedding_model}
       on_behalf_of_user: false
 
   # ---------------------------------------------------------------------------
@@ -227,7 +236,7 @@ resources:
 
     commerce_swarm_db: &commerce_swarm_db
       name: "Commerce Swarm Lakebase"
-      project: "commerce-swarm"
+      project: ${var.lakebase_project}
       description: "Lakebase Postgres for agent memory, checkpointer, and UCP idempotency log"
       client_id: *client_id
       client_secret: *client_secret

--- a/examples/15_complete_applications/hardware_store/hardware_store.yaml
+++ b/examples/15_complete_applications/hardware_store/hardware_store.yaml
@@ -14,6 +14,12 @@ parameters:
   warehouse_id:
     description: SQL warehouse ID for the UC OTEL trace tables' initial DDL
     default: d1be2f7fe7faacb1
+  llm:
+    description: Chat/reasoning serving endpoint (agents, tool-calling, judge).
+    default: databricks-claude-sonnet-4-5
+  embedding_model:
+    description: Text embedding serving endpoint for vector search.
+    default: databricks-gte-large-en
 
 # =============================================================================
 # Multi-Agent AI Orchestration Framework Configuration
@@ -44,25 +50,25 @@ resources:
   models:
     # Primary LLM for general tasks
     default_llm:
-      name: databricks-claude-sonnet-4-5  # Databricks serving endpoint name
+      name: ${var.llm}  # Databricks serving endpoint name
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
 
     # LLM optimized for tool calling and function execution
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 8192
 
     # LLM for evaluating and judging responses (guardrails)
     judge_llm: &judge_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.5                              # Higher temperature for diverse judgments
       max_tokens: 8192
 
     # Embedding model for vector search and semantic similarity
     embedding_model: &embedding_model
-      name: databricks-gte-large-en                 # Text embedding model
+      name: ${var.embedding_model}                 # Text embedding model
 
   # ---------------------------------------------------------------------------
   # VECTOR STORES

--- a/examples/15_complete_applications/hardware_store/hardware_store_instructed.yaml
+++ b/examples/15_complete_applications/hardware_store/hardware_store_instructed.yaml
@@ -11,6 +11,15 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  llm:
+    description: Chat/reasoning serving endpoint (agents, tool-calling, judge).
+    default: databricks-claude-sonnet-4-5
+  decomposition_llm:
+    description: Fast serving endpoint for query decomposition (lower latency).
+    default: databricks-claude-haiku-4-5
+  embedding_model:
+    description: Text embedding serving endpoint for vector search.
+    default: databricks-gte-large-en
 
 # =============================================================================
 # Hardware Store with Instructed Retriever
@@ -42,31 +51,31 @@ resources:
   models:
     # Primary LLM for agent reasoning
     default_llm:
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 8192
 
     # LLM optimized for tool calling
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 8192
 
     # Fast LLM for query decomposition (smaller model = lower latency)
     decomposition_llm: &decomposition_llm
-      name: databricks-claude-haiku-4-5
+      name: ${var.decomposition_llm}
       temperature: 0.0
       max_tokens: 1024
 
     # LLM for evaluating responses
     judge_llm: &judge_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.5
       max_tokens: 8192
 
     # Embedding model for vector search
     embedding_model: &embedding_model
-      name: databricks-gte-large-en
+      name: ${var.embedding_model}
 
   # ---------------------------------------------------------------------------
   # VECTOR STORES

--- a/examples/15_complete_applications/hardware_store/hardware_store_lakebase.yaml
+++ b/examples/15_complete_applications/hardware_store/hardware_store_lakebase.yaml
@@ -11,6 +11,24 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  llm:
+    description: Primary chat/tool-calling serving endpoint for agents.
+    default: databricks-claude-sonnet-4-6
+  fallback_llm:
+    description: Fallback chat serving endpoint when the primary endpoint errors.
+    default: databricks-claude-sonnet-4-5
+  fast_llm:
+    description: Fast/cheap serving endpoint for supervisor routing and memory query.
+    default: databricks-gpt-oss-120b
+  judge_llm:
+    description: Serving endpoint used to evaluate/judge responses (guardrails, eval).
+    default: databricks-claude-sonnet-4-5
+  embedding_model:
+    description: Text embedding serving endpoint for vector search and memory recall.
+    default: databricks-gte-large-en
+  lakebase_project:
+    description: Lakebase (Postgres) project name for agent memory and checkpoints.
+    default: retail-consumer-goods
 
 # =============================================================================
 # Multi-Agent AI Orchestration Framework Configuration
@@ -70,30 +88,30 @@ resources:
       # "Multiple tool calls are not supported" issue
       # (trace tr-fd4dfaea04c4517f43081e2c3bf0df25) can't recur.
       # Restores the cheaper/faster supervisor for routing decisions.
-      name: databricks-gpt-oss-120b                 # Databricks serving endpoint name
+      name: ${var.fast_llm}                         # Databricks serving endpoint name
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
 
     # LLM optimized for tool calling and function execution
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-sonnet-4-6
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 8192
       fallbacks:
-      - databricks-claude-sonnet-4-5
+      - ${var.fallback_llm}
 
 
 
     # LLM for evaluating and judging responses (guardrails)
     # Note: Claude models support structured output (response_schema) for Literal feedback types
     judge_llm: &judge_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.judge_llm}
       temperature: 0.5                              # Higher temperature for diverse judgments
       max_tokens: 8192
 
     # Embedding model for vector search and semantic similarity
     embedding_model: &embedding_model
-      name: databricks-gte-large-en                 # Text embedding model
+      name: ${var.embedding_model}                  # Text embedding model
       on_behalf_of_user: false
 
   # ---------------------------------------------------------------------------
@@ -167,7 +185,7 @@ resources:
     # Lakebase database for agent memory and checkpoints
     retail_database: &retail_database
       name: "Retail and Consumer Goods Database"
-      project: "retail-consumer-goods"  # Autoscaling Lakebase project name
+      project: ${var.lakebase_project}  # Autoscaling Lakebase project name
       description: "Database for agent memory and checkpoints"
       client_id: *client_id
       client_secret: *client_secret

--- a/examples/15_complete_applications/loyalty_offer_personalization/loyalty_offer_personalization.yaml
+++ b/examples/15_complete_applications/loyalty_offer_personalization/loyalty_offer_personalization.yaml
@@ -42,6 +42,18 @@ parameters:
   genie_space_id:
     description: Genie space id — provided at run time by the provision-genie task (taskValue). Supply --param to reuse an existing space.
     provided: true
+  llm:
+    description: Chat/reasoning serving endpoint for tool-calling agents
+    default: databricks-claude-sonnet-4-5
+  fast_llm:
+    description: Fast chat serving endpoint for supervisor, decomposition, and query tasks
+    default: databricks-gpt-5-4-mini
+  fallback_llm:
+    description: Fallback chat serving endpoint when the primary llm is unavailable
+    default: databricks-claude-sonnet-4-6
+  embedding_model:
+    description: Embedding serving endpoint for vector search and memory store
+    default: databricks-gte-large-en
 
 # =============================================================================
 # VARIABLES (shared secrets for the retail_consumer_goods service principal)
@@ -99,21 +111,21 @@ resources:
   # judge, decomposition) references one of these via YAML anchor.
   models:
     fast_llm: &fast_llm
-      name: databricks-gpt-5-4-mini
+      name: ${var.fast_llm}
       ai_gateway: true
       temperature: 0.1
       max_tokens: 4096
 
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       ai_gateway: true
       temperature: 0.1
       max_tokens: 4096
       fallbacks:
-      - databricks-claude-sonnet-4-6
+      - ${var.fallback_llm}
 
     embedding_model: &embedding_model
-      name: databricks-gte-large-en
+      name: ${var.embedding_model}
       on_behalf_of_user: true
 
   # Role aliases — share the underlying endpoint definitions above so we

--- a/examples/15_complete_applications/sporting_goods_store/sporting_goods_store.yaml
+++ b/examples/15_complete_applications/sporting_goods_store/sporting_goods_store.yaml
@@ -23,6 +23,21 @@ parameters:
   sales_pricing_genie_space_id:
     description: Genie space id for the sales & pricing analytics room — provided at run time by the provision-genie task (taskValue). Supply --param to reuse an existing space.
     provided: true
+  llm:
+    description: Chat/reasoning serving endpoint for tool-calling and judge tasks
+    default: databricks-claude-sonnet-4-5
+  fast_llm:
+    description: Fast chat serving endpoint for supervisor, verifier, decomposition, and query tasks
+    default: databricks-gpt-5-4-mini
+  fallback_llm:
+    description: Fallback chat serving endpoint when the primary llm is unavailable
+    default: databricks-claude-sonnet-4-6
+  embedding_model:
+    description: Embedding serving endpoint for vector search and memory store
+    default: databricks-gte-large-en
+  lakebase_project:
+    description: Lakebase project name reused for agent memory + checkpointer
+    default: retail-consumer-goods
 
 # =============================================================================
 # Sporting Goods Store - Merchandiser 360
@@ -82,44 +97,44 @@ resources:
   # ---------------------------------------------------------------------------
   models:
     fast_llm: &fast_llm
-      name: databricks-gpt-5-4-mini
+      name: ${var.fast_llm}
       temperature: 0.1
       max_tokens: 4096
       on_behalf_of_user: true
 
     supervisor_llm: &supervisor_llm
-      name: databricks-gpt-5-4-mini
+      name: ${var.fast_llm}
       temperature: 0.1
       max_tokens: 1024
       on_behalf_of_user: true
 
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 4096
       on_behalf_of_user: true
       fallbacks:
-      - databricks-claude-sonnet-4-6
+      - ${var.fallback_llm}
 
     judge_llm: &judge_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.5
       max_tokens: 8192
 
     verifier_llm: &verifier_llm
-      name: databricks-gpt-5-4-mini
+      name: ${var.fast_llm}
       temperature: 0.1
       max_tokens: 2048
       on_behalf_of_user: true
 
     decomposition_llm: &decomposition_llm
-      name: databricks-gpt-5-4-mini
+      name: ${var.fast_llm}
       temperature: 0.0
       max_tokens: 1024
       on_behalf_of_user: true
 
     embedding_model: &embedding_model
-      name: databricks-gte-large-en
+      name: ${var.embedding_model}
 
   # ---------------------------------------------------------------------------
   # VECTOR STORES
@@ -284,7 +299,7 @@ resources:
   databases:
     retail_database: &retail_database
       name: "retail-consumer-goods"
-      project: "retail-consumer-goods"  # Autoscaling Lakebase project name
+      project: "${var.lakebase_project}"  # Autoscaling Lakebase project name
       description: "Databricks Lakebase for agent memory and checkpoints"
       client_id: *client_id
       client_secret: *client_secret

--- a/examples/15_complete_applications/sporting_goods_store/sporting_goods_store_slim.yaml
+++ b/examples/15_complete_applications/sporting_goods_store/sporting_goods_store_slim.yaml
@@ -11,6 +11,30 @@ parameters:
   schema:
     description: Schema within the catalog
     default: sporting_goods_store
+  llm:
+    description: Chat/reasoning serving endpoint for tool-calling and judge tasks
+    default: databricks-claude-sonnet-4-5
+  fast_llm:
+    description: Fast chat serving endpoint for supervisor, decomposition, and query tasks
+    default: databricks-gpt-5-4-mini
+  fallback_llm:
+    description: Fallback chat serving endpoint when the primary llm is unavailable
+    default: databricks-claude-sonnet-4-6
+  embedding_model:
+    description: Embedding serving endpoint for vector search and memory store
+    default: databricks-gte-large-en
+  warehouse_id:
+    description: SQL Warehouse id used by Genie + provisioning. Override per workspace via --var.
+    default: 4b9b953939869799
+  merchandising_genie_space_id:
+    description: Genie space id for the merchandising analytics room
+    default: 01f124c2646f1ed4846cae3f8b36df02
+  sales_pricing_genie_space_id:
+    description: Genie space id for the sales & pricing analytics room
+    default: 01f124c2690f1dcb93a15057c2a74339
+  lakebase_project:
+    description: Lakebase project name reused for agent memory + checkpointer
+    default: retail-consumer-goods
 
 # =============================================================================
 # Sporting Goods Store - Merchandiser 360
@@ -70,38 +94,38 @@ resources:
   # ---------------------------------------------------------------------------
   models:
     fast_llm: &fast_llm
-      name: databricks-gpt-5-4-mini
+      name: ${var.fast_llm}
       temperature: 0.1
       max_tokens: 4096
       on_behalf_of_user: true
 
     supervisor_llm: &supervisor_llm
-      name: databricks-gpt-5-4-mini
+      name: ${var.fast_llm}
       temperature: 0.1
       max_tokens: 1024
       on_behalf_of_user: true
 
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 4096
       on_behalf_of_user: true
       fallbacks:
-      - databricks-claude-sonnet-4-6
+      - ${var.fallback_llm}
 
     judge_llm: &judge_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.5
       max_tokens: 8192
 
     decomposition_llm: &decomposition_llm
-      name: databricks-gpt-5-4-mini
+      name: ${var.fast_llm}
       temperature: 0.0
       max_tokens: 1024
       on_behalf_of_user: true
 
     embedding_model: &embedding_model
-      name: databricks-gte-large-en
+      name: ${var.embedding_model}
 
   # ---------------------------------------------------------------------------
   # VECTOR STORES
@@ -145,7 +169,7 @@ resources:
     shared_warehouse: &shared_warehouse
       # name: "Shared Endpoint"
       name: "Shared Unity Catalog Serverless"
-      warehouse_id: 4b9b953939869799
+      warehouse_id: ${var.warehouse_id}
       on_behalf_of_user: false
 
   # ---------------------------------------------------------------------------
@@ -156,13 +180,13 @@ resources:
       name: "Merchandising Analytics - Sporting Goods"
       description: "Genie room for merchandising analytics including assortment planning, demand forecasting, purchase order tracking, category performance, and seasonal trend analysis"
       on_behalf_of_user: false
-      space_id: 01f124c2646f1ed4846cae3f8b36df02
+      space_id: ${var.merchandising_genie_space_id}
 
     sales_pricing_room: &sales_pricing_room
       name: "Sales and Pricing Analytics - Sporting Goods"
       description: "Genie room for sales performance analysis, pricing strategy, margin analytics, promotional effectiveness, and revenue tracking across stores and channels"
       on_behalf_of_user: false
-      space_id: 01f124c2690f1dcb93a15057c2a74339
+      space_id: ${var.sales_pricing_genie_space_id}
 
   # ---------------------------------------------------------------------------
   # FUNCTIONS
@@ -183,7 +207,7 @@ resources:
   databases:
     retail_database: &retail_database
       name: "retail-consumer-goods"
-      project: "retail-consumer-goods"  # Autoscaling Lakebase project name
+      project: "${var.lakebase_project}"  # Autoscaling Lakebase project name
       description: "Databricks Lakebase for agent memory and checkpoints"
       client_id: *client_id
       client_secret: *client_secret

--- a/examples/16_instructed_retriever/instructed_retriever.yaml
+++ b/examples/16_instructed_retriever/instructed_retriever.yaml
@@ -11,6 +11,15 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  llm:
+    description: Chat/reasoning serving endpoint for agent reasoning
+    default: databricks-claude-sonnet-4-5
+  decomposition_llm:
+    description: Fast chat serving endpoint for query decomposition and reranking
+    default: databricks-claude-haiku-4-5
+  embedding_model:
+    description: Embedding serving endpoint for vector search
+    default: databricks-gte-large-en
 
 schemas:
   retail_schema: &retail_schema
@@ -21,18 +30,18 @@ resources:
   models:
     # Primary LLM for agent reasoning
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 8192
 
     # Fast LLM for query decomposition (smaller model = lower latency)
     decomposition_llm: &decomposition_llm
-      name: databricks-claude-haiku-4-5
+      name: ${var.decomposition_llm}
       temperature: 0.0
       max_tokens: 1024
 
     embedding_model: &embedding_model
-      name: databricks-gte-large-en
+      name: ${var.embedding_model}
 
   vector_stores:
     products_vector_store: &products_vector_store

--- a/examples/16_test_scenarios/genie_provisioning_only.yaml
+++ b/examples/16_test_scenarios/genie_provisioning_only.yaml
@@ -38,6 +38,9 @@ parameters:
   genie_parent_path:
     description: Workspace folder for the Genie space
     default: /Users/${workspace.current_user.userName}
+  llm:
+    description: Chat/reasoning serving endpoint registered for deploy-agents
+    default: databricks-claude-sonnet-4-5
 
 schemas:
   loyalty_schema: &loyalty_schema
@@ -48,7 +51,7 @@ resources:
   # A minimum-viable LLM resource so deploy-agents has something to register.
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       ai_gateway: true
 
   warehouses:

--- a/examples/17_parallel_tools/parallel_tool_calls.yaml
+++ b/examples/17_parallel_tools/parallel_tool_calls.yaml
@@ -10,6 +10,9 @@ parameters:
   schema:
     description: Schema within the catalog
     default: default
+  llm:
+    description: Chat/reasoning serving endpoint used by the agent
+    default: databricks-claude-sonnet-5
 
 #
 # Test configuration for parallel tool calling observability
@@ -23,7 +26,7 @@ parameters:
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.1
 
 tools:

--- a/examples/18_visualization/vega_lite_visualization.yaml
+++ b/examples/18_visualization/vega_lite_visualization.yaml
@@ -11,6 +11,9 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  llm:
+    description: Chat/reasoning serving endpoint used by the agent
+    default: databricks-claude-sonnet-5
 
 # Example configuration demonstrating the Vega-Lite visualization tool
 # This tool generates portable Vega-Lite JSON specs from structured data.
@@ -25,7 +28,7 @@ resources:
   # Define the LLM for the agent
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4  # Databricks serving endpoint name
+      name: ${var.llm}  # Databricks serving endpoint name
 
   # Define the warehouse to execute SQL against
   warehouses:

--- a/examples/19_background_agents/deep_research.yaml
+++ b/examples/19_background_agents/deep_research.yaml
@@ -11,6 +11,12 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  llm:
+    description: Chat/reasoning serving endpoint used by the agent
+    default: databricks-claude-sonnet-5
+  lakebase_project:
+    description: Lakebase project backing the checkpointer + long-running responses store
+    default: retail-consumer-goods
 
 # =============================================================================
 # Long-Running Agent Example — Deep Research (aws-field-eng / retail-consumer-goods)
@@ -54,14 +60,14 @@ schemas:
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       temperature: 0.3
       max_tokens: 2048
 
   databases:
     retail_database: &retail_database
       name: "Retail and Consumer Goods Database"
-      project: "retail-consumer-goods"
+      project: ${var.lakebase_project}
       description: "Lakebase for checkpointer + long-running responses"
       client_id: *client_id
       client_secret: *client_secret

--- a/examples/20_a2a_protocol/a2a_background.yaml
+++ b/examples/20_a2a_protocol/a2a_background.yaml
@@ -16,16 +16,24 @@
 # the LLM layer, see the per-resource ``on_behalf_of_user: true`` on
 # ``default_llm``.
 
+parameters:
+  llm:
+    description: Chat/reasoning serving endpoint used by the agent
+    default: databricks-gpt-5-4-mini
+  lakebase_project:
+    description: Lakebase project backing the A2A task store + checkpointer
+    default: dao-ai-a2a-demo
+
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-gpt-5-4-mini
+      name: ${var.llm}
       on_behalf_of_user: true
 
   databases:
     a2a_demo_db: &a2a_demo_db
       name: dao-ai-a2a-demo
-      project: dao-ai-a2a-demo
+      project: ${var.lakebase_project}
       description: Lakebase project for A2A task persistence + LangGraph checkpointer.
 
 tools:

--- a/examples/20_a2a_protocol/a2a_hitl_obo.yaml
+++ b/examples/20_a2a_protocol/a2a_hitl_obo.yaml
@@ -24,10 +24,15 @@
 # also persist the A2A task store via ``a2a.task_store.database``
 # (see a2a_background.yaml).
 
+parameters:
+  llm:
+    description: Chat/reasoning serving endpoint used by the agent
+    default: databricks-gpt-5-4-mini
+
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-gpt-5-4-mini
+      name: ${var.llm}
       # Route inference through the calling user's token. Verified end-to-
       # end via A2A by inspecting the MLflow trace and the app logs.
       on_behalf_of_user: true

--- a/examples/20_a2a_protocol/a2a_minimal.yaml
+++ b/examples/20_a2a_protocol/a2a_minimal.yaml
@@ -12,10 +12,15 @@
 # No Unity Catalog tables, Vector Search indexes, or Genie rooms required —
 # only Foundation Model API access (default on every Databricks workspace).
 
+parameters:
+  llm:
+    description: Chat/reasoning serving endpoint used by the agent
+    default: databricks-gpt-5-4-mini
+
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-gpt-5-4-mini
+      name: ${var.llm}
 
 agents:
   greeter: &greeter

--- a/examples/21_lakebase_search/reranked.yaml
+++ b/examples/21_lakebase_search/reranked.yaml
@@ -16,6 +16,10 @@
 # a specific model + top_n.
 
 parameters:
+  llm:
+    default: databricks-claude-sonnet-4-5
+  embedding_model:
+    default: databricks-gte-large-en
   lakebase_project:
     default: my-lakebase-project
   schema_name:
@@ -51,7 +55,7 @@ variables:
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
 
   databases:
     kb_lakebase: &kb_lakebase
@@ -69,7 +73,7 @@ resources:
       content_column: passage
       embedding_column: embedding
       tsvector_column: passage_tsv
-      embedding_model: databricks-gte-large-en
+      embedding_model: ${var.embedding_model}
       metadata_columns: [category, priority]
 
     # Same table, narrower metadata surface for the ANN-only variant.
@@ -81,7 +85,7 @@ resources:
       content_column: passage
       embedding_column: embedding
       tsvector_column: passage_tsv
-      embedding_model: databricks-gte-large-en
+      embedding_model: ${var.embedding_model}
       metadata_columns: [category]
 
 retrievers:


### PR DESCRIPTION
## What
Parameterize Databricks resource values across the example config corpus (46 files) so defaults are overridable per environment via `--param`, refresh deprecated model pins, and fix three pre-existing broken configs found along the way.

Follows up #235 (which parameterized the 4 live-test-matrix configs) — same pattern, applied corpus-wide.

## Parameterization
Each bare literal → a top-level `parameters:` entry (literal as `default:`) referenced via `${var.*}`, for:
- `catalog`, `schema`
- `llm` (+ `fallback_llm` / role-specific names where multiple distinct models exist)
- `embedding_model`
- `genie_space_id`, `warehouse_id`, `lakebase_project`

Reuses the canonical param names already established in the corpus. The `databricks:/<model>` URI form and `fallbacks:` lists are parameterized too. Values already sourced from env/secret are left as-is (only bare literals parameterized).

```
uv run dao-ai agent up -c <config> --param llm=databricks-claude-sonnet-5 -p <profile>
```

## Deprecated model refresh
Deprecated/unavailable endpoints → `databricks-claude-sonnet-5` (as the param default):
`databricks-claude-sonnet-4`, `databricks-claude-3-7-sonnet`, `databricks-claude-haiku`, `databricks-gpt-4o-mini`.
Supported models kept as their existing defaults (`sonnet-4-5`/`4-6`, `opus-4-6`, `haiku-4-5`, `gpt-5-4-mini`, `gpt-oss-120b`, `gte-large-en`, `meta-llama-3-1-8b`).

## Incidental fixes (pre-existing, unrelated to parameterization)
Three configs had a swarm `default_agent` referencing a nonexistent YAML anchor (undefined-alias error, broken on `main`):
- `filtered_mcp`: `*general_agent` → `*safe_sql_agent`
- `conversation_summarization`: `*main_agent` → `*conversational_agent`
- `human_in_the_loop`: `*main_agent` → `*admin_agent`

## Verification
- Every config that loaded before still loads; the three alias-broken configs now load clean.
- No deprecated model literal remains anywhere; `--param` overrides verified.
- Config-only PR — no source changes.

## Not included
- `cache_threshold_optimization.yaml` (an app-less `optimizations` config) surfaced a real source bug in `AppConfig.initialize()` (guards `self.app` on one line but not the next). Being fixed in a separate source PR to keep this one config-only.
- Configs already fully parameterized on `main` are untouched.

This pull request and its description were written by Isaac.