### PR TITLE
docs(examples): per-app READMEs + parameterize endpoints/models across complete applications

### DIFF
--- a/examples/15_complete_applications/README.md
+++ b/examples/15_complete_applications/README.md
@@ -2,7 +2,9 @@
 
 **Production-ready examples combining multiple features**
 
-End-to-end configurations demonstrating best practices for real-world deployments.
+End-to-end configurations demonstrating best practices for real-world deployments. Each
+application lives in its own directory with a dedicated deep-dive README — this page is the
+directory that links to all of them.
 
 ## Architecture Overview
 
@@ -58,267 +60,29 @@ flowchart TB
     style Data fill:#f3e5f5,stroke:#7b1fa2
 ```
 
-## Examples
+## Applications
 
-| File | Pattern | Description |
-|------|---------|-------------|
-| [`hardware_store.yaml`](./hardware_store/hardware_store.yaml) | 👔 Supervisor | Multi-agent supervisor with full features |
-| [`hardware_store_swarm.yaml`](./hardware_store/hardware_store_swarm.yaml) | 🐝 Swarm | Swarm orchestration with handoffs |
-| [`hardware_store_lakebase.yaml`](./hardware_store/hardware_store_lakebase.yaml) | 👔 Supervisor + 🧠 Lakebase | Supervisor with PostgreSQL memory persistence |
-| [`hardware_store_instructed.yaml`](./hardware_store/hardware_store_instructed.yaml) | 🎯 Instructed | Hardware store with instructed retrieval |
-| [`sporting_goods_store.yaml`](./sporting_goods_store/sporting_goods_store.yaml) | 👔 Supervisor + 🧠 Lakebase | Merchandiser 360 multi-agent system for sporting goods lifecycle management |
-| [`procurement_supplier_a2a/`](./procurement_supplier_a2a/) | 🔁 A2A pair | Procurement officer agent calls a wholesale-supplier agent over the Google A2A protocol — two coordinated Databricks Apps deployments |
+Every application below has its own deep-dive README (architecture diagrams, per-agent breakdown,
+data plane, design rationale, deploy steps, and sample prompts). Start with the README, then open
+the config.
 
-## Hardware Store Supervisor Architecture
+| Application | Config(s) | Orchestration | Feature stack | Docs |
+|---|---|---|---|---|
+| **Brick Store** | [`brick_store.yaml`](./brick_store/brick_store.yaml) | 👔 Supervisor · 7 agents | Lakebase memory · Genie · Vector Search · OBO · guardrails + monitoring | [README](./brick_store/README.md) |
+| **Commerce** | [`commerce_supervisor.yaml`](./commerce/commerce_supervisor.yaml) · [`commerce_swarm.yaml`](./commerce/commerce_swarm.yaml) | 👔 Supervisor / 🔁 Pipeline · 10–11 agents | Lakebase memory · 3× Vector Search · MCP · Unity AI Gateway · guardrails (B2B + B2C) | [supervisor](./commerce/commerce_supervisor.README.md) · [swarm](./commerce/commerce_swarm.README.md) |
+| **Deep Research** | [`deep_research.yaml`](./deep_research/deep_research.yaml) | 🐝 Swarm · 6 agents | Genie · Tavily web search · tiered reasoning LLMs | [README](./deep_research/README.md) |
+| **Executive Assistant** | [`executive_assistant.yaml`](./executive_assistant/executive_assistant.yaml) | 🤖 Single agent | Genie · Tavily web search | [README](./executive_assistant/README.md) |
+| **Genie + Genie MCP** | [`genie_and_genie_mcp.yaml`](./genie_and_genie_mcp/genie_and_genie_mcp.yaml) | 👔 Supervisor · 2 agents | Native Genie tool vs. managed Genie **MCP** over the same space | [README](./genie_and_genie_mcp/README.md) |
+| **Genie + Vector Search Hybrid** | [`genie_vector_search_hybrid.yaml`](./genie_vector_search_hybrid/genie_vector_search_hybrid.yaml) | 👔 Supervisor · 2 agents | Structured Genie/SQL path + unstructured Vector Search path | [README](./genie_vector_search_hybrid/README.md) |
+| **Hardware Store** | [`hardware_store.yaml`](./hardware_store/hardware_store.yaml) · [`_instructed`](./hardware_store/hardware_store_instructed.yaml) · [`_swarm`](./hardware_store/hardware_store_swarm.yaml) · [`_lakebase`](./hardware_store/hardware_store_lakebase.yaml) | 👔 Supervisor / 🐝 Swarm · 5–7 agents | Vector Search · instructed retrieval (RRF + FlashRank) · Lakebase · MCP · guardrails · SQL tools + HITL | [README](./hardware_store/README.md) |
+| **Loyalty Offer Personalization** | [`loyalty_offer_personalization.yaml`](./loyalty_offer_personalization/loyalty_offer_personalization.yaml) | 👔 Supervisor · 7 agents | Lakebase memory · Genie · Vector Search · 7 UC SQL functions incl. `ai_query` ranker | [README](./loyalty_offer_personalization/README.md) |
+| **Procurement ↔ Supplier (A2A)** | [`procurement.yaml`](./procurement_supplier_a2a/procurement.yaml) · [`supplier.yaml`](./procurement_supplier_a2a/supplier.yaml) | 🔁 A2A pair · 2 apps | Google A2A protocol · cross-app calls · on-behalf-of-user identity forwarding | [README](./procurement_supplier_a2a/README.md) |
+| **Quick Serve Restaurant** | [`quick_serve_restaurant.yaml`](./quick_serve_restaurant/quick_serve_restaurant.yaml) | 🐝 Swarm · single `barista` | Vector Search over menu · UC SQL functions · in-memory state | [README](./quick_serve_restaurant/README.md) |
+| **Reservations System** | [`reservations_system.yaml`](./reservations_system/reservations_system.yaml) | 👔 Supervisor · 1 agent | Human-in-the-loop confirmation · in-memory checkpointer *(minimal demo)* | [README](./reservations_system/README.md) |
+| **Sporting Goods Store — Merchandiser 360** | [`sporting_goods_store.yaml`](./sporting_goods_store/sporting_goods_store.yaml) · [`_slim`](./sporting_goods_store/sporting_goods_store_slim.yaml) | 👔 Supervisor · 7 agents | Lakebase memory · 2× Genie rooms · Vector Search · guardrails + monitoring | [README](./sporting_goods_store/README.md) |
 
-```mermaid
-%%{init: {'theme': 'base'}}%%
-flowchart TB
-    subgraph User["👤 Customer"]
-        Query["Do you have Dewalt drills?<br/>What's the price and stock?"]
-    end
-
-    subgraph Supervisor["🎯 Supervisor Agent"]
-        Router["Routing LLM<br/>Analyzes request<br/>Routes to specialist"]
-    end
-
-    subgraph Specialists["👷 Specialized Agents"]
-        General["💬 General"]
-        Orders["📋 Orders"]
-        DIY["🔧 DIY"]
-        Product["🛒 Product"]
-        Inventory["📦 Inventory"]
-        Comparison["⚖️ Comparison"]
-        Recommendation["💡 Recommendation"]
-    end
-
-    subgraph Features["✨ Applied Features"]
-        Memory["🧠 Memory"]
-        Middleware["🔒 Middleware"]
-        Guard["🛡️ Guardrails"]
-    end
-
-    Query --> Router
-    Router --> General
-    Router --> Orders
-    Router --> DIY
-    Router --> Product
-    Router --> Inventory
-    Router --> Comparison
-    Router --> Recommendation
-    Specialists --> Features
-
-    style Supervisor fill:#fff3e0,stroke:#e65100
-    style Specialists fill:#e8f5e9,stroke:#2e7d32
-    style Features fill:#e3f2fd,stroke:#1565c0
-```
-
-## Hardware Store Swarm Architecture
-
-```mermaid
-%%{init: {'theme': 'base'}}%%
-flowchart TB
-    subgraph User["👤 Customer"]
-        Query["Compare Dewalt vs Milwaukee drills<br/>Check stock for both"]
-    end
-
-    subgraph Swarm["🐝 Agent Swarm"]
-        General["💬 General<br/>Entry Point"]
-        Orders["📋 Orders"]
-        DIY["🔧 DIY"]
-        Product["🛒 Product"]
-        Inventory["📦 Inventory<br/>Terminal"]
-        Comparison["⚖️ Comparison"]
-        Recommendation["💡 Recommendation"]
-    end
-
-    subgraph Features["✨ Applied Features"]
-        Memory["🧠 Memory"]
-        Middleware["🔒 Swarm Middleware"]
-    end
-
-    Query --> General
-    General -->|handoff| Orders
-    General -->|handoff| DIY
-    General -->|handoff| Product
-    General -->|handoff| Inventory
-    General -->|handoff| Comparison
-    General -->|handoff| Recommendation
-    DIY -->|handoff| Product
-    DIY -->|handoff| Inventory
-    DIY -->|handoff| Recommendation
-    Swarm --> Features
-
-    style General fill:#1565c0,stroke:#0d47a1,color:#fff
-    style Inventory fill:#42BA91,stroke:#00875C
-    style Swarm fill:#e8f5e9,stroke:#2e7d32
-    style Features fill:#e3f2fd,stroke:#1565c0
-```
-
-**Swarm Handoff Configuration:**
-- **General** (blue, entry point): Can handoff to any agent
-- **DIY**: Can handoff to product, inventory, recommendation
-- **Inventory** (green): Terminal agent with no outbound handoffs
-
----
-
-## Sporting Goods Store - Merchandiser 360
-
-A multi-agent system for sporting goods merchandising lifecycle management. Covers the full merchandiser workflow: assortment planning, demand forecasting, purchase orders, pricing strategy, sales analytics, and inventory management across categories like athletic footwear, apparel, team sports, fitness equipment, outdoor/camping, cycling, golf, and accessories.
-
-### Merchandiser 360 Architecture
-
-```mermaid
-%%{init: {'theme': 'base'}}%%
-flowchart TB
-    subgraph User["👤 Merchandiser"]
-        Query["What's the demand forecast<br/>for running shoes next quarter?"]
-    end
-
-    subgraph SupervisorLayer["🎯 Supervisor"]
-        Router["Routing LLM<br/>gpt-5-4-mini<br/>Routes to specialist"]
-    end
-
-    subgraph Specialists["👷 7 Specialized Agents"]
-        Assortment["📊 Assortment<br/>Planning"]
-        Forecasting["📈 Demand<br/>Forecasting"]
-        PurchaseOrder["📋 Purchase<br/>Orders"]
-        Pricing["💲 Pricing<br/>Strategy"]
-        Sales["🏷️ Sales<br/>Analytics"]
-        InventoryAgent["📦 Inventory<br/>Management"]
-        General["💬 General<br/>Assistant"]
-    end
-
-    subgraph MemoryLayer["🧠 Lakebase Persistent Memory"]
-        Checkpointer["Checkpointer"]
-        Store["User Store<br/>per-user namespace"]
-        Extraction["Memory Extraction<br/>user_profile, preference, episode"]
-    end
-
-    subgraph DataLayer["☁️ Databricks Platform"]
-        GenieRooms["🧞 Genie Rooms x2"]
-        UCFunctions["⚙️ UC Functions x6"]
-        VectorSearch["🔍 Vector Search"]
-        Lakebase["🗄️ Lakebase"]
-        LLMs["🧠 LLM Endpoints"]
-    end
-
-    Query --> Router
-    Router --> Assortment
-    Router --> Forecasting
-    Router --> PurchaseOrder
-    Router --> Pricing
-    Router --> Sales
-    Router --> InventoryAgent
-    Router --> General
-    Specialists --> MemoryLayer
-    Specialists --> DataLayer
-
-    style SupervisorLayer fill:#fff3e0,stroke:#e65100
-    style Specialists fill:#e8f5e9,stroke:#2e7d32
-    style MemoryLayer fill:#e3f2fd,stroke:#1565c0
-    style DataLayer fill:#f3e5f5,stroke:#7b1fa2
-```
-
-### Agents
-
-| Agent | Description | Tools |
-|-------|-------------|-------|
-| **Assortment Planning** | Category mix, planogram strategy, seasonal transitions, product lifecycle | Genie (Merchandising Analytics), Vector Search |
-| **Demand Forecasting** | Sales predictions, trend analysis, seasonal demand, stockout risk | Genie (Merchandising Analytics), Current Time |
-| **Purchase Orders** | PO lifecycle, vendor relations, buying decisions, receiving | Genie (Merchandising Analytics), find_inventory_by_sku |
-| **Pricing Strategy** | Markdowns, promotions, competitive pricing, clearance, margin analysis | Genie (Sales & Pricing), find_product_by_sku, find_product_by_upc |
-| **Sales Analytics** | Store comparisons, revenue tracking, department sales, return analysis | Genie (Sales & Pricing), find_inventory_by_sku, Vector Search |
-| **Inventory Management** | Stock levels, replenishment, allocation, store-level availability | find_inventory_by_sku/upc, find_store_inventory_by_sku/upc, Vector Search |
-| **General Assistant** | Product information, store inquiries, general questions | Vector Search |
-
-### Tools and Data Sources
-
-```mermaid
-%%{init: {'theme': 'base'}}%%
-flowchart LR
-    subgraph GenieTools["🧞 Genie Rooms"]
-        G1["Merchandising Analytics<br/>Assortment, demand, POs,<br/>category performance"]
-        G2["Sales & Pricing Analytics<br/>Revenue, margins, promos,<br/>competitive pricing"]
-    end
-
-    subgraph UCTools["⚙️ Unity Catalog Functions"]
-        UC1["find_product_by_sku"]
-        UC2["find_product_by_upc"]
-        UC3["find_inventory_by_sku"]
-        UC4["find_inventory_by_upc"]
-        UC5["find_store_inventory_by_sku"]
-        UC6["find_store_inventory_by_upc"]
-    end
-
-    subgraph VSTools["🔍 Vector Search"]
-        VS1["Product Catalog Search<br/>Hybrid query + Instructed retrieval<br/>Decomposition + Reranking"]
-    end
-
-    subgraph Caching["⚡ Caching Layer"]
-        C1["LRU Cache<br/>capacity: 100, TTL: 1h"]
-        C2["Semantic Cache<br/>similarity: 0.85, TTL: 24h"]
-    end
-
-    GenieTools --> Caching
-
-    style GenieTools fill:#e3f2fd,stroke:#1565c0
-    style UCTools fill:#e8f5e9,stroke:#2e7d32
-    style VSTools fill:#fff3e0,stroke:#e65100
-    style Caching fill:#fce4ec,stroke:#c2185b
-```
-
-### Key Features
-
-- **Lakebase Persistent Memory** -- Checkpointer for conversation state, per-user namespace store, and background memory extraction across three schemas (`user_profile`, `preference`, `episode`). Memories are auto-injected into agent context (limit: 5).
-- **Instructed Retrieval** -- Vector search with query decomposition into up to 3 sub-queries, Reciprocal Rank Fusion (RRF, k=60) for merging, normalized filter case (uppercase), and LLM-based reranking with domain-specific instructions.
-- **Genie Caching** -- Dual-layer caching on both Genie rooms: LRU cache (100 capacity, 1h TTL) plus context-aware semantic cache via Lakebase (0.85 similarity threshold, 24h TTL). Persistent conversation history enabled.
-- **Monitoring** -- Built-in scorers (`safety`, `completeness`, `relevance_to_query`, `tool_call_efficiency`) at 100% sample rate, plus custom guideline scorers at 50% (`merchandising_accuracy`, `tool_usage_quality`, `response_professionalism`).
-- **Reusable Prompts** -- 7 prompts defined as first-class config objects with `environment` and `domain` tags, referenced by the agents via YAML anchors.
-- **Middleware** -- Store number field validation (`store_num`) ensures inventory and sales lookups are scoped to the correct location.
-- **Evaluation** -- 25 auto-generated eval questions with merchandising-specific guidelines covering all 7 agent specializations and multiple user personas (merchandiser, buyer, pricing analyst, store manager, demand planner).
-- **Service Principal** -- Dedicated `retail_consumer_goods_sp` service principal with secrets managed via Unity Catalog scopes.
-- **LLM Fallbacks** -- Tool-calling LLM configured with automatic fallback (`claude-sonnet-4-6` -> `claude-sonnet-4-5`).
-
-### Datasets
-
-| Table | Description |
-|-------|-------------|
-| `products` | Product catalog with SKU, UPC, brand, sport category, pricing, and descriptions |
-| `inventory` | Stock levels across all stores and warehouses |
-| `dim_stores` | Store dimension table with location and attributes |
-| `sales_orders` | Sales transaction history |
-| `purchase_orders` | Purchase order records with vendor and status tracking |
-| `pricing_history` | Historical pricing changes, markdowns, and promotions |
-
-All tables live in `retail_consumer_goods.sporting_goods_store` within Unity Catalog.
-
-### Quick Start
-
-```bash
-# Validate the sporting goods store configuration
-dao-ai validate -c examples/15_complete_applications/sporting_goods_store/sporting_goods_store.yaml
-
-# Run in chat mode
-dao-ai chat -c examples/15_complete_applications/sporting_goods_store/sporting_goods_store.yaml
-
-# Visualize the multi-agent architecture
-dao-ai graph -c examples/15_complete_applications/sporting_goods_store/sporting_goods_store.yaml -o sporting_goods_architecture.png
-
-# Deploy to Databricks
-dao-ai workflow up -c examples/15_complete_applications/sporting_goods_store/sporting_goods_store.yaml
-```
-
-### Sample Prompts
-
-- "What Nike running shoes do we carry?"
-- "What's the demand forecast for running shoes next quarter?"
-- "Show me open purchase orders from Nike"
-- "What are our margin targets for footwear?"
-- "How are trail running shoes performing this month?"
-- "What's the stock level on SKU NKE-RUN-001?"
-
----
+**Orchestration legend:** 👔 Supervisor (hub-and-spoke routing) · 🐝 Swarm (peer handoffs) ·
+🔁 Pipeline / A2A (staged or app-to-app).
 
 ## Feature Integration
 
@@ -460,19 +224,28 @@ app:
 
 ## Quick Start
 
+Every application follows the same lifecycle. Point `-c` at any config above; use `-p` to select
+your Databricks profile. Apps that ship a `data/` + `functions/` directory provision their infra
+with `workflow up`; config-only apps use `agent up`.
+
 ```bash
-# Validate complete application
+# Validate any complete application
 dao-ai validate -c examples/15_complete_applications/hardware_store/hardware_store.yaml
 
-# Run in chat mode
-dao-ai chat -c examples/15_complete_applications/hardware_store/hardware_store.yaml
+# Run in chat mode (local)
+dao-ai chat -c examples/15_complete_applications/hardware_store/hardware_store.yaml -p DEFAULT
 
-# Visualize architecture
+# Visualize the multi-agent architecture
 dao-ai graph -c examples/15_complete_applications/hardware_store/hardware_store.yaml -o architecture.png
 
