### PR TITLE
docs(examples): describe first-class tool types as current best practice

### DIFF
--- a/examples/15_complete_applications/genie_and_genie_mcp/README.md
+++ b/examples/15_complete_applications/genie_and_genie_mcp/README.md
@@ -4,9 +4,9 @@
 
 | ✨ Feature | What this example shows |
 |---|---|
-| 🔀 **Two Genie transports, one space** | `employee_agent` uses `type: genie` (native factory tool); `inventory_agent` uses `type: mcp` against `…/api/2.0/mcp/genie/{space_id}`. Both resolve `retail_genie_room` (same `space_id`). |
+| 🔀 **Two Genie transports, one space** | `employee_agent` uses `type: genie` (native, in-process); `inventory_agent` uses `type: mcp` against `…/api/2.0/mcp/genie/{space_id}`. Both resolve `retail_genie_room` (same `space_id`). |
 | 👔 **Supervisor orchestration** | A single supervisor LLM routes each turn to one of two specialists based on their `handoff_prompt` descriptions. Hub-and-spoke, not a pipeline. |
-| 🛠️ **First-class `genie` tool** | The employee path is `type: genie` — typed fields, no boilerplate. Delegates to `dao_ai.tools.create_genie_tool`, talks to Genie over the Conversation API in-process using the deployed identity. |
+| 🛠️ **First-class `genie` tool** | The employee path is `type: genie` — typed fields, no boilerplate. Talks to Genie over the Conversation API in-process using the deployed identity. |
 | 🌐 **Managed Genie MCP** | The inventory path is `type: mcp` with a `genie_room` — dao-ai builds the managed MCP URL and calls Genie as an external MCP tool, authenticated with an explicit service principal. |
 | 🔑 **Explicit SP creds on the MCP leg only** | `genie_mcp` wires `client_id` / `client_secret` / `workspace_host` from the `retail_consumer_goods` secret scope. The `genie` tool leg needs none — it rides the serving/App identity. |
 | 🧩 **Config-only, no assets to provision** | No `data/` or `functions/` dir. The Genie space and its underlying tables are **prerequisites**, not created by deploy. `dao-ai agent up` just registers + serves. |
@@ -64,7 +64,7 @@ Both legs answer the *same kind of question* against the *same Genie space*. Wha
 | | 🛠️ `genie_tool` (employee_agent) | 🌐 `genie_mcp` (inventory_agent) |
 |---|---|---|
 | **YAML type** | `function.type: genie` | `function.type: mcp` |
-| **How dao-ai wires it** | `dao_ai.tools.create_genie_tool(genie_room=…)` — a typed first-class tool | Builds `https://{host}/api/2.0/mcp/genie/{space_id}` and registers it as an MCP tool |
+| **How dao-ai wires it** | First-class `type: genie` with a `genie_room` | Builds `https://{host}/api/2.0/mcp/genie/{space_id}` and registers it as an MCP tool |
 | **Where it runs** | In-process inside the agent; Genie **Conversation API** | Out-of-process call to Databricks' **managed Genie MCP server** |
 | **Auth** | Deployed identity (App / serving SP); no creds in config | Explicit service principal — `client_id` / `client_secret` / `workspace_host` from the `retail_consumer_goods` secret scope |
 | **Extra config** | Just `genie_room` | `genie_room` **+** three secret-backed credentials |

--- a/examples/15_complete_applications/genie_and_genie_mcp/genie_and_genie_mcp.yaml
+++ b/examples/15_complete_applications/genie_and_genie_mcp/genie_and_genie_mcp.yaml
@@ -120,7 +120,7 @@ tools:
   genie_tool: &genie_tool
     name: genie_tool
     function:
-      type: genie  # Tool type: factory function
+      type: genie  # First-class Genie tool
       name: genie_tool
       description: Answers questions about retail products and inventory
       genie_room: *retail_genie_room

--- a/examples/15_complete_applications/genie_vector_search_hybrid/genie_vector_search_hybrid.yaml
+++ b/examples/15_complete_applications/genie_vector_search_hybrid/genie_vector_search_hybrid.yaml
@@ -98,7 +98,7 @@ tools:
   genie_tool: &genie_tool
     name: genie
     function:
-      type: genie  # Tool type: factory function
+      type: genie  # First-class Genie tool
       name: my_genie_tool
       description: Query retail sales, inventory, and store metrics from the Retail AI Genie space
       genie_room: *retail_genie_room


### PR DESCRIPTION
## Summary

Follow-up to #239. Removes old-vs-new / internal-factory framing for the first-class tool shapes so the docs describe only the current best practice.

The `type: genie` / `type: vector_search` / `type: search` / `type: lakebase_search` shorthands are the recommended shape. READMEs now describe them directly instead of exposing the `create_*_tool` factory delegation behind them.

- **`genie_and_genie_mcp` README** — describe `type: genie` as first-class; drop the `create_genie_tool` delegation mentions.
- **`genie_and_genie_mcp` / `genie_vector_search_hybrid` configs** — fix leftover `# Tool type: factory function` comments sitting on `type: genie` lines.

Genuinely factory-based tools are left as-is, since they have no first-class shorthand:
- Tavily web search (`langchain_tavily.TavilySearch`) — note the first-class `type: search` wraps **DuckDuckGo**, a different provider, so this is not the "old shape" of `type: search`.
- The A2A `query_supplier` tool, the reservations custom tool, and `app_info`.

## Verification
- All configs parse; all README code fences balanced.
- No `create_genie_tool` / `create_vector_search_tool` / `create_search_tool` references remain in any README.

This pull request and its description were written by Isaac.