### PR TITLE
fix(config): guard self.app in initialize()/shutdown() for app-less configs

### DIFF
--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -11159,21 +11159,32 @@ class AppConfig(BaseModel):
 
         self._resolve_all_resources()
 
-        logger.debug("Calling initialization hooks...")
-        initialization_functions: Sequence[Callable[..., Any]] = create_hooks(
-            self.app.initialization_hooks
-        )
-        for initialization_function in initialization_functions:
-            logger.debug(
-                f"Running initialization hook: {initialization_function.__name__}"
+        # ``app`` is Optional — app-less configs (e.g. an ``optimizations``-only
+        # config for cache-threshold tuning) have no initialization hooks. Guard
+        # like the log_level check above; without this, from_file() on such a
+        # config raises AttributeError on ``self.app.initialization_hooks``.
+        if self.app is not None:
+            logger.debug("Calling initialization hooks...")
+            initialization_functions: Sequence[Callable[..., Any]] = create_hooks(
+                self.app.initialization_hooks
             )
-            initialization_function(self)
+            for initialization_function in initialization_functions:
+                logger.debug(
+                    f"Running initialization hook: {initialization_function.__name__}"
+                )
+                initialization_function(self)
 
         self._initialized = True
         atexit.register(self.shutdown)
 
     def shutdown(self) -> None:
         from dao_ai.hooks.core import create_hooks
+
+        # ``app`` is Optional — app-less configs have no shutdown hooks. Guard
+        # to match initialize(); otherwise shutdown() (called from from_file)
+        # raises AttributeError on ``self.app.shutdown_hooks``.
+        if self.app is None:
+            return
 
         logger.debug("Calling shutdown hooks...")
         shutdown_functions: Sequence[Callable[..., Any]] = create_hooks(

--- a/tests/dao_ai/test_config.py
+++ b/tests/dao_ai/test_config.py
@@ -66,6 +66,17 @@ def test_app_config_should_shutdown(config: AppConfig) -> None:
 
 
 @pytest.mark.unit
+def test_app_less_config_initialize_and_shutdown_are_guarded() -> None:
+    """``app`` is Optional (e.g. an ``optimizations``-only config). initialize()
+    and shutdown() must guard ``self.app`` — before the guard they raised
+    AttributeError on ``self.app.{initialization,shutdown}_hooks``."""
+    cfg = AppConfig.model_construct(app=None)
+    # Neither should raise despite app being None.
+    cfg.initialize()
+    cfg.shutdown()
+
+
+@pytest.mark.unit
 def test_mcp_function_model_validate_bearer_header_preserves_existing_prefix() -> None:
     """Test that validate_bearer_header preserves existing 'Bearer ' prefix."""
     mcp_function = McpFunctionModel(


### PR DESCRIPTION
## What
Guard `self.app` in `AppConfig.initialize()` and `shutdown()` so app-less configs load.

## Why
`app` is `Optional` on `AppConfig`. An `optimizations`-only config (e.g. `examples/04_genie/cache_threshold_optimization.yaml`, driven via `config.optimizations.optimize()`) legitimately has no `app:` block. But:
- `initialize()` guarded `self.app` for `log_level`, then dereferenced `self.app.initialization_hooks` unconditionally.
- `shutdown()` dereferenced `self.app.shutdown_hooks` unconditionally.

So `AppConfig.from_file()` on such a config raised `AttributeError: 'NoneType' object has no attribute 'initialization_hooks'` (then `'shutdown_hooks'`). Surfaced while validating the example corpus for #237.

## How
Guard both hook paths on `self.app is not None`, matching the existing `log_level` guard. App-bearing configs are unchanged — hooks still run.

## Verification
- `examples/04_genie/cache_threshold_optimization.yaml` now loads via `from_file` (previously raised); app-bearing configs still load and run hooks.
- Regression test loads an `app=None` config through `initialize()` + `shutdown()`; verified it fails with either guard reverted. Full `test_config.py` suite green (33 passed).

Split out of the #237 examples PR to keep that one config-only.

This pull request and its description were written by Isaac.