-# Deploy to Databricks
-dao-ai workflow up -c examples/15_complete_applications/hardware_store/hardware_store.yaml
+# Deploy — provision infra (Vector Search, Lakebase, Genie…) + deploy the agent
+dao-ai workflow up -c examples/15_complete_applications/hardware_store/hardware_store.yaml -p DEFAULT
+
+# Deploy a config-only app (no infra to provision)
+dao-ai agent up -c examples/15_complete_applications/reservations_system/reservations_system.yaml -p DEFAULT
 ```
+
+See each application's README for its exact provisioning path and verification steps.
 
 ## Deployment Options
 

--- a/examples/15_complete_applications/brick_store/README.md
+++ b/examples/15_complete_applications/brick_store/README.md
@@ -1,0 +1,489 @@
+# Brick Store — In-Store Associate Companion
+
+> **Multi-agent companion for the retail floor on dao-ai.** A **supervisor** routing coordinator fronts **7 specialist agents** covering the whole in-store experience — product lookup, real-time inventory + nearby-store checks, BOPIS pickups, customer appointment prep, personal styling, and manager-on-duty employee oversight. Lakebase-backed persistent memory learns each associate's role and workflow across sessions, a single Genie room powers ad-hoc analytics, and **on-behalf-of-user credentials** run every model, retriever, warehouse, and Genie call so the app respects the requester's own Unity Catalog grants.
+
+| ✨ Feature | What this example shows |
+|---|---|
+| 👔 **Supervisor orchestration** | A dedicated routing coordinator (`supervisor`) that answers nothing itself — it reads the request and hands off to exactly one of 7 specialists via handoff tools. Hub-and-spoke: specialists return to the supervisor, not to each other. |
+| 🧑‍💼 **On-behalf-of-user everywhere** | `on_behalf_of_user: true` on every LLM, vector store, warehouse, Genie room, and embedding call — so inventory, customer, and analytics reads resolve against the **associate's own** UC permissions. Only UC functions and Lakebase are SP-backed. |
+| 🧠 **Persistent associate memory** | Lakebase checkpointer + namespaced store + background extraction of `user_profile` / `preference` / `episode`. `auto_inject: true` prepends the top-5 memories to each agent's prompt, so the companion learns an associate's store, shift, and workflow over time. |
+| 📊 **Genie room, two doors** | One Genie space (`brickstore_genie_room`) exposed as **two tools** — `query_store_ops_analytics` and `query_employee_insights` — so the supervisor's routing heuristics cleanly separate store-ops analytics from team analytics. Backed by a two-tier cache (LRU + embedding-similarity). |
+| 🔎 **Decomposed hybrid retrieval** | The `products` retriever runs HYBRID search with LLM query **decomposition** (≤3 subqueries, RRF fusion), an LLM reranker, and a `ms-marco-MiniLM` cross-encoder rerank — turning "black Adidas Gazelle size 10" into structured filters. |
+| 📍 **Haversine nearby-store search** | `find_nearby_stores_inventory` computes great-circle distance from lat/long to find the closest stores that actually have the SKU in stock — the out-of-stock fallback path. |
+| 🛡️ **Custom-field validation middleware** | `store_validation` requires a `store_num` on every turn before any agent runs — inventory, task, and customer lookups are all store-scoped. |
+| 📈 **Production monitoring + guidelines** | `sample_rate: 1.0` with `safety` / `completeness` / `relevance_to_query` / `tool_call_efficiency` scorers plus three custom guideline groups (accuracy, tool-usage, professionalism). |
+| 🚀 **One config → MS + Apps** | The same YAML deploys to Model Serving and Databricks Apps. OBO on 18 resources + 15 SP-backed UC fns + 1 Lakebase keeps the app under the Apps 20-resource budget. |
+
+---
+
+## Architecture
+
+The system is built from a few interacting layers. Each layer below has a focused diagram; together they describe the full picture.
+
+### 1. System layers
+
+The top-level shape: client (an associate with a `store_num`) → app (validation middleware + memory injection + supervisor + 7 specialists) → the model, data, memory, and analytics planes. Everything except UC functions and Lakebase runs on the associate's own token.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1565c0', 'fontSize': '14px'}}}%%
+flowchart LR
+    Client["🖥️ Associate<br/>store_num + user_id"]
+
+    subgraph App["🚀 Databricks App · brick_store_dao"]
+        direction TB
+        MW["🛡️ store_validation<br/>(require store_num)"]
+        MI["🧠 memory inject<br/>(top-5)"]
+        Sup["👔 supervisor<br/>gpt-5-4-mini"]
+        Spokes["🧑‍💼 7 specialists<br/>claude-sonnet-4-5"]
+        Ext["💾 extraction (bg)"]
+        MW --> MI --> Sup --> Spokes
+        Spokes -.-> Ext
+    end
+
+    Models["🤖 Model Serving<br/>OBO chat · embed"]
+    Lakebase[("🗄️ Lakebase<br/>SP-backed memory")]
+    UC["🏛️ Unity Catalog<br/>10 tables · 15 UC fns · 2 VS indexes"]
+    Genie["📊 Genie room<br/>+ 2-tier cache"]
+
+    Client --> App
+    Spokes <-.->|chat / tool-call| Models
+    Spokes <-.->|checkpoint + memory| Lakebase
+    MI <-.->|search| Lakebase
+    Ext -.->|write| Lakebase
+    Spokes -->|UC fns + VS| UC
+    Spokes <-.->|NL analytics| Genie
+    Genie <-.->|cache| Lakebase
+
+    style App fill:#fff8e1,stroke:#f57f17,stroke-width:2px
+    style Models fill:#f3e5f5,stroke:#7b1fa2
+    style Lakebase fill:#e8f5e9,stroke:#2e7d32
+    style UC fill:#e3f2fd,stroke:#1565c0
+    style Genie fill:#ede7f6,stroke:#512da8
+    style Spokes fill:#fffde7,stroke:#fbc02d
+```
+
+**Key wiring details that are easy to miss:**
+- **OBO is inverted vs. a typical dao-ai app.** Here almost everything is `on_behalf_of_user: true` — the chat/tool models, the embedding model, both vector stores, the warehouse, and the Genie room. The associate's forwarded token drives every read, so per-user UC grants are enforced end-to-end. The two exceptions are **UC functions** (SP-backed) and **Lakebase** (SP-backed) — see [Why these design choices](#why-these-design-choices).
+- **UC functions are SP-backed on purpose.** `DatabricksFunctionClient` runs UC functions over Spark Connect serverless, and the OBO token forwarded by Model Serving does not carry the `databricks-connect` OAuth scope. With OBO the tools throw `PERMISSION_DENIED: required scopes: databricks-connect`. The SP path uses workspace credentials and works in both Model Serving and Apps.
+- **The Genie room's cache lives in Lakebase.** The `context_aware_cache` embeds each question and does a `0.85`-similarity lookup before re-running Genie — so paraphrased analytics questions hit cache. That cache table shares the same Lakebase project as agent memory.
+
+### 2. Orchestration topology
+
+This is a classic **supervisor / hub-and-spoke**, not a pipeline. The supervisor is a pure router — it holds no data tools (only `app_info`) and is explicitly instructed to answer nothing itself. It picks one specialist per turn; the specialist does its tool work and returns.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1565c0', 'fontSize': '14px'}}}%%
+flowchart TB
+    Start(("user msg<br/>+ store_num"))
+    Supervisor["👔 supervisor<br/>gpt-5-4-mini<br/><i>route only · no data tools</i>"]
+
+    subgraph Specialists["7 Specialist Agents · claude-sonnet-4-5"]
+        direction TB
+        General["💬 general"]
+        Product["🏷️ product"]
+        Inventory["📦 inventory"]
+        Orders["🛍️ orders (BOPIS)"]
+        Customer["👤 customer"]
+        Stylist["✨ stylist"]
+        Employee["👥 employee"]
+    end
+
+    End(("response"))
+
+    Start ==> Supervisor
+    Supervisor -.->|handoff| General
+    Supervisor -.->|handoff| Product
+    Supervisor -.->|handoff| Inventory
+    Supervisor -.->|handoff| Orders
+    Supervisor -.->|handoff| Customer
+    Supervisor -.->|handoff| Stylist
+    Supervisor -.->|handoff| Employee
+
+    General ==> End
+    Product ==> End
+    Inventory ==> End
+    Orders ==> End
+    Customer ==> End
+    Stylist ==> End
+    Employee ==> End
+
+    style Supervisor fill:#fff3e0,stroke:#e65100,stroke-width:3px
+    style Product fill:#e1f5fe,stroke:#0277bd
+    style Inventory fill:#e1f5fe,stroke:#0277bd
+    style Stylist fill:#fce4ec,stroke:#c2185b
+    style Specialists fill:#fafafa,stroke:#9e9e9e
+    style Start fill:#e0e0e0,stroke:#424242
+    style End fill:#e0e0e0,stroke:#424242
+```
+
+**Wired in the YAML as:**
+```yaml
+app:
+  agents: [*general, *orders, *product, *inventory, *customer, *stylist, *employee]
+  orchestration:
+    memory: *memory
+    supervisor:
+      model: *supervisor_llm          # gpt-5-4-mini — routing only
+      tools: [*app_info_tool]          # no data tools by design
+      prompt: |
+        You are a routing coordinator ... You do NOT answer questions
+        yourself ... You MUST hand off every request to one of: general,
+        orders, product, inventory, customer, stylist, employee.
+      middleware: [*store_validation]  # require store_num before routing
+```
+
+Each specialist advertises a `handoff_prompt` (e.g. inventory: *"Stock levels at this store, nearby-store availability, out-of-stock alternatives, or hold guidance."*) that the supervisor reads to pick the target.
+
+### 3. Per-turn execution lifecycle
+
+The full sequence for one associate turn. The validation middleware and background extraction never appear in the `agents:` block directly — dao-ai wires them in from `middleware:` and `memory.extraction`.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'fontSize': '13px'}}}%%
+sequenceDiagram
+    autonumber
+    actor User as Associate
+    participant V as 🛡️ store_validation
+    participant MI as 🧠 memory inject
+    participant Sup as 👔 supervisor<br/>(gpt-5-4-mini)
+    participant Spec as 🧑‍💼 specialist<br/>(claude-sonnet-4-5)
+    participant Store as 🗄️ Lakebase store
+    participant Tools as 🛠️ UC fn / VS / Genie
+    participant Ext as 💾 extraction (bg)
+
+    User->>V: message + store_num + user_id
+    V->>V: store_num present? else ask for it
+    V->>Sup: pass message
+
+    MI->>Store: search memories (ns=user_id)
+    Store-->>MI: top-5
+    MI-->>Sup: ## Memories injected
+    Sup->>Sup: pick specialist (handoff tool-call)
+
+    Sup->>Spec: handoff_to_<specialist>
+    MI->>Store: search memories
+    Store-->>MI: top-5
+    MI-->>Spec: ## Memories injected
+    Spec->>Tools: find_*_uc / product_vector_search / query_*_analytics
+    Tools-->>Spec: rows / documents / analytics
+    Spec-->>Sup: specialist answer
+    Sup-->>User: response
+
+    Note over Sup,Ext: turn complete · post-turn (async)
+    Sup-->>Ext: turn finalized
+    Ext->>Store: write user_profile / preference / episode
+```
+
+**Observations:**
+- **The supervisor pays one LLM call to route**, on the fast `gpt-5-4-mini` endpoint. Specialists run the heavier `claude-sonnet-4-5` because they do the multi-step tool reasoning (resolve SKU → check stock → find nearby stores → synthesize).
+- **Memory injection fires before every LLM call** (`auto_inject: true`, `auto_inject_limit: 5`) — it prepends a `## Memories` block sourced from a semantic search of the Lakebase store, namespaced by `user_id`.
+- **Extraction is decoupled** (`background_extraction: true`) so it never blocks the reply. It uses the Claude `extraction_model` to distil the turn into `user_profile` / `preference` / `episode` records, with a `query_model` on the fast endpoint for search-query rephrasing.
+- **`store_validation` gates the whole turn.** If `store_num` is missing, the middleware asks for it before any agent runs — inventory/task/customer lookups are store-scoped and meaningless without it. `user_id` is optional.
+
+### 4. Persistent memory across shifts
+
+Same `user_id`, new thread → the companion still knows the associate's store, role, and recent workflow. Lakebase is durable, so learning survives across sessions.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'fontSize': '13px'}}}%%
+sequenceDiagram
+    autonumber
+    actor A as Associate (sarah.associate)
+    participant Sup as 👔 supervisor
+    participant Inv as 📦 inventory
+    participant MW as 🧠 memory
+    participant Store as 🗄️ Lakebase store<br/>(ns=user_id)
+    participant Ext as 💾 extraction (bg)
+
+    rect rgb(232, 245, 233)
+        Note over A,Ext: Shift 1 — thread A
+        A->>Sup: "Check black Gazelles at Downtown Market" (store 101)
+        Sup-->>Inv: handoff
+        Note over MW: injects ## Memories (empty on first use)
+        Inv->>A: stock answer
+        Note over Ext: async
+        Ext->>Store: write user_profile {role: associate, store_num: 101}
+        Ext->>Store: append episode {workflow: in-aisle assist}
+    end
+
+    rect rgb(227, 242, 253)
+        Note over A,Ext: Shift 2 — new thread, same user_id
+        A->>Sup: "Any of these left nearby?"
+        Sup-->>Inv: handoff
+        MW->>Store: semantic search
+        Store-->>MW: {store 101, in-aisle assist}
+        MW->>Inv: prepend ## Memories
+        Inv->>Inv: default reference store → 101
+        Inv->>A: nearby-store availability, no re-ask
+    end
+```
+
+**Three memory schemas extracted automatically** (`extraction.schemas`), guided by instructions that tell the extractor to capture the associate's role (associate / manager / stylist / pickup-desk), their `store_num`, typical workflow, frequently-referenced customers/products/departments, and notable interactions (hold placements, prep sessions, BOPIS pickups, styling outcomes, overdue-task flags):
+
+| Schema | Cardinality | Example contents |
+|---|---|---|
+| `user_profile` | 1 per user | `{role: "stylist", store_num: "101", workflow: "appointment prep"}` |
+| `preference` | many per user | `{preferred_store: 101}`, `{preferred_shift: "morning"}` |
+| `episode` | many per user | `{event: "styling_session", customer: "CUST-005", outcome: "3-look capsule"}` |
+
+---
+
+## Agents
+
+All 7 specialists run `tool_calling_llm` (**databricks-claude-sonnet-4-5**, temp 0.1, with a self-referencing fallback). The supervisor runs `supervisor_llm` (**databricks-gpt-5-4-mini**, temp 0.1, 1024 tokens) and holds no data tools.
+
+| # | Agent | Model | Tools | Role |
+|---|---|---|---|---|
+| — | `supervisor` | gpt-5-4-mini | `app_info` | Routing coordinator. Answers nothing; hands off to exactly one specialist. `store_validation` middleware attached. |
+| 1 | `general` | claude-sonnet-4-5 | `current_time`, `find_store_details_by_location`, `find_store_by_number_uc`, `find_upcoming_customer_appointments_uc`, `get_customer_details_uc`, `query_store_ops_analytics` | Store info, hours, location, services; quick customer/appointment context; fallback + specialist deferral. |
+| 2 | `orders` | claude-sonnet-4-5 | `current_time`, `get_customer_details_uc`, `query_store_ops_analytics` | BOPIS pickups, cross-channel order tracking, delivery scheduling. **Holds are narrative-only** (`HOLD-<store_id>-<yyyymmddhhmm>`) — never claims a row was written. |
+| 3 | `product` | claude-sonnet-4-5 | `product_vector_search`, `find_product_by_sku_uc`, `find_product_by_upc_uc`, `query_store_ops_analytics` | Catalog lookup (SKU/UPC/description), comparisons, recommendations. Absorbs the "compare" + "recommend" roles. |
+| 4 | `inventory` | claude-sonnet-4-5 | `find_inventory_by_sku_uc`, `find_inventory_by_upc_uc`, `find_store_inventory_by_sku_uc`, `find_store_inventory_by_upc_uc`, `find_nearby_stores_inventory_uc`, `product_vector_search` | Home-store stock, all-store stock, and Haversine nearby-store fallback when a SKU is out. |
+| 5 | `customer` | claude-sonnet-4-5 | `find_upcoming_customer_appointments_uc`, `get_customer_details_uc`, `get_customer_preparation_summary_uc`, `product_vector_search`, `find_inventory_by_sku_uc` | Pre-visit prep — "who's coming in today and what should I have ready." Surfaces `requires_manager_greeting`; treats alerts/dietary/accessibility as sensitive. |
+| 6 | `stylist` | claude-sonnet-4-5 | `get_customer_details_uc`, `get_customer_preparation_summary_uc`, `product_vector_search`, `find_store_inventory_by_sku_uc`, `find_personal_shopping_associates_uc` | Active styling sessions: build a 3-look capsule from prep-sheet preferences, confirm stock, find an available stylist. |
+| 7 | `employee` | claude-sonnet-4-5 | `find_top_employees_by_department_uc`, `find_personal_shopping_associates_uc`, `find_employee_manager_uc`, `find_task_assignments_uc`, `query_employee_insights` | Manager-on-duty: top performers, task status/overdue, manager lookup, team-level analytics. |
+
+**Model assignment rationale:**
+- **`gpt-5-4-mini`** (`fast_llm` / `supervisor_llm` / `query_model` / `decomposition_llm`) — routing, memory-query rephrasing, and retrieval query decomposition. Fast, cheap, high tool-call fidelity.
+- **`claude-sonnet-4-5`** (`tool_calling_llm` / `judge_llm` / `extraction_model`) — the specialists' multi-step reasoning, the offline eval judge, and background memory extraction.
+- **`databricks-gte-large-en`** — embeddings for both vector-search indexes, the Lakebase memory store, and the Genie context-aware cache.
+
+---
+
+## Data plane
+
+### Schema layout
+
+Everything lands in `retail_consumer_goods.store_ops` (`${var.catalog}.${var.schema}`).
+
+```
+retail_consumer_goods.store_ops/
+├── 📊 Core tables (via datasets:)
+│   ├── products              ← VS source (long_description embedded); 40+ cols
+│   ├── inventory             ← per-store on-hand, backstock, aisle, popularity
+│   ├── dim_stores            ← store directory w/ lat/long (Haversine source)
+│   ├── customers             ← profiles: tier, size/color/brand prefs, alerts…
+│   ├── appointments          ← customer appointment scheduling
+│   ├── employee_tasks        ← task assignments + 3 helper VIEWs
+│   ├── employee_performance  ← monthly perf + 3 helper VIEWs
+│   ├── managers              ← manager directory + lookup VIEW
+│   └── (customers.sql also creates upcoming_customer_appointments + customer_preparation_summary VIEWs)
+│
+├── 🧪 Brand-rep demo tables (kept for Genie coverage)
+│   └── customer_brand_profiles · product_performance · customer_feedback
+│       · competitive_insights · sales_interactions
+│
+├── 🛠️ UC Functions (15 registered; 1 more present but unregistered)
+│   ├── Product/inventory:  find_product_by_sku · find_product_by_upc
+│   │                       find_inventory_by_sku · find_inventory_by_upc
+│   │                       find_store_inventory_by_sku · find_store_inventory_by_upc
+│   │                       find_store_by_number · find_nearby_stores_inventory
+│   ├── Employee/customer:  find_top_employees_by_department
+│   │                       find_personal_shopping_associates · find_employee_manager
+│   │                       find_task_assignments · find_upcoming_customer_appointments
+│   │                       get_customer_details · get_customer_preparation_summary
+│   └── (present, not wired: extract_store_numbers.sql)
+│
+└── 🔍 VS Indexes (2) — STANDARD endpoint dbdemos_vs_endpoint, gte-large-en embeddings
+    ├── product_description_index ← source: products.long_description  (HYBRID + decomposition + rerank)
+    ├── store_details_indexed     ← source: dim_stores.store_details_text  (ANN)
+```
+
+### Synthetic data overview
+
+Data is committed as static `*.sql` DDL + `*_data.sql` seed files — no runtime generation.
+
+| Table | Rows (seed) | Notes |
+|---|---|---|
+| `products` | ~14 | Apparel / footwear / accessories / electronics / home goods. Deep column set (SKU, UPC, brand, department, category, color, size, base_price, `long_description` for VS). Brands include Adidas, Nike, Lululemon. |
+| `inventory` | ~31 | Per-store on-hand quantity, warehouse backstock, retail amount, popularity, aisle location. |
+| `dim_stores` | ~158 | Store directory with `latitude`/`longitude` (drives Haversine nearby-store search), hours, type, departments. Named stores like Downtown Market (101), Marina Market (102), Mission Market (103). |
+| `customers` | ~5 | Rich profiles: tier, style/size/color/brand preferences, lifetime spend, satisfaction, upcoming appointment, and sensitive fields (`dietary_restrictions`, `accessibility_needs`, `customer_alerts`). Uses ids like `CUST-005`. |
+| `appointments` | ~5 | Customer appointment scheduling: type, date/time, store, stylist, status. |
+| `employee_tasks` | ~19 | Task assignments (store, employee, type, priority, status, due, overdue flag) + `employee_daily_tasks` / `task_performance_metrics` / `manager_task_overview` views. |
+| `employee_performance` | ~23 | Monthly sales achievement, task completion, satisfaction, attendance, by department + `top_*` views. Uses ids like `EMP-016`. |
+| `managers` | ~9 | Manager directory: contact info, department, comms prefs, schedule + `manager_employee_lookup` view. |
+| `brand_rep_demo_*` | ~48 tuples / 5 tables | Brand-rep training tables (`customer_brand_profiles`, `product_performance`, `customer_feedback`, `competitive_insights`, `sales_interactions`) kept for Genie analytics coverage. |
+
+**Two representative UC functions:**
+- `find_nearby_stores_inventory(reference_store_id, sku[], max_results)` — joins `dim_stores` + `inventory`, computes **Haversine great-circle miles** from the reference store's lat/long, and returns the closest stores that carry the SKU in stock. This is the inventory agent's out-of-stock fallback.
+- `get_customer_preparation_summary(customer_id[])` — returns sizes, colors, brand preferences, accessibility needs, hours-until-appointment, and a `requires_manager_greeting` flag for the customer/stylist prep workflow.
+
+---
+
+## Why these design choices?
+
+### Why supervisor / hub-and-spoke instead of a pipeline?
+
+The in-store workflows are **independent, single-shot intents** — "is this in stock," "who's coming in," "who's my top performer." There's no fixed multi-stage sequence to model, so a linear pipeline would be a poor fit. A supervisor that reads the request and routes to one specialist keeps each agent focused and makes "add a specialist" a one-line change to the `agents:` list plus a `handoff_prompt`.
+
+### Why on-behalf-of-user on almost everything?
+
+An in-store companion reads **customer PII, employee performance, and store analytics**. Running those reads on the associate's own token means Unity Catalog enforces per-user grants end-to-end — a floor associate and a manager-on-duty see exactly what their own permissions allow, with no app-level access logic to maintain. That's why the LLMs, embeddings, both vector stores, the warehouse, and the Genie room are all `on_behalf_of_user: true`.
+
+### …except UC functions and Lakebase — why?
+
+- **UC functions** run over Spark Connect serverless via `DatabricksFunctionClient`, and the OBO token forwarded by Model Serving lacks the `databricks-connect` OAuth scope — so OBO functions fail with `PERMISSION_DENIED: required scopes: databricks-connect`. SP-backed functions use workspace credentials and work in both Model Serving and Apps.
+- **Lakebase** is agent *memory* — it must persist across users and sessions under one stable identity, so it's SP-backed by design. (See the vault note on the OBO/`databricks-connect` scope gap.)
+
+This also keeps the app under the **Apps 20-resource budget**: 15 SP-backed UC functions + 1 Lakebase = 16, with the OBO-flagged models/stores/warehouse/Genie resolved via the runtime user credential rather than counting against the budget.
+
+### Why expose one Genie room as two tools?
+
+`query_store_ops_analytics` and `query_employee_insights` point at the **same** `brickstore_genie_room`, but the two tool descriptions give the supervisor sharper routing signal: store-ops/sales/inventory/BOPIS trends vs. team/performance/task analytics. It's the routing heuristic that benefits, not the data.
+
+### Why the two-tier Genie cache?
+
+Genie calls are relatively slow and metered. The `lru_cache` (exact-match, TTL 1h, capacity 100) catches repeated questions; the `context_aware_cache` embeds the question and does a `0.85`-cosine lookup (TTL 24h) so **paraphrased** questions ("how did 101 do last week" vs "show me store 101's weekly numbers") also hit cache. Both invalidate on empty results so a transient miss isn't cached forever.
+
+### Why decomposition + double rerank on the product retriever?
+
+Floor language is messy — "black Adidas Gazelle size 10" is a filter query, not a semantic one. The `decomposition_llm` splits it into ≤3 subqueries and extracts structured filters (`brand_name=ADIDAS`, `merchandise_class=FOOTWEAR`, `color=BLACK`, `size=10`), fused with RRF. An LLM reranker then applies constraint priorities, and a `ms-marco-MiniLM-L-12-v2` cross-encoder does the final precision pass. The `dim_stores` retriever, by contrast, is plain ANN — store-name search doesn't need the machinery.
+
+### Why narrative-only holds and notifications?
+
+There's no write-side tool for placing holds or sending stylist notifications. The prompts (and the monitoring guidelines) make the agents **draft** a `HOLD-<store_id>-<yyyymmddhhmm>` confirmation or a notification message and tell the user to act — never claim a row was inserted. This keeps the demo honest about what the data plane actually supports.
+
+---
+
+## Deploy
+
+### Prerequisites
+
+- **Profile**: `DEFAULT` (or your equivalent) configured via `databricks configure`
+- **Secret scope**: `retail_consumer_goods` with keys `RETAIL_AI_DATABRICKS_CLIENT_ID`, `RETAIL_AI_DATABRICKS_CLIENT_SECRET`, and `RETAIL_AI_DATABRICKS_HOST`
+- **Service principal**: the SP behind those secrets has `USE_CATALOG` / `USE_SCHEMA` / `SELECT` / `EXECUTE` on `retail_consumer_goods.store_ops`
+- **Vector Search endpoint**: `dbdemos_vs_endpoint` exists (or change `endpoint.name` in both vector stores)
+- **Genie space + Warehouse**: `parameters.genie_space_id` and `parameters.warehouse_id` point at a real Genie space and serverless SQL warehouse (or let `GenieRoomModel.create()` provision the space on first run and paste the id back)
+- **Lakebase**: project `retail-consumer-goods` (`parameters.lakebase_project`) available
+
+### Validate + provision + deploy
+
+```bash
+# Validate first (catches schema, anchor, and graph-construction errors)
+DATABRICKS_CONFIG_PROFILE=DEFAULT uv run dao-ai validate \
+  -c examples/15_complete_applications/brick_store/brick_store.yaml
+
+# Provision data + UC fns + VS indexes + Genie, then deploy MS + App in one shot
+uv run dao-ai workflow up \
+  -c examples/15_complete_applications/brick_store/brick_store.yaml \
+  -p DEFAULT \
+  --mode apps
+```
+
+`workflow up` provisions the Lakebase project, creates `retail_consumer_goods.store_ops` + the 10 dataset tables (and their helper views), registers the 15 UC functions, builds the 2 Delta-Sync VS indexes on the shared endpoint, wires the Genie room, then registers the Model Serving endpoint (`brick_store_dao`) and launches the Databricks App (`brick_store_dao`).
+
+### Verify
+
+```bash
+# Tables + functions created
+databricks --profile DEFAULT tables list retail_consumer_goods.store_ops
+
+# Lakebase project ONLINE
+databricks --profile DEFAULT database list-database-instances | grep retail-consumer-goods
+
+# App running
+databricks --profile DEFAULT apps get brick_store_dao
+```
+
+---
+
+## Sample prompts
+
+All prompts below come **verbatim from `examples.yaml`**. Each turn carries `custom_inputs.configurable.user_id` and `store_num` (the `store_validation` middleware requires `store_num`). Personas in the examples: `sarah.associate`, `maria.stylist`, `marcus.associate` (brand rep), and `sf.customer` / `sf.employee` / `sf.manager`. Stores: Downtown Market (101), Marina Market (102), Mission Market (103).
+
+### `product` — catalog lookup, comparison, recommendation
+
+| Prompt | Persona · store | Expected route |
+|---|---|---|
+| *"Can you tell me about the Adidas Gazelle Classic Sneakers? What's the price and available colors?"* | sf.customer · 101 | supervisor → **product** (`product_vector_search`) |
+| *"Can you tell me about SKU ADI-GAZ-001?"* | sf.customer · 101 | supervisor → **product** (`find_product_by_sku_uc`) |
+| *"Can you compare Adidas Gazelle (SKU: ADI-GAZ-001) and Adidas Samba (SKU: ADI-SMB-001) sneakers?"* | sf.customer · 101 | supervisor → **product** |
+| *"Can you recommend sneakers similar to Adidas Gazelle? I like retro suede styles."* | sf.customer · 101 | supervisor → **product** |
+
+### `inventory` — stock at home store, all stores, and nearby fallback
+
+| Prompt | Persona · store | Expected route |
+|---|---|---|
+| *"Hey Assistant, can you check if we have Adidas Gazelle sneakers in black at our Downtown Market location?"* | sarah.associate · 101 | supervisor → **inventory** (`find_store_inventory_by_sku_uc`) |
+| *"How many Adidas Samba Classic Sneakers do you have in stock across all San Francisco stores?"* | sf.customer · 101 | supervisor → **inventory** (`find_inventory_by_sku_uc`) |
+| *"Assistant, can you check which nearby stores have black Gazelles in stock?"* | sarah.associate · 101 | supervisor → **inventory** (`find_nearby_stores_inventory_uc`) |
+| *"The Adidas Gazelle in black is out of stock. What would you recommend that's similar?"* | sf.customer · 101 | supervisor → **inventory** / **product** |
+
+### `customer` + `stylist` — appointment prep and active styling
+
+| Prompt | Persona · store | Expected route |
+|---|---|---|
+| *"Show me everything I need to know about Victoria Chen."* | maria.stylist · 101 | supervisor → **customer** (`get_customer_details_uc`) |
+| *"I have a styling appointment with Victoria Sterling today. Help me prepare."* | maria.stylist · 101 | supervisor → **stylist** (`get_customer_preparation_summary_uc`) |
+| *"Victoria is here for her appointment. She's looking at sneakers but seems unsure. What should I recommend?"* | maria.stylist · 101 | supervisor → **stylist** |
+| *"What upcoming appointments do we have for customer CUST-001 at our San Francisco stores?"* | sf.employee · 101 | supervisor → **customer** (`find_upcoming_customer_appointments_uc`) |
+
+### `orders` — BOPIS and order tracking
+
+| Prompt | Persona · store | Expected route |
+|---|---|---|
+| *"Assistant, can you place a hold on black Gazelles, size 10, at Marina Market for this customer?"* | sarah.associate · 101 | supervisor → **orders** (narrative `HOLD-…`) |
+| *"When will my online order of Adidas Samba sneakers arrive at the Marina Market? Order number is 12345."* | sf.customer · 102 | supervisor → **orders** |
+
+### `employee` — manager-on-duty
+
+| Prompt | Persona · store | Expected route |
+|---|---|---|
+| *"Who are the top performing employees in the Footwear department at our San Francisco stores?"* | sf.manager · 101 | supervisor → **employee** (`find_top_employees_by_department_uc`) |
+| *"Who is the manager for employee EMP-016 at the Downtown Market store?"* | sf.employee · 101 | supervisor → **employee** (`find_employee_manager_uc`) |
+| *"Which personal shopping associates are available for sneaker styling appointments in San Francisco?"* | sf.employee · 101 | supervisor → **employee** (`find_personal_shopping_associates_uc`) |
+
+### `general` + Genie analytics
+
+| Prompt | Persona · store | Expected route |
+|---|---|---|
+| *"What are your store hours and location for the Downtown Market in San Francisco?"* | sf.customer · 101 | supervisor → **general** (`find_store_details_by_location`) |
+| *"Find me BrickMart stores in San Francisco that carry Adidas footwear."* | sf.customer · 101 | supervisor → **general** |
+| *"Show me how Nike Air Max products perform at our store."* | marcus.associate · 101 | supervisor → **product** / **general** (`query_store_ops_analytics`) |
+| *"What do customers say when they choose Adidas over Nike?"* | marcus.associate · 101 | supervisor → Genie analytics |
+
+---
+
+## File layout
+
+```
+brick_store/
+├── README.md                         # this file
+├── brick_store.yaml                  # dao-ai config (parameters → app)
+├── examples.yaml                     # sample conversation flows (prompt source)
+├── data/                             # DDL + seed data
+│   ├── products.sql + product_data.sql
+│   ├── inventory.sql + inventory_data.sql
+│   ├── dim_stores.sql + dim_stores_data.sql
+│   ├── customers.sql + customers_data.sql          # + 2 prep VIEWs
+│   ├── appointments.sql + appointments_data.sql
+│   ├── employee_tasks.sql + employee_tasks_data.sql          # + 3 VIEWs
+│   ├── employee_performance.sql + employee_performance_data.sql   # + 3 VIEWs
+│   ├── managers.sql + managers_data.sql            # + 1 VIEW
+│   ├── task_assignments.sql
+│   └── brand_rep_demo_tables.sql / _data.sql / _queries.sql / _validation.sql
+└── functions/                        # UC SQL functions
+    ├── find_product_by_sku.sql            find_product_by_upc.sql
+    ├── find_inventory_by_sku.sql          find_inventory_by_upc.sql
+    ├── find_store_inventory_by_sku.sql    find_store_inventory_by_upc.sql
+    ├── find_store_by_number.sql           find_nearby_stores_inventory.sql
+    ├── find_top_employees_by_department.sql
+    ├── find_personal_shopping_associates.sql
+    ├── find_employee_manager.sql          find_task_assignments.sql
+    ├── find_upcoming_customer_appointments.sql
+    ├── get_customer_details.sql           get_customer_preparation_summary.sql
+    └── extract_store_numbers.sql          # present, not registered in YAML
+```
+
+---
+
+## Related dao-ai patterns referenced
+
+- **Supervisor orchestration** — `examples/13_orchestration/` supervisor patterns
+- **Lakebase memory + extraction** — `examples/15_complete_applications/hardware_store_lakebase.yaml`
+- **Genie tool + context-aware cache** — Genie `type: genie` tools with `lru_cache` + `context_aware_cache`
+- **Decomposed hybrid retrieval** — `retrievers.*.instructed.decomposition` + `rerank`
+- **On-behalf-of-user auth** — `on_behalf_of_user` flags across models, stores, warehouse, Genie
+- **Custom-field validation middleware** — `dao_ai.middleware.create_custom_field_validation_middleware`
+- **Commerce Swarm (pipeline sibling)** — `examples/15_complete_applications/commerce/commerce_supervisor.README.md`

--- a/examples/15_complete_applications/brick_store/brick_store.yaml
+++ b/examples/15_complete_applications/brick_store/brick_store.yaml
@@ -11,12 +11,18 @@ parameters:
   schema:
     description: Schema within the catalog
     default: store_ops
+  vector_search_endpoint:
+    description: Vector Search endpoint hosting the indexes for this app
+    default: dbdemos_vs_endpoint
   llm:
     description: Primary chat/reasoning + tool-calling serving endpoint for the agents
-    default: databricks-claude-sonnet-4-5
+    default: databricks-claude-sonnet-5
   fast_llm:
     description: Fast serving endpoint for supervisor routing, decomposition, and lightweight calls
     default: databricks-gpt-5-4-mini
+  fallback_llm:
+    description: Same-class fallback serving endpoint (one generation back) the primary llm falls back to when unavailable
+    default: databricks-claude-sonnet-4-5
   embedding_model:
     description: Embedding serving endpoint for vector search and memory
     default: databricks-gte-large-en
@@ -115,7 +121,7 @@ resources:
       max_tokens: 4096
       on_behalf_of_user: true
       fallbacks:
-      - ${var.llm}
+      - ${var.fallback_llm}
 
     judge_llm: &judge_llm
       name: ${var.llm}
@@ -141,7 +147,7 @@ resources:
       embedding_model: *embedding_model
       on_behalf_of_user: true
       endpoint:
-        name: dbdemos_vs_endpoint
+        name: ${var.vector_search_endpoint}
         type: STANDARD
       index:
         schema: *brickstore_schema
@@ -170,7 +176,7 @@ resources:
       embedding_model: *embedding_model
       on_behalf_of_user: true
       endpoint:
-        name: dbdemos_vs_endpoint
+        name: ${var.vector_search_endpoint}
         type: STANDARD
       index:
         schema: *brickstore_schema

--- a/examples/15_complete_applications/commerce/commerce_supervisor.yaml
+++ b/examples/15_complete_applications/commerce/commerce_supervisor.yaml
@@ -39,12 +39,18 @@ parameters:
   schema:
     description: Schema within the catalog
     default: commerce_swarm
+  vector_search_endpoint:
+    description: Vector Search endpoint hosting the indexes for this app
+    default: dbdemos_vs_endpoint
   warehouse_id:
     description: SQL warehouse ID used for UC trace_location export
     default: d58e5fb998498840
   llm:
     description: Chat/reasoning serving endpoint for all agents (routed via AI Gateway)
-    default: databricks-claude-sonnet-4-6
+    default: databricks-claude-sonnet-5
+  fallback_llm:
+    description: Same-class fallback serving endpoint (one generation back) the primary llm falls back to when unavailable
+    default: databricks-claude-sonnet-4-5
   embedding_model:
     description: Text embedding serving endpoint for Vector Search + memory recall
     default: databricks-gte-large-en
@@ -113,6 +119,8 @@ resources:
       ai_gateway: true
       temperature: 0.1
       max_tokens: 8192
+      fallbacks:
+      - ${var.fallback_llm}
 
     # Background memory extraction — uses fast_llm to avoid competing with foreground
     extraction_llm: &extraction_llm
@@ -141,7 +149,7 @@ resources:
     products_vector_store: &products_vector_store
       embedding_model: *embedding_model
       endpoint:
-        name: dbdemos_vs_endpoint
+        name: ${var.vector_search_endpoint}
         type: STANDARD
       index:
         schema: *retail_schema
@@ -167,7 +175,7 @@ resources:
     faqs_vector_store: &faqs_vector_store
       embedding_model: *embedding_model
       endpoint:
-        name: dbdemos_vs_endpoint
+        name: ${var.vector_search_endpoint}
         type: STANDARD
       index:
         schema: *retail_schema
@@ -188,7 +196,7 @@ resources:
     policies_vector_store: &policies_vector_store
       embedding_model: *embedding_model
       endpoint:
-        name: dbdemos_vs_endpoint
+        name: ${var.vector_search_endpoint}
         type: STANDARD
       index:
         schema: *retail_schema

--- a/examples/15_complete_applications/commerce/commerce_swarm.yaml
+++ b/examples/15_complete_applications/commerce/commerce_swarm.yaml
@@ -29,12 +29,18 @@ parameters:
   schema:
     description: Schema within the catalog
     default: commerce_swarm
+  vector_search_endpoint:
+    description: Vector Search endpoint hosting the indexes for this app
+    default: dbdemos_vs_endpoint
   warehouse_id:
     description: SQL warehouse ID used for UC trace_location export
     default: d58e5fb998498840
   llm:
     description: Chat/reasoning serving endpoint for all agents (routed via AI Gateway)
-    default: databricks-claude-sonnet-4-6
+    default: databricks-claude-sonnet-5
+  fallback_llm:
+    description: Same-class fallback serving endpoint (one generation back) the primary llm falls back to when unavailable
+    default: databricks-claude-sonnet-4-5
   embedding_model:
     description: Text embedding serving endpoint for Vector Search + memory recall
     default: databricks-gte-large-en
@@ -103,6 +109,8 @@ resources:
       ai_gateway: true
       temperature: 0.1
       max_tokens: 8192
+      fallbacks:
+      - ${var.fallback_llm}
 
     # Background memory extraction — uses fast_llm to avoid competing with foreground
     extraction_llm: &extraction_llm
@@ -131,7 +139,7 @@ resources:
     products_vector_store: &products_vector_store
       embedding_model: *embedding_model
       endpoint:
-        name: dbdemos_vs_endpoint
+        name: ${var.vector_search_endpoint}
         type: STANDARD
       index:
         schema: *retail_schema
@@ -157,7 +165,7 @@ resources:
     faqs_vector_store: &faqs_vector_store
       embedding_model: *embedding_model
       endpoint:
-        name: dbdemos_vs_endpoint
+        name: ${var.vector_search_endpoint}
         type: STANDARD
       index:
         schema: *retail_schema
@@ -178,7 +186,7 @@ resources:
     policies_vector_store: &policies_vector_store
       embedding_model: *embedding_model
       endpoint:
-        name: dbdemos_vs_endpoint
+        name: ${var.vector_search_endpoint}
         type: STANDARD
       index:
         schema: *retail_schema

--- a/examples/15_complete_applications/deep_research/README.md
+++ b/examples/15_complete_applications/deep_research/README.md
@@ -1,0 +1,373 @@
+# Deep Research Swarm — Executive Strategy Assistant
+
+> **Reference implementation of a 6-agent research swarm on dao-ai.** A collaborative team of specialists — coordinator, KPI analyst, market intelligence, financial strategy, operations, and synthesizer — that turns a single C-suite research brief into an integrated, data-driven strategic report. Every agent shares one **Genie room** over `retail_consumer_goods.store_ops`, agents **hand off directly to each other** (no central hub), and the graph terminates only at the synthesizer.
+
+| ✨ Feature | What this example shows |
+|---|---|
+| 🐝 **Swarm orchestration** | Six peers with an explicit, directed **handoff graph**. Any agent can pull in the next specialist it needs; `strategy_synthesizer` is the single terminal node (`handoffs: []`). No supervisor / hub-and-spoke. |
+| 🧭 **Coordinator entrypoint** | `default_agent: research_lead` — every turn starts at the coordinator, which scopes the inquiry and fans out to specialists. It is *not* a router that every agent returns to. |
+| 🧠 **Reasoning-tiered models** | Three model tiers by cognitive load: `default_llm` (coordination) → `reasoning_llm` (analysis, temp 0.2) → `deep_reasoning_llm` (finance + synthesis, 32K tokens, Claude-Sonnet-4 with a Sonnet-4-5 fallback). |
+| 🗣️ **Shared Genie tool** | All six agents carry the *same* `executive_research_genie_tool` bound to one Genie space (`space_id: 01f05dd0…`), giving every specialist NL→SQL access to the same governed warehouse tables. |
+| 🌐 **Web-research capable** | `TAVILY_API_KEY` is provisioned as a serving env var (sourced from `env` or the `retail_consumer_goods` secret scope) so the market-intelligence workflow can reach external sources. |
+| ⏱️ **Bounded recursion** | Every agent prompt caps graph recursion at 5 iterations and is told to *"run as many tools as you can concurrently"* — keeps a swarm from looping and encourages parallel Genie calls. |
+| 🚀 **Model Serving deploy** | Ships as a registered UC model + serving endpoint (`deep_research_executive_assistant_dao`), `users` granted `CAN_QUERY`. No Lakebase, no Vector Search — this app is purely reasoning + Genie. |
+
+---
+
+## Architecture
+
+The system is three interacting layers: the client, a swarm of six reasoning agents deployed behind a Model Serving endpoint, and the governed data + model backends they call. Each layer has a focused diagram below.
+
+### 1. System layers
+
+The top-level shape: client → Model Serving endpoint (a `ResponsesAgent` wrapping the 6-agent swarm) → Foundation Model API (Claude tiers), one Genie space over `retail_consumer_goods.store_ops`, and outbound web research via Tavily. Traces flow to MLflow.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1565c0', 'fontSize': '14px'}}}%%
+flowchart LR
+    Client["🖥️ Executive Client<br/>Chat · Notebook · API"]
+
+    subgraph Endpoint["🚀 Model Serving · deep_research_executive_assistant_dao"]
+        direction TB
+        Lead["🧭 research_lead<br/><i>entrypoint</i>"]
+        Swarm["🐝 6-agent swarm<br/>directed handoff graph"]
+        Lead --> Swarm
+    end
+
+    FMAPI["🤖 Foundation Model API<br/>claude-sonnet-4-5 · claude-sonnet-4"]
+    Genie["🗣️ Genie Space<br/>Executive Research Room"]
+    Tavily["🌐 Tavily Web Search<br/>TAVILY_API_KEY"]
+    UC["🏛️ Unity Catalog<br/>retail_consumer_goods.store_ops"]
+    MLflow["📊 MLflow Tracing"]
+
+    Client --> Endpoint
+    Swarm <-.->|chat completions| FMAPI
+    Swarm <-.->|NL → SQL| Genie
+    Swarm <-.->|external context| Tavily
+    Genie -->|governed query| UC
+    Endpoint -.->|spans| MLflow
+
+    style Endpoint fill:#fff8e1,stroke:#f57f17,stroke-width:2px
+    style FMAPI fill:#f3e5f5,stroke:#7b1fa2
+    style Genie fill:#e8f5e9,stroke:#2e7d32
+    style UC fill:#e3f2fd,stroke:#1565c0
+    style Tavily fill:#fce4ec,stroke:#c2185b
+    style Swarm fill:#fffde7,stroke:#fbc02d
+    style MLflow fill:#ede7f6,stroke:#512da8
+```
+
+**Key wiring details that are easy to miss:**
+- **Every agent shares one tool instance.** `executive_research_genie_tool` (a `type: genie` tool) is defined once with a YAML anchor and attached to all six agents. There is exactly one Genie space (`space_id: 01f05dd06c421ad6b522bf7a517cf6d2`) — specialists don't each get their own space; they all query the same governed room and rely on their prompts to ask domain-appropriate questions.
+- **The Genie room is the data plane.** The config declares 8 `tables` and 7 `functions` under `retail_consumer_goods.store_ops`, but they are *not* attached to agents as UC-function tools — they are the objects the Genie space sits on top of. The swarm's only agent-facing tool is the Genie tool.
+- **Tavily is a serving env var, not a wired tool.** `environment_vars.TAVILY_API_KEY` is injected into the endpoint (`{{secrets/retail_consumer_goods/TAVILY_API_KEY}}`), enabling the market-intelligence workflow's external research. In this config version the only tool explicitly bound to agents is the Genie tool.
+
+### 2. Swarm topology
+
+This is a **directed handoff graph**, not a hub-and-spoke. `research_lead` is the entrypoint and can reach any specialist. Analysis flows generally left-to-right (data → market → finance → operations), and every path converges on `strategy_synthesizer`, which is the single terminal node with **no outbound handoffs**. Any specialist can also hand *back* to `strategy_synthesizer` early, and the synthesizer's *prompt* lets it request more work — but the wired outbound edges are exactly those below.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1565c0', 'fontSize': '14px'}}}%%
+flowchart LR
+    Start(("exec brief"))
+
+    Lead["🧭 research_lead<br/>default_llm<br/><i>coordinator · entrypoint</i>"]
+    KPI["📈 kpi_analyst<br/>reasoning_llm<br/><i>data foundation</i>"]
+    Market["🌐 market_intelligence<br/>reasoning_llm<br/><i>competitive context</i>"]
+    Fin["💰 financial_strategy<br/><b>deep_reasoning_llm</b><br/><i>ROI · modeling</i>"]
+    Ops["⚙️ operations_expert<br/>reasoning_llm<br/><i>efficiency · execution</i>"]
+    Synth["🎯 strategy_synthesizer<br/><b>deep_reasoning_llm</b><br/><i>terminal · exec deliverable</i>"]
+    End(("strategic report"))
+
+    Start ==> Lead
+
+    Lead --> KPI
+    Lead --> Market
+    Lead --> Fin
+    Lead --> Ops
+    Lead --> Synth
+
+    KPI --> Market
+    KPI --> Fin
+    KPI --> Ops
+    KPI --> Synth
+
+    Market --> Fin
+    Market --> Synth
+
+    Fin --> Ops
+    Fin --> Synth
+
+    Ops --> Synth
+
+    Synth ==> End
+
+    style Lead fill:#fff3e0,stroke:#e65100,stroke-width:3px
+    style Fin fill:#e1f5fe,stroke:#0277bd,stroke-width:2px
+    style Synth fill:#c5e1a5,stroke:#558b2f,stroke-width:3px
+    style Start fill:#e0e0e0,stroke:#424242
+    style End fill:#e0e0e0,stroke:#424242
+```
+
+**Wired in the YAML as:**
+```yaml
+orchestration:
+  swarm:
+    default_agent: research_lead        # entrypoint every turn
+    handoffs:
+      research_lead:                     # can reach all five peers
+      - kpi_analyst
+      - market_intelligence
+      - financial_strategy
+      - operations_expert
+      - strategy_synthesizer
+      kpi_analyst:
+      - market_intelligence
+      - financial_strategy
+      - operations_expert
+      - strategy_synthesizer
+      market_intelligence:
+      - financial_strategy
+      - strategy_synthesizer
+      financial_strategy:
+      - operations_expert
+      - strategy_synthesizer
+      operations_expert:
+      - strategy_synthesizer
+      strategy_synthesizer: []           # terminal — no outbound edges
+```
+
+**Why the graph narrows as it flows right.** `research_lead` and `kpi_analyst` are "wide" (they can fan to almost everyone) because coordination and data-gathering feed every other domain. Downstream specialists have progressively fewer edges — `operations_expert` can only go to the synthesizer — because by then the useful next move is almost always synthesis. This encodes the intended research pipeline *as graph structure* while still allowing the coordinator to jump straight to any specialist for a narrow inquiry.
+
+### 3. Per-turn execution lifecycle
+
+A full run for the canonical "comprehensive executive research report" brief. The coordinator scopes the work, pulls the KPI foundation first (as its prompt mandates), fans out to the domain specialists, and everything converges on the synthesizer for the C-suite deliverable. Each agent may issue multiple concurrent Genie queries.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'fontSize': '13px'}}}%%
+sequenceDiagram
+    autonumber
+    actor Exec as 👔 Executive
+    participant Lead as 🧭 research_lead
+    participant KPI as 📈 kpi_analyst
+    participant Market as 🌐 market_intelligence
+    participant Fin as 💰 financial_strategy
+    participant Ops as ⚙️ operations_expert
+    participant Synth as 🎯 strategy_synthesizer
+    participant Genie as 🗣️ Genie space
+    participant Web as 🌐 Tavily
+
+    Exec->>Lead: comprehensive research brief
+    Note over Lead: scope · domain map · sequencing
+    Lead->>Genie: initial framing query
+    Genie-->>Lead: baseline metrics
+
+    Lead->>KPI: handoff (start with data)
+    Note over KPI: 12-month trends · benchmarking
+    KPI->>Genie: customer / financial / ops KPIs (concurrent)
+    Genie-->>KPI: metric rows
+
+    KPI->>Market: handoff (need external context)
+    Market->>Web: industry & competitor research
+    Market->>Genie: validate vs internal data
+    Genie-->>Market: comparison rows
+
+    Market->>Fin: handoff (model the impact)
+    Note over Fin: deep_reasoning_llm · 32K tokens
+    Fin->>Genie: revenue / margin / cash-flow pulls
+    Genie-->>Fin: financial rows
+
+    Fin->>Ops: handoff (operational levers)
+    Ops->>Genie: inventory turns · productivity · tasks
+    Genie-->>Ops: operational rows
+
+    Ops->>Synth: handoff (synthesize)
+    Note over Synth: integrate all domains · priority matrix
+    Synth-->>Exec: executive summary · recommendations · roadmap · risks · success metrics
+```
+
+**Observations:**
+- **The coordinator's prompt mandates the sequence.** `research_lead` is instructed to *"always start with kpi_analyst for foundational data analysis"* before pulling market, financial, or operations specialists — so even though its handoff edges reach everyone, the intended first hop is the KPI foundation.
+- **The synthesizer is the only agent that produces the executive deliverable.** Its prompt defines the fixed six-part structure: Executive Summary → Integrated Analysis → Strategic Recommendations → Implementation Roadmap → Risk Management → Success Metrics.
+- **Concurrency is a first-class instruction.** Every prompt ends with *"Run as many tools as you can concurrently"* — a single specialist turn can issue several Genie queries in parallel rather than serially.
+- **Recursion is capped at 5** in every prompt, which bounds how many handoff hops a swarm can take before it must converge on the synthesizer.
+
+---
+
+## Agents
+
+All six agents carry the single shared `executive_research_genie_tool`. Model tier is the primary differentiator.
+
+| # | Agent | Model alias | Underlying model | Role |
+|---|---|---|---|---|
+| 1 | `research_lead` | `default_llm` | claude-sonnet-4-5 · temp 0.1 · 16K | **Coordinator / executive interface.** Scopes the inquiry, maps domains, sequences the team, assures coverage. Entrypoint (`default_agent`). |
+| 2 | `kpi_analyst` | `reasoning_llm` | claude-sonnet-4-5 · temp 0.2 · 16K | **Data foundation.** CAC/LTV/churn/NPS, financial & operational KPIs, 12-month trends, benchmarking, cross-validation. The mandated first hop. |
+| 3 | `market_intelligence` | `reasoning_llm` | claude-sonnet-4-5 · temp 0.2 · 16K | **External context.** Industry trends, competitive intel, regulatory landscape, market sizing. The web-research workflow (Tavily) lives here. |
+| 4 | `financial_strategy` | `deep_reasoning_llm` | claude-sonnet-4 · temp 0.1 · 32K · fallback → sonnet-4-5 | **Financial modeling & ROI.** Cost-benefit, risk-adjusted returns, investment prioritization. Highest token budget for long chains. |
+| 5 | `operations_expert` | `reasoning_llm` | claude-sonnet-4-5 · temp 0.2 · 16K | **Efficiency & execution.** Process optimization, supply-chain/inventory, productivity, cost reduction, implementation planning. |
+| 6 | `strategy_synthesizer` | `deep_reasoning_llm` | claude-sonnet-4 · temp 0.1 · 32K · fallback → sonnet-4-5 | **Terminal synthesizer.** Consolidates all domains into the six-part C-suite deliverable. Single node with no outbound handoffs. |
+
+**Model-tier rationale (from `resources.models`):**
+- **`default_llm`** (claude-sonnet-4-5, temp 0.1) — coordination is orchestration, not deep analysis; low temperature keeps scoping deterministic.
+- **`reasoning_llm`** (claude-sonnet-4-5, temp 0.2) — the three analytic specialists run at a slightly higher temperature to surface non-obvious patterns and hypotheses.
+- **`deep_reasoning_llm`** (claude-sonnet-4, temp 0.1, **32K tokens**) — financial modeling and final synthesis need the longest reasoning chains and the largest output budget; they carry a `claude-sonnet-4-5` fallback for capacity resilience.
+- Two extra aliases are declared but unused by agents in this config: `fast_llm` (llama-3-1-8b) and `tool_calling_llm` (sonnet-4-5 with a sonnet-4 fallback) — available for future specialization.
+
+---
+
+## Data plane
+
+There are **no local `data/` or `functions/` SQL files** in this example. The swarm reaches its data exclusively through the Genie space, which sits on top of pre-existing Unity Catalog objects in `retail_consumer_goods.store_ops`. The config declares those objects so `dao-ai` can wire the Genie tool and validate references — it does not create them.
+
+```
+retail_consumer_goods.store_ops/         # backs the Genie space
+├── 📊 Tables (8)
+│   ├── employee_performance
+│   ├── products
+│   ├── inventory
+│   ├── customers
+│   ├── managers
+│   ├── employee_tasks
+│   ├── appointments
+│   └── evaluation
+│
+├── 🛠️ UC Functions (7) — declared for reference; Genie plans over them
+│   ├── find_inventory_by_sku      · find_inventory_by_upc
+│   ├── find_product_by_sku        · find_product_by_upc
+│   ├── find_store_by_number
+│   └── find_store_inventory_by_sku · find_store_inventory_by_upc
+│
+└── 🗣️ Genie Space — "Executive Research Genie Room"
+    space_id: 01f05dd06c421ad6b522bf7a517cf6d2
+    exposed to all 6 agents as executive_research_genie_tool
+```
+
+**Prerequisite, not provisioned by this config:** the Genie space and the `store_ops` tables must already exist in your workspace. Point `genie_rooms.executive_research_genie_room.space_id` at your own space, and adjust the `executive_research_schema` anchor (`catalog_name` / `schema_name`) if your data lives elsewhere.
+
+---
+
+## Why these design choices?
+
+### Why a swarm instead of a supervisor pipeline?
+
+Deep executive research is **non-linear and iterative** — a financial anomaly may send you back to KPIs, a market trend may reshape the operational plan. A swarm lets specialists hand off to whichever peer their findings demand, rather than forcing every step back through a central router. The directed handoff graph still encodes the *intended* flow (data → market → finance → ops → synthesis) without hard-coding it into a single supervisor.
+
+### Why does every agent share one Genie tool instead of scoped tools?
+
+The research domains all draw from the **same governed warehouse**. Giving each specialist its own narrow tool set would fragment access and force artificial handoffs just to fetch a number. Instead, every agent gets the full Genie room and relies on its **prompt** to ask domain-appropriate questions — the KPI analyst asks about churn and LTV, operations asks about inventory turns, all against one space. Unity Catalog governs what the space can see; the prompts govern what each agent asks.
+
+### Why three model tiers?
+
+Cost and capability follow cognitive load. Coordination (`default_llm`) and mid-weight analysis (`reasoning_llm`) run on Sonnet-4-5; only the two agents that do the heaviest, longest reasoning — financial modeling and final synthesis — get `deep_reasoning_llm` with a 32K output budget. Spending the large-context budget only where multi-domain integration happens is more efficient than uniformly maxing tokens everywhere.
+
+### Why cap recursion at 5 and push concurrency?
+
+Swarms can loop — A hands to B hands back to A. Every prompt caps graph recursion at **5 iterations** to guarantee convergence on the synthesizer, and instructs each agent to *"run as many tools as you can concurrently"* so a single research turn issues parallel Genie queries instead of a slow serial chain. Together these bound both depth and latency.
+
+### Why a fallback on the deep-reasoning models?
+
+`deep_reasoning_llm` and `tool_calling_llm` declare `fallbacks` (Sonnet-4 → Sonnet-4-5). The heaviest agents are the ones you least want to fail on a capacity blip mid-report; the fallback trades a small quality delta for availability on the two nodes that own the final deliverable.
+
+---
+
+## Deploy
+
+### Prerequisites
+
+- **Profile**: `DEFAULT` (or your equivalent Databricks profile) configured via `databricks configure`
+- **Genie space**: The Executive Research space (`space_id: 01f05dd06c421ad6b522bf7a517cf6d2`) exists — or update the `space_id` in the YAML to point at yours
+- **Data**: `retail_consumer_goods.store_ops` tables exist and the Genie space is built over them
+- **Secret / env**: `TAVILY_API_KEY` available either as an environment variable or as key `TAVILY_API_KEY` in the `retail_consumer_goods` secret scope
+- **Serving mode**: This app has no `orchestration.mode` override, so it deploys to **Model Serving** (`ServingMode.MODEL_SERVING`, the default) — a registered UC model + serving endpoint, not a Databricks App
+
+### Validate + deploy
+
+```bash
+# Validate first (catches schema, anchor, and swarm graph-construction errors)
+DATABRICKS_CONFIG_PROFILE=DEFAULT uv run dao-ai validate \
+  -c examples/15_complete_applications/deep_research/deep_research.yaml
+
+# Deploy to Model Serving
+uv run dao-ai workflow up \
+  -c examples/15_complete_applications/deep_research/deep_research.yaml \
+  -p DEFAULT \
+  --mode model_serving
+```
+
+This registers `retail_consumer_goods.store_ops.deep_research_dao` and deploys the serving endpoint `deep_research_executive_assistant_dao`, granting `users` the `CAN_QUERY` entitlement.
+
+### Verify
+
+```bash
+# Registered model version exists
+databricks --profile DEFAULT registered-models get \
+  retail_consumer_goods.store_ops.deep_research_dao
+
+# Serving endpoint READY
+databricks --profile DEFAULT serving-endpoints get deep_research_executive_assistant_dao
+```
+
+---
+
+## Sample prompts
+
+The canonical prompt is defined in **`examples.yaml`** (`comprehensive_executive_research`). It is a single, deliberately maximal C-suite brief that exercises the entire swarm end-to-end. Run it with the custom inputs from the file:
+
+```jsonc
+// custom_inputs.configurable (from examples.yaml)
+{ "thread_id": "1", "user_id": "ali_ghodsi", "store_num": 101 }
+```
+
+**The brief (verbatim, abridged for length):**
+
+> *"I need a comprehensive executive research report analyzing our Q3 2025 performance and strategic positioning. Please conduct a deep dive analysis covering: Customer KPI Performance (CAC, LTV, churn, retention, NPS, satisfaction over the past 12 months); Financial Performance (revenue growth, margin trends, profitability, cash flow, ROI); Operational Efficiency (inventory turnover, productivity ratios, supply chain, cost trends); and Market Position (competitive standing, market share, industry benchmarks, external dynamics)…"*
+
+The brief then poses five **strategic questions** the swarm must address (quoted from `examples.yaml`):
+
+- *"Where are we underperforming relative to industry benchmarks and why?"*
+- *"What are the top 3 strategic opportunities for growth in the next 6-12 months?"*
+- *"What operational improvements could deliver the highest ROI?"*
+- *"How do current market trends impact our strategic priorities?"*
+- *"What are the financial implications of recommended strategic initiatives?"*
+
+…and specifies the **deliverable** it expects back — the exact six-part structure `strategy_synthesizer` produces:
+
+- Executive summary with 3-4 key strategic insights
+- Integrated analysis across all business dimensions
+- Prioritized strategic recommendations with clear rationale
+- Implementation roadmap with timelines and resource requirements
+- Risk assessment and mitigation strategies
+- Success metrics for tracking progress
+
+**Expected route:** `research_lead` → `kpi_analyst` → `market_intelligence` → `financial_strategy` → `operations_expert` → `strategy_synthesizer`, with each specialist issuing one or more Genie queries against the Executive Research space.
+
+### Invoke the endpoint
+
+```bash
+databricks --profile DEFAULT serving-endpoints query deep_research_executive_assistant_dao \
+  --request '{
+    "input": [{"role":"user","content":"Analyze our Q3 2025 customer KPI performance and give me the top 3 growth opportunities."}],
+    "custom_inputs": {"configurable": {"thread_id":"1","user_id":"ali_ghodsi","store_num":101}}
+  }'
+```
+
+---
+
+## File layout
+
+```
+deep_research/
+├── README.md              # this file
+├── deep_research.yaml     # dao-ai config — 6-agent swarm, Genie tool, 3 model tiers
+└── examples.yaml          # canonical comprehensive_executive_research brief
+```
+
+No `data/` or `functions/` directories — the data plane is the external Genie space over `retail_consumer_goods.store_ops`.
+
+---
+
+## Related dao-ai patterns referenced
+
+- **Swarm orchestration** — `examples/13_orchestration/swarm_pattern.yaml`
+- **Genie tool** — `examples/15_complete_applications/commerce/` (Genie-backed retail agents)
+- **Model tiers + fallbacks** — `resources.models` in this config (`deep_reasoning_llm`, `tool_calling_llm`)
+- **Commerce Swarm** (companion complete-app, pipeline variant) — `examples/15_complete_applications/commerce/commerce_swarm.README.md`

