### PR TITLE
docs(examples): rename prompt_registry example to reusable_prompts + drop stale registry framing

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -246,7 +246,7 @@ Define reusable prompts as first-class config objects and share them across agen
 
 | Example | Description |
 |---------|-------------|
-| `prompt_registry.yaml` | Reusable inline prompts referenced via YAML anchors |
+| `reusable_prompts.yaml` | Reusable inline prompts referenced via YAML anchors |
 
 **Prerequisites:** None  
 **Next:** Add validation and monitoring in `12_middleware/`

--- a/examples/11_prompt_engineering/README.md
+++ b/examples/11_prompt_engineering/README.md
@@ -31,7 +31,7 @@ flowchart TB
 
 | File | Description |
 |------|-------------|
-| [`prompt_registry.yaml`](./prompt_registry.yaml) | Reusable inline prompts referenced via YAML anchors |
+| [`reusable_prompts.yaml`](./reusable_prompts.yaml) | Reusable inline prompts referenced via YAML anchors |
 
 ## Configuration
 
@@ -90,10 +90,10 @@ Variables are filled at runtime from the request `Context` (see `make_prompt`).
 
 ```bash
 # Validate prompt configuration
-dao-ai validate -c examples/11_prompt_engineering/prompt_registry.yaml
+dao-ai validate -c examples/11_prompt_engineering/reusable_prompts.yaml
 
 # Run with the configured prompts
-dao-ai chat -c examples/11_prompt_engineering/prompt_registry.yaml
+dao-ai chat -c examples/11_prompt_engineering/reusable_prompts.yaml
 ```
 
 ## Best Practices

--- a/examples/11_prompt_engineering/reusable_prompts.yaml
+++ b/examples/11_prompt_engineering/reusable_prompts.yaml
@@ -25,22 +25,25 @@ parameters:
     default: databricks-gte-large-en
 
 # =============================================================================
-# Multi-Agent AI Orchestration Framework Configuration
-# =============================================================================
-# This configuration file demonstrates the complete setup for a multi-agent system
-# including schemas, resources, tools, agents, and orchestration patterns.
-#
 # FEATURE: Reusable Prompts
-# ================================================
-# This example showcases how to define reusable prompts as first-class config
-# objects. Key benefits:
+# =============================================================================
+# Prompts are first-class config objects: declare a prompt once in the
+# `prompts:` block and reference it from any number of agents (and guardrails
+# or supervisors) via a YAML anchor. The template text lives inline in the
+# config — there is no external prompt-registry round-trip.
 #
-# 1. Define Once, Reuse Everywhere: Declare a prompt as a YAML anchor and
-#    reference it from any number of agents.
-# 2. Centralized Management: Keep prompt text in one place in the config.
-# 3. Readability: Keep long prompt bodies out of the agent definitions.
+# Key benefits:
+#   1. Define once, reuse everywhere — reference a prompt by anchor (*name).
+#   2. Centralized management — prompt text lives in one place.
+#   3. Readability — keep long prompt bodies out of the agent definitions.
 #
-# See the "PROMPTS CONFIGURATION" section below for detailed examples.
+# A prompt supports: name (label used in logs/traces), template (with optional
+# {variable} placeholders filled from the request Context at runtime),
+# description, an optional Unity Catalog `schema` qualifier (label only), and
+# tags. See the "PROMPTS CONFIGURATION" section below for worked examples.
+#
+# This example wires the prompts into a small supervisor-routed multi-agent
+# hardware-store assistant so the pattern is shown in a realistic setting.
 # =============================================================================
 
 # =============================================================================
@@ -159,22 +162,6 @@ resources:
     find_store_inventory_by_sku: &find_store_inventory_by_sku
       schema: *retail_schema
       name: find_store_inventory_by_sku             # Store-specific SKU inventory lookup
-
-
-
-
-
-
-      # Optional: Additional PostgreSQL connection parameters
-      # Uncomment and modify as needed for your specific setup
-      # connection_kwargs:                            # Additional connection parameters
-      #   autocommit: True                            # Enable autocommit mode
-      #   prepare_threshold: 0                        # Disable prepared statements
-      #   sslmode: require                            # Require SSL connection
-      #   connect_timeout: 10                         # Connection timeout in seconds
-      # Optional: Connection pool configuration
-      # max_pool_size: 20                             # Maximum connections in pool
-      # timeout: 5                                    # Connection timeout in seconds
 
 # =============================================================================
 # RETRIEVERS CONFIGURATION