--- a/examples/15_complete_applications/deep_research/deep_research.yaml
+++ b/examples/15_complete_applications/deep_research/deep_research.yaml
@@ -1,5 +1,28 @@
 # yaml-language-server: $schema=../../../schemas/model_config_schema.json
 
+# =============================================================================
+# PARAMETERS
+# =============================================================================
+parameters:
+  llm:
+    description: Primary chat/reasoning + tool-calling serving endpoint for the agents
+    default: databricks-claude-sonnet-5
+  fast_llm:
+    description: Fast/cheap serving endpoint for lightweight calls
+    default: databricks-gpt-5-4-mini
+  reasoning_llm:
+    description: Serving endpoint for reasoning-heavy synthesis
+    default: databricks-claude-sonnet-5
+  deep_reasoning_llm:
+    description: Extended-context serving endpoint for the deepest reasoning steps
+    default: databricks-claude-opus-4-6
+  fallback_llm:
+    description: Fallback chat serving endpoint when a primary endpoint is unavailable
+    default: databricks-claude-sonnet-4-5
+  genie_space_id:
+    description: Genie space id for the Executive Research Genie room
+    default: 01f05dd06c421ad6b522bf7a517cf6d2
+
 variables:
   tavily_search_key:
     options:
@@ -15,33 +38,33 @@ schemas:
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 16384
 
     fast_llm:
-      name: databricks-meta-llama-3-1-8b-instruct
+      name: ${var.fast_llm}
       temperature: 0.1
       max_tokens: 8192
 
     tool_calling_llm:
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 16384
       fallbacks:
-      - databricks-claude-sonnet-4
+      - ${var.fallback_llm}
 
     reasoning_llm: &reasoning_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.reasoning_llm}
       temperature: 0.2
       max_tokens: 16384
 
     deep_reasoning_llm: &deep_reasoning_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.deep_reasoning_llm}
       temperature: 0.1
       max_tokens: 32768
       fallbacks:
-      - databricks-claude-sonnet-4-5
+      - ${var.llm}
 
   tables:
     employee_performance:
@@ -109,7 +132,7 @@ resources:
     executive_research_genie_room: &executive_research_genie_room
       name: "Executive Research Genie Room"
       description: "A specialized room for deep executive research and analysis"
-      space_id: 01f05dd06c421ad6b522bf7a517cf6d2
+      space_id: ${var.genie_space_id}
 
 tools:
   executive_research_genie_tool: &executive_research_genie_tool