@@ -674,25 +661,16 @@ prompts:
 
 
 # ==============================================================================
-# AGENTS CONFIGURATION  
+# AGENTS CONFIGURATION
 # ==============================================================================
-# Agents can use prompts in two ways:
-# 1. Inline prompt strings (traditional approach - shown below)
-# 2. Prompt references (new approach - using prompts defined above)
+# An agent's `prompt:` field accepts either an inline string or a reference to
+# a prompt defined in the `prompts:` block above (via YAML anchor). Every agent
+# below uses a reference — e.g. `prompt: *general_prompt` — which is the
+# recommended pattern:
 #
-# To use a prompt reference, replace the inline prompt with:
-#   prompt: *general_prompt
-#
-# Example:
-#   general:
-#     name: general
-#     model: *tool_calling_llm
-#     prompt: *general_prompt  # References the prompt from the prompts section
-#
-# Benefits of using prompt references:
-# - Centralized prompt management
-# - Define a prompt once and reuse it across multiple agents
-# - Keep long prompt bodies out of the agent definitions
+# - Centralized prompt management — edit the text in one place.
+# - Define a prompt once and reuse it across multiple agents.
+# - Keep long prompt bodies out of the agent definitions.
 # ==============================================================================
 
 agents:
@@ -809,14 +787,14 @@ agents:
 # and agent orchestration patterns for the multi-agent system
 
 app:
-  name: prompt_registry_dao                      # Application name  
+  name: reusable_prompts_dao                      # Application name
   description: "Multi-agent system for retail customer service and product assistance"
   log_level: TRACE                                   # Logging level for the application
   registered_model:                                 # MLflow registered model configuration
     schema: *retail_schema
                                                     # Schema where model will be registered
-    name: prompt_registry_dao
-  endpoint_name: hardware_store_supervisor_dao                    # Model serving endpoint name
+    name: reusable_prompts_dao
+  endpoint_name: reusable_prompts_dao                    # Model serving endpoint name
   tags:                                             # Tags for resource organization
     business: rcg                                   # Business unit identifier
     streaming: true                                 # Indicates streaming capabilities
@@ -834,7 +812,6 @@ app:
   - *general
                                                     # General purpose agent
   orchestration:                                    # Agent orchestration configuration
-    #memory: *memory                                 # Reference to memory configuration
     supervisor:                                     # Supervisor orchestration pattern
       model: *tool_calling_llm
                                                     # LLM for routing decisions


### PR DESCRIPTION
## Summary

`examples/11_prompt_engineering/prompt_registry.yaml` was named and framed around a **prompt registry** that no longer exists in dao-ai. In `e3db0a0` (PR #192) the MLflow/Unity Catalog prompt-registry load/store integration (and GEPA prompt optimization) was removed because the registry stayed in Beta and wasn't reaching GA.

Today `PromptModel` is **inline-only**: `name` + `template` (required) plus optional `schema` (a decorative UC-namespace label), `description`, and `tags`. There is no registration, versioning, alias, or URI resolution. Agents reference prompts by YAML anchor (`prompt: *general_prompt`); `{user_id}`/`{store_num}` placeholders are filled from the request `Context` at runtime.

The feature the example demonstrates — **reusable inline prompts shared across agents** — is still current and worth an example. This PR realigns the file with that reality.

## Changes
- **Rename** `prompt_registry.yaml` → `reusable_prompts.yaml` (`git mv`, history preserved).
- **Rename** app + endpoint to `reusable_prompts_dao` (was `prompt_registry_dao`; the `endpoint_name` also had a stale `hardware_store_supervisor_dao` copy-paste mismatch).
- **Reframe** the header and agents comments around "reusable inline prompts"; drop the outdated old-vs-new narrative ("traditional inline" vs "new registry approach").
- **Remove dead cruft**: an orphaned PostgreSQL `connection_kwargs` comment block left dangling under `functions:`, and a `#memory: *memory` reference to a non-existent anchor.
- **Update references**: the example link in `examples/11_prompt_engineering/README.md` (table + quick-start commands) and `docs/examples.md`.

The config is otherwise functionally unchanged — it already used only supported `PromptModel` fields.

## Verification
- `dao-ai validate -c examples/11_prompt_engineering/reusable_prompts.yaml` builds the prompt middleware for every agent, resolves the `PromptModel` references (`prompt_type=PromptModel`), and detects the `{user_id}`/`{store_num}` template variables — reaching agent-graph build before the expected local auth wall.
- No `prompt_registry` references remain anywhere in the repo.

This pull request and its description were written by Isaac.