--- a/examples/15_complete_applications/executive_assistant/README.md
+++ b/examples/15_complete_applications/executive_assistant/README.md
@@ -1,0 +1,194 @@
+# Executive Assistant — Single-Agent Genie + Web Search Analyst
+
+> **Reference implementation of a single-agent executive analyst on dao-ai.** One reasoning agent (`executive_assistant_genie`) that answers C-suite questions by querying a **Databricks Genie room** for internal business data and reaching out to the **web via Tavily** for external context — then formats findings in an executive-summary-first structure. No custom orchestration, no memory, no data provisioning: the simplest useful shape for a data-grounded assistant.
+
+| ✨ Feature | What this example shows |
+|---|---|
+| 🧑‍💼 **Single-agent design** | Exactly one agent, no supervisor/handoff graph. The whole app is one `ResponsesAgent` with two tools. |
+| 🧞 **Genie as a tool** | `type: genie` tool wraps an existing Genie space (natural-language → SQL over `retail_consumer_goods`). The agent decides when and how many times to query. |
+| 🌐 **Live web search** | `langchain_tavily.TavilySearch` wired as a `type: factory` tool for external benchmarks / market context — a real tool span, not just an env var. |
+| 🧠 **Claude Sonnet reasoning** | `databricks-claude-sonnet-4-5` at `temperature: 0.1` — deterministic, multi-step reasoning for executive analysis. |
+| 🗂️ **Executive prompt contract** | A long system prompt fixes a 5-part response structure (Executive Summary → Metrics → Root Cause → Recommendations → Risk). |
+| 🔐 **Secret-backed API key** | `TAVILY_API_KEY` resolves from the `retail_consumer_goods` secret scope (or a local env var), injected as an app environment variable. |
+| 📡 **Streaming enabled** | `tags.streaming: true`; users get `CAN_QUERY` on the deployed endpoint. |
+
+---
+
+## Architecture
+
+This is a **single-agent** app. There is no routing graph — one agent owns the turn end to end, calling either tool (or both, repeatedly) until it can answer.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1565c0', 'fontSize': '14px'}}}%%
+flowchart LR
+    Client["🖥️ Client<br/>Chat · API"]
+
+    subgraph App["🚀 executive_assistant_dao"]
+        direction TB
+        Agent["🧑‍💼 executive_assistant_genie<br/><b>claude-sonnet-4-5</b><br/><i>temp 0.1 · 8192 tok</i>"]
+    end
+
+    Genie["🧞 Genie room<br/>space 01f05dd0…f6d2"]
+    Tavily["🌐 Tavily<br/>web search"]
+    UC["🏛️ Unity Catalog<br/>retail_consumer_goods.store_ops<br/><i>Genie's tables (prereq)</i>"]
+
+    Client --> App
+    Agent <-.->|"NL → SQL (tool)"| Genie
+    Agent <-.->|"web query (tool)"| Tavily
+    Genie -->|reads| UC
+
+    style App fill:#fff8e1,stroke:#f57f17,stroke-width:2px
+    style Agent fill:#e1f5fe,stroke:#0277bd,stroke-width:2px
+    style Genie fill:#f3e5f5,stroke:#7b1fa2
+    style Tavily fill:#e8f5e9,stroke:#2e7d32
+    style UC fill:#e3f2fd,stroke:#1565c0
+```
+
+### Per-turn execution
+
+The agent loops over its two tools autonomously — the system prompt explicitly instructs it to make **multiple tool calls** to cross-validate before answering.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'fontSize': '13px'}}}%%
+sequenceDiagram
+    autonumber
+    actor Exec as 👔 Executive
+    participant Agent as 🧑‍💼 executive_assistant_genie<br/>(claude-sonnet-4-5)
+    participant Genie as 🧞 Genie room
+    participant Tavily as 🌐 Tavily
+
+    Exec->>Agent: business question (+ user_id / store_num)
+    loop until enough evidence
+        Agent->>Genie: NL question → SQL over UC tables
+        Genie-->>Agent: result rows
+        opt needs external context
+            Agent->>Tavily: web query (max_results=5, advanced)
+            Tavily-->>Agent: ranked web results
+        end
+    end
+    Agent->>Agent: synthesize — Exec Summary → Metrics → Root Cause → Recs → Risk
+    Agent-->>Exec: streamed executive answer
+```
+
+---
+
+## Agents
+
+| # | Agent | Model | Tools | Role |
+|---|---|---|---|---|
+| 1 | `executive_assistant_genie` | **databricks-claude-sonnet-4-5** (`temp 0.1`, `max_tokens 8192`) | `executive_assistant_genie_tool` (genie), `tavily_search_tool` (factory) | Executive data analyst & strategic advisor. Queries Genie for internal KPIs/inventory/employee/store metrics, uses Tavily for external benchmarks, and returns a structured executive brief. |
+
+**Tool detail:**
+
+| Tool | Type | Wiring | Notes |
+|---|---|---|---|
+| `executive_assistant_genie_tool` | `genie` | `genie_room` → space `01f05dd06c421ad6b522bf7a517cf6d2` | Natural-language querying of the data warehouse. The Genie space and its underlying tables are a **prerequisite** — this config does not create them. |
+| `tavily_search_tool` | `factory` | `langchain_tavily.TavilySearch` (`max_results: 5`, `topic: general`, `search_depth: advanced`) | A real, wired LangChain tool — appears as its own tool span. It also depends on `TAVILY_API_KEY` being present (see below). |
+
+---
+
+## Why these design choices?
+
+### Why a single agent instead of a supervisor/handoff graph?
+The job is narrow: answer executive business questions from one data warehouse plus the open web. There is no B2C/B2B split, no specialist domains, no transactional side effects — nothing that needs routing. A single agent with two tools is the honest minimum. Adding a supervisor would only add an LLM call and trace noise.
+
+### Why Claude Sonnet at temperature 0.1?
+Executive analysis is multi-step reasoning: read metrics, find correlations, attribute root cause, recommend action. `claude-sonnet-4-5` is the right tier for that quality bar. `temperature: 0.1` keeps numeric analysis and recommendations stable across runs; `max_tokens: 8192` leaves room for the full 5-part response structure.
+
+### Why Genie *as a tool* rather than a fixed SQL function?
+Executive questions are open-ended ("why did retention dip?"), so the agent needs to ask ad-hoc questions and drill down. A Genie space turns natural language into SQL on demand and lets the agent iterate — exactly what a `type: genie` tool provides. Hard-coding UC functions would fix the question set in advance.
+
+### Why is Tavily a tool and not just retrieval?
+External context (industry benchmarks, competitor moves, market conditions) isn't in the warehouse. Wiring Tavily as a `factory` tool lets the agent decide *when* external signal is worth fetching, and keeps that fetch observable as its own span. Note the two-part dependency: the **tool** is wired in `tools:`, and its **API key** is supplied separately via `TAVILY_API_KEY`.
+
+### Why secret-backed config for the API key?
+`variables.tavily_search_key` accepts either a local env var (`TAVILY_API_KEY`) or the `retail_consumer_goods` scope secret, and `app.environment_vars` injects `{{secrets/retail_consumer_goods/TAVILY_API_KEY}}` into the deployed app. No key material lives in the YAML.
+
+---
+
+## Deploy
+
+### Prerequisites
+
+These are **inputs this config assumes exist** — it provisions none of them (there is no `data/` or `functions/` directory here):
+
+- **Profile**: `DEFAULT` (or your equivalent) configured via `databricks configure`.
+- **Genie space**: `01f05dd06c421ad6b522bf7a517cf6d2` exists and is granted to the runtime principal. Update `genie_rooms.executive_assistant_genie_room.space_id` to point at your own space.
+- **Genie's underlying tables**: whatever `retail_consumer_goods.store_ops` (or your Genie space) queries must already be populated. This app reads them through Genie; it does not create or load them.
+- **Secret scope**: `retail_consumer_goods` exists with key `TAVILY_API_KEY` (or export `TAVILY_API_KEY` locally).
+- **Registered-model target**: `retail_consumer_goods.store_ops` catalog/schema exists for the `executive_assistant_dao` model.
+
+### Validate + deploy
+
+```bash
+# Validate first (schema, anchors, tool/agent wiring, graph construction)
+DATABRICKS_CONFIG_PROFILE=DEFAULT uv run dao-ai validate \
+  -c examples/15_complete_applications/executive_assistant/executive_assistant.yaml
+
+# Deploy the app
+uv run dao-ai workflow up \
+  -c examples/15_complete_applications/executive_assistant/executive_assistant.yaml \
+  -p DEFAULT \
+  --mode apps
+```
+
+The `app:` block registers the model `executive_assistant_dao` in `retail_consumer_goods.store_ops`, serves it under endpoint `executive_assistant_agent_dao`, injects `TAVILY_API_KEY`, and grants `users` the `CAN_QUERY` entitlement. There is no data/VS/UC-function provisioning stage — deploy is model-registration + serving only.
+
+### Verify
+
+```bash
+# App running
+databricks --profile DEFAULT apps get executive_assistant_dao
+
+# Serving endpoint ready
+databricks --profile DEFAULT serving-endpoints get executive_assistant_agent_dao
+```
+
+---
+
+## Sample prompts
+
+The canonical example is defined in [`examples.yaml`](./examples.yaml). It shows the expected request shape — a user message plus `custom_inputs.configurable` carrying `thread_id`, `user_id`, and `store_num`:
+
+```yaml
+# examples.yaml → average_sales_percentage
+messages:
+  - role: user
+    content: "Hey Assistant, What is the average sales achievement percentage for employees?"
+custom_inputs:
+  configurable:
+    thread_id: "1"
+    user_id: "ali_ghodsi"
+    store_num: 101
+```
+
+That prompt routes to the Genie tool (employee-performance data) and comes back as an executive brief.
+
+**Other questions this agent is designed for** (drawn from the system prompt's stated responsibilities — verify against your own Genie space's tables before relying on them):
+
+- *"Which customer segments are churning fastest this quarter, and why?"* — Genie (customer KPIs) → root-cause analysis
+- *"How is inventory turnover trending, and where are we seeing stockouts?"* — Genie (inventory/supply chain)
+- *"Compare our store performance across locations and flag the underperformers."* — Genie (store performance)
+- *"What are current retail industry benchmarks for NPS, and how do we compare?"* — Tavily (external) + Genie (internal NPS)
+
+---
+
+## File layout
+
+```
+executive_assistant/
+├── README.md                    # this file
+├── executive_assistant.yaml     # dao-ai config — 1 agent, 2 tools, app block
+└── examples.yaml                # canonical sample prompt + custom_inputs shape
+```
+
+> No `data/` or `functions/` directory. Any tables the Genie room reads are **prerequisites**, not assets this example provisions.
+
+---
+
+## Related dao-ai patterns referenced
+
+- **Genie tool** — `type: genie` first-class tool ([`reference_dao_ai_first_class_tool_types`])
+- **Factory tools** — `langchain_tavily.TavilySearch` via `type: factory`
+- **Multi-agent + Genie contrast** — `examples/15_complete_applications/commerce/commerce_supervisor.README.md` (when a single agent isn't enough)
+- **Secret-backed variables** — `variables.*.options` with `env` / `scope`+`secret` fallback

--- a/examples/15_complete_applications/executive_assistant/executive_assistant.yaml
+++ b/examples/15_complete_applications/executive_assistant/executive_assistant.yaml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../schemas/model_config_schema.json
 
+# =============================================================================
+# PARAMETERS
+# =============================================================================
+parameters:
+  llm:
+    description: Chat/reasoning serving endpoint for the executive assistant agent
+    default: databricks-claude-sonnet-5
+  genie_space_id:
+    description: Genie space id for the Executive Assistant Genie room
+    default: 01f05dd06c421ad6b522bf7a517cf6d2
+
 variables:
   tavily_search_key:
     options:
@@ -16,7 +27,7 @@ resources:
   models:
     # LLM for complex reasoning tasks
     reasoning_llm: &reasoning_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 8192
 
@@ -25,7 +36,7 @@ resources:
     executive_assistant_genie_room: &executive_assistant_genie_room
       name: "Executive Assistant Genie Room"
       description: "A room for Genie agents to interact"
-      space_id: 01f05dd06c421ad6b522bf7a517cf6d2
+      space_id: ${var.genie_space_id}
 
 
 tools:

--- a/examples/15_complete_applications/genie_and_genie_mcp/README.md
+++ b/examples/15_complete_applications/genie_and_genie_mcp/README.md
@@ -1,0 +1,182 @@
+# Genie & Genie MCP — Two Paths to the Same Genie Space
+
+> **Side-by-side reference for the two ways a dao-ai agent can reach Databricks Genie: the native `type: genie` tool (in-process Conversation API) vs. `type: mcp` (Genie's managed MCP server).** A supervisor routes between an `employee_agent` (Genie tool) and an `inventory_agent` (Genie MCP), *both wired to the same Genie space* — so the only variable is the transport.
+
+| ✨ Feature | What this example shows |
+|---|---|
+| 🔀 **Two Genie transports, one space** | `employee_agent` uses `type: genie` (native factory tool); `inventory_agent` uses `type: mcp` against `…/api/2.0/mcp/genie/{space_id}`. Both resolve `retail_genie_room` (same `space_id`). |
+| 👔 **Supervisor orchestration** | A single supervisor LLM routes each turn to one of two specialists based on their `handoff_prompt` descriptions. Hub-and-spoke, not a pipeline. |
+| 🛠️ **First-class `genie` tool** | The employee path is `type: genie` — typed fields, no boilerplate. Delegates to `dao_ai.tools.create_genie_tool`, talks to Genie over the Conversation API in-process using the deployed identity. |
+| 🌐 **Managed Genie MCP** | The inventory path is `type: mcp` with a `genie_room` — dao-ai builds the managed MCP URL and calls Genie as an external MCP tool, authenticated with an explicit service principal. |
+| 🔑 **Explicit SP creds on the MCP leg only** | `genie_mcp` wires `client_id` / `client_secret` / `workspace_host` from the `retail_consumer_goods` secret scope. The `genie` tool leg needs none — it rides the serving/App identity. |
+| 🧩 **Config-only, no assets to provision** | No `data/` or `functions/` dir. The Genie space and its underlying tables are **prerequisites**, not created by deploy. `dao-ai agent up` just registers + serves. |
+| 🤖 **Uniform model** | `databricks-claude-sonnet-4` for both specialists and the supervisor router; `on_behalf_of_user: false` everywhere. |
+
+---
+
+## Architecture
+
+The supervisor fans out to two specialists. The interesting part is what happens *below* each specialist: identical intent (ask Genie a question against the retail space), two completely different call paths.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1565c0', 'fontSize': '14px'}}}%%
+flowchart LR
+    User(("user msg"))
+
+    Supervisor["👔 supervisor<br/>claude-sonnet-4<br/><i>routes by handoff_prompt</i>"]
+
+    subgraph Specialists["Specialist agents"]
+        direction TB
+        Emp["👥 employee_agent<br/>claude-sonnet-4"]
+        Inv["📦 inventory_agent<br/>claude-sonnet-4"]
+    end
+
+    GenieTool["🛠️ genie_tool<br/><b>type: genie</b><br/>Conversation API · in-process<br/>deployed identity"]
+    GenieMcp["🌐 genie_mcp<br/><b>type: mcp</b><br/>/api/2.0/mcp/genie/{space_id}<br/>service-principal creds"]
+
+    Space[("💬 Genie Space<br/>retail_genie_room<br/>space_id 01f05dd0…f6d2")]
+    UC["🏛️ Unity Catalog<br/>retail_consumer_goods.store_ops"]
+
+    User --> Supervisor
+    Supervisor -.->|LLM route| Emp
+    Supervisor -.->|LLM route| Inv
+
+    Emp -->|calls| GenieTool
+    Inv -->|calls| GenieMcp
+
+    GenieTool ==>|"native"| Space
+    GenieMcp  ==>|"MCP"| Space
+    Space --> UC
+
+    style Supervisor fill:#fff3e0,stroke:#e65100,stroke-width:3px
+    style Emp fill:#e3f2fd,stroke:#1565c0,stroke-width:2px
+    style Inv fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
+    style GenieTool fill:#e1f5fe,stroke:#0277bd,stroke-width:2px
+    style GenieMcp fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
+    style Space fill:#fffde7,stroke:#fbc02d,stroke-width:2px
+    style UC fill:#e3f2fd,stroke:#1565c0
+```
+
+### The two transports, contrasted
+
+Both legs answer the *same kind of question* against the *same Genie space*. What differs is how the SQL round-trip is made and who authenticates it.
+
+| | 🛠️ `genie_tool` (employee_agent) | 🌐 `genie_mcp` (inventory_agent) |
+|---|---|---|
+| **YAML type** | `function.type: genie` | `function.type: mcp` |
+| **How dao-ai wires it** | `dao_ai.tools.create_genie_tool(genie_room=…)` — a typed first-class tool | Builds `https://{host}/api/2.0/mcp/genie/{space_id}` and registers it as an MCP tool |
+| **Where it runs** | In-process inside the agent; Genie **Conversation API** | Out-of-process call to Databricks' **managed Genie MCP server** |
+| **Auth** | Deployed identity (App / serving SP); no creds in config | Explicit service principal — `client_id` / `client_secret` / `workspace_host` from the `retail_consumer_goods` secret scope |
+| **Extra config** | Just `genie_room` | `genie_room` **+** three secret-backed credentials |
+| **Reaches** | `retail_genie_room` → `space_id 01f05dd0…f6d2` | Same `retail_genie_room` → same `space_id` |
+
+**Why both are in one example:** it isolates the transport. Because the Genie space is held constant, any difference you observe in traces, latency, or auth failures is attributable to the tool type — nothing else.
+
+---
+
+## Agents
+
+| # | Agent | Model | Tool | Genie transport | Role |
+|---|---|---|---|---|---|
+| 1 | `employee_agent` | claude-sonnet-4 | `genie_tool` | **native** (`type: genie`) | Employee performance, task assignments, daily activities, workforce management. |
+| 2 | `inventory_agent` | claude-sonnet-4 | `genie_mcp` | **MCP** (`type: mcp`) | Inventory levels, stock, product availability, reordering. |
+
+The **supervisor** (`orchestration.supervisor`, `fast_llm` = claude-sonnet-4) reads each specialist's `handoff_prompt` and routes a turn to whichever one matches the user's intent. The specialists' prompts (`employee_prompt`, `inventory_prompt`) are registered in Unity Catalog under `retail_consumer_goods.store_ops` and instruct each agent to "use the genie tool to query the … database" — the routing target, not the transport, is what the supervisor decides.
+
+The employee prompt names the tables it expects Genie to know about: `employee_daily_tasks`, `employee_performance`, and `employee_tasks` in `retail_consumer_goods.store_ops`. These must already be modeled in the Genie space.
+
+---
+
+## Why these design choices?
+
+### Why point both agents at the *same* Genie space?
+This example is a **transport comparison**, not a functional demo. Holding the space, the model, and the catalog constant means the `genie` vs. `mcp` distinction is the only independent variable — ideal for teaching which to reach for and for eyeballing the difference in MLflow trace spans.
+
+### Why `type: genie` for one and `type: mcp` for the other?
+- **`type: genie`** is the low-friction default: typed fields, one `genie_room` reference, no credentials, runs in-process over the Conversation API. Reach for it when the agent lives inside a dao-ai app that already has an identity.
+- **`type: mcp`** is the interop path: it calls Genie through Databricks' *managed MCP server*, so the exact same capability is exposed the way any MCP-speaking client would consume it. Reach for it when you want MCP semantics (external clients, uniform tool surface, cross-system reuse) or need to pin a specific service principal.
+
+### Why does only the MCP leg carry service-principal credentials?
+The managed Genie MCP server is an external endpoint (`…/api/2.0/mcp/genie/{space_id}`), so the agent must present credentials to it — here a service principal pulled from the `retail_consumer_goods` secret scope. The native `genie` tool runs inside the agent process and uses the deployed identity (the App or serving service principal), so no extra secrets are declared.
+
+### Why no `data/` or `functions/` directory?
+Nothing here is a created asset. The Genie space (`01f05dd0…f6d2`) and its backing tables are **prerequisites** you point the config at. That is why deploy uses `dao-ai agent up` (register + serve) rather than `dao-ai workflow up` (which is for examples that also provision tables, UC functions, and Vector Search indexes).
+
+---
+
+## Deploy
+
+### Prerequisites
+
+- **Profile**: `DEFAULT` (or your equivalent) configured via `databricks configure`.
+- **Genie space**: `space_id 01f05dd06c421ad6b522bf7a517cf6d2` exists and can answer questions about the `retail_consumer_goods.store_ops` employee/inventory tables. Override `parameters.genie_space_id` to use your own.
+- **Underlying tables**: The employee/inventory tables the Genie space is built on already exist in `retail_consumer_goods.store_ops` (override `parameters.catalog` / `parameters.schema` as needed).
+- **Secret scope** (for the MCP leg): `retail_consumer_goods` scope holds `RETAIL_AI_DATABRICKS_CLIENT_ID`, `RETAIL_AI_DATABRICKS_CLIENT_SECRET`, and `RETAIL_AI_DATABRICKS_HOST`. The service principal must have `CAN RUN` on the Genie space and `SELECT` on its tables.
+
+### Provision + deploy
+
+```bash
+# Validate first (catches schema, anchor, and graph-construction errors)
+DATABRICKS_CONFIG_PROFILE=DEFAULT uv run dao-ai validate \
+  -c examples/15_complete_applications/genie_and_genie_mcp/genie_and_genie_mcp.yaml
+
+# Generate + deploy + start the Databricks App (default --mode apps)
+uv run dao-ai agent up \
+  -c examples/15_complete_applications/genie_and_genie_mcp/genie_and_genie_mcp.yaml \
+  -p DEFAULT
+```
+
+`agent up` registers the MLflow model (`retail_consumer_goods.store_ops.genie_and_genie_mcp_dao`), deploys the bundle, links the trace destination, and launches the App (`genie_and_genie_mcp_dao`). The model serving endpoint is named `dao_pepsi_genie_demo`; all `users` are granted `CAN_QUERY`.
+
+### Verify
+
+```bash
+# App running
+databricks --profile DEFAULT apps get genie_and_genie_mcp_dao
+
+# Inspect the Genie MCP tool the inventory_agent will call
+uv run dao-ai mcp tools \
+  -c examples/15_complete_applications/genie_and_genie_mcp/genie_and_genie_mcp.yaml \
+  -p DEFAULT
+```
+
+---
+
+## Sample prompts
+
+> ⚠️ **Illustrative only.** These are the examples embedded in each agent's `handoff_prompt` in the config — they show the *kind* of question that routes to each specialist. They are not validated against live data, and the exact answers depend on your Genie space's contents.
+
+**Routes to `employee_agent` → `genie_tool` (native Genie):**
+- "What tasks are assigned to John today?"
+- "Show me employee performance metrics."
+- "How is Sarah performing?"
+- "Who completed the most tasks this week?"
+
+**Routes to `inventory_agent` → `genie_mcp` (Genie MCP):**
+- "What's the current inventory level?"
+- "Do we have product X in stock?"
+- "Show me low stock items."
+- "What products need reordering?"
+
+To confirm the transport split, pull the MLflow trace for a turn and check the tool span: the employee turn shows a `genie_tool` / Conversation-API span; the inventory turn shows an MCP tool span hitting `…/api/2.0/mcp/genie/{space_id}`.
+
+---
+
+## File layout
+
+```
+genie_and_genie_mcp/
+├── README.md                    # this file
+└── genie_and_genie_mcp.yaml     # dao-ai config — the whole example
+```
+
+No `data/` or `functions/` — the Genie space and its tables are prerequisites, not created assets.
+
+---
+
+## Related dao-ai patterns referenced
+
+- **First-class `genie` tool** — `reference/dao_ai_first_class_tool_types`
+- **Managed MCP tool types** (`genie` / `sql` / `vector-search` / `functions`) — `McpFunctionModel.mcp_url` in `src/dao_ai/config.py`
+- **Supervisor orchestration** — other `examples/13_orchestration/` supervisor configs
+- **Secret-backed service-principal auth** — `variables:` block with `scope` / `secret` options

--- a/examples/15_complete_applications/genie_and_genie_mcp/genie_and_genie_mcp.yaml
+++ b/examples/15_complete_applications/genie_and_genie_mcp/genie_and_genie_mcp.yaml
@@ -14,6 +14,9 @@ parameters:
   genie_space_id:
     description: Databricks Genie space ID
     default: 01f05dd06c421ad6b522bf7a517cf6d2
+  llm:
+    description: Chat/tool-calling serving endpoint for both agents
+    default: databricks-claude-sonnet-5
 
 variables:
   client_id: &client_id
@@ -44,11 +47,11 @@ schemas:
 resources:
   models:
     fast_llm: &fast_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       on_behalf_of_user: false
 
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-sonnet-4
+      name: ${var.llm}
       on_behalf_of_user: false
 
   genie_rooms:

--- a/examples/15_complete_applications/genie_vector_search_hybrid/README.md
+++ b/examples/15_complete_applications/genie_vector_search_hybrid/README.md
@@ -1,0 +1,178 @@
+# Genie × Vector Search Hybrid — Structured + Unstructured Retrieval
+
+> **A minimal supervisor over two retrieval agents that read the same retail domain two different ways.** One agent answers with **structured** analytics through a Genie space (natural language → SQL over governed tables); the other answers with **unstructured** semantic search over a Vector Search product index. A supervisor classifies each turn and routes to whichever retrieval path fits the question.
+
+| ✨ Feature | What this example shows |
+|---|---|
+| 🧭 **Supervisor orchestration** | `app.orchestration.supervisor` is a central router. It reads each user turn, picks one worker agent via an auto-generated `handoff_to_<agent>` tool, and the worker hands control back — hub-and-spoke, not a pipeline |
+| 🔀 **Hybrid retrieval** | The two worker agents deliberately cover the two halves of retrieval: `genie` (structured/SQL) and `vector_search` (unstructured/semantic). The interesting question this example poses is *which path does a given question belong to?* |
+| 🧮 **Structured path — Genie** | `genie_tool` (`type: genie`) talks to the **"Retail AI Genie Room"** space. Genie turns natural language into SQL and executes it against curated retail tables — right for aggregations, filters, counts, joins |
+| 🔎 **Unstructured path — Vector Search** | `vector_search_tool` (`type: vector_search`) runs ANN similarity search over `products_index`, embedding the `description` column with `databricks-gte-large-en` — right for fuzzy "find me something like…" product discovery |
+| 🧱 **Prerequisite-driven** | This directory ships **config only** — no `data/`, no `functions/`. The Genie space, the `products` source table, and the `products_index` are **prerequisites** you point the config at |
+| 🎛️ **Single reasoning model** | `databricks-claude-sonnet-4` at `temperature: 0.1` drives both workers *and* the supervisor router — consistent, low-variance routing and answers |
+
+> ⚠️ **This is a skeleton/template example.** The two worker agents ship with **placeholder** `prompt` and `handoff_prompt` text (literally `"Answers questions about foo"` / `"…about bar"`). The *retrieval wiring* — Genie room, Vector Search index, retriever, tools, supervisor — is real and complete; the agent instructions are stubs you are expected to fill in for your domain. Everything below documents what the config wires up, and flags the stubs where they matter.
+
+---
+
+## Architecture
+
+A supervisor sits in front of two worker agents. Each worker owns exactly one retrieval tool, and those two tools reach into two different stores over the same retail domain: Genie issues governed SQL against Delta tables; Vector Search does ANN similarity over an embedded index. The supervisor's one job is to decide which store a question belongs to.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1565c0', 'fontSize': '14px'}}}%%
+flowchart TB
+    Start(("user turn"))
+
+    Supervisor["🧭 supervisor<br/>claude-sonnet-4<br/><i>route: structured vs unstructured</i>"]
+
+    subgraph Workers["Worker agents"]
+        direction TB
+        Genie["📊 genie<br/>claude-sonnet-4<br/><i>structured / SQL</i>"]
+        VS["🔎 vector_search<br/>claude-sonnet-4<br/><i>unstructured / semantic</i>"]
+    end
+
+    GenieTool["🛠️ genie_tool<br/><i>type: genie</i>"]
+    VSTool["🛠️ product_vector_search_tool<br/><i>type: vector_search</i>"]
+
+    GenieRoom["🗣️ Retail AI Genie Room<br/>space_id 01f0…82ea<br/><i>NL → SQL</i>"]
+    Index[("🔢 products_index<br/>ANN · num_results 10<br/>embed: description")]
+    Tables[("📋 retail tables<br/>governed by Genie")]
+    Embed["🧬 databricks-gte-large-en"]
+
+    Start ==> Supervisor
+    Supervisor -.->|handoff_to_genie| Genie
+    Supervisor -.->|handoff_to_vector_search| VS
+    Genie -.->|handoff back| Supervisor
+    VS -.->|handoff back| Supervisor
+
+    Genie --> GenieTool --> GenieRoom --> Tables
+    VS --> VSTool --> Index
+    Embed -.->|query + doc vectors| Index
+
+    style Supervisor fill:#fff3e0,stroke:#e65100,stroke-width:3px
+    style Genie fill:#e1f5fe,stroke:#0277bd,stroke-width:2px
+    style VS fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
+    style GenieRoom fill:#e8f5e9,stroke:#2e7d32
+    style Index fill:#fce4ec,stroke:#c2185b
+    style Tables fill:#e3f2fd,stroke:#1565c0
+    style Workers fill:#fafafa,stroke:#9e9e9e
+```
+
+**How a turn flows:**
+1. Every user turn starts at the **supervisor**. It classifies the request and calls exactly one `handoff_to_<agent>` tool (`handoff_to_genie` or `handoff_to_vector_search`).
+2. The chosen worker invokes its single tool, gets results, and composes an answer.
+3. The worker calls its injected `handoff_to_supervisor` tool to return control. The supervisor decides whether it is done or needs the other worker, then produces the final response.
+
+This is **hub-and-spoke**: workers never hand off to each other, only back to the supervisor. Compare the [commerce_supervisor](../commerce/commerce_supervisor.README.md) example for the same pattern at a larger scale.
+
+---
+
+## Agents
+
+| Agent | Model | Tool | Retrieval kind | What it is for |
+|---|---|---|---|---|
+| `genie` | `databricks-claude-sonnet-4` | `genie_tool` (`type: genie`) → **Retail AI Genie Room** | **Structured** (NL → SQL over Delta tables) | Analytical questions that need aggregation, filtering, counting, or joining governed retail data |
+| `vector_search` | `databricks-claude-sonnet-4` | `product_vector_search_tool` (`type: vector_search`) → `products_index` | **Unstructured** (ANN semantic similarity) | Open-ended product discovery over the free-text `description` column |
+
+**Genie path (structured).** `genie_tool` targets the Genie space `space_id: 01f01c91f1f414d59daaefd2b7ec82ea` (overridable via `RETAIL_AI_GENIE_SPACE_ID`). Genie translates the user's natural language into SQL and runs it against the tables in that space, so this path is authoritative for "how many", "what's the total", "which stores", "filter by X" style questions.
+
+**Vector Search path (unstructured).** `product_vector_search_tool` runs through `products_retriever` over `products_index` (endpoint `one-env-shared-endpoint-12`, `STANDARD`). It embeds the `description` column with `databricks-gte-large-en`, searches with `query_type: ANN`, and returns the top **10** results. Columns returned: `product_id`, `sku`, `upc`, `brand_name`, `product_name`, `merchandise_class`, `class_cd`, `description`. This path is right for "find me something like…" where the match is semantic, not a SQL predicate.
+
+> The `genie` and `vector_search` agents' `prompt`/`handoff_prompt` fields are **placeholders** in the shipped config. Before deploying for real, replace them with instructions that describe your domain and, critically, give the supervisor clear `handoff_prompt` routing signals (e.g. genie = "counts, totals, filters, joins over retail data"; vector_search = "semantic product lookup / discovery").
+
+---
+
+## Why these design choices?
+
+### Why split retrieval into two agents at all?
+Structured and unstructured retrieval have different failure modes and different "shapes" of good answer. A Genie/SQL query is exact and auditable but brittle to fuzzy intent; a vector search is tolerant of fuzzy intent but can't do arithmetic or exact joins. Giving each its own agent keeps each tool's contract clean and lets the supervisor make one crisp routing decision instead of one agent juggling two very different tools.
+
+### Why a supervisor instead of a pipeline?
+There is no fixed order between the two paths — a turn needs *one or the other* (occasionally both). A supervisor is the natural fit: it inspects the turn and routes. A linear pipeline would force every question through a stage it doesn't need. (When stages *do* have a fixed order, the [commerce](../commerce/commerce_supervisor.README.md) pipeline/swarm variants are the better reference.)
+
+### Why the same model everywhere?
+Routing quality and answer quality both benefit from a strong reasoner, and at `temperature: 0.1` `databricks-claude-sonnet-4` gives low-variance routing. Keeping one model alias (`default_llm`) across supervisor + both workers keeps the example minimal; you can split it later (e.g. a cheaper router) exactly as the larger commerce examples do.
+
+### Why is there no `data/` or `functions/` directory?
+This example is about **routing between two existing stores**, not provisioning them. The Genie space, the `products` table, and `products_index` are **prerequisites**. That keeps the example focused on the hybrid-retrieval pattern rather than on data setup — and makes it a drop-in template to point at retail data you already have.
+
+---
+
+## Deploy
+
+### Prerequisites
+- **Profile**: a configured Databricks CLI profile (e.g. `DEFAULT`).
+- **Genie space**: the space referenced by `space_id` (or set `RETAIL_AI_GENIE_SPACE_ID`) exists and is scoped to your retail tables.
+- **Source table**: `${catalog}.${schema}.products` exists (defaults: `nfleming.retail_ai.products`). Override with the `catalog` / `schema` parameters.
+- **Vector Search index**: `products_index` exists on endpoint `one-env-shared-endpoint-12` (`STANDARD`), embedding `description` via `databricks-gte-large-en`. Change `endpoint.name` / `index.name` in the YAML to match your workspace.
+
+### Validate + bring up
+
+```bash
+# Validate first (catches schema, anchor, and graph-construction errors)
+DATABRICKS_CONFIG_PROFILE=DEFAULT uv run dao-ai validate \
+  -c examples/15_complete_applications/genie_vector_search_hybrid/genie_vector_search_hybrid.yaml
+
+# Generate + deploy + start as a Databricks App (default --mode apps)
+uv run dao-ai agent up \
+  -c examples/15_complete_applications/genie_vector_search_hybrid/genie_vector_search_hybrid.yaml \
+  -p DEFAULT
+```
+
+To deploy to a Model Serving endpoint instead of an App:
+
+```bash
+uv run dao-ai agent up \
+  -c examples/15_complete_applications/genie_vector_search_hybrid/genie_vector_search_hybrid.yaml \
+  --mode model_serving -p DEFAULT
+```
+
+This registers the model `genie_vector_search_hybrid_dao` and (in `model_serving` mode) the endpoint `genie_and_vector_search_agent_dao`. The app grants `CAN_MANAGE` to all `users`.
+
+> Because this directory ships no datasets, use `dao-ai agent up` (build + deploy the agent). `dao-ai workflow up` is for examples that also provision tables/VS/UC functions — this one assumes those already exist.
+
+### Verify
+
+```bash
+# App running
+databricks --profile DEFAULT apps get genie_vector_search_hybrid_dao
+
+# Or interactive chat against the config
+uv run dao-ai chat \
+  -c examples/15_complete_applications/genie_vector_search_hybrid/genie_vector_search_hybrid.yaml -p DEFAULT
+```
+
+---
+
+## Sample prompts (illustrative)
+
+> ⚠️ **Illustrative only.** The shipped agent prompts are placeholders, so these are *not* validated against a deployed app — they are examples of the kind of question each retrieval path is designed for, derived from the tool and retriever config. Adapt them to your data after filling in the agent prompts.
+
+| Intended path | Illustrative prompt | Why it routes there |
+|---|---|---|
+| **`genie`** (structured / SQL) | *"How many products are in each merchandise class?"* | Aggregation over governed columns — a SQL job for Genie |
+| **`genie`** (structured / SQL) | *"List brands with more than 20 SKUs."* | Grouped count + filter — exact, not semantic |
+| **`vector_search`** (unstructured / semantic) | *"Find me a lightweight waterproof jacket for hiking."* | Free-text intent matched against embedded `description` |
+| **`vector_search`** (unstructured / semantic) | *"Show products similar to a stainless steel travel mug."* | Semantic similarity, no SQL predicate expresses it |
+
+---
+
+## File layout
+
+```
+genie_vector_search_hybrid/
+├── README.md                          # this file
+└── genie_vector_search_hybrid.yaml    # dao-ai config (supervisor + 2 retrieval agents)
+```
+
+No `data/` or `functions/` — the Genie space, `products` table, and `products_index` are prerequisites, not created here.
+
+---
+
+## Related dao-ai patterns referenced
+
+- **Supervisor orchestration** — `examples/13_orchestration/supervisor_pattern.yaml`
+- **Supervisor at scale (commerce)** — `examples/15_complete_applications/commerce/commerce_supervisor.README.md`
+- **Genie tool (`type: genie`)** — natural language → SQL over a Genie space
+- **Vector Search tool (`type: vector_search`)** — ANN semantic retrieval via a retriever + VS index

--- a/examples/15_complete_applications/genie_vector_search_hybrid/genie_vector_search_hybrid.yaml
+++ b/examples/15_complete_applications/genie_vector_search_hybrid/genie_vector_search_hybrid.yaml
@@ -11,6 +11,18 @@ parameters:
   schema:
     description: Schema within the catalog
     default: retail_ai
+  vector_search_endpoint:
+    description: Vector Search endpoint hosting the indexes for this app
+    default: dbdemos_vs_endpoint
+  llm:
+    description: Primary chat/tool-calling serving endpoint for both agents and the supervisor
+    default: databricks-claude-sonnet-5
+  embedding_model:
+    description: Text embedding serving endpoint for vector search
+    default: databricks-gte-large-en
+  genie_space_id:
+    description: Genie space id for the Retail AI Genie room
+    default: 01f01c91f1f414d59daaefd2b7ec82ea
 
 schemas:
   retail_schema: &retail_schema
@@ -21,12 +33,12 @@ resources:
   models:
     # Primary LLM for general tasks
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4  # Databricks serving endpoint name
+      name: ${var.llm}  # Databricks serving endpoint name
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
 
     embedding_model: &embedding_model
-      name: databricks-gte-large-en                 # Text embedding model
+      name: ${var.embedding_model}                  # Text embedding model
 
   vector_stores:
     # Product information vector store for similarity search
@@ -34,7 +46,7 @@ resources:
       embedding_model: *embedding_model
                                                     # Reference to embedding model above
       endpoint:                                     # Vector search endpoint configuration
-        name: one-env-shared-endpoint-12            # Databricks vector search endpoint
+        name: ${var.vector_search_endpoint}                   # Databricks vector search endpoint
         type: STANDARD                              # Endpoint type (STANDARD or OPTIMIZED_STORAGE)
       index:                                        # Vector search index configuration
         schema: *retail_schema
@@ -61,9 +73,7 @@ resources:
     retail_genie_room: &retail_genie_room
       name: "Retail AI Genie Room"                  # Human-readable name
       description: "A room for Genie agents to interact"  # Description
-      space_id:
-        env: RETAIL_AI_GENIE_SPACE_ID
-        default_value: 01f01c91f1f414d59daaefd2b7ec82ea
+      space_id: ${var.genie_space_id}               # Databricks Genie space ID
 
 retrievers:
   # Product information retriever using vector search
@@ -90,7 +100,7 @@ tools:
     function:
       type: genie  # Tool type: factory function
       name: my_genie_tool
-      description: My Answers questions about genie
+      description: Query retail sales, inventory, and store metrics from the Retail AI Genie space
       genie_room: *retail_genie_room
                                                   # Reference to Genie room config
 
@@ -113,9 +123,13 @@ agents:
     tools:                                          # Tools available to this agent
     - *genie_tool
     prompt: |                                       # System prompt defining agent behavior
-      Answers questions about foo
+      You answer structured retail questions by querying the Retail AI Genie space.
+      Use the genie tool for anything that needs aggregation or filtering over the data:
+      sales, revenue, order counts, inventory levels, and store or brand comparisons.
+      Base every answer on the tool results and do not invent numbers.
     handoff_prompt: |                               # Conditions for routing to this agent
-      Answers all foo questions
+      Route here for structured data questions: sales, revenue, inventory levels,
+      order counts, and store or brand metrics that need aggregation or filtering.
 
   vector_search: &vector_search
     name: vector_search                                   # Agent identifier
@@ -125,9 +139,13 @@ agents:
     tools:                                          # Tools available to this agent
     - *vector_search_tool
     prompt: |                                       # System prompt defining agent behavior
-      Answers questions about bar
+      You help customers find products by searching the product catalog with vector search.
+      Use the vector search tool for descriptive, natural-language product questions:
+      "waterproof hiking boots", "something like a Dewalt drill", or matches by
+      brand, product name, or merchandise class. Summarize the returned products clearly.
     handoff_prompt: |                               # Conditions for routing to this agent
-      Answers all bar questions
+      Route here for product discovery and semantic search: finding items by
+      description, features, or similarity rather than exact sales or inventory numbers.
 
 app:
   name: genie_vector_search_hybrid_dao             # Application name  

--- a/examples/15_complete_applications/hardware_store/README.md
+++ b/examples/15_complete_applications/hardware_store/README.md
@@ -1,0 +1,438 @@
+# Hardware Store — one retail assistant, four orchestration patterns
+
+> **A home-improvement / hardware-store customer-service assistant, shipped as FOUR dao-ai config variants over a single shared data plane.** Every variant answers the same kinds of shopper questions (products, inventory, comparisons, DIY, orders) against the same two Unity Catalog tables, the same six UC SQL functions, and the same Vector Search index. What changes between variants is *how the agents are wired together* — a plain supervisor, an instructed-retrieval supervisor, a peer-to-peer swarm, and a Lakebase-backed persistent-memory supervisor. Pick the variant that matches the capability you want to demo; the data underneath never moves.
+
+| ✨ Feature | Where it shows up |
+|---|---|
+| 👔 **Supervisor routing** | `hardware_store.yaml` — a routing LLM picks one of 7 specialists per turn |
+| 🎯 **Instructed retrieval** | `hardware_store_instructed.yaml` — query decomposition → RRF merge → FlashRank rerank |
+| 🐝 **Swarm handoffs** | `hardware_store_swarm.yaml` — agents hand off peer-to-peer, no central router |
+| 🧠 **Lakebase persistent memory** | `hardware_store_lakebase.yaml` — checkpointer + store + background memory extraction |
+| 🔁 **Fallback LLM chains** | `hardware_store_lakebase.yaml` — `claude-sonnet-4-6 → claude-sonnet-4-5` |
+| ⚡ **Mixed-model assignment** | `hardware_store_lakebase.yaml` — `gpt-oss-120b` supervisor + `claude` workers |
+| 🗄️ **`type: sql` Lakebase tools** | `hardware_store_lakebase.yaml` — parameterized SQL with HITL approval + signed audit |
+| 📍 **MS trace persistence to UC** | `hardware_store.yaml` — service principal + experiment + `trace_location` |
+
+---
+
+## Variant comparison
+
+| Variant | Config file | Orchestration | Agents | Distinctive feature |
+|---|---|---|---|---|
+| **Baseline supervisor** | `hardware_store.yaml` | 👔 Supervisor | 7 | Full Model-Serving trace persistence to UC (service principal + pinned experiment + `trace_location`); `llm_judge` guardrail defined |
+| **Instructed retrieval** | `hardware_store_instructed.yaml` | 👔 Supervisor | 5 | Instructed retriever: HYBRID search + LLM query decomposition (3 sub-queries) + RRF (k=60) merge + FlashRank (`ms-marco-MiniLM-L-12-v2`) rerank; adds a fast Haiku decomposition LLM |
+| **Swarm** | `hardware_store_swarm.yaml` | 🐝 Swarm | 7 | Peer-to-peer handoffs (no supervisor); `general` is entry + universal router, `inventory` is terminal; in-memory checkpointer + store |
+| **Lakebase memory** | `hardware_store_lakebase.yaml` | 👔 Supervisor | 7 | Lakebase persistent checkpointer + store + background memory extraction (`user_profile`/`preference`/`episode`); fallback LLM chain; mixed models; `type: sql` tools with HITL + audit |
+
+All four resolve to the same catalog/schema default: **`retail_consumer_goods.hardware_store`**.
+
+---
+
+## Architecture
+
+Every variant is built from the same layers: a client hits the app, requests flow through validation middleware into an orchestration layer over 5–7 specialist agents, and the agents reach into Databricks (LLM endpoints, Vector Search, UC functions). The pieces that *differ* per variant are the orchestration layer and the memory/trace wiring — those are broken out in the per-variant topology subsections below.
+
+### Shared system layers
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1565c0', 'fontSize': '14px'}}}%%
+flowchart LR
+    Client["🖥️ Client<br/>Chat · REST /invocations"]
+
+    subgraph App["🚀 dao-ai app"]
+        direction TB
+        MW["🔒 store_validation<br/>middleware"]
+        Orch["🎭 Orchestration<br/>(supervisor OR swarm)"]
+        Agents["👷 5–7 specialist agents"]
+        MW --> Orch --> Agents
+    end
+
+    LLM["🧠 LLM Endpoints<br/>claude-sonnet · gpt-oss · gte-large-en"]
+    UC["🏛️ Unity Catalog<br/>products · inventory · 6 UC fns"]
+    VS["🔍 Vector Search<br/>products_index @ dbdemos_vs_endpoint"]
+    LB[("🗄️ Lakebase<br/>memory + SQL tools<br/>(lakebase variant only)")]
+
+    Client --> App
+    Agents <-.->|chat completions| LLM
+    Agents -->|UC fn tools| UC
+    Agents -->|product_search| VS
+    Agents <-.->|checkpoint · memory · sql| LB
+
+    style App fill:#fff8e1,stroke:#f57f17,stroke-width:2px
+    style LLM fill:#f3e5f5,stroke:#7b1fa2
+    style UC fill:#e3f2fd,stroke:#1565c0
+    style VS fill:#fff3e0,stroke:#e65100
+    style LB fill:#e8f5e9,stroke:#2e7d32
+```
+
+**Shared across all four variants:**
+- `store_validation` middleware (`dao_ai.middleware.create_custom_field_validation_middleware`) requires `store_num` on every request; `user_id` is optional. In the supervisor variants it wraps the supervisor; in the swarm it is applied swarm-wide so *every* agent enforces it.
+- The `vector_search` tool (`product_vector_search_tool`) hits `products_index`, and the six UC functions back the SKU/UPC lookup tools.
+- Every variant deploys the same two Delta tables and six UC functions (see [Data plane](#data-plane)).
+
+### Baseline supervisor topology (`hardware_store.yaml`)
+
+```mermaid
+%%{init: {'theme': 'base'}}%%
+flowchart TB
+    Query["👤 'How many big green egg grills<br/>do you have in stock?'"]
+    Router["🎯 Supervisor<br/>tool_calling_llm (claude-sonnet-4-5)<br/>routes to one specialist"]
+
+    subgraph Specialists["👷 7 Specialists"]
+        General["💬 general"]
+        Orders["📋 orders"]
+        DIY["🔧 diy"]
+        Product["🛒 product"]
+        Inventory["📦 inventory"]
+        Comparison["⚖️ comparison"]
+        Recommendation["💡 recommendation"]
+    end
+
+    Query --> Router
+    Router --> General & Orders & DIY & Product & Inventory & Comparison & Recommendation
+
+    style Router fill:#fff3e0,stroke:#e65100
+    style Specialists fill:#e8f5e9,stroke:#2e7d32
+```
+
+The routing LLM reads each agent's `handoff_prompt` and dispatches one specialist per turn. This variant is the only one wired for **Model-Serving trace persistence**: it pins a `service_principal` (client id/secret from the `retail_consumer_goods` secret scope), an existing MLflow `experiment.id`, and a `trace_location` that materializes the four OTEL Delta tables under the schema via a SQL warehouse. It also *defines* an `llm_judge` guardrail (though agents leave `guardrails: []`, so it is available to attach, not active by default).
+
+### Instructed-retrieval topology (`hardware_store_instructed.yaml`)
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'fontSize': '13px'}}}%%
+flowchart LR
+    Q["👤 'Find me Milwaukee cordless<br/>drills, not the M12 line'"]
+
+    subgraph Instructed["🎯 Instructed retriever"]
+        direction TB
+        Decomp["🧩 Decompose<br/>decomposition_llm (claude-haiku-4-5)<br/>≤3 sub-queries + filters"]
+        Hybrid["🔍 HYBRID search × N<br/>brand/class/exclusion filters"]
+        RRF["➕ RRF merge<br/>k=60"]
+        Rerank["🏅 FlashRank rerank<br/>ms-marco-MiniLM-L-12-v2 · top_n 10"]
+        Decomp --> Hybrid --> RRF --> Rerank
+    end
+
+    Router["🎯 Supervisor<br/>claude-sonnet-4-5"]
+    subgraph Specialists["👷 5 Specialists"]
+        General2["💬 general"]
+        Product2["🛒 product"]
+        Inventory2["📦 inventory"]
+        Comparison2["⚖️ comparison"]
+        Recommendation2["💡 recommendation"]
+    end
+
+    Q --> Router --> Specialists
+    Specialists -->|product_search| Instructed
+
+    style Instructed fill:#e1f5fe,stroke:#0277bd
+    style Router fill:#fff3e0,stroke:#e65100
+    style Specialists fill:#e8f5e9,stroke:#2e7d32
+```
+
+This variant swaps the plain ANN retriever for an **instructed** one. The `product_search` tool takes a natural-language query, uses a fast Haiku model to decompose it into up to 3 filtered sub-queries (few-shot examples teach brand/category/exclusion filter translation), runs them as HYBRID searches, merges with Reciprocal Rank Fusion (`rrf_k: 60`), then reranks the merged set with a local FlashRank cross-encoder (`ms-marco-MiniLM-L-12-v2`) down to `top_n: 10`. It drops the `orders` and `diy` agents — this variant is focused on retrieval quality for product discovery, comparison, and recommendation. A `products_retriever_standard` (plain ANN) is also defined for side-by-side comparison but is not attached to a tool.
+
+### Swarm topology (`hardware_store_swarm.yaml`)
+
+```mermaid
+%%{init: {'theme': 'base'}}%%
+flowchart TB
+    Query["👤 'Compare two drills, then<br/>check stock for both'"]
+
+    subgraph Swarm["🐝 Agent Swarm (no supervisor)"]
+        General["💬 general<br/>entry + universal router"]
+        Orders["📋 orders"]
+        DIY["🔧 diy"]
+        Product["🛒 product"]
+        Inventory["📦 inventory<br/>terminal"]
+        Comparison["⚖️ comparison"]
+        Recommendation["💡 recommendation"]
+    end
+
+    Query --> General
+    General -->|handoff to any| Orders & DIY & Product & Inventory & Comparison & Recommendation
+    DIY -->|handoff| Product
+    DIY -->|handoff| Inventory
+    DIY -->|handoff| Recommendation
+
+    style General fill:#1565c0,stroke:#0d47a1,color:#fff
+    style Inventory fill:#42BA91,stroke:#00875C
+    style Swarm fill:#e8f5e9,stroke:#2e7d32
+```
+
+There is no central router. `create_swarm()` gives each agent handoff tools built from the target agents' `handoff_prompt`s. Handoff wiring in the YAML:
+
+- **`general`** (entry point, `default_agent`): `handoffs.general` is null → can hand off to **any** agent. It is the universal triage router.
+- **`diy`**: can hand off only to `product`, `inventory`, and `recommendation` — a focused DIY → product-info → stock → suggestion workflow.
+- **`inventory`**: `handoffs.inventory: []` → **terminal** agent, no outbound handoffs; it completes the conversation.
+- Every other agent (unlisted) can hand off to any agent by default.
+
+Memory here is **in-memory** (a `default_checkpointer` and `default_store` with no `database` block → type inferred as memory), namespaced by `{user_id}`. `store_validation` is applied swarm-wide.
+
+### Lakebase-memory topology (`hardware_store_lakebase.yaml`)
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'fontSize': '13px'}}}%%
+flowchart TB
+    Query["👤 'What is my favorite color?'<br/>(answered from memory across turns)"]
+    Router["🎯 Supervisor<br/>fast_llm (gpt-oss-120b)"]
+
+    subgraph Specialists["👷 7 Specialists (claude-sonnet-4-6 → 4-5 fallback)"]
+        General["💬 general<br/>+ category_inventory (sql)<br/>+ deactivate_product (sql · HITL)"]
+        Others["orders · diy · product<br/>inventory · comparison · recommendation"]
+    end
+
+    subgraph Memory["🧠 Lakebase persistent memory"]
+        direction TB
+        CP["Checkpointer"]
+        Store["Store · ns={user_id}"]
+        Ext["Background extraction<br/>user_profile · preference · episode<br/>auto_inject: 5"]
+    end
+
+    LB[("🗄️ Lakebase Postgres<br/>project: retail-consumer-goods")]
+
+    Query --> Router --> Specialists
+    Specialists <-.->|checkpoint + memory| Memory
+    Memory <-.-> LB
+    General -->|type: sql| LB
+
+    style Router fill:#fff3e0,stroke:#e65100
+    style Specialists fill:#e8f5e9,stroke:#2e7d32
+    style Memory fill:#e3f2fd,stroke:#1565c0
+    style LB fill:#e8f5e9,stroke:#2e7d32
+```
+
+This is the production-grade variant. The supervisor runs on the cheap/fast `gpt-oss-120b`; the seven workers run on `claude-sonnet-4-6` with an automatic fallback to `claude-sonnet-4-5` if the primary endpoint errors. A Lakebase (`retail-consumer-goods`) project backs both the checkpointer and the long-term store, and a **background memory-extraction** pass distills each turn into three structured schemas (`user_profile`, `preference`, `episode`), auto-injecting up to 5 relevant memories into agent prompts. The `general` agent additionally gets two first-class `type: sql` tools that run parameterized statements against Lakebase Postgres (details in [Data plane](#data-plane)).
+
+---
+
+## Agents
+
+All variants draw from the same roster of specialist agents. Each agent's `prompt` opens with the `{user_id}` / `{store_num}` context block and a "use tools first" instruction; each `handoff_prompt` tells the router/swarm when to pick it.
+
+| Agent | Role | Tools (baseline / lakebase) | In variants |
+|---|---|---|---|
+| **general** | General store info, policies, hours, services | `vector_search` (+ `category_inventory`, `deactivate_product` in lakebase; **none** in swarm) | all 4 |
+| **orders** | Order tracking, delivery, cancellations, returns | none (no tools assigned) | baseline, swarm, lakebase |
+| **diy** | How-to guidance, project & tool advice | `vector_search` | baseline, swarm, lakebase |
+| **product** | Single-product details, specs, pricing | `find_product_by_sku_uc`, `find_product_by_upc_uc`, `vector_search` | all 4 |
+| **inventory** | Stock levels, availability (terminal in swarm) | `find_inventory_by_sku_uc`, `find_inventory_by_upc_uc`, `vector_search` | all 4 |
+| **comparison** | Side-by-side comparison of 2+ products | `vector_search`, `find_product_by_sku_uc` | all 4 |
+| **recommendation** | Tailored product suggestions | `vector_search` | all 4 |
+
+**Per-variant roster differences:**
+- **Baseline / swarm / lakebase** ship all 7 agents.
+- **Instructed** ships only 5 — it drops `orders` and `diy` to focus on retrieval-quality use cases (product, inventory, comparison, recommendation, general).
+- **Swarm** gives `general` an empty tool list (`tools: []`) — it is pure triage/router and hands off to a tool-carrying specialist.
+- **Lakebase** attaches the two `type: sql` tools to `general` only.
+- The instructed variant's `vector_search` tool is named `product_search` and is backed by the instructed retriever; the other three use the plain ANN retriever.
+
+---
+
+## Data plane
+
+**The data plane is identical across all four variants** — the same two Delta tables, six UC SQL functions, and one Vector Search index in **`retail_consumer_goods.hardware_store`**. Only the lakebase variant adds a *separate* Lakebase Postgres store on top (for memory + its two SQL tools).
+
+### Schema layout
+
+```
+retail_consumer_goods.hardware_store/
+├── 📊 Tables (2) — Delta, CLUSTER BY AUTO + enableChangeDataFeed
+│   ├── products      ← VS source (description embedded); loaded from products.snappy.parquet
+│   └── inventory     ← FK products.product_id;            loaded from inventory.snappy.parquet
+│
+├── 🛠️ UC Functions (6) — all READS SQL DATA, take ARRAY<STRING> keys
+│   ├── find_product_by_sku(sku[])              → product rows
+│   ├── find_product_by_upc(upc[])              → product rows
+│   ├── find_inventory_by_sku(sku[])            → inventory joined to products
+│   ├── find_inventory_by_upc(upc[])            → inventory joined to products
+│   ├── find_store_inventory_by_sku(store, sku[]) → store-scoped inventory
+│   └── find_store_inventory_by_upc(store, upc[]) → store-scoped inventory
+│
+└── 🔍 VS Index (1) — Delta-Sync on shared endpoint dbdemos_vs_endpoint (STANDARD)
+    └── products_index ← source: products.description, primary_key product_id
+```
+
+### Table schemas
+
+**`products`** — master catalog, `product_id BIGINT` PK:
+
+| Column | Type | Notes |
+|---|---|---|
+| `product_id` | BIGINT | PK |
+| `sku` | STRING | 5–8 alphanumeric internal code |
+| `upc` | STRING | 12-digit barcode |
+| `brand_name` | STRING | e.g. Milwaukee, DeWalt, Makita, Craftsman, Black+Decker, Ryobi, Bosch, Stanley, Husky |
+| `product_name` | STRING | display name (often includes model numbers) |
+| `merchandise_class` | STRING | e.g. Power Tools, Hand Tools, Paint, Plumbing, Electrical, Lumber, Hardware, Outdoor |
+| `class_cd` | STRING | subcategory code |
+| `description` | STRING | **embedded** into `products_index` |
+
+**`inventory`** — stock + pricing + location, `inventory_id BIGINT` PK, `product_id` FK → `products`:
+
+| Column | Type | Notes |
+|---|---|---|
+| `inventory_id` | BIGINT | PK |
+| `product_id` | BIGINT | FK → products |
+| `store` | STRING | store identifier |
+| `store_quantity` | INT | on-hand at store |
+| `warehouse` | STRING | backup warehouse id |
+| `warehouse_quantity` | INT | on-hand at warehouse |
+| `retail_amount` | DECIMAL(11,2) | price |
+| `popularity_rating` | STRING | high/medium/low |
+| `department` | STRING | store department |
+| `aisle_location` | STRING | physical aisle |
+| `is_closeout` | BOOLEAN | clearance flag |
+
+Data is shipped as static Snappy parquet (`products.snappy.parquet`, `inventory.snappy.parquet`) and loaded at deploy against the `.sql` DDL — no runtime generation. The UC-function `test:` blocks exercise known keys (`sku: "00176279"`, `upc: "0017627748017"`, `store: "35048"`), so those values exist in the seed data.
+
+### UC functions
+
+All six are thin, safe `READS SQL DATA` table functions that accept `ARRAY<STRING>` keys (so an agent can batch multiple SKUs/UPCs in one call) and return typed rows. The `find_inventory_*` variants join `inventory` to `products` so the agent gets brand/name alongside stock; the `find_store_inventory_*` variants add a `store` filter for location-scoped lookups. The base config's tools only expose the four non-store functions; all six are deployed via `unity_catalog_functions:` in every variant.
+
+### Lakebase Postgres store (lakebase variant only)
+
+The lakebase variant adds a `retail_database` (Lakebase project `retail-consumer-goods`, SP auth, `on_behalf_of_user: false`) that backs the memory checkpointer/store *and* two `type: sql` tools:
+
+- **`category_inventory`** — a read tool: `SELECT product_name, on_hand FROM inventory WHERE store_num = %(store_num)s AND category = %(category)s`. The LLM supplies `category`; `store_num` is bound server-side from the runtime `Context` (never exposed to the model). Demonstrates mixed LLM/context parameter sourcing.
+- **`deactivate_product`** — a *mutating* tool: `UPDATE products SET active = false WHERE product_id = %(product_id)s`, guarded by `human_in_the_loop` (approve/reject) and an `audit` block that writes a signed receipt (identity + args + `trace_id`) to `audit_receipts`.
+
+> These two tools target **Lakebase Postgres tables** (`inventory` with `store_num`/`category`/`on_hand`, `products` with an `active` flag), which are a different, illustrative schema from the UC Delta `products`/`inventory` above. They demonstrate the `type: sql` tool surface (parameter binding, HITL, audit) rather than querying the shared Delta plane.
+
+---
+
+## Why these design choices?
+
+### Why four variants over one data plane?
+
+Because the interesting variation in an agentic app is *orchestration and retrieval*, not the data. Holding the catalog, functions, and index fixed lets you compare patterns apples-to-apples: the same "how many Big Green Egg grills are in stock?" question exercises supervisor routing, swarm handoffs, instructed retrieval, and persistent memory without changing a single row. It also keeps deploy cost down — provision the data once, then stand up whichever agent topology you want to show.
+
+### When would I pick each?
+
+- **`hardware_store.yaml` (baseline supervisor)** — the default starting point. Clean hub-and-spoke routing, all 7 agents, and it is the reference for **getting MLflow traces to persist to Unity Catalog** from a Model-Serving endpoint (service principal + pinned experiment + `trace_location`). Start here, then layer on capabilities.
+- **`hardware_store_instructed.yaml` (instructed retrieval)** — when **search quality** is the story. Decomposition + RRF + FlashRank meaningfully improves recall/precision on messy natural-language product queries with brand/category/exclusion intent ("Milwaukee cordless drills, not the M12 line"). Pick it for retrieval-heavy demos; it deliberately trims to 5 agents.
+- **`hardware_store_swarm.yaml` (swarm)** — when you want to show **peer-to-peer collaboration** without a central router, or model a fixed workflow (DIY → product → inventory → recommendation) with a terminal agent. Good for illustrating handoff mechanics and autonomous agent behavior.
+- **`hardware_store_lakebase.yaml` (Lakebase memory)** — the **production-shaped** variant. Persistent cross-session memory, background extraction, mixed-model cost control (cheap supervisor, capable workers), fallback chains for reliability, and governed mutating SQL with HITL + audit. Pick it when the demo needs to *remember* the user and survive endpoint hiccups.
+
+### Why a fast supervisor + capable workers (lakebase)?
+
+`gpt-oss-120b` is fast and cheap and only has to make a routing decision, so it drives the supervisor. The seven workers do the reasoning and tool work, so they get `claude-sonnet-4-6`. Spending the Claude budget where response quality matters — and only there — is more efficient than uniform Sonnet everywhere.
+
+### Why a fallback LLM chain (lakebase)?
+
+`tool_calling_llm` lists `fallbacks: [claude-sonnet-4-5]` under `claude-sonnet-4-6`. If the primary endpoint errors or is unavailable, the worker automatically retries on the fallback — reliability without changing agent code. (Per the config comment, the supervisor was intentionally reverted to `gpt-oss-120b` after an orchestration change made the earlier "multiple tool calls not supported" issue impossible to recur.)
+
+### Why in-memory for swarm but Lakebase for the memory variant?
+
+The swarm variant is demonstrating **handoff topology**, so it uses the zero-dependency in-memory checkpointer/store — nothing to provision. The lakebase variant is demonstrating **durable personalization**, which requires a real Postgres store so memories survive across threads and sessions.
+
+---
+
+## Deploy
+
+Same commands for every variant — just change `-c <file>`. Set your Databricks profile once (the vault convention is `DEFAULT`).
+
+### Validate
+
+```bash
+# Baseline supervisor
+uv run dao-ai validate -c examples/15_complete_applications/hardware_store/hardware_store.yaml
+
+# Instructed retrieval
+uv run dao-ai validate -c examples/15_complete_applications/hardware_store/hardware_store_instructed.yaml
+
+# Swarm
+uv run dao-ai validate -c examples/15_complete_applications/hardware_store/hardware_store_swarm.yaml
+
+# Lakebase memory
+uv run dao-ai validate -c examples/15_complete_applications/hardware_store/hardware_store_lakebase.yaml
+```
+
+### Chat / visualize locally
+
+```bash
+# Interactive chat against any variant
+uv run dao-ai chat -c examples/15_complete_applications/hardware_store/hardware_store_swarm.yaml
+
+# Render the multi-agent graph to an image
+uv run dao-ai graph -c examples/15_complete_applications/hardware_store/hardware_store.yaml -o hardware_store_architecture.png
+```
+
+### Deploy + provision
+
+```bash
+# Provision data + functions + VS index, register the model, launch the app
+uv run dao-ai workflow up \
+  -c examples/15_complete_applications/hardware_store/hardware_store.yaml \
+  -p DEFAULT
+```
+
+`workflow up` provisions the shared data plane (creates the two tables and loads the parquet, deploys the six UC functions, creates the `products_index` Delta-Sync index on `dbdemos_vs_endpoint`), then registers the model and deploys the app. The lakebase variant additionally provisions the `retail-consumer-goods` Lakebase project for memory + SQL tools.
+
+### Prerequisites
+
+- **Profile**: `DEFAULT` (or equivalent) via `databricks configure`.
+- **Vector Search endpoint**: `dbdemos_vs_endpoint` exists, or change `endpoint.name` in the config.
+- **SQL Warehouse**: the baseline variant's `parameters.warehouse_id` (`d1be2f7fe7faacb1`) must point at a serverless warehouse for the OTEL trace-table DDL; override with `--param warehouse_id=...`.
+- **Secret scope** (baseline + lakebase): `retail_consumer_goods` scope with keys `RETAIL_AI_DATABRICKS_CLIENT_ID` / `RETAIL_AI_DATABRICKS_CLIENT_SECRET` for the pinned service principal.
+- Model endpoints are parameterized — override any default without editing the file, e.g. `--param llm=databricks-claude-sonnet-4-5`.
+
+---
+
+## Sample prompts
+
+These are the exact examples shipped in [`examples.yaml`](./examples.yaml). Each sets `custom_inputs.configurable` to `thread_id: "1"`, `user_id: john_smith`, `store_num: 87887` (the `diy` example uses `store_num: 123`).
+
+| Example key | Prompt | Exercises |
+|---|---|---|
+| `general_example` | *"Can you answer this general question about your billing process?"* | **general** agent |
+| `orders_example` | *"Can you give me an update on my order. The order number is 12345"* | **orders** agent |
+| `diy_example` | *"Can you tell me how to fix a leaky faucet?"* | **diy** agent (`store_num: 123`) |
+| `product_example` | *"Can you give me information about the Big Green Egg grill?"* | **product** agent |
+| `inventory_example` | *"How many big green egg grills do you have in stock?"* | **inventory** agent |
+| `comparison_example` | *"Can you compare items with product ids 14523 and 25163"* | **comparison** agent |
+| `recommendation_example` | *"Can you a stain color to go with my beige lawn furniture?"* | **recommendation** agent |
+| `product_image_example` | *"Can you give me information about this item?"* + `doritos_upc.png` | product agent, **image/UPC input** |
+| `comparison_image_example` | *"Can you compare these items?"* + `doritos_upc.png`, `lays_upc.png` | comparison agent, **multi-image input** |
+| `favorite_color_is` | *"My favorite color is red?"* | **memory write** (swarm/lakebase) |
+| `what_is_my_favorite_color` | *"What is my favorite color?"* | **memory recall** (swarm/lakebase) |
+
+The `favorite_color_is` → `what_is_my_favorite_color` pair is the memory smoke test: run them in sequence on the same `user_id`/`thread_id` and the second should recall the answer from the first (in-memory for the swarm variant, durable Lakebase for the lakebase variant).
+
+The `input_example` blocks in the configs offer variant-flavored one-liners too — e.g. the instructed variant's *"Find me Milwaukee cordless drills, not the M12 line"* showcases exclusion-filter decomposition.
+
+---
+
+## File layout
+
+```
+hardware_store/                              # shared use-case dir — 4 variants, one data plane
+├── README.md                                # this file
+├── hardware_store.yaml                      # 👔 baseline supervisor + MS trace persistence
+├── hardware_store_instructed.yaml           # 🎯 instructed retrieval (decomp + RRF + FlashRank)
+├── hardware_store_swarm.yaml                # 🐝 peer-to-peer swarm + in-memory store
+├── hardware_store_lakebase.yaml             # 🧠 supervisor + Lakebase memory + fallback + sql tools
+├── examples.yaml                            # sample prompts (source of the table above)
+├── data/                                    # shared Delta tables — DDL + parquet
+│   ├── products.sql   + products.snappy.parquet
+│   └── inventory.sql  + inventory.snappy.parquet
+└── functions/                               # shared UC SQL functions (6)
+    ├── find_product_by_sku.sql
+    ├── find_product_by_upc.sql
+    ├── find_inventory_by_sku.sql
+    ├── find_inventory_by_upc.sql
+    ├── find_store_inventory_by_sku.sql
+    └── find_store_inventory_by_upc.sql
+```
+
+---
+
+## Related dao-ai patterns referenced
+
+- **Supervisor orchestration** — the baseline and lakebase variants; see also `examples/13_orchestration/`
+- **Swarm orchestration + handoffs** — `hardware_store_swarm.yaml`; `examples/13_orchestration/swarm_pattern.yaml`
+- **Instructed retrieval (decomposition + RRF + rerank)** — `hardware_store_instructed.yaml`
+- **Lakebase persistent memory + background extraction** — `hardware_store_lakebase.yaml`; parallels the commerce swarm memory model in `examples/15_complete_applications/commerce/`
+- **`type: sql` tools with HITL + audit** — `hardware_store_lakebase.yaml`
+- **MS trace persistence to UC** — `hardware_store.yaml` (`service_principal` + `experiment` + `trace_location`)
+- **Sibling complete applications** — `commerce/`, `sporting_goods_store/`, `procurement_supplier_a2a/`

--- a/examples/15_complete_applications/hardware_store/hardware_store.yaml
+++ b/examples/15_complete_applications/hardware_store/hardware_store.yaml
@@ -11,11 +11,17 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  vector_search_endpoint:
+    description: Vector Search endpoint hosting the indexes for this app
+    default: dbdemos_vs_endpoint
   warehouse_id:
     description: SQL warehouse ID for the UC OTEL trace tables' initial DDL
     default: d1be2f7fe7faacb1
   llm:
     description: Chat/reasoning serving endpoint (agents, tool-calling, judge).
+    default: databricks-claude-sonnet-5
+  fallback_llm:
+    description: Same-class fallback serving endpoint (one generation back) the primary llm falls back to when unavailable
     default: databricks-claude-sonnet-4-5
   embedding_model:
     description: Text embedding serving endpoint for vector search.
@@ -59,6 +65,8 @@ resources:
       name: ${var.llm}
       temperature: 0.1
       max_tokens: 8192
+      fallbacks:
+      - ${var.fallback_llm}
 
     # LLM for evaluating and judging responses (guardrails)
     judge_llm: &judge_llm
@@ -80,7 +88,7 @@ resources:
       embedding_model: *embedding_model
                                                     # Reference to embedding model above
       endpoint:                                     # Vector search endpoint configuration
-        name: dbdemos_vs_endpoint            # Databricks vector search endpoint
+        name: ${var.vector_search_endpoint}            # Databricks vector search endpoint
         type: STANDARD                              # Endpoint type (STANDARD or OPTIMIZED_STORAGE)
       index:                                        # Vector search index configuration
         schema: *retail_schema

--- a/examples/15_complete_applications/hardware_store/hardware_store_instructed.yaml
+++ b/examples/15_complete_applications/hardware_store/hardware_store_instructed.yaml
@@ -11,8 +11,14 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  vector_search_endpoint:
+    description: Vector Search endpoint hosting the indexes for this app
+    default: dbdemos_vs_endpoint
   llm:
     description: Chat/reasoning serving endpoint (agents, tool-calling, judge).
+    default: databricks-claude-sonnet-5
+  fallback_llm:
+    description: Same-class fallback serving endpoint (one generation back) the primary llm falls back to when unavailable
     default: databricks-claude-sonnet-4-5
   decomposition_llm:
     description: Fast serving endpoint for query decomposition (lower latency).
@@ -60,6 +66,8 @@ resources:
       name: ${var.llm}
       temperature: 0.1
       max_tokens: 8192
+      fallbacks:
+      - ${var.fallback_llm}
 
     # Fast LLM for query decomposition (smaller model = lower latency)
     decomposition_llm: &decomposition_llm
@@ -84,7 +92,7 @@ resources:
     products_vector_store: &products_vector_store
       embedding_model: *embedding_model
       endpoint:
-        name: dbdemos_vs_endpoint
+        name: ${var.vector_search_endpoint}
         type: STANDARD
       index:
         schema: *retail_schema

--- a/examples/15_complete_applications/hardware_store/hardware_store_lakebase.yaml
+++ b/examples/15_complete_applications/hardware_store/hardware_store_lakebase.yaml
@@ -11,9 +11,12 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  vector_search_endpoint:
+    description: Vector Search endpoint hosting the indexes for this app
+    default: dbdemos_vs_endpoint
   llm:
     description: Primary chat/tool-calling serving endpoint for agents.
-    default: databricks-claude-sonnet-4-6
+    default: databricks-claude-sonnet-5
   fallback_llm:
     description: Fallback chat serving endpoint when the primary endpoint errors.
     default: databricks-claude-sonnet-4-5
@@ -22,7 +25,7 @@ parameters:
     default: databricks-gpt-oss-120b
   judge_llm:
     description: Serving endpoint used to evaluate/judge responses (guardrails, eval).
-    default: databricks-claude-sonnet-4-5
+    default: databricks-claude-sonnet-5
   embedding_model:
     description: Text embedding serving endpoint for vector search and memory recall.
     default: databricks-gte-large-en
@@ -124,7 +127,7 @@ resources:
       embedding_model: *embedding_model
                                                     # Reference to embedding model above
       endpoint:                                     # Vector search endpoint configuration
-        name: dbdemos_vs_endpoint            # Databricks vector search endpoint
+        name: ${var.vector_search_endpoint}            # Databricks vector search endpoint
         type: STANDARD                              # Endpoint type (STANDARD or OPTIMIZED_STORAGE)
       index:                                        # Vector search index configuration
         schema: *retail_schema

--- a/examples/15_complete_applications/hardware_store/hardware_store_swarm.yaml
+++ b/examples/15_complete_applications/hardware_store/hardware_store_swarm.yaml
@@ -11,11 +11,17 @@ parameters:
   schema:
     description: Schema within the catalog
     default: hardware_store
+  vector_search_endpoint:
+    description: Vector Search endpoint hosting the indexes for this app
+    default: dbdemos_vs_endpoint
   # Model endpoints are parameterized so defaults are overridable per
   # environment (e.g. --param llm=databricks-claude-sonnet-5) without editing
   # the config. Defaults track current GA Foundation Model API endpoints.
   llm:
     description: Chat/reasoning serving endpoint (agents, tool-calling, judge).
+    default: databricks-claude-sonnet-5
+  fallback_llm:
+    description: Same-class fallback serving endpoint (one generation back) the primary llm falls back to when unavailable
     default: databricks-claude-sonnet-4-5
   embedding_model:
     description: Text embedding serving endpoint for vector search.
@@ -59,6 +65,8 @@ resources:
       name: ${var.llm}
       temperature: 0.1
       max_tokens: 8192
+      fallbacks:
+      - ${var.fallback_llm}
 
     # LLM for evaluating and judging responses (guardrails)
     judge_llm: &judge_llm
@@ -80,7 +88,7 @@ resources:
       embedding_model: *embedding_model
                                                     # Reference to embedding model above
       endpoint:                                     # Vector search endpoint configuration
-        name: dbdemos_vs_endpoint            # Databricks vector search endpoint
+        name: ${var.vector_search_endpoint}            # Databricks vector search endpoint
         type: STANDARD                              # Endpoint type (STANDARD or OPTIMIZED_STORAGE)
       index:                                        # Vector search index configuration
         schema: *retail_schema

--- a/examples/15_complete_applications/loyalty_offer_personalization/README.md
+++ b/examples/15_complete_applications/loyalty_offer_personalization/README.md
@@ -1,0 +1,529 @@
+# Loyalty Offer Personalization — Receipt-Driven Offer Ranking Companion
+
+> **A supervisor-routed operator companion for loyalty/CRM marketers and merchandisers who investigate, explain, and re-run LLM-ranked offer assignments across a ~40M-customer loyalty program.** Seven specialist agents sit behind a routing supervisor, backed by a Customer 360 built from receipts, an `ai_query`-powered offer ranker that is the *single source of truth* for the personalization prompt, a vector retriever over the offer catalog, a Genie room for cross-segment analytics, and Lakebase persistent memory that learns each operator's investigative habits.
+
+| ✨ Feature | What this example shows |
+|---|---|
+| 🧭 **Supervisor routing** | A dedicated `fast_llm` supervisor reads each request and hands off to exactly one of 7 specialists via handoff tools. Specialists return control to the supervisor — a **hub-and-spoke** topology, not a pipeline. One handoff per turn; multi-specialist requests are chained across returns. |
+| 🎯 **`ai_query` ranker as single source of truth** | `rank_offers_for_customer(...)` builds the personalization prompt inline and calls `ai_query('databricks-claude-sonnet-4-5', … responseFormat=STRUCT<…>)`. The **same UC function** powers the real-time what-if agent, the batch refresh job, and any external scoring surface — edit the prompt once, every surface picks it up. |
+| 🧠 **Lakebase persistent memory** | Reuses the existing `retail-consumer-goods` Lakebase project for checkpointer + namespaced store + background extraction of `user_profile` / `preference` / `episode`. Learns each operator's segments, repeat-investigated customers, and preferred analytical lenses. |
+| 🔍 **Instructed vector retriever** | Hybrid VS over `offer_catalog.description` with LLM query-decomposition (brand/category/discount/season filters lifted from natural language), LLM rerank, and a `ms-marco` cross-encoder rerank on top. |
+| 💬 **One Genie room, two tool faces** | A single Genie space is exposed under two tool names (`query_segment_analytics`, `query_redemption_outcomes`) so the supervisor's routing heuristics can distinguish segment analytics from redemption outcomes. LRU + context-aware (semantic) caching on both. |
+| 🛡️ **Unity AI Gateway** | `ai_gateway: true` on every chat endpoint — uniform governance, usage tracking, rate-limit pooling. Sonnet primary with a Sonnet-4-6 fallback. |
+| 🎛️ **Mixed-model assignment** | `gpt-5-4-mini` for routing, query decomposition, rerank, and memory-query rephrasing; `claude-sonnet-4-5` for the 7 tool-calling specialists, memory extraction, the eval judge, and the `ai_query` ranker itself. |
+| 🔒 **SP-backed everywhere it matters** | UC functions run SP-backed because `rank_offers_for_customer` calls `ai_query` via Spark Connect and the OBO token lacks the databricks-connect scope. Chat models are SP-backed so eager client construction at Model-Serving load time doesn't fail without a user token. |
+| 📦 **20-resource budget discipline** | 7 UC fns + 1 Lakebase + 1 VS + 1 Genie + 3 dedup'd LLMs. Deliberate omissions (`refresh_offer_rankings` batch fn, `receipts`/`receipt_lines`/`customers_x_eligible_offers` from Genie) documented inline to stay under the Databricks Apps resource cap. |
+| 🚀 **Dual deploy target** | The same config deploys to **Model Serving** (`--mode model_serving`) and **Databricks Apps** (`--mode apps`) — one `workflow up` per target. |
+
+---
+
+## Architecture
+
+The system is built from a few interacting layers. Each diagram below is focused; together they describe the full picture.
+
+### 1. System layers
+
+Client → App (routing supervisor + memory middleware + 7 specialists) → AI Gateway, Lakebase, Unity Catalog (tables, UC functions, VS index), and the Genie room. The `ai_query` ranker is inside UC — the agents invoke it as a UC-function tool, and a batch job invokes it out-of-band.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1565c0', 'fontSize': '14px'}}}%%
+flowchart LR
+    Client["🖥️ Operator<br/>CRM marketer · merchandiser"]
+
+    subgraph App["🚀 Databricks App / Model Serving"]
+        direction TB
+        MI["🧠 memory inject<br/>(auto_inject, K=5)"]
+        Sup["🧭 supervisor<br/>gpt-5-4-mini"]
+        Spec["👥 7 specialists"]
+        Ext["💾 extraction (bg)"]
+        MI --> Sup --> Spec
+        Spec -.-> Ext
+    end
+
+    Gateway["🛡️ Unity AI Gateway"]
+    Lakebase[("🗄️ Lakebase<br/>retail-consumer-goods")]
+    Genie["💬 Genie room<br/>Loyalty Offers Analytics v2"]
+    UC["🏛️ Unity Catalog<br/>9 tables · 7 UC fns · VS index"]
+    AIQ["⚙️ ai_query ranker<br/>rank_offers_for_customer"]
+
+    Client --> App
+    Spec <-.->|chat completions| Gateway
+    Spec <-.->|checkpoint + memory| Lakebase
+    MI <-.->|semantic search| Lakebase
+    Spec -->|UC fn / VS tools| UC
+    Spec -.->|NL analytics| Genie
+    UC --> AIQ
+    AIQ -.->|ai_query| Gateway
+
+    style App fill:#fff8e1,stroke:#f57f17,stroke-width:2px
+    style Gateway fill:#f3e5f5,stroke:#7b1fa2
+    style Lakebase fill:#e8f5e9,stroke:#2e7d32
+    style UC fill:#e3f2fd,stroke:#1565c0
+    style Genie fill:#e0f7fa,stroke:#00838f
+    style AIQ fill:#ffe0b2,stroke:#ef6c00,stroke-width:2px
+```
+
+**Wiring details that are easy to miss:**
+- The `⚙️ ai_query ranker` is a **UC SQL function**, not a Python tool. When the `what_if_ranker` agent calls `rank_offers_for_customer_uc`, Unity Catalog runs the SQL, which itself issues `ai_query('databricks-claude-sonnet-4-5', …)` back through the gateway. So a single agent turn can cascade into a second, server-side LLM call inside the warehouse.
+- The **Genie room is one physical space** but shows up as two tools. Both point at `*loyalty_genie_room`; the descriptions differ so the supervisor routes "top-N by segment" to `segment_analyst` and "did offer X lift redemption" to `redemption_outcomes`.
+- Memory injection (`auto_inject: true`) fires **before** each specialist LLM call, prepending up to 5 stored memories; background extraction runs **after** the turn so it never blocks the response.
+
+### 2. Supervisor topology
+
+This is a **hub-and-spoke supervisor**, not a linear pipeline. The supervisor holds no data tools (only `app_info`) — its sole job is to emit exactly one `handoff_to_<specialist>` tool call. Specialists do their tool work and return control to the supervisor; multi-specialist requests are handled by chaining handoffs across returns.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1565c0', 'fontSize': '14px'}}}%%
+flowchart TB
+    Start(("operator msg"))
+    Sup{"🧭 supervisor<br/>gpt-5-4-mini<br/><i>routes — no data tools</i>"}
+
+    subgraph Specialists["👥 Specialist agents — all claude-sonnet-4-5"]
+        direction TB
+        CI["👤 customer_intelligence<br/>C360 + receipts"]
+        OC["🏷️ offer_catalog<br/>VS search + eligibility"]
+        RE["🔎 ranking_explainer<br/>stored ranking rationale"]
+        WI["🧪 what_if_ranker<br/>ai_query re-rank"]
+        SA["📊 segment_analyst<br/>Genie + top-N"]
+        RO["📈 redemption_outcomes<br/>Genie + performance"]
+        GEN["💬 general<br/>meta / capabilities"]
+    end
+
+    Start --> Sup
+    Sup -.->|handoff| CI
+    Sup -.->|handoff| OC
+    Sup -.->|handoff| RE
+    Sup -.->|handoff| WI
+    Sup -.->|handoff| SA
+    Sup -.->|handoff| RO
+    Sup -.->|handoff| GEN
+
+    CI ==>|return| Sup
+    OC ==>|return| Sup
+    RE ==>|return| Sup
+    WI ==>|return| Sup
+    SA ==>|return| Sup
+    RO ==>|return| Sup
+    GEN ==>|return| Sup
+
+    Sup ==> End(("response"))
+
+    style Sup fill:#fff3e0,stroke:#e65100,stroke-width:3px
+    style WI fill:#ffe0b2,stroke:#ef6c00,stroke-width:2px
+    style Specialists fill:#fafafa,stroke:#9e9e9e
+    style Start fill:#e0e0e0,stroke:#424242
+    style End fill:#e0e0e0,stroke:#424242
+```
+
+**Wired in the YAML as `app.orchestration`:**
+```yaml
+app:
+  agents:                       # the 7 specialists
+  - *general
+  - *customer_intelligence
+  - *offer_catalog
+  - *ranking_explainer
+  - *what_if_ranker
+  - *segment_analyst
+  - *redemption_outcomes
+  orchestration:
+    memory: *memory             # Lakebase checkpointer + store + extraction
+    supervisor:
+      model: *fast_llm          # gpt-5-4-mini — routing only
+      tools: [*app_info_tool]   # deliberately no data tools
+      prompt: |
+        ... emit exactly ONE handoff tool call per response ...
+```
+
+The supervisor prompt is explicit: **one handoff per response.** For a request like *"pull C-00007's profile AND explain why O-0001 should rank top-3,"* it routes to `customer_intelligence` first; when that specialist returns, the supervisor issues the next handoff to `ranking_explainer` with the prior result already in the conversation.
+
+### 3. Per-turn execution lifecycle
+
+The full sequence of a single operator turn — including the `ai_query` cascade that makes the what-if ranker distinctive.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'fontSize': '13px'}}}%%
+sequenceDiagram
+    autonumber
+    actor Op as Operator
+    participant MI as 🧠 memory_context
+    participant Sup as 🧭 supervisor
+    participant Spec as 🧪 what_if_ranker
+    participant Gateway as 🛡️ AI Gateway
+    participant UC as 🏛️ UC fn (Spark Connect)
+    participant AIQ as ⚙️ ai_query
+    participant Store as 🗄️ Lakebase store
+    participant Ext as 💾 extraction (bg)
+
+    Op->>MI: "Re-rank C-00007 with O-0099 added"
+    MI->>Store: semantic search (K=5)
+    Store-->>MI: prior memories
+    MI-->>Sup: ## Memories injected
+    Sup->>Gateway: chat.completions (gpt-5-4-mini)
+    Gateway-->>Sup: tool_call: handoff_to_what_if_ranker
+
+    Sup->>Spec: handoff
+    MI->>Store: search memories
+    MI-->>Spec: ## Memories injected
+    Spec->>Gateway: chat.completions (claude-sonnet-4-5)
+    Gateway-->>Spec: tool_call: rank_offers_for_customer_uc
+
+    Spec->>UC: invoke(customer_id, prompt_version, candidate_offer_ids)
+    Note over UC,AIQ: UC SQL builds prompt from customer_features<br/>+ offer_catalog, then calls ai_query
+    UC->>AIQ: ai_query('databricks-claude-sonnet-4-5', …, responseFormat)
+    AIQ->>Gateway: chat.completions (structured JSON)
+    Gateway-->>AIQ: {"ranking":{"offers":[…10…]}}
+    AIQ-->>UC: parsed ARRAY<STRUCT<offer_id,rank,score,reason>>
+    UC-->>Spec: 10-element ranking
+
+    Spec->>Gateway: chat.completions (format table + summary)
+    Gateway-->>Spec: rank | offer_id | score | reason
+    Spec-->>Sup: return control
+    Sup-->>Op: response
+
+    Note over Sup,Ext: turn complete · post-turn (async)
+    Sup-->>Ext: turn finalized
+    Ext->>Gateway: chat.completions (extraction_model)
+    Gateway-->>Ext: {role, focus segments, investigated customers}
+    Ext->>Store: write user_profile / preference / episode
+```
+
+**Observations:**
+- The what-if turn produces **three foreground LLM calls**: the supervisor route, the specialist's tool-selection call, and the specialist's formatting call — plus a **fourth server-side LLM call** inside `ai_query`. That nested call is where the actual ranking happens.
+- `rank_offers_for_customer` quotes the LLM's `reason` strings **verbatim**; the specialist prompt forbids editing them. The eval `factual_grounding` guideline enforces the same for stored rankings.
+- Extraction is decoupled from the response path — it runs even if the operator closes the connection, and shows up as a separate span branch.
+
+### 4. Personalization across sessions
+
+Same `user_id`, new thread → the operator's investigative habits still apply. Extraction captures the operator's role, focus segments, repeat-investigated customers, and preferred analytical lenses.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'fontSize': '13px'}}}%%
+sequenceDiagram
+    autonumber
+    actor Op as Operator
+    participant MW as 🧠 memory middleware
+    participant Store as 🗄️ Lakebase store<br/>(ns = user_id)
+    participant Ext as 💾 extraction (bg)
+
+    rect rgb(232, 245, 233)
+        Note over Op,Ext: Session 1 — thread A
+        Op->>MW: "Which offers underperformed in Footwear last week?"
+        Note over MW: memories empty on first interaction
+        Op-->>Ext: turn finalized
+        Ext->>Store: user_profile {role: merchandiser}
+        Ext->>Store: preference {lens: "underperformers by segment", focus: "Footwear"}
+    end
+
+    rect rgb(227, 242, 253)
+        Note over Op,Ext: Session 2 — thread B (new), same user_id
+        Op->>MW: "Show me last week's numbers"
+        MW->>Store: semantic search (K=5)
+        Store-->>MW: role=merchandiser, focus=Footwear, lens=underperformers
+        MW->>Op: (supervisor + specialist see prior focus)
+        Ext->>Store: episode {investigation: "weekly underperformer review"}
+    end
+```
+
+**Three memory schemas extracted in the background** (`extraction.schemas`): `user_profile`, `preference`, `episode`. The extraction instructions target the operator's role (loyalty/CRM marketer, merchandiser, category manager, data scientist), the segments/categories they focus on, customers they investigate repeatedly, offer ids they reference often, and notable what-if runs or flagged offers.
+
+### 5. Data provisioning + ranking refresh
+
+`dao-ai workflow up` runs a provisioning DAG inside a Databricks Job: create the schema, load the 9 datasets (5 bronze + 2 gold CTAS + 1 output + 1 eval), create the 7 UC functions, provision the VS index and Genie room, then deploy the agent. The `offer_rankings` output table is **empty at deploy** — it is populated out-of-band by the batch refresh.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1565c0', 'fontSize': '13px'}}}%%
+flowchart TB
+    subgraph Deploy["⚙️ dao-ai workflow up"]
+        direction TB
+        Bronze["1️⃣ bronze tables<br/>loyalty_events · offer_catalog<br/>receipts · receipt_lines · redemptions"]
+        Gold["2️⃣ gold CTAS<br/>customer_features<br/>customers_x_eligible_offers"]
+        Out["3️⃣ output + eval<br/>offer_rankings (empty) · evaluation"]
+        Fns["4️⃣ 7 UC functions"]
+        Prov["5️⃣ VS index + Genie room"]
+        DeployAgent["6️⃣ deploy agent (Apps / MS)"]
+        Bronze --> Gold --> Out --> Fns --> Prov --> DeployAgent
+    end
+
+    subgraph Refresh["🔁 batch refresh (out-of-band, scheduled SQL)"]
+        direction TB
+        RF["INSERT INTO offer_rankings<br/>SELECT * FROM refresh_offer_rankings('v1', …)"]
+        RFN["refresh_offer_rankings<br/>→ rank_offers_for_customer<br/>→ ai_query (per customer)"]
+        RF --> RFN
+    end
+
+    Out -.->|populated later| Refresh
+
+    style Deploy fill:#fff3e0,stroke:#e65100
+    style Refresh fill:#e8f5e9,stroke:#2e7d32
+    style RFN fill:#ffe0b2,stroke:#ef6c00
+```
+
+**Notes:**
+- `customer_features` and `customers_x_eligible_offers` are **`CREATE OR REPLACE TABLE AS`** (CTAS) — their `*_data.sql` files are no-ops (`SELECT 1`); the DDL itself computes the rows from bronze. Dataset order matters: bronze first, then the gold tables that join over them.
+- The batch refresh is a scheduled `INSERT` (see `refresh_offer_rankings.sql` header). For 40M customers, shard by `customer_id % N` and run shards in parallel; the fn filters to customers with `eligible_offer_count >= 10`.
+- VS index (`offer_catalog_index`) syncs from `offer_catalog.description` on the shared `dbdemos_vs_endpoint`. `offer_catalog` and `offer_rankings` carry `delta.enableChangeDataFeed = true`.
+
+---
+
+## Agents
+
+All seven specialists run on `claude-sonnet-4-5` (`*tool_calling_llm`, with a `claude-sonnet-4-6` fallback); the supervisor runs on `gpt-5-4-mini` (`*fast_llm`).
+
+| # | Agent | Model | Tools | Role |
+|---|---|---|---|---|
+| — | `supervisor` | gpt-5-4-mini | `app_info` | Routing coordinator. No data tools. Emits exactly one `handoff_to_<specialist>` per turn; chains multi-specialist requests across returns. |
+| 1 | `customer_intelligence` | claude-sonnet-4-5 | `get_customer_features_uc`, `get_recent_receipts_uc`, `query_segment_analytics` | Customer 360: profile (tier, RFM, brand/category prefs, price tolerance, redemption history) + recent receipts. Calls the two UC fns **in parallel**. |
+| 2 | `offer_catalog` | claude-sonnet-4-5 | `offer_catalog_search` (VS), `check_offer_eligibility_uc` | Search the catalog by natural-language description (brand/category/discount/season) and check whether a customer is eligible for a specific offer. |
+| 3 | `ranking_explainer` | claude-sonnet-4-5 | `get_offer_ranking_uc`, `get_customer_features_uc` | Explain a **stored** ranking: surface the LLM's per-offer `reason`/`score` verbatim, tie it back to concrete C360 features. Pulls features in parallel. |
+| 4 | `what_if_ranker` | claude-sonnet-4-5 | `rank_offers_for_customer_uc`, `get_customer_features_uc` | Run a **fresh** LLM ranking now — optionally with a custom candidate pool. This is the surface that triggers the `ai_query` cascade. |
+| 5 | `segment_analyst` | claude-sonnet-4-5 | `query_segment_analytics` (Genie), `top_offers_by_segment_uc` | Cross-segment analytics: top-N customers/offers, brand mix by tier, segment-level aggregates. UC fn for canned top-N, Genie for ad-hoc. |
+| 6 | `redemption_outcomes` | claude-sonnet-4-5 | `query_redemption_outcomes` (Genie), `top_offers_by_segment_uc` | Post-hoc performance: did rankings drive redemption, which offers over/under-performed vs their rank position, lapsed-member behavior. |
+| 7 | `general` | claude-sonnet-4-5 | `current_time`, `app_info` | Meta-questions, capability discovery, time-relative queries. Hands substantive requests back for routing. |
+
+**Model assignment rationale:**
+- **`gpt-5-4-mini`** (`fast_llm`) — routing, VS query-decomposition, VS rerank, and memory-query rephrasing. Fast, cheap, strong tool-call fidelity for structured triage work.
+- **`claude-sonnet-4-5`** (`tool_calling_llm`) — the 7 specialists (multi-step reasoning over features + rankings + analytics), background memory extraction, the eval judge, and the `ai_query` ranker prompt. `claude-sonnet-4-6` is the declared fallback.
+- **AI Gateway on every chat endpoint** — uniform governance, usage tracking, rate-limit pooling.
+
+---
+
+## Data plane
+
+### Schema layout
+
+```
+retail_consumer_goods.loyalty_offers/
+├── 📊 Bronze tables (5) — synthetic, seeded-random via range()
+│   ├── loyalty_events        ← member lifecycle: ENROLL / TIER_CHANGE / VISIT …
+│   ├── offer_catalog         ← 100 active offers (VS source: description)
+│   ├── receipts              ← receipt headers (channel, basket_total, on_promo)
+│   ├── receipt_lines         ← line items (sku, brand, category, discount)
+│   └── redemptions           ← past redemptions (brand-biased to cohort top brand)
+│
+├── 🥇 Gold tables (2) — CREATE OR REPLACE TABLE AS (CTAS), no seed rows
+│   ├── customer_features             ← Customer 360, one row/customer (RFM, prefs,
+│   │                                    price_tolerance, redemption history)
+│   └── customers_x_eligible_offers   ← per-customer candidate pool (≤30 offers,
+│                                        tier + spend + validity filtered)
+│
+├── 📤 Output + eval (2)
+│   ├── offer_rankings        ← EMPTY at deploy; filled by refresh_offer_rankings.
+│   │                            ranking = ARRAY<STRUCT<offer_id,rank,score,reason>>
+│   └── evaluation            ← 25 eval payloads
+│
+├── 🛠️ UC Functions (7)
+│   ├── get_customer_features(customer_id)
+│   ├── get_recent_receipts(customer_id, days)
+│   ├── check_offer_eligibility(customer_id, offer_id)
+│   ├── get_offer_ranking(customer_id, prompt_version)         ← reads stored ranking
+│   ├── top_offers_by_segment(segment, window_days)
+│   ├── rank_offers_for_customer(customer_id, prompt_version,  ← ⚙️ ai_query ranker
+│   │                            candidate_offer_ids)
+│   └── refresh_offer_rankings(prompt_version, model_endpoint) ← batch; NOT a tool
+│
+└── 🔍 VS index (1) — offer_catalog_index on dbdemos_vs_endpoint (STANDARD)
+    └── source: offer_catalog.description (HYBRID search, num_results=40)
+```
+
+### Synthetic data overview
+
+| Table | Rows | Notes |
+|---|---|---|
+| `loyalty_events` | ~10K enroll + ~20% tier-change | 10K customers `C-00001..C-10000`, enrolled 6mo–5yr ago. The `10000` in the DDL is the scaling knob. |
+| `offer_catalog` | 100 | 10 named brands (Nike, Adidas, Lululemon, Patagonia, REI, Levis, GAP, JCrew, BananaRepublic, Puma) + `ALL_BRANDS` catalog-wide. Categories: Footwear, Activewear, Outerwear, Denim, Apparel-Tops/Bottoms, Accessories. Each offer carries `margin_class` (A/B/C), `discount_kind`, `eligibility_json`, validity window, `seasonal_tag`. |
+| `receipts` | ~60K | `range(60000)` — ~6/customer over 18mo, channels STORE/ONLINE/APP, 35% on-promo. |
+| `receipt_lines` | ~60K | One line/receipt; brand biased by `customer_id % 10` cohort so top-brand aggregations are realistic. |
+| `redemptions` | ~15K | `range(15000)` — offer choice biased toward the cohort's top brand, so redemption history *correlates with* brand preference — the key signal the ranker should learn. |
+| `customer_features` | ~10K (CTAS) | One row/customer: `loyalty_tier`, RFM (`visits_90d`, `aov`, `total_lifetime_spend`), `price_tolerance_score`, `top_brands`/`top_categories`, `redemptions_90d`, `promo_response_rate`. `avoided_*` arrays are empty placeholders. |
+| `customers_x_eligible_offers` | ~10K (CTAS) | Per-customer eligible pool, capped at 30, affinity-sorted (brand → category → offer). Feeds the batch ranker. |
+| `offer_rankings` | 0 at deploy | Partitioned by `prompt_version`. Populated by the batch refresh. |
+| `evaluation` | 25 | Eval payloads for the MLflow eval run. |
+
+Data is deterministic (seeded `rand()` calls) and generated in-warehouse — no external data files, no runtime generation.
+
+### The `ai_query` ranker (single source of truth)
+
+`rank_offers_for_customer(customer_id, prompt_version, candidate_offer_ids)` is the heart of the app. It:
+
+1. Pulls the customer's `customer_features` row and the attributes of the candidate offers (from `offer_catalog`, filtered by `array_contains`).
+2. Serializes both to JSON and builds a `<task>/<customer_profile>/<candidate_offers>` prompt **inline in SQL**.
+3. Calls `ai_query('databricks-claude-sonnet-4-5', <prompt>, responseFormat => 'STRUCT<ranking: STRUCT<offers: ARRAY<STRUCT<offer_id, rank, score, reason>>>>', modelParameters => (temperature 0.1, max_tokens 1500))`.
+4. Parses the structured JSON back into `ARRAY<STRUCT<offer_id: STRING, rank: INT, score: DOUBLE, reason: STRING>>` (exactly `least(size(candidates), 10)` elements). Each `reason` is one sentence citing the specific customer feature that drove the rank.
+
+Because the prompt lives inline in this one function, **three surfaces share the exact same ranking logic**: the `what_if_ranker` agent (real-time, single customer), `refresh_offer_rankings(...)` (batch, all eligible customers via a JOIN over `customers_x_eligible_offers`), and any external real-time scoring endpoint. Edit the function → every surface updates. `refresh_offer_rankings` is intentionally **not** registered as an agent tool (it's the offline batch entrypoint), which also saves a slot against the Apps 20-resource cap.
+
+---
+
+## Why these design choices?
+
+### Why a supervisor hub-and-spoke instead of a pipeline?
+
+Operators ask heterogeneous questions ("who is this customer?", "why this ranking?", "re-run it", "how did it perform?"). There's no fixed linear flow — the right specialist depends entirely on intent. A routing supervisor that dispatches to one of seven specialists and lets them return matches that reality. The one-handoff-per-turn rule keeps traces clean and makes multi-specialist requests explicit (chained across returns) rather than letting the supervisor fan out uncontrollably.
+
+### Why put the ranking prompt in a UC function calling `ai_query` instead of in the agent?
+
+**Single source of truth across three surfaces.** The batch refresh (nightly, 40M customers), the interactive what-if agent, and any external scoring endpoint must produce identical rankings, or "why was this ranked here?" stops being answerable. Putting the prompt inline in one SQL function guarantees that. It also pushes the heavy per-customer LLM call into the warehouse where it can be sharded and scheduled, instead of into the agent runtime.
+
+### Why one Genie room exposed as two tools?
+
+A single space over `customer_features` + `redemptions` + `offer_catalog` + `offer_rankings` covers both analytics use cases. But the supervisor routes better when the *tool descriptions* are specialized: `query_segment_analytics` for cross-segment aggregates, `query_redemption_outcomes` for performance/lift. Two named tool faces over one room gives sharp routing without a second Genie resource.
+
+### Why are receipts and the candidate-pool table hidden from Genie?
+
+`receipts`/`receipt_lines` are the raw transactional source already aggregated into `customer_features`; exposing them adds little to cross-segment analytics and burns resource slots. `customers_x_eligible_offers` is an intermediate candidate pool consumed by the ranker, not an analytics surface. Dropping all three keeps the app under the Databricks Apps 20-resource budget (7 UC fns + 1 Lakebase + 1 VS + 1 Genie + 3 dedup'd LLMs).
+
+### Why SP-backed functions and models (not OBO)?
+
+`rank_offers_for_customer` calls `ai_query` via Spark Connect, and the on-behalf-of-user token lacks the `databricks-connect` scope — so it must be SP-backed. The other UC fns are SP-backed for consistency. Chat models are SP-backed because dao-ai eagerly constructs chat clients during graph build, and at Model-Serving load time there is no user token — OBO models fail with `model_serving_user_credentials auth: Unable to authenticate`. The vector store and embedding model *do* use OBO, since retrieval carries the caller's identity.
+
+### Why an instructed retriever with decomposition + double rerank?
+
+Operators describe offers in natural language ("high-discount outerwear this winter"). The instructed retriever lifts structured filters (`brand`, `category`, `discount_pct >=`, `seasonal_tag`) from the query text via `fast_llm` decomposition (up to 3 subqueries, RRF fusion `k=60`), then reranks — first an LLM rerank keyed on the customer's brand/category affinity and price tolerance, then a `ms-marco-MiniLM-L-12-v2` cross-encoder. The result is high-precision catalog search without the operator writing filters.
+
+### Why mixed models?
+
+`gpt-5-4-mini` is fast and cheap — right for routing, query decomposition, rerank, and memory rephrasing, which are all high-frequency and structured. `claude-sonnet-4-5` earns its cost on the specialists' multi-step reasoning and the ranking prompt where output quality drives the whole app. Spending the Sonnet budget where it moves the needle beats applying it uniformly.
+
+---
+
+## Deploy
+
+### Prerequisites
+
+- **Profile**: `DEFAULT` (or your equivalent) configured via `databricks configure`.
+- **Secret scope**: `retail_consumer_goods` with `RETAIL_AI_DATABRICKS_CLIENT_ID`, `RETAIL_AI_DATABRICKS_CLIENT_SECRET`, and `RETAIL_AI_DATABRICKS_HOST`.
+- **Service principal**: `retail_consumer_goods_sp` with `READ` on the scope and `USE_CATALOG` / `USE_SCHEMA` / `SELECT` / `EXECUTE` on the target catalog.
+- **Lakebase project**: the existing `retail-consumer-goods` project (reused for memory — not created by this app).
+- **Vector Search endpoint**: `dbdemos_vs_endpoint` exists (or change `endpoint.name`).
+- **Genie parent path**: `genie_parent_path` folder exists in the workspace. The room is provisioned on first deploy (SP-backed); pass `--param genie_space_id=<id>` to reuse an existing space.
+- **SQL Warehouse**: override `--var warehouse_id=<id>` for your workspace (default `d58e5fb998498840`).
+
+### Validate
+
+```bash
+DATABRICKS_CONFIG_PROFILE=DEFAULT uv run dao-ai validate \
+  -c examples/15_complete_applications/loyalty_offer_personalization/loyalty_offer_personalization.yaml
+```
+
+### Provision + deploy
+
+This app ships `data/` + `functions/`, so use **`workflow up`** (it provisions the schema, tables, UC functions, VS index, and Genie room before deploying the agent — `agent up` does **not** provision). The same config targets both Model Serving and Databricks Apps; run one command per target:
+
+```bash
+# Deploy to Model Serving
+uv run dao-ai workflow up \
+  -c examples/15_complete_applications/loyalty_offer_personalization/loyalty_offer_personalization.yaml \
+  -p DEFAULT --mode model_serving
+
+# Deploy to Databricks Apps
+uv run dao-ai workflow up \
+  -c examples/15_complete_applications/loyalty_offer_personalization/loyalty_offer_personalization.yaml \
+  -p DEFAULT --mode apps
+```
+
+After the first deploy, populate the rankings out-of-band so `ranking_explainer` and `redemption_outcomes` have data:
+
+```sql
+INSERT INTO retail_consumer_goods.loyalty_offers.offer_rankings
+SELECT * FROM retail_consumer_goods.loyalty_offers.refresh_offer_rankings('v1', 'databricks-claude-sonnet-4-5');
+```
+
+### Verify
+
+```bash
+# Tables + functions created
+databricks --profile DEFAULT tables list retail_consumer_goods loyalty_offers
+
+# Model Serving endpoint READY
+databricks --profile DEFAULT serving-endpoints get loyalty_offers_dao
+
+# App running
+databricks --profile DEFAULT apps get loyalty_offers_dao
+
+# Iterate interactively
+uv run dao-ai chat -c .../loyalty_offer_personalization.yaml -p DEFAULT
+```
+
+---
+
+## Sample prompts
+
+These come directly from `examples.yaml`. Each sets `custom_inputs.configurable.user_id` (e.g. `loyalty_marketer_01`, `merchandiser_01`) so memory namespaces per operator, and a `thread_id`.
+
+#### `customer_intelligence` — Customer 360
+- *"Tell me about customer C-00007. Pull their profile and recent purchases."*
+- *"Who is C-00042 and what brands do they actually buy?"*
+
+#### `offer_catalog` — catalog search + eligibility
+- *"Find Nike running shoe offers that are still active and apply to Silver-tier members."*
+- *"Show me high-discount offers (30% or more off) for outerwear this fall."*
+- *"Is customer C-00007 eligible for offer O-0099?"*
+
+#### `ranking_explainer` — explain a stored ranking
+- *"Why was offer O-0007 ranked first for customer C-00007?"*
+- *"What was the lowest-ranked offer for C-00100 and why?"*
+
+#### `what_if_ranker` — fresh `ai_query` re-rank
+- *"Add offer O-0099 to the candidate pool for C-00007 and re-rank."*
+- *"Re-rank for customer C-00007 using their currently eligible offers."*
+
+#### `segment_analyst` — cross-segment analytics
+- *"Which 10 customers were most active in Footwear last 90 days?"*
+- *"Which loyalty tier saw the highest redemption rate on offer O-0011?"*
+- *"Brand mix by loyalty tier for the last 90 days?"*
+
+#### `redemption_outcomes` — post-hoc performance
+- *"Did the winter coat sale O-0083 lift redemption among lapsed members?"*
+- *"Which offers underperformed last week relative to their ranking position?"*
+
+#### `general` / routing
+- *"What can you help me do as a loyalty marketer?"*
+
+#### Chained / multi-specialist (supervisor chains handoffs across returns)
+- *"Pull C-00007's profile and explain why offer O-0001 should rank in their top 3."*
+- *"Build me a list of the top 5 customers most likely to redeem outerwear next month, and show their stored rankings."*
+
+The app's default `input_example` is: *"Tell me about customer C-00007 and explain why offer O-0007 was ranked first for them."*
+
+---
+
+## File layout
+
+```
+loyalty_offer_personalization/
+├── README.md                              # this file
+├── loyalty_offer_personalization.yaml     # dao-ai config (994 lines)
+├── examples.yaml                          # demo prompts (one per specialist)
+├── data/                                  # 9 datasets — DDL + data pairs
+│   ├── loyalty_events.sql       + _data.sql   # bronze: member lifecycle
+│   ├── offer_catalog.sql        + _data.sql   # bronze: 100 offers (VS source)
+│   ├── receipts.sql             + _data.sql   # bronze: ~60K receipt headers
+│   ├── receipt_lines.sql        + _data.sql   # bronze: line items
+│   ├── redemptions.sql          + _data.sql   # bronze: ~15K redemptions
+│   ├── customer_features.sql    + _data.sql   # gold CTAS: Customer 360
+│   ├── customers_x_eligible_offers.sql + _data.sql  # gold CTAS: candidate pool
+│   ├── offer_rankings.sql       + _data.sql   # output: empty at deploy
+│   └── evaluation.sql           + _data.sql   # 25 eval payloads
+└── functions/                             # 7 UC SQL functions
+    ├── get_customer_features.sql
+    ├── get_recent_receipts.sql
+    ├── check_offer_eligibility.sql
+    ├── get_offer_ranking.sql              # reads stored ranking
+    ├── top_offers_by_segment.sql
+    ├── rank_offers_for_customer.sql       # ⚙️ ai_query ranker — single source of truth
+    └── refresh_offer_rankings.sql         # batch refresh (not an agent tool)
+```
+
+---
+
+## Related dao-ai patterns referenced
+
+- **Supervisor orchestration** — `app.orchestration.supervisor` in this config; contrast the pipeline variant in `examples/15_complete_applications/commerce/commerce_supervisor.README.md`.
+- **Lakebase memory** — `examples/15_complete_applications/hardware_store_lakebase.yaml`.
+- **Instructed / decomposing retriever** — the `retrievers.offer_catalog_retriever.instructed` block here.
+- **`ai_query` in a UC function** — `functions/rank_offers_for_customer.sql`.
+- **Genie tool** — `examples/` Genie-room patterns; one room, two tool faces here.
+- **AI Gateway** — `examples/01_getting_started/ai_gateway.yaml`.
+</content>
+</invoke>

--- a/examples/15_complete_applications/loyalty_offer_personalization/loyalty_offer_personalization.yaml
+++ b/examples/15_complete_applications/loyalty_offer_personalization/loyalty_offer_personalization.yaml
@@ -30,6 +30,9 @@ parameters:
   schema:
     description: Schema within the catalog
     default: loyalty_offers
+  vector_search_endpoint:
+    description: Vector Search endpoint hosting the indexes for this app
+    default: dbdemos_vs_endpoint
   genie_parent_path:
     description: Workspace folder where the Genie space is created. Must already exist.
     default: "/Users/${workspace.current_user.userName}"
@@ -44,13 +47,13 @@ parameters:
     provided: true
   llm:
     description: Chat/reasoning serving endpoint for tool-calling agents
-    default: databricks-claude-sonnet-4-5
+    default: databricks-claude-sonnet-5
   fast_llm:
     description: Fast chat serving endpoint for supervisor, decomposition, and query tasks
     default: databricks-gpt-5-4-mini
   fallback_llm:
     description: Fallback chat serving endpoint when the primary llm is unavailable
-    default: databricks-claude-sonnet-4-6
+    default: databricks-claude-sonnet-4-5
   embedding_model:
     description: Embedding serving endpoint for vector search and memory store
     default: databricks-gte-large-en
@@ -143,7 +146,7 @@ resources:
       embedding_model: *embedding_model
       on_behalf_of_user: true
       endpoint:
-        name: dbdemos_vs_endpoint
+        name: ${var.vector_search_endpoint}
         type: STANDARD
       index:
         schema: *loyalty_schema

--- a/examples/15_complete_applications/procurement_supplier_a2a/README.md
+++ b/examples/15_complete_applications/procurement_supplier_a2a/README.md
@@ -90,20 +90,20 @@ cd <repo root>
 uv run dao-ai agent generate \
   -c examples/15_complete_applications/procurement_supplier_a2a/supplier.yaml \
   -o ../output-supplier-a2a \
-  -p fevm
+  -p DEFAULT
 
 # Deploy + start.
 cd ../output-supplier-a2a
-databricks bundle deploy --target dev -p fevm
-databricks bundle run dao-ai-supplier-a2a --target dev -p fevm
+databricks bundle deploy --target dev -p DEFAULT
+databricks bundle run dao-ai-supplier-a2a --target dev -p DEFAULT
 cd -
 ```
 
 ### 2. (Optional) Sanity-check the supplier
 
 ```bash
-SUPPLIER_URL=$(databricks apps get dao-ai-supplier-a2a -p fevm --output json | jq -r .url)
-TOKEN=$(databricks auth token -p fevm | jq -r .access_token)
+SUPPLIER_URL=$(databricks apps get dao-ai-supplier-a2a -p DEFAULT --output json | jq -r .url)
+TOKEN=$(databricks auth token -p DEFAULT | jq -r .access_token)
 curl -sf "$SUPPLIER_URL/.well-known/agent-card.json" \
   -H "Authorization: Bearer $TOKEN" | jq '.name, .version'
 ```
@@ -115,12 +115,12 @@ curl -sf "$SUPPLIER_URL/.well-known/agent-card.json" \
 uv run dao-ai agent generate \
   -c examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml \
   -o ../output-procurement-a2a \
-  -p fevm
+  -p DEFAULT
 
 # Deploy + start.
 cd ../output-procurement-a2a
-databricks bundle deploy --target dev -p fevm
-databricks bundle run dao-ai-procurement-a2a --target dev -p fevm
+databricks bundle deploy --target dev -p DEFAULT
+databricks bundle run dao-ai-procurement-a2a --target dev -p DEFAULT
 cd -
 ```
 
@@ -133,8 +133,8 @@ rest at runtime.
 ### 4. Try it end-to-end
 
 ```bash
-PROC_URL=$(databricks apps get dao-ai-procurement-a2a -p fevm --output json | jq -r .url)
-TOKEN=$(databricks auth token -p fevm | jq -r .access_token)
+PROC_URL=$(databricks apps get dao-ai-procurement-a2a -p DEFAULT --output json | jq -r .url)
+TOKEN=$(databricks auth token -p DEFAULT | jq -r .access_token)
 
 # Responses-API form (uses ``input``, not ``messages``).
 curl -sf -X POST "$PROC_URL/invocations" \
@@ -193,8 +193,8 @@ in a second terminal — `create_a2a_agent_tool` logs an
 `Invoking A2A agent` line before every hop:
 
 ```bash
-PROC_URL=$(databricks apps get dao-ai-procurement-a2a -p fevm --output json | jq -r .url)
-TOKEN=$(databricks auth token -p fevm | jq -r .access_token)
+PROC_URL=$(databricks apps get dao-ai-procurement-a2a -p DEFAULT --output json | jq -r .url)
+TOKEN=$(databricks auth token -p DEFAULT | jq -r .access_token)
 
 curl -sN -H "Authorization: Bearer $TOKEN" "$PROC_URL/logz/stream?source=APP" \
   | grep --line-buffered -E "Invoking A2A agent|query_supplier|dao_ai.a2a"
@@ -389,14 +389,14 @@ the same output directory and redeploy:
 # Supplier:
 uv run dao-ai agent generate \
   -c examples/15_complete_applications/procurement_supplier_a2a/supplier.yaml \
-  -o ../output-supplier-a2a -p fevm
-(cd ../output-supplier-a2a && databricks bundle deploy --target dev -p fevm)
+  -o ../output-supplier-a2a -p DEFAULT
+(cd ../output-supplier-a2a && databricks bundle deploy --target dev -p DEFAULT)
 
 # Procurement:
 uv run dao-ai agent generate \
   -c examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml \
-  -o ../output-procurement-a2a -p fevm
-(cd ../output-procurement-a2a && databricks bundle deploy --target dev -p fevm)
+  -o ../output-procurement-a2a -p DEFAULT
+(cd ../output-procurement-a2a && databricks bundle deploy --target dev -p DEFAULT)
 ```
 
 ---

--- a/examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml
+++ b/examples/15_complete_applications/procurement_supplier_a2a/procurement.yaml
@@ -29,10 +29,15 @@
 #
 # Pair with ``supplier.yaml``. See ``README.md`` for the deploy workflow.
 
+parameters:
+  llm:
+    description: Chat serving endpoint for the procurement officer agent
+    default: databricks-gpt-5-4-mini
+
 resources:
   models:
     procurement_llm: &procurement_llm
-      name: databricks-gpt-5-4-mini
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 4096
       # OBO on the procurement-side LLM. The Databricks Apps proxy

--- a/examples/15_complete_applications/procurement_supplier_a2a/supplier.yaml
+++ b/examples/15_complete_applications/procurement_supplier_a2a/supplier.yaml
@@ -17,6 +17,11 @@
 # Pair with ``procurement.yaml`` (deployed separately). See ``README.md`` in
 # this directory for the end-to-end deployment workflow.
 
+parameters:
+  llm:
+    description: Chat serving endpoint for the supplier agent
+    default: databricks-gpt-5-4-mini
+
 resources:
   models:
     # Single supplier-side LLM. ``on_behalf_of_user: true`` routes inference
@@ -26,7 +31,7 @@ resources:
     # the proxy chain — assuming the procurement-side A2A tool is configured
     # to forward a user token (see procurement.yaml notes).
     supplier_llm: &supplier_llm
-      name: databricks-gpt-5-4-mini
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 2048
       on_behalf_of_user: true

--- a/examples/15_complete_applications/quick_serve_restaurant/README.md
+++ b/examples/15_complete_applications/quick_serve_restaurant/README.md
@@ -1,0 +1,348 @@
+# Quick-Serve Restaurant — ☕ Coffee-Shop Barista Agent
+
+> **A single-agent order-management assistant for a specialty coffee shop, built on dao-ai.** One `barista` agent — running `claude-sonnet-4-5` — discovers menu items by semantic search, describes drinks, processes orders, and pulls a customer's order history. Menu recall is powered by a single Vector Search index over human-written item reviews, and every data operation is a Unity Catalog SQL function the agent calls as a tool.
+
+| ✨ Feature | What this example shows |
+|---|---|
+| 🐝 **Single-agent swarm** | `orchestration.swarm` with **one** agent (`barista`) as the `default_agent`. The swarm shape is used, but there is exactly one node — no multi-agent routing, no handoffs. The cleanest possible dao-ai app. |
+| 🔎 **Vector Search over the menu** | One Delta index (`items_description_vs_index`) embeds the `item_review` column with `databricks-gte-large-en`. All three retrieval UC functions call `VECTOR_SEARCH(...)` directly inside SQL. |
+| 🛠️ **UC-function tools** | Four `unity_catalog` tools (recommend / describe / order-history / place-order) plus one `python` tool (`current_time`). Tool docstrings live in the SQL `COMMENT`s — the LLM reads them verbatim to decide when to call each. |
+| 🧠 **In-memory conversation state** | `checkpointer` + `store` are declared with **no database backend** (`type inferred as memory`). State lives for the life of the serving process, namespaced by `{user_id}`. The store's semantic layer uses the same `gte-large-en` embedding. |
+| 🔐 **SP-backed order writes** | `insert_coffee_order` runs Python inside UC and needs a `WorkspaceClient`, so it takes `host` / `client_id` / `client_secret` as `partial_args` sourced from the `retail_consumer_goods` secret scope. The read-only tools are SP-backed by the serving identity. |
+| ⚙️ **Data + functions provisioned by dao-ai** | `datasets:` (4 tables) and `unity_catalog_functions:` (4 SQL DDL files) are deployed by `dao-ai workflow up` — this app owns its schema end-to-end. |
+| 🧪 **Built-in evaluation** | `evaluation:` block wires a `judge_llm` (`claude-sonnet-4-5`, temp 0.5) over a 25-example eval set written to `retail_consumer_goods.quick_serve_restaurant.evaluation`. |
+
+> **Not present here** (called out so you don't go looking): no MCP tools, no Postgres/Lakebase-backed persistence (the `PGHOST`/`PGPORT`/`PGDATABASE` variables are declared but the memory config binds to neither), no multi-agent orchestration, and no `ai_gateway: true` on the models.
+
+---
+
+## Architecture
+
+### 1. System shape
+
+A client talks to one deployed agent. The `barista` calls UC-function tools, which in turn hit either the menu Vector Search index or the raw Delta tables. Conversation state is kept in-process.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1565c0', 'fontSize': '14px'}}}%%
+flowchart LR
+    Client["🖥️ Client<br/>Web · Chat"]
+
+    subgraph App["🚀 Deployed Agent"]
+        direction TB
+        Barista["☕ barista<br/><b>claude-sonnet-4-5</b><br/>(fallback: sonnet-4)"]
+        Mem["🧠 in-memory<br/>checkpointer + store<br/>ns = {user_id}"]
+        Barista <-.-> Mem
+    end
+
+    subgraph Tools["🛠️ Tools"]
+        direction TB
+        T1["match_item_by_description_and_price"]
+        T2["lookup_items_by_descriptions"]
+        T3["match_historical_item_order_by_date"]
+        T4["insert_coffee_order"]
+        T5["current_time (python)"]
+    end
+
+    subgraph UC["🏛️ retail_consumer_goods.quick_serve_restaurant"]
+        direction TB
+        VS[("🔎 items_description_vs_index<br/>embed: item_review")]
+        ItemsRaw[("items_raw · menu + prices")]
+        OrdersRaw[("orders_raw · history")]
+        Fulfil[("fulfil_item_orders · new orders")]
+    end
+
+    Embed["🧬 databricks-gte-large-en"]
+
+    Client --> App
+    Barista --> Tools
+    T1 --> VS
+    T1 --> ItemsRaw
+    T2 --> VS
+    T3 --> VS
+    T3 --> ItemsRaw
+    T3 --> OrdersRaw
+    T4 -->|SP creds| Fulfil
+    Embed -.->|vectors| VS
+    Mem <-.-> Embed
+
+    style App fill:#fff8e1,stroke:#f57f17,stroke-width:2px
+    style Tools fill:#fafafa,stroke:#9e9e9e
+    style UC fill:#e3f2fd,stroke:#1565c0
+    style VS fill:#f3e5f5,stroke:#7b1fa2
+    style Embed fill:#fce4ec,stroke:#c2185b
+    style Barista fill:#fffde7,stroke:#fbc02d,stroke-width:2px
+```
+
+**Wiring details that are easy to miss:**
+- The three read tools (`match_item_by_description_and_price`, `lookup_items_by_descriptions`, `match_historical_item_order_by_date`) all resolve names through the **same** VS index — `VECTOR_SEARCH(...)` is embedded *inside* the SQL function body, then joined back to `items_raw` / `orders_raw` for price, size, and history. The agent never queries Vector Search directly; it goes through UC.
+- `insert_coffee_order` is the only **write** path. It's a Python UC function that opens a `WorkspaceClient(host, client_id, client_secret)`, finds the "Shared Endpoint" warehouse by name, and `INSERT`s into `fulfil_item_orders`. Those three credentials come in as `partial_args` from the `retail_consumer_goods` secret scope — that's why the app declares `RETAIL_AI_DATABRICKS_*` environment vars.
+- Memory is **not durable**. `default_checkpointer` and `default_store` have no `database:` block, so dao-ai infers the in-memory type. Restart the endpoint → conversation state resets.
+
+### 2. Per-turn execution
+
+A single agent means a single LLM node. Every turn is: inject in-memory context → LLM decides which UC tool(s) to call → synthesize → respond.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'fontSize': '13px'}}}%%
+sequenceDiagram
+    autonumber
+    actor User
+    participant B as ☕ barista<br/>(claude-sonnet-4-5)
+    participant M as 🧠 store<br/>(in-memory, ns=user_id)
+    participant UC as 🛠️ UC function
+    participant VS as 🔎 items_description_vs_index
+
+    User->>B: message + user_id + thread_id
+    M-->>B: prior context (this process only)
+
+    alt "What cold drinks under $5?"
+        B->>UC: match_item_by_description_and_price(desc, low, high, size)
+        UC->>VS: VECTOR_SEARCH(item_review)
+        VS-->>UC: top-3 item_names
+        UC-->>B: item rows (name, size, category, price)
+    else "What does the mocha taste like?"
+        B->>UC: lookup_items_by_descriptions(desc)
+        UC->>VS: VECTOR_SEARCH(num_results=1)
+        VS-->>B: item_review text
+    else "What did I order last week?"
+        B->>UC: match_historical_item_order_by_date(desc, start, end, size)
+        UC->>VS: VECTOR_SEARCH(num_results=3)
+        UC->>UC: join items_raw + orders_raw on date range
+        UC-->>B: historical line items
+    else "I'll take a medium cappuccino"
+        B->>B: confirm name + size
+        B->>UC: insert_coffee_order(coffee_name, size, session_id)
+        UC-->>B: "Row successfully inserted - SUCCEEDED"
+    end
+
+    B-->>User: response
+    B->>M: checkpoint turn
+```
+
+**Observations:**
+- **One LLM call per reasoning step** — there is no supervisor / planner / composer split. The barista prompt itself contains the routing logic ("Use `match_item_by_...` when customers ask for recommendations…").
+- `thread_id` arrives as `custom_inputs.configurable.thread_id`; the prompt surfaces it as **Session ID** and passes it into `insert_coffee_order` as `session_id`, so each fulfilled order is tagged with the conversation it came from.
+- `user_id` drives the memory `namespace` (`namespace: "{user_id}"`) so different callers get isolated stores — but only within the process lifetime.
+
+### 3. Data provisioning DAG
+
+`dao-ai workflow up` stages a job that creates the schema, loads the 4 datasets, deploys the 4 UC functions, builds the VS index, then deploys the agent.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1565c0', 'fontSize': '13px'}}}%%
+flowchart TB
+    subgraph Deploy["⚙️ dao-ai workflow up"]
+        direction TB
+        Ingest["1️⃣ ingest-and-transform<br/>4 datasets: DDL + CSV load"]
+        UCFns["2️⃣ unity-catalog-tools<br/>4 UC SQL functions"]
+        VSProv["3️⃣ provision-vector-search<br/>items_description_vs_index"]
+        DeployAgent["4️⃣ deploy-agent<br/>register model + serve"]
+        Ingest --> UCFns --> VSProv --> DeployAgent
+    end
+
+    subgraph Schema["🏛️ retail_consumer_goods.quick_serve_restaurant"]
+        direction TB
+        subgraph Tables["📊 4 Delta Tables — CDF enabled"]
+            direction LR
+            Items[("items_raw<br/>24 SKUs")]
+            Orders[("orders_raw<br/>~521 orders")]
+            Desc[("items_description<br/>menu reviews")]
+            Ful[("fulfil_item_orders<br/>DDL only")]
+        end
+        Idx[("🔎 items_description_vs_index<br/>source: items_description.item_review")]
+        Fns["🛠️ 4 UC Functions"]
+    end
+
+    Embed["🧬 databricks-gte-large-en"]
+
+    Ingest --> Tables
+    UCFns --> Fns
+    VSProv --> Idx
+    Desc ==>|source| Idx
+    Embed -.->|managed embedding| Idx
+
+    style Deploy fill:#fff3e0,stroke:#e65100
+    style Schema fill:#e3f2fd,stroke:#1565c0
+    style Tables fill:#e1f5fe,stroke:#0277bd
+    style Idx fill:#f3e5f5,stroke:#7b1fa2
+    style Embed fill:#fce4ec,stroke:#c2185b
+```
+
+**Notes:**
+- The VS index's **source table is `items_description`**, not `items_raw`. It embeds the long-form `item_review` narrative (great semantic recall), and the retrieval functions join the returned `item_name` back to `items_raw` for structured fields like price and size.
+- `fulfil_item_orders` ships as **DDL only** — it's empty at deploy and populated at runtime by `insert_coffee_order`.
+- All source tables set `delta.enableChangeDataFeed = true` so the index can sync incrementally.
+
+---
+
+## Agents
+
+| # | Agent | Model | Tools | Role |
+|---|---|---|---|---|
+| 1 | `barista` | **claude-sonnet-4-5** (`temperature: 0.1`, `max_tokens: 8192`, fallback → `claude-sonnet-4`) | `match_item_by_description_and_price`, `lookup_items_by_descriptions`, `match_historical_item_order_by_date`, `insert_coffee_order`, `current_time` | The whole app. Discovers menu items, describes drinks, checks prices by range/size, processes orders, and retrieves order history. Routing logic lives inside the `barista_prompt`. |
+
+**Model assignment:** `tool_calling_llm` (Claude Sonnet 4.5 at low temperature) is used for the agent because the whole job is high-fidelity tool selection + argument construction — pick the right UC function and fill `low_price` / `high_price` / `size` correctly. The `judge_llm` used by `evaluation:` is the same model at a higher temperature (0.5) for diverse scoring. Embeddings use `databricks-gte-large-en`.
+
+**Prompt design:** `barista_prompt` is a first-class `prompts:` object (registered to `retail_consumer_goods.quick_serve_restaurant.barista_prompt`) rather than an inline string. It maps each customer intent to a specific tool, and hard-codes UX rules: always confirm **size** before ordering (pricing varies by size), use price-range filters when the customer states a budget, and follow up after every answer. `{user_id}` and `{thread_id}` are templated in at the top.
+
+---
+
+## Data plane
+
+### Schema layout
+
+```
+retail_consumer_goods.quick_serve_restaurant/
+├── 📊 Tables (4) — all Delta with CDF
+│   ├── items_raw            ← 24 SKU rows (menu + price + size + category)
+│   ├── orders_raw           ← ~521 historical order line items
+│   ├── items_description    ← per-item long-form reviews (VS source)
+│   └── fulfil_item_orders   ← DDL only; new orders written at runtime
+│
+├── 🛠️ UC Functions (4)
+│   ├── match_item_by_description_and_price(description, low_price, high_price, size)
+│   ├── lookup_items_by_descriptions(description)          → item_review
+│   ├── match_historical_item_order_by_date(description, start, end, size)
+│   └── insert_coffee_order(host, client_id, client_secret, coffee_name, size, session_id)
+│
+└── 🔎 VS Index (1) — endpoint: dbdemos_vs_endpoint (STANDARD)
+    └── items_description_vs_index ← source: items_description.item_review · pk: item_name
+```
+
+### Synthetic data overview
+
+| Table | Rows | Notes |
+|---|---|---|
+| `items_raw` | 24 | 14 distinct drinks/snacks across **3 categories** — Hot Drinks (14 rows), Cold Drinks (8), Snacks (2). Sizes: Medium / Large, or `N/A` for single-size items (Espresso, Flat White, sandwiches). Prices $2.15–$5.60. |
+| `orders_raw` | ~521 | 2024 order history keyed by `item_id`, with `quantity`, `cust_name`, and `in_or_out` (dine-in `in` vs takeout `out`). |
+| `items_description` | 14 items | Long-form narrative reviews (flavor / texture / aroma / origin) — the corpus embedded for menu semantic search. CSV is `multiLine` with `"`-escaping. |
+| `fulfil_item_orders` | 0 at deploy | `uuid`, `coffee_name`, `size`, `order_timestamp` (default `current_timestamp()`), `session_id`. Written by `insert_coffee_order`. |
+
+**Menu snapshot:** Cappuccino, Latte, Flat White, Caramel Macchiato, Espresso, Mocha, White Mocha, Hot Chocolate (Hot Drinks); Cold Coffee, Cold Mocha, Iced Tea, Lemonade (Cold Drinks); Ham & Cheese and Salami & Mozzarella sandwiches (Snacks).
+
+---
+
+## Why these design choices?
+
+### Why a single-agent "swarm" instead of just an agent?
+
+`orchestration.swarm` with one `default_agent` is the simplest valid dao-ai app: it exercises the full serving + memory + tool machinery without any routing complexity. It's the natural starting point before you add specialists — bolt on a `menu` agent and an `orders` agent later and the swarm shape already supports handoffs. Here, all the "routing" is prompt-internal, which keeps the whole app in one readable place.
+
+### Why embed reviews, not menu rows?
+
+`items_raw` is structured (name, SKU, size, price) — perfect for exact filters, terrible for "something sweet and cold." `items_description` holds paragraph-length flavor/texture/aroma text, which is what gives semantic search real recall on vague customer language. The retrieval functions get the best of both: `VECTOR_SEARCH` over reviews to find the *right item names*, then a SQL join back to `items_raw` for the *exact price and size*.
+
+### Why put Vector Search inside SQL functions?
+
+Wrapping `VECTOR_SEARCH(...)` in a UC function means the agent's tool surface is plain SQL functions with rich `COMMENT` docstrings — no bespoke retriever tool to configure, and price/size filtering happens in the same query as the semantic match. The `match_item_by_description_and_price` function filters `BETWEEN low_price AND high_price` and `item_size ILIKE size` right alongside the vector hit.
+
+### Why is `insert_coffee_order` the only tool with credentials?
+
+Reads run under the serving identity automatically. But the write path needs to run arbitrary Python (`WorkspaceClient` → `statement_execution`) inside UC, so it needs an explicit service-principal token. Those `host` / `client_id` / `client_secret` args are marked "automatically provided by the system context. Do not ask customers for this value." in the SQL comments and are injected via `partial_args` from the secret scope — the LLM never sees or fills them.
+
+### Why in-memory state instead of Lakebase?
+
+For a demo / workshop app, per-process memory is enough to show multi-turn context and per-user namespacing without provisioning a database. The Postgres variables (`PGHOST`, `PGPORT`, `PGDATABASE`) are declared so the config can be upgraded to a durable Lakebase checkpointer/store by adding a `database:` block — but as shipped, restarting the endpoint clears state. (See the `hardware_store_lakebase` example for the durable variant.)
+
+---
+
+## Deploy
+
+### Prerequisites
+
+- **Profile**: `DEFAULT` (or your equivalent) configured via `databricks configure`
+- **Secret scope**: `retail_consumer_goods` with `RETAIL_AI_DATABRICKS_CLIENT_ID`, `RETAIL_AI_DATABRICKS_CLIENT_SECRET`, `RETAIL_AI_DATABRICKS_HOST` (backing `insert_coffee_order`)
+- **Vector Search endpoint**: `dbdemos_vs_endpoint` exists (or change `resources.vector_stores.*.endpoint.name`)
+- **SQL Warehouse**: a warehouse whose name contains `Shared Endpoint` (the `insert_coffee_order` Python looks it up by name); the config also pins `warehouse_id: 148ccb90800933a1` — update to your own
+
+### Validate + deploy
+
+```bash
+# Validate first (schema + anchors + graph construction)
+DATABRICKS_CONFIG_PROFILE=DEFAULT uv run dao-ai validate \
+  -c examples/15_complete_applications/quick_serve_restaurant/quick_serve_restaurant.yaml
+
+# Provision data + functions + VS index, then deploy the agent.
+# Use `workflow up` (not `agent up`) because this app OWNS datasets: + unity_catalog_functions:.
+uv run dao-ai workflow up \
+  -c examples/15_complete_applications/quick_serve_restaurant/quick_serve_restaurant.yaml \
+  -p DEFAULT
+```
+
+The config declares a Model Serving target — `app.registered_model` = `retail_consumer_goods.quick_serve_restaurant.quick_serve_restaurant_dao` and `app.endpoint_name` = `coffee_shop_agent_dao`, with `CAN_QUERY` granted to `users`. Choose the deploy target at the CLI:
+
+```bash
+# Databricks App (default)
+uv run dao-ai agent up -c .../quick_serve_restaurant.yaml -p DEFAULT
+
+# Model Serving endpoint (coffee_shop_agent_dao)
+uv run dao-ai agent up -c .../quick_serve_restaurant.yaml --mode model_serving -p DEFAULT
+```
+
+> `agent up` deploys the agent only. Run `workflow up` first (or once) so the schema, tables, UC functions, and VS index exist.
+
+### Verify
+
+```bash
+# Tables + functions created
+databricks --profile DEFAULT tables list retail_consumer_goods quick_serve_restaurant
+databricks --profile DEFAULT functions list retail_consumer_goods quick_serve_restaurant
+
+# Endpoint (if deployed to Model Serving)
+databricks --profile DEFAULT serving-endpoints get coffee_shop_agent_dao
+```
+
+---
+
+## Sample prompts
+
+Straight from [`examples.yaml`](./examples.yaml) — each sets `custom_inputs.configurable.thread_id` + `user_id`:
+
+| Intent | Prompt | `user_id` | Tool expected |
+|---|---|---|---|
+| **Menu recommendation** | *"What cold coffee drinks do you have under $5?"* | `sarah_jones` | `match_item_by_description_and_price` (desc=cold coffee, high_price=5.0) |
+| **Item description** | *"What does your caramel macchiato taste like? I want to know more about it before ordering."* | `mike_chen` | `lookup_items_by_descriptions` |
+| **Place order** | *"I'd like to order a medium cappuccino please."* | `alex_rodriguez` | `insert_coffee_order` (coffee_name=Cappuccino, size=Medium) |
+| **Order history** | *"What coffee orders did I place last week? I want to see my order history."* | `emma_wilson` | `match_historical_item_order_by_date` |
+
+The config's `input_example` uses a simpler probe: *"How much is a green tea?"* with `user_id: my_user_id`.
+
+Invoke a deployed endpoint:
+
+```bash
+databricks --profile DEFAULT serving-endpoints query coffee_shop_agent_dao --json '{
+  "input": [{"role": "user", "content": "What cold coffee drinks do you have under $5?"}],
+  "custom_inputs": {"configurable": {"thread_id": "1", "user_id": "sarah_jones"}}
+}'
+```
+
+---
+
+## File layout
+
+```
+quick_serve_restaurant/
+├── README.md                          # this file
+├── quick_serve_restaurant.yaml        # dao-ai config (single-agent swarm)
+├── examples.yaml                      # 4 sample prompts (source for the table above)
+├── data/                              # DDL + seed data (4 tables)
+│   ├── items_raw.sql   + items_raw.csv          # 24 menu SKUs
+│   ├── orders_raw.sql  + orders_raw.csv         # ~521 historical orders
+│   ├── items_description.sql + items_description.csv  # review corpus (VS source)
+│   └── fulfil_item_orders.sql                   # DDL only — runtime order sink
+└── functions/                         # 4 UC SQL functions
+    ├── match_item_by_description_and_price.sql
+    ├── lookup_items_by_descriptions.sql
+    ├── match_historical_item_order_by_date.sql
+    └── insert_coffee_order.sql                  # Python UC fn — the write path
+```
+
+---
+
+## Related dao-ai patterns referenced
+
+- **Swarm orchestration** — `examples/13_orchestration/swarm_pattern.yaml`
+- **UC-function tools** — `examples/03_tools/unity_catalog_tool.yaml`
+- **Vector Search retriever** — `examples/03_tools/vector_search_tool.yaml`
+- **Durable Lakebase memory (the upgrade path)** — `examples/15_complete_applications/hardware_store_lakebase.yaml`
+- **Prompt registry objects** — `examples/02_prompts/`

--- a/examples/15_complete_applications/quick_serve_restaurant/quick_serve_restaurant.yaml
+++ b/examples/15_complete_applications/quick_serve_restaurant/quick_serve_restaurant.yaml
@@ -11,6 +11,18 @@ parameters:
   schema:
     description: Schema within the catalog
     default: quick_serve_restaurant
+  vector_search_endpoint:
+    description: Vector Search endpoint hosting the indexes for this app
+    default: dbdemos_vs_endpoint
+  llm:
+    description: Primary chat/reasoning + tool-calling + judge serving endpoint
+    default: databricks-claude-sonnet-5
+  fallback_llm:
+    description: Fallback chat serving endpoint when the primary llm is unavailable
+    default: databricks-claude-sonnet-4-5
+  embedding_model:
+    description: Text embedding serving endpoint for vector search
+    default: databricks-gte-large-en
 
 # =============================================================================
 # Multi-Agent AI Orchestration Framework Configuration
@@ -78,27 +90,27 @@ resources:
 
     # LLM optimized for tool calling and function execution
     tool_calling_llm: &tool_calling_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 8192
       fallbacks:                                     # Fallback models if primary fails
-      - databricks-claude-sonnet-4
+      - ${var.fallback_llm}
 
     # LLM for complex reasoning tasks
     reasoning_llm:
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.1
       max_tokens: 8192
 
     # LLM for evaluating and judging responses (guardrails)
     judge_llm: &judge_llm
-      name: databricks-claude-sonnet-4-5
+      name: ${var.llm}
       temperature: 0.5                              # Higher temperature for diverse judgments
       max_tokens: 8192
 
     # Embedding model for vector search and semantic similarity
     embedding_model: &embedding_model
-      name: databricks-gte-large-en                 # Text embedding model
+      name: ${var.embedding_model}                  # Text embedding model
 
   # ---------------------------------------------------------------------------
   # VECTOR STORES
@@ -110,7 +122,7 @@ resources:
       embedding_model: *embedding_model
                                                     # Reference to embedding model above
       endpoint:                                     # Vector search endpoint configuration
-        name: dbdemos_vs_endpoint            # Databricks vector search endpoint
+        name: ${var.vector_search_endpoint}            # Databricks vector search endpoint
         type: STANDARD                              # Endpoint type (STANDARD or OPTIMIZED_STORAGE)
       index:                                        # Vector search index configuration
         schema: *qsr_schema

--- a/examples/15_complete_applications/reservations_system/README.md
+++ b/examples/15_complete_applications/reservations_system/README.md
@@ -1,0 +1,146 @@
+# Reservations System — Human-in-the-Loop Confirmation Demo
+
+> **The smallest useful dao-ai app: one supervisor, one `reservation` agent, and a single tool that pauses for human approval before it commits.** This example exists to teach one thing clearly — how a `human_in_the_loop` block on a tool turns an ordinary agent call into an approve/edit/reject checkpoint, backed by an in-memory conversation checkpointer.
+
+| ✨ Feature | What this example shows |
+|---|---|
+| 🧍 **Human-in-the-loop tool** | `reservation_tool` carries a `human_in_the_loop` block — the agent's call is **interrupted** and surfaced to a reviewer before it executes |
+| 🧩 **Single-agent supervisor** | Supervisor orchestration with exactly one downstream agent (`reservation`) — the minimal shape of a dao-ai multi-agent app |
+| 💾 **In-memory checkpointer** | `default_checkpointer` with no database → type inferred as **memory**. Required for HITL: the interrupt is persisted so the turn can resume after approval |
+| 🏭 **Factory tool** | The tool is built by a factory function (`retail.tools.create_reservation_tool`), not UC/VS/Genie — no data or functions ship with this example |
+
+---
+
+## Architecture
+
+No data assets, no Vector Search, no Lakebase. A user message enters the supervisor, which hands off to the single `reservation` agent; when that agent decides to call `reservation_tool`, the HITL middleware pauses the graph and waits for a human decision before the tool runs.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1565c0', 'fontSize': '14px'}}}%%
+flowchart LR
+    User(("user msg"))
+
+    subgraph App["🚀 reservations_system_dao"]
+        direction TB
+        Supervisor["👔 supervisor<br/>claude-sonnet-4<br/><i>routes to reservation</i>"]
+        Reservation["📅 reservation<br/>claude-sonnet-4<br/><i>book · cancel · check availability</i>"]
+        subgraph HITL["🧍 human-in-the-loop gate"]
+            Review["⏸️ interrupt<br/><i>approve / edit / reject</i>"]
+        end
+        Tool["🏭 reservation_tool<br/>retail.tools.create_reservation_tool"]
+        Supervisor --> Reservation
+        Reservation -.->|tool call| Review
+        Review ==>|approved| Tool
+    end
+
+    Mem[("💾 in-memory checkpointer<br/>default_checkpointer")]
+    End(("response"))
+
+    User --> App
+    Reservation <-.->|checkpoint / resume| Mem
+    Tool --> End
+
+    style App fill:#fff8e1,stroke:#f57f17,stroke-width:2px
+    style HITL fill:#fce4ec,stroke:#c2185b,stroke-width:2px
+    style Reservation fill:#e1f5fe,stroke:#0277bd
+    style Mem fill:#e8f5e9,stroke:#2e7d32
+    style User fill:#e0e0e0,stroke:#424242
+    style End fill:#e0e0e0,stroke:#424242
+```
+
+---
+
+## Agents
+
+| # | Agent | Model | Tools | Role |
+|---|---|---|---|---|
+| — | `supervisor` | `databricks-claude-sonnet-4` | — | Orchestration entry point. With a single downstream agent, its only routing target is `reservation`. |
+| 1 | `reservation` | `databricks-claude-sonnet-4` | `reservation_tool` | Books, cancels, and checks availability for reservations. Its one tool is HITL-gated. |
+
+Both the agent and the supervisor router run on `databricks-claude-sonnet-4` (`temperature: 0.1`, `max_tokens: 8192`).
+
+---
+
+## How the HITL confirmation works
+
+This is the point of the example. The `reservation_tool` function block carries:
+
+```yaml
+tools:
+  reservation_tool:
+    name: reservation_tool
+    function:
+      type: factory
+      name: retail.tools.create_reservation_tool
+      human_in_the_loop:
+        review_prompt: |
+          Would you like to reserver your reservation?
+```
+
+When `human_in_the_loop` is present on a tool's `function`, dao-ai wires **LangChain's `HumanInTheLoopMiddleware`** onto the agent (`create_hitl_middleware_from_tool_models` in `dao_ai.middleware.human_in_the_loop`). At runtime:
+
+1. The `reservation` agent decides to call `reservation_tool`.
+2. Instead of executing immediately, the middleware raises a **LangGraph `interrupt`**. The graph pauses, and the `review_prompt` (`"Would you like to reserver your reservation?"`) is surfaced to the reviewer as the interrupt description.
+3. The reviewer returns one of the allowed decisions. This config sets no `allowed_decisions`, so the model default applies: **`approve`, `edit`, `reject`**.
+   - **approve** → the tool runs with the original arguments
+   - **edit** → the reviewer modifies the arguments, then the tool runs
+   - **reject** → the tool is skipped and the turn ends with feedback
+4. On resume, the checkpointer replays state and execution continues from the interrupt.
+
+**Why the in-memory checkpointer is not optional here.** The middleware requires a checkpointer to persist the paused turn between the interrupt and the human's decision. This app supplies one via `memory.checkpointer` (`default_checkpointer`, no database → inferred as memory), which also gives the conversation short-term state within a session. A `respond` decision and a tamper-evident `audit` block are both available on the model but are **not** configured in this example.
+
+---
+
+## Deploy
+
+This app ships **no data, functions, or Vector Search**, so there is nothing to provision — use `dao-ai agent up` (not `workflow up`).
+
+```bash
+CONFIG=examples/15_complete_applications/reservations_system/reservations_system.yaml
+
+# Validate first (schema + anchor + graph construction)
+uv run dao-ai validate -c "$CONFIG"
+
+# Bring it up as a Databricks App (default --mode apps)
+uv run dao-ai agent up -c "$CONFIG" -p DEFAULT
+
+# ...or deploy to a Model Serving endpoint instead
+uv run dao-ai agent up -c "$CONFIG" --mode model_serving -p DEFAULT
+```
+
+The config registers the model as `nfleming.retail_ai.reservations_system_dao`, names the App `reservations_system_dao`, and (in Model Serving mode) targets endpoint `reservation_agent_dao`. Adjust the `catalog` / `schema` parameters for your workspace.
+
+---
+
+## Sample prompts
+
+*Illustrative — derived from the agent prompt and the config's `input_example`; this example ships no validated prompt set.* Each prompt that reaches `reservation_tool` triggers the HITL interrupt described above.
+
+| Prompt | Expected behavior |
+|---|---|
+| *"Can you create a reservation for me?"* | Routes to `reservation`; a booking tool call raises the approval interrupt |
+| *"Book a table for two on Friday at 7pm."* | Same — pauses on the `review_prompt` before committing |
+| *"Cancel my reservation."* | Cancellation flows through the same HITL gate |
+| *"Do you have availability this weekend?"* | Availability check — may answer without triggering the confirmation interrupt |
+
+The `input_example` passes `custom_inputs.configurable.user_id = john.smith@databricks.com`; `conversation_id` is auto-generated as a UUID when not supplied.
+
+---
+
+## File layout
+
+```
+reservations_system/
+├── README.md                     # this file
+└── reservations_system.yaml      # dao-ai config (whole app — ~88 lines)
+```
+
+No `data/`, `functions/`, or `examples.yaml` — everything the app needs is in the single YAML.
+
+---
+
+## Related dao-ai patterns referenced
+
+- **HITL middleware** — `src/dao_ai/middleware/human_in_the_loop.py` (`HumanInTheLoopModel`, `create_hitl_middleware_from_tool_models`)
+- **Audit receipts on HITL tools** — `src/dao_ai/middleware/audit_hitl.py` (the `audit` block, not used here)
+- **A richer complete app** — `examples/15_complete_applications/commerce/commerce_supervisor.README.md`

--- a/examples/15_complete_applications/reservations_system/reservations_system.yaml
+++ b/examples/15_complete_applications/reservations_system/reservations_system.yaml
@@ -11,6 +11,9 @@ parameters:
   schema:
     description: Schema within the catalog
     default: retail_ai
+  llm:
+    description: Chat serving endpoint for the reservation agent
+    default: databricks-claude-sonnet-5
 
 schemas:
   retail_schema: &retail_schema
@@ -24,7 +27,7 @@ schemas:
 resources:
   models:
     default_llm: &default_llm
-      name: databricks-claude-sonnet-4  # Databricks serving endpoint name
+      name: ${var.llm}  # Databricks serving endpoint name
       temperature: 0.1                              # Low temperature for consistent responses
       max_tokens: 8192                              # Maximum tokens per response
 memory: &memory

--- a/examples/15_complete_applications/sporting_goods_store/README.md
+++ b/examples/15_complete_applications/sporting_goods_store/README.md
@@ -1,0 +1,372 @@
+# Sporting Goods Store — Merchandiser 360 — one data plane, two orchestration profiles
+
+> **A multi-agent merchandising assistant for a sporting-goods retailer (think Dick's / SportsPlex).** This directory ships **two dao-ai configs over one shared data plane**: a **full** build (`sporting_goods_store.yaml`) that auto-provisions its Genie rooms, runs OBO end-to-end, and adds a retrieval verifier + UPC-lookup coverage; and a **slim** build (`sporting_goods_store_slim.yaml`) that reuses pre-built Genie spaces, runs on a stable service principal, and trims the tool surface. Both are 7-agent **supervisor** systems with Lakebase persistent memory, two Genie analytics rooms, instructed vector search, and production monitoring. Pick the full config for a from-scratch provision on a fresh workspace; pick slim for a fast redeploy against infrastructure that already exists.
+
+---
+
+## Variant comparison
+
+| | **Full** — `sporting_goods_store.yaml` | **Slim** — `sporting_goods_store_slim.yaml` |
+|---|---|---|
+| App name | `sporting_goods_store_dao` | `sporting_goods_store_slim` |
+| Registered model | `sporting_goods_store_dao` | `sporting_goods_store_slim` |
+| Endpoint name | `sporting_goods_store_dao` | `sporting_goods_store_dao` *(shared)* |
+| Agents | 7 (supervisor + 7 specialists) | 7 (identical roster) |
+| Genie rooms | 2 — **auto-provisioned** on first deploy (`table_sources`, `text_instructions`, `sample_questions` declared; `space_id` supplied at run time via the `provision-genie` taskValue) | 2 — **reuse existing spaces** by hardcoded `space_id` (no table sources / instructions / auto-provisioning) |
+| UC functions wired | **6** — SKU **and** UPC variants of product / inventory / store-inventory lookups | **3** — SKU-only variants (`find_product_by_sku`, `find_inventory_by_sku`, `find_store_inventory_by_sku`) |
+| Retrieval verifier | ✅ `verifier_llm` + retriever `verifier:` block (`warn_and_retry`, 1 retry) | ❌ no verifier model, no verifier block |
+| Vector store auth | OBO — `on_behalf_of_user: true` | SP — `on_behalf_of_user: false`, `target_qps: 500` on endpoint |
+| Warehouse auth | OBO — `on_behalf_of_user: true` | SP — `on_behalf_of_user: false` |
+| `tables:` resource block | ✅ declared (needed to feed Genie auto-provisioning) | ❌ omitted |
+| `genie_parent_path` param | ✅ (where new Genie spaces are created) | ❌ (spaces already exist) |
+| Default `warehouse_id` | `d58e5fb998498840` | `4b9b953939869799` |
+
+**What slim trims, in one sentence:** the machinery you only need the *first* time — Genie-space creation, the UPC lookup functions, the retrieval verifier, and per-user OBO — leaving a leaner config that redeploys fast against already-provisioned infrastructure. Everything downstream (prompts, memory, middleware, monitoring, evaluation, the 6-table dataset) is byte-for-byte identical between the two.
+
+---
+
+## Architecture
+
+Both variants are the same shape: a routing **supervisor** that never answers directly, seven merchandising specialists, a Lakebase memory layer that wraps every turn, and a Databricks data plane (two Genie rooms, UC functions, vector search). The diagram below is the shared architecture; the two call-outs mark where the variants diverge.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1565c0', 'fontSize': '14px'}}}%%
+flowchart TB
+    subgraph User["👤 Merchandiser"]
+        Query["What's the demand forecast<br/>for running shoes next quarter?"]
+    end
+
+    subgraph SupervisorLayer["🎯 Supervisor (routing only)"]
+        Router["supervisor_llm · gpt-5-4-mini<br/><i>never answers — always hands off</i><br/>+ store_validation middleware<br/>+ app_info tool"]
+    end
+
+    subgraph Specialists["👷 7 Specialized Agents · tool_calling_llm (claude-sonnet-4-5)"]
+        Assortment["📊 assortment_planning"]
+        Forecasting["📈 forecasting"]
+        PurchaseOrder["📋 purchase_order"]
+        Pricing["💲 pricing"]
+        Sales["🏷️ sales"]
+        InventoryAgent["📦 inventory"]
+        General["💬 general"]
+    end
+
+    subgraph MemoryLayer["🧠 Lakebase Persistent Memory (retail-consumer-goods project)"]
+        Checkpointer["checkpointer<br/>conversation state"]
+        Store["store · ns={user_id}<br/>semantic memory"]
+        Extraction["background extraction<br/>user_profile · preference · episode<br/>auto_inject (limit 5)"]
+    end
+
+    subgraph DataLayer["☁️ Databricks Platform"]
+        GenieMerch["🧞 Genie: Merchandising Analytics"]
+        GenieSales["🧞 Genie: Sales & Pricing Analytics"]
+        UCFunctions["⚙️ UC Functions<br/><b>6 (full)</b> / <b>3 (slim)</b>"]
+        VectorSearch["🔍 Vector Search<br/>products_description_index"]
+        Lakebase[("🗄️ Lakebase")]
+        LLMs["🧠 LLM Endpoints + fallback"]
+    end
+
+    Query --> Router
+    Router --> Assortment
+    Router --> Forecasting
+    Router --> PurchaseOrder
+    Router --> Pricing
+    Router --> Sales
+    Router --> InventoryAgent
+    Router --> General
+    Specialists --> MemoryLayer
+    Specialists --> DataLayer
+
+    style SupervisorLayer fill:#fff3e0,stroke:#e65100
+    style Specialists fill:#e8f5e9,stroke:#2e7d32
+    style MemoryLayer fill:#e3f2fd,stroke:#1565c0
+    style DataLayer fill:#f3e5f5,stroke:#7b1fa2
+```
+
+**Where the variants differ on this diagram:**
+- **Genie rooms** — Full declares `table_sources` + `text_instructions` + `sample_questions` and creates the spaces on first deploy (the `provision-genie` job task emits the `space_id` as a taskValue). Slim points `space_id` at spaces that already exist and skips creation.
+- **UC Functions** — Full wires all 6 (SKU + UPC); slim wires the 3 SKU-only functions. This only changes which tools the `inventory` and `pricing` agents carry (see the Agents table).
+- **Auth path** — Full runs the vector store and warehouse **on behalf of the calling user** (OBO); slim runs them under the `retail_consumer_goods_sp` service principal. Genie rooms, UC functions, and Lakebase are SP-backed (`on_behalf_of_user: false`) in **both**.
+
+### Genie routing — two rooms, one job each
+
+The two Genie rooms are the analytical backbone. They are deliberately split by concern so each specialist queries a focused semantic space.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1565c0', 'fontSize': '14px'}}}%%
+flowchart LR
+    subgraph MerchRoom["🧞 Merchandising Analytics"]
+        M1["products · inventory<br/>purchase_orders · dim_stores"]
+        MUsers["assortment_planning<br/>forecasting · purchase_order"]
+    end
+
+    subgraph SalesRoom["🧞 Sales & Pricing Analytics"]
+        S1["products · sales_orders<br/>pricing_history · dim_stores"]
+        SUsers["pricing · sales"]
+    end
+
+    subgraph Cache["⚡ Dual-layer Genie cache (both rooms)"]
+        C1["LRU · capacity 100 · TTL 1h"]
+        C2["context-aware semantic cache<br/>Lakebase · similarity 0.85 · TTL 24h"]
+        C3["persist_conversation: true"]
+    end
+
+    MUsers --> MerchRoom --> Cache
+    SUsers --> SalesRoom --> Cache
+
+    style MerchRoom fill:#e3f2fd,stroke:#1565c0
+    style SalesRoom fill:#fff3e0,stroke:#e65100
+    style Cache fill:#fce4ec,stroke:#c2185b
+```
+
+---
+
+## Agents
+
+Seven specialists plus a routing supervisor, identical in both variants except for the tool lists on `inventory` and `pricing` (slim has no UPC-lookup functions). Every specialist runs the shared `tool_calling_llm` (`databricks-claude-sonnet-4-5`, with `databricks-claude-sonnet-4-6` as an automatic fallback); the supervisor runs the faster `supervisor_llm` (`databricks-gpt-5-4-mini`).
+
+| Agent | Role | Tools (full) | Slim delta |
+|---|---|---|---|
+| **supervisor** | Routing coordinator. Explicitly instructed: *"You do NOT answer questions yourself… Always hand off. Never answer directly."* Carries `store_validation` middleware + `app_info`. | `app_info` | same |
+| **assortment_planning** | Category mix, planogram strategy, seasonal transitions, SKU rationalization | `merchandising_analytics` (Genie), `product_vector_search` | same |
+| **forecasting** | Demand prediction, trend/velocity analysis, stockout-risk assessment | `merchandising_analytics` (Genie), `current_time` | same |
+| **purchase_order** | PO lifecycle, vendor management, reorder quantities, receiving | `merchandising_analytics` (Genie), `find_inventory_by_sku_uc` | same |
+| **pricing** | Markdowns, promotions, competitive pricing, margin analysis, clearance | `sales_pricing_analytics` (Genie), `find_product_by_sku_uc`, `find_product_by_upc_uc` | drops `find_product_by_upc_uc` |
+| **sales** | Performance analytics, revenue tracking, store comparisons, returns. Has `recursion_limit: 12` + explicit efficiency guidelines (one comprehensive Genie query, watch `cache_hit`) | `sales_pricing_analytics` (Genie), `find_inventory_by_sku_uc`, `product_vector_search` | same |
+| **inventory** | Stock levels, replenishment, allocation, store-level availability | `find_inventory_by_sku_uc`, `find_inventory_by_upc_uc`, `find_store_inventory_by_sku_uc`, `find_store_inventory_by_upc_uc`, `product_vector_search` | drops both `_by_upc_uc` (keeps 3 tools) |
+| **general** | Product info + store inquiries not owned by a specialist | `product_vector_search` | same |
+
+Each specialist's prompt carries the same header (`User Id`, `Store Number`), a responsibilities section, explicit tool-usage guidance, and a response-style section. All seven prompts are first-class `prompts:` objects tagged `environment: production`, `domain: merchandising`, and registered to the `sporting_goods_store` schema. Every agent's `handoff_prompt` is a one-line description the supervisor routes against.
+
+---
+
+## Data plane (shared by both variants)
+
+Both configs point at **`retail_consumer_goods.sporting_goods_store`** in Unity Catalog and provision the identical dataset, functions, and vector index. This section is written once because nothing here differs between full and slim.
+
+### Schema layout
+
+```
+retail_consumer_goods.sporting_goods_store/
+├── 📊 Tables (6) — Delta, CDF + auto-optimize enabled
+│   ├── products          ← 30 rows · VS source (long_description embedded)
+│   ├── inventory         ← 24 rows · per-product × store snapshot
+│   ├── dim_stores        ← 5 rows  · store dimension
+│   ├── sales_orders      ← 15 rows · transaction line items
+│   ├── purchase_orders   ← 10 rows · PO line items
+│   └── pricing_history   ← 15 rows · price-change events
+│
+├── 🛠️ UC Functions (6 defined; full wires all 6, slim wires 3)
+│   ├── find_product_by_sku(sku ARRAY<STRING>)              ← slim ✅
+│   ├── find_product_by_upc(upc ARRAY<STRING>)              ← slim ✗
+│   ├── find_inventory_by_sku(sku ARRAY<STRING>)            ← slim ✅
+│   ├── find_inventory_by_upc(upc ARRAY<STRING>)            ← slim ✗
+│   ├── find_store_inventory_by_sku(store, sku ARRAY<STRING>) ← slim ✅
+│   └── find_store_inventory_by_upc(store, upc ARRAY<STRING>) ← slim ✗
+│
+└── 🔍 VS index — products_description_index
+    └── source: products.long_description · pk: product_id
+        endpoint: dbdemos_vs_endpoint (STANDARD)
+```
+
+### Tables
+
+| Table | Rows | What it holds |
+|---|---|---|
+| `products` | 30 | Master catalog: `sku`, `upc`, `brand_name`, `merchandise_class`, `department_name`, `sport_category`, `base_price`/`msrp`/`cost`, seasonal + merchandising + supplier + lifecycle attributes, and a rich `long_description` (the VS embedding source). |
+| `inventory` | 24 | Per-product × store stock: `store_quantity`, `warehouse_quantity`, `stockout_risk_level`, `is_out_of_stock`/`is_low_stock`, demand predictions, `aisle_location`. |
+| `dim_stores` | 5 | Store dimension: SportsPlex Denver flagship, Austin South, Chicago North, Portland Pearl, Orlando outlet — with region/district hierarchy, format, sqft, department flags. |
+| `sales_orders` | 15 | Sales line items: `qty`, `unit_price`, `discount_amount`, `margin_amount`/`margin_pct`, `channel` (in_store/online/mobile_app), `is_return`. |
+| `purchase_orders` | 10 | PO line items: `supplier_name`, `quantity_ordered`/`received`, `po_status` (draft→received→cancelled), `expected`/`actual_delivery_date`, `buy_plan_id`, `buyer_name`. |
+| `pricing_history` | 15 | Price-change events: `original_price`/`new_price`, `price_change_type` (initial/markdown/clearance/promotion/competitive/rollback), `markdown_pct`, `promotion_name`, `effective_date`/`end_date`. |
+
+All tables carry `delta.enableChangeDataFeed = true` so the Vector Search Delta-Sync and downstream analytics stay incremental. The catalog/schema come from `parameters.catalog` / `parameters.schema` and can be overridden with `--param`.
+
+### Catalog & brands
+
+The synthetic catalog spans athletic footwear, apparel, team sports, fitness equipment, outdoor/camping, cycling, golf, and accessories — across 21 brands: **Nike, Adidas, Under Armour, New Balance, Patagonia, The North Face, Columbia, Wilson, Spalding, Coleman, YETI, Osprey, Trek, Giro, Oakley, Garmin, Hydro Flask, Callaway, Lululemon, Bowflex, Rogue Fitness**. SKUs follow a `AAA-AAA-999` pattern (e.g. `NKE-RUN-001`); store identifiers are `DEN-FLAG`, `AUS-SOUTH`, `CHI-NORTH`, `PDX-PEARL`.
+
+### UC functions
+
+All six functions take an `ARRAY<STRING>` of SKUs or UPCs (so a single call can look up many products) and return a typed `TABLE`. The `find_store_inventory_by_*` pair additionally take a `store` argument and are the store-scoped lookups the `inventory` agent uses once `store_num` is known. Function comments steer the agent explicitly — e.g. *"Use product_vector_search to find SKUs first if you only know product descriptions… For broad inventory queries without specific SKUs, use the Genie analytics tool instead."* Each function is registered with a smoke test (`sku: ["NKE-RUN-001"]`, `store: "DEN-FLAG"`) that runs during provisioning.
+
+### Instructed vector search
+
+`products_retriever` wraps `products_description_index` with the instructed-retrieval stack (identical in both variants except full adds the `verifier` sub-block):
+
+- **Hybrid search** — `query_type: HYBRID`, `num_results: 50`
+- **Query decomposition** — up to 3 sub-queries via `decomposition_llm`, merged with Reciprocal Rank Fusion (`rrf_k: 60`), filter case normalized to uppercase. Ships five worked filter examples (e.g. `"Nike running shoes"` → `{brand_name: NIKE, sport_category: RUNNING, merchandise_class: FOOTWEAR}`).
+- **LLM rerank** — domain instructions (boost specified brands, prefer exact `sport_category`, honor price sensitivity), `top_n: 10`
+- **Verifier (full only)** — `verifier_llm`, `on_failure: warn_and_retry`, `max_retries: 1`
+- **Cross-encoder rerank** — `ms-marco-MiniLM-L-12-v2`, `top_n: 20`
+
+### Memory (Lakebase)
+
+Both variants share the same `memory:` block, backed by the **`retail-consumer-goods`** Lakebase project (`on_behalf_of_user: false` — SP-backed):
+
+- **checkpointer** — durable conversation state
+- **store** — semantic memory namespaced per user (`namespace: "{user_id}"`), embedded with `databricks-gte-large-en`
+- **extraction** — background extraction into three schemas (`user_profile`, `preference`, `episode`), `auto_inject: true` (limit 5), `background_extraction: true`. Extraction runs on `tool_calling_llm`; the memory-search query is rephrased by `fast_llm`. Instructions target the user's name/role/focus areas, preferred categories/brands, stores managed, and notable pricing/buying/assortment decisions.
+
+---
+
+## Why these design choices?
+
+### When to use full vs slim
+
+| Pick **full** when… | Pick **slim** when… |
+|---|---|
+| Deploying to a **fresh workspace** with no Genie spaces yet — it creates them for you and emits the `space_id`s | The Genie spaces (and the rest of the infra) **already exist** and you just want a fast redeploy |
+| You want **per-user (OBO) governance** on catalog reads and Genie — each merchandiser's queries run under their own identity/permissions | You want a **stable service-principal** identity for predictable auth (no OBO token plumbing) |
+| You need **UPC lookups** (barcode-driven flows) alongside SKU | Your flows are **SKU-only** and you want a leaner tool surface |
+| You want the extra **retrieval verifier** guardrail on VS results | You're optimizing for latency/cost and accept VS results without the verifier pass |
+
+Because both write to the **same schema, same dataset, same Genie rooms**, you can provision once with the full config, capture the emitted Genie `space_id`s, drop them into the slim config's parameter defaults, then iterate with slim from then on. The two apps have distinct app + registered-model names, so they can coexist in one workspace.
+
+### Why a routing-only supervisor?
+
+The supervisor prompt is emphatic that it holds **no tools and no data** and must hand off every request. This keeps routing cheap (it runs the fast `gpt-5-4-mini`) and keeps every substantive answer inside a specialist whose prompt, tools, and monitoring guidelines are purpose-built for that merchandising function. The only tool it carries is `app_info` (self-description / capability discovery).
+
+### Why split Genie into two rooms?
+
+Merchandising analytics (assortment, demand, POs, category performance over `products`/`inventory`/`purchase_orders`) and sales-&-pricing analytics (revenue, margin, promo lift over `sales_orders`/`pricing_history`) are different question spaces with different join patterns and text instructions. Two focused rooms give Genie tighter grounding than one catch-all room, and each room carries its own dual-layer cache.
+
+### Why dual-layer Genie caching?
+
+Each Genie tool wraps an **LRU cache** (100 entries, 1h TTL) *and* a **context-aware semantic cache** (Lakebase-backed, 0.85 similarity, 24h TTL), both with `invalidate_on_empty_result: true` and `persist_conversation: true`. The LRU catches exact repeats; the semantic layer catches paraphrases. The `sales` prompt even teaches the model to watch `cache_hit`/`consecutive_cache_hits` and call the feedback tool to break a stale-cache loop — a runtime signal, not a config toggle.
+
+### Why the store-number middleware?
+
+`store_validation` (`create_custom_field_validation_middleware`) sits on the supervisor and requires a `store_num` (example `DEN-FLAG`) before inventory/sales lookups run, so store-scoped queries resolve to the correct location. `user_id` is captured too (optional) to key the Lakebase memory namespace.
+
+### Why mixed models + a fallback?
+
+`gpt-5-4-mini` (fast, cheap) handles routing, decomposition, verification, and memory-query rephrasing; `claude-sonnet-4-5` handles the tool-calling specialists where reasoning quality matters, with `claude-sonnet-4-6` wired as an automatic fallback so a single endpoint hiccup doesn't drop the turn.
+
+---
+
+## Deploy
+
+Both configs carry a `datasets:` block and `unity_catalog_functions:` block, so the **workflow** bundle is the right entry point — it stands up the schema, loads the six tables, deploys the UC functions, provisions Vector Search + Lakebase (+ Genie spaces for the full variant), deploys the agent as a Databricks App, and runs evaluation, all as one Databricks Job DAG. Substitute `sporting_goods_store_slim.yaml` in any command below to operate the slim variant.
+
+### Prerequisites
+
+- **Profile** configured (e.g. `DEFAULT`) via `databricks configure`
+- **Secret scope** `retail_consumer_goods` with `RETAIL_AI_DATABRICKS_CLIENT_ID`, `RETAIL_AI_DATABRICKS_CLIENT_SECRET`, `RETAIL_AI_DATABRICKS_HOST` (env-var fallbacks are declared)
+- **Vector Search endpoint** `dbdemos_vs_endpoint` exists (or change `endpoint.name`)
+- **SQL Warehouse** — override `--param warehouse_id=<id>` for your workspace (defaults differ per variant)
+- **Slim only** — the two Genie spaces must already exist; set `--param merchandising_genie_space_id=…` / `--param sales_pricing_genie_space_id=…` (or edit the defaults)
+
+### Validate
+
+```bash
+# Full
+uv run dao-ai validate -c examples/15_complete_applications/sporting_goods_store/sporting_goods_store.yaml
+
+# Slim
+uv run dao-ai validate -c examples/15_complete_applications/sporting_goods_store/sporting_goods_store_slim.yaml
+```
+
+### Chat locally
+
+```bash
+uv run dao-ai chat -c examples/15_complete_applications/sporting_goods_store/sporting_goods_store.yaml
+```
+
+### Visualize the graph
+
+```bash
+uv run dao-ai graph \
+  -c examples/15_complete_applications/sporting_goods_store/sporting_goods_store.yaml \
+  -o sporting_goods_architecture.png
+```
+
+### Provision + deploy (workflow)
+
+```bash
+# Full — provisions everything incl. Genie spaces, then deploys the App
+uv run dao-ai workflow up \
+  -c examples/15_complete_applications/sporting_goods_store/sporting_goods_store.yaml \
+  -p DEFAULT
+
+# Slim — reuses existing Genie spaces; pass the space IDs if not baked into defaults
+uv run dao-ai workflow up \
+  -c examples/15_complete_applications/sporting_goods_store/sporting_goods_store_slim.yaml \
+  -p DEFAULT
+```
+
+`dao-ai workflow up` = `generate → deploy → run` for the provisioning job. Use `workflow generate` / `deploy` / `run` for granular control, and `workflow destroy` to tear it down. To deploy the agent alone (without re-provisioning data), use the `agent` verb group (`dao-ai agent up … --mode apps` for a Databricks App, `--mode model_serving` for a serving endpoint). Both variants target Databricks **Apps** (`enable_chat_proxy: true`, `permissions: CAN_QUERY` for `users`); the shared `endpoint_name` means a Model-Serving deploy of one variant would reuse the `sporting_goods_store_dao` endpoint name.
+
+---
+
+## Sample prompts
+
+Grounded in the two configs' `app_info` sample prompts and the evaluation `question_guidelines`. Personas map to the supervisor's routing targets; queries reference real brands/SKUs/stores from the catalog.
+
+### Quick start (from `app_info` sample_prompts — identical in both variants)
+
+- "What Nike running shoes do we carry?"
+- "What's the demand forecast for running shoes next quarter?"
+- "Show me open purchase orders from Nike"
+- "What are our margin targets for footwear?"
+- "How are trail running shoes performing this month?"
+- "What's the stock level on SKU NKE-RUN-001?"
+
+### By specialist (from the evaluation persona guidelines)
+
+| Agent | Prompt | Persona |
+|---|---|---|
+| **assortment_planning** | "Plan the fall assortment transition for outdoor gear" | Merchandiser |
+| **forecasting** | "What is the demand forecast for camping equipment this summer?" | Demand planner |
+| **purchase_order** | "Which purchase orders are overdue from Nike?" | Buyer |
+| **pricing** | "What markdowns should we take on winter outerwear?" · "How did the Spring Running promotion perform on Nike Pegasus?" | Pricing analyst |
+| **sales** | "Compare sales performance between Denver flagship and Portland stores" · "Show me the top 10 selling products by revenue this month" | Store manager |
+| **inventory** | "What products have critical stockout risk across our stores?" · "What is our current inventory position on Adidas Ultraboost?" | Store manager |
+| **general** | "What products do we carry for basketball?" | Any |
+
+Every chat/eval turn supplies `custom_inputs.configurable` with `user_id: merchandiser_01` and `store_num: DEN-FLAG` (the `store_validation` middleware requires `store_num`).
+
+---
+
+## Monitoring & evaluation (shared)
+
+Both variants ship identical production monitoring and evaluation:
+
+- **Monitoring** — built-in scorers `safety`, `completeness`, `relevance_to_query`, `tool_call_efficiency` at `sample_rate: 1.0`, plus custom guideline scorers at `guidelines_sample_rate: 0.5`: `merchandising_accuracy` (counts/prices/PO status must come from tools, not fabricated), `tool_usage_quality` (Genie for aggregates, UC fns for specific SKU/UPC, VS for attribute search), and `response_professionalism` (retail terminology, consistent currency formatting, actionable next steps).
+- **Evaluation** — `num_evals: 25` judged by `judge_llm` (`claude-sonnet-4-5`), spanning five personas (merchandiser, buyer, pricing analyst, store manager, demand planner) and all seven specializations, written to a `evaluation` table in the schema. Guideline set `merchandising_relevance` enforces catalog-grounded, tool-sourced, seasonally-aware answers.
+
+---
+
+## File layout
+
+```
+sporting_goods_store/                              # shared use-case dir
+├── README.md                                      # this file (covers both variants)
+├── sporting_goods_store.yaml                      # FULL — auto-provision Genie, OBO, 6 UC fns, verifier
+├── sporting_goods_store_slim.yaml                 # SLIM — reuse Genie spaces, SP auth, 3 UC fns
+├── data/                     # DDL + seed data (6 tables × 2 files) — shared
+│   ├── products.sql        + product_data.sql        (30 rows)
+│   ├── inventory.sql       + inventory_data.sql       (24 rows)
+│   ├── dim_stores.sql      + dim_stores_data.sql      (5 rows)
+│   ├── sales_orders.sql    + sales_orders_data.sql    (15 rows)
+│   ├── purchase_orders.sql + purchase_orders_data.sql (10 rows)
+│   └── pricing_history.sql + pricing_history_data.sql (15 rows)
+└── functions/                # 6 UC SQL functions — shared
+    ├── find_product_by_sku.sql
+    ├── find_product_by_upc.sql
+    ├── find_inventory_by_sku.sql
+    ├── find_inventory_by_upc.sql
+    ├── find_store_inventory_by_sku.sql
+    └── find_store_inventory_by_upc.sql
+```
+
+> Note: there is **no `examples.yaml`** in this directory. The sample prompts above are sourced from each config's `app_info.args.sample_prompts` and the `evaluation.question_guidelines` — they are grounded in the shipped configs, not invented.
+
+---
+
+## Related dao-ai patterns referenced
+
+- **Supervisor orchestration** — `examples/15_complete_applications/hardware_store/hardware_store.yaml`
+- **Lakebase memory** — `examples/15_complete_applications/hardware_store/hardware_store_lakebase.yaml`
+- **Instructed retrieval** — `examples/15_complete_applications/hardware_store/hardware_store_instructed.yaml`
+- **Commerce supervisor / swarm (Lakebase + Genie + VS)** — `examples/15_complete_applications/commerce/`
+- **Genie tool + caching** — see the `tools:` blocks in either config

--- a/examples/15_complete_applications/sporting_goods_store/sporting_goods_store.yaml
+++ b/examples/15_complete_applications/sporting_goods_store/sporting_goods_store.yaml
@@ -11,6 +11,9 @@ parameters:
   schema:
     description: Schema within the catalog
     default: sporting_goods_store
+  vector_search_endpoint:
+    description: Vector Search endpoint hosting the indexes for this app
+    default: dbdemos_vs_endpoint
   genie_parent_path:
     description: Workspace folder where Genie spaces are created. Must already exist.
     default: "/Users/${workspace.current_user.userName}"
@@ -25,13 +28,13 @@ parameters:
     provided: true
   llm:
     description: Chat/reasoning serving endpoint for tool-calling and judge tasks
-    default: databricks-claude-sonnet-4-5
+    default: databricks-claude-sonnet-5
   fast_llm:
     description: Fast chat serving endpoint for supervisor, verifier, decomposition, and query tasks
     default: databricks-gpt-5-4-mini
   fallback_llm:
     description: Fallback chat serving endpoint when the primary llm is unavailable
-    default: databricks-claude-sonnet-4-6
+    default: databricks-claude-sonnet-4-5
   embedding_model:
     description: Embedding serving endpoint for vector search and memory store
     default: databricks-gte-large-en
@@ -144,7 +147,7 @@ resources:
       embedding_model: *embedding_model
       on_behalf_of_user: true
       endpoint:
-        name: dbdemos_vs_endpoint
+        name: ${var.vector_search_endpoint}
         type: STANDARD
       index:
         schema: *sporting_goods_schema

--- a/examples/15_complete_applications/sporting_goods_store/sporting_goods_store_slim.yaml
+++ b/examples/15_complete_applications/sporting_goods_store/sporting_goods_store_slim.yaml
@@ -11,15 +11,18 @@ parameters:
   schema:
     description: Schema within the catalog
     default: sporting_goods_store
+  vector_search_endpoint:
+    description: Vector Search endpoint hosting the indexes for this app
+    default: dbdemos_vs_endpoint
   llm:
     description: Chat/reasoning serving endpoint for tool-calling and judge tasks
-    default: databricks-claude-sonnet-4-5
+    default: databricks-claude-sonnet-5
   fast_llm:
     description: Fast chat serving endpoint for supervisor, decomposition, and query tasks
     default: databricks-gpt-5-4-mini
   fallback_llm:
     description: Fallback chat serving endpoint when the primary llm is unavailable
-    default: databricks-claude-sonnet-4-6
+    default: databricks-claude-sonnet-4-5
   embedding_model:
     description: Embedding serving endpoint for vector search and memory store
     default: databricks-gte-large-en
@@ -135,7 +138,7 @@ resources:
       embedding_model: *embedding_model
       on_behalf_of_user: false
       endpoint:
-        name: dbdemos_vs_endpoint
+        name: ${var.vector_search_endpoint}
         type: STANDARD
         # Public Preview: provision target queries-per-second on the endpoint.
         # STANDARD only. Honored at create time only — if the endpoint already


### PR DESCRIPTION
## Summary

Restructures `examples/15_complete_applications/` so every complete application is self-documented and every environment-specific resource is an overridable parameter with a sensible default.

### Directory + docs
- **Moved 3 loose root configs** (`genie_and_genie_mcp`, `genie_vector_search_hybrid`, `reservations_system`) into their own project directories, matching the established one-dir-per-app pattern.
- **Added a deep-dive README to each of the 10 previously-undocumented apps** — architecture diagrams, per-agent breakdown, data plane, deploy steps, and sample prompts — each grounded in its actual config, with depth scaled to real complexity (146 lines for the minimal reservations demo up to 529 for loyalty).
- **Converted the top-level README into an applications directory/TOC** over all 12 apps; migrated the inline Hardware Store + Sporting Goods deep-dives out into their own READMEs so nothing is documented twice.

### Config parameterization (defaults preserve prior behavior unless noted)
- **Vector Search endpoint** — standardized on `dbdemos_vs_endpoint` via `${var.vector_search_endpoint}` across all VS-using configs.
- **Genie space ids** — parameterized via `${var.*genie_space_id}` with defaults (`deep_research`, `executive_assistant`, `genie_vector_search_hybrid`).
- **Model endpoints** — every model name is now a `${var...}` parameter with a default.
- **Refreshed model defaults to latest endpoints** — primary reasoning → `claude-sonnet-5`; `deep_research` deepest step → `claude-opus-4-6`; dropped `meta-llama` fast_llm → `gpt-5-4-mini`.
- **Fallback pattern** — agent apps target the larger primary and fall back to a **same-class** endpoint one generation back (`claude-sonnet-5` → `claude-sonnet-4-5`). Added fallbacks to commerce (×2) and hardware_store base/swarm/instructed; fixed `brick_store`, which previously fell back to itself.

Also fills in `genie_vector_search_hybrid`'s placeholder `foo`/`bar` agent prompts with realistic structured-vs-semantic routing instructions.

## Verification
- All 18 configs parse as valid YAML; all README code fences balanced.
- Live `dao-ai validate` confirms `${var...}` substitution (endpoint, genie space, model, fallback chain) resolves — reaching agent-graph build before the expected local auth wall.
- No config regressions: only `.md` and parameterization changes; behavior-preserving defaults.

This pull request and its description were written by Isaac.