### PR TITLE
feat(cli): add `dao-ai service-principal` (create | store | grant)

### DIFF
--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -2619,10 +2619,24 @@ def _handle_sp_provision(options, config, sp, WorkspaceClient) -> None:
     print(f"{verb} service principal: {result.display_name}")
     print(f"  client_id: {result.client_id}")
     if result.stored:
-        print(f"  secret stored in scope: {result.stored_scope} (not printed)")
+        print(f"  secret stored in scope '{result.stored_scope}' (value hidden):")
+        print(f"    {result.stored_client_id_key}     = <client id>")
+        print(f"    {result.stored_client_secret_key} = <client secret>")
     if result.grant_plan is not None:
-        print(f"  granted {len(result.grant_plan.grants)} resource(s)")
+        _print_grants(result.grant_plan, applied=True)
     print("\n✓ Service principal is ready for this config.")
+
+
+def _print_grants(plan, *, applied: bool) -> None:
+    """Print a readable list of the grants in a plan (secret-free)."""
+    header = "grants applied" if applied else "grants (dry-run — nothing applied)"
+    print(f"  {header} ({len(plan.grants)}):")
+    if not plan.grants:
+        print("    (no grantable resources found in config)")
+        return
+    for g in plan.grants:
+        target = f"{g.securable_type} {g.target}" if g.securable_type else g.target
+        print(f"    [{g.kind}] {target} -> {', '.join(g.privileges)}")
 
 
 def _handle_sp_create(options, config, sp, WorkspaceClient) -> None:
@@ -2707,14 +2721,8 @@ def _handle_sp_grant(options, config, sp, WorkspaceClient) -> None:
     w = WorkspaceClient()
     plan = sp.grant(w, principal=principal, config=config, dry_run=options.dry_run)
 
-    header = "Would grant" if options.dry_run else "Granted"
-    print(f"{header} to principal {plan.principal}:")
-    if not plan.grants:
-        print("  (no grantable resources found in config)")
-        return
-    for g in plan.grants:
-        target = f"{g.securable_type}:{g.target}" if g.securable_type else g.target
-        print(f"  [{g.kind}] {target} -> {', '.join(g.privileges)}")
+    print(f"principal {plan.principal}")
+    _print_grants(plan, applied=not options.dry_run)
 
 
 def _empty_config() -> "AppConfig":

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -2628,15 +2628,27 @@ def _handle_sp_provision(options, config, sp, WorkspaceClient) -> None:
 
 
 def _print_grants(plan, *, applied: bool) -> None:
-    """Print a readable list of the grants in a plan (secret-free)."""
-    header = "grants applied" if applied else "grants (dry-run — nothing applied)"
-    print(f"  {header} ({len(plan.grants)}):")
+    """Print a readable list of the grants in a plan (secret-free).
+
+    When ``applied`` (real run), reports each grant's success and a failure count;
+    otherwise labels the list as a dry-run plan.
+    """
+    if not applied:
+        print(f"  grants (dry-run — nothing applied) ({len(plan.grants)}):")
+    else:
+        failed = sum(1 for g in plan.grants if g.applied is False)
+        ok = sum(1 for g in plan.grants if g.applied is True)
+        suffix = f"{ok} applied" + (f", {failed} failed" if failed else "")
+        print(f"  grants ({suffix}):")
     if not plan.grants:
         print("    (no grantable resources found in config)")
         return
     for g in plan.grants:
         target = f"{g.securable_type} {g.target}" if g.securable_type else g.target
-        print(f"    [{g.kind}] {target} -> {', '.join(g.privileges)}")
+        status = ""
+        if applied and g.applied is False:
+            status = "  ✗ FAILED"
+        print(f"    [{g.kind}] {target} -> {', '.join(g.privileges)}{status}")
 
 
 def _handle_sp_create(options, config, sp, WorkspaceClient) -> None:

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -2684,10 +2684,19 @@ def _handle_sp_store(options, config, sp, WorkspaceClient) -> None:
         client_id_key_override=options.client_id_key,
         client_secret_key_override=options.client_secret_key,
     )
+    missing: list[str] = []
     if not scope:
+        missing.append("--scope")
+    if not cid_key:
+        missing.append("--client-id-key")
+    if not csec_key:
+        missing.append("--client-secret-key")
+    if missing:
         logger.error(
-            "No secret scope. Pass --scope, or -c a config whose service_principals "
-            "reference a secret scope."
+            "Cannot determine where to store the credentials: the config has no "
+            "service_principals block or client_id/client_secret variables to infer "
+            f"{', '.join(missing)} from. Pass them explicitly (they must match the "
+            "scope/keys your config reads its credentials from)."
         )
         sys.exit(1)
 

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -1545,6 +1545,99 @@ Examples:
         help="Stream logs continuously (apps only; not supported for model_serving)",
     )
 
+    # -------------------------------------------------------------------------
+    # service-principal (alias: sp) — create | grant | store
+    # -------------------------------------------------------------------------
+    sp_parser: ArgumentParser = subparsers.add_parser(
+        "service-principal",
+        aliases=["sp"],
+        help="Create a service principal, grant it config resources, store its secret",
+        description="""
+Manage the service principal a dao-ai agent runs as.
+
+Sub-commands:
+  create  Create (or reuse) a workspace service principal and mint an OAuth
+          secret. Prints the client id + one-time secret.
+  store   Write the client id / secret into a Databricks secret scope.
+  grant   Grant the service principal the read/execute privileges an agent
+          needs on every resource declared in the config (catalog, schema,
+          table, function, vector index, warehouse, genie room, ...).
+
+All three read the config (-c) for defaults; explicit flags override.
+        """,
+        epilog="""
+Examples:
+  dao-ai sp create -c config/model_config.yaml                      # name derived from app.name
+  dao-ai sp create -c config/model_config.yaml --name my-agent-sp   # explicit name
+  dao-ai sp store  -c config/model_config.yaml --client-id ID --client-secret SECRET
+  dao-ai sp grant  -c config/model_config.yaml                      # principal from config
+  dao-ai sp grant  -c config/model_config.yaml --dry-run            # print grants, apply nothing
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_GLOBAL],
+    )
+    sp_verbs = sp_parser.add_subparsers(dest="subcommand", required=True)
+
+    # create
+    sp_create_parser: ArgumentParser = sp_verbs.add_parser(
+        "create",
+        help="Create (or reuse) a service principal and mint an OAuth secret",
+        parents=[_GLOBAL],
+    )
+    sp_create_parser.add_argument(
+        "-c", "--config", type=str, metavar="FILE",
+        help="Config file; app.name provides the default service-principal name",
+    )
+    sp_create_parser.add_argument(
+        "--name", type=str, default=None,
+        help="Service-principal display name (default: <app.name>-sp)",
+    )
+    sp_create_parser.add_argument(
+        "--lifetime", type=str, default=None,
+        help="OAuth secret lifetime (e.g. 7776000s); default is the workspace maximum",
+    )
+    sp_create_parser.add_argument(
+        "--json", action="store_true", help="Emit the result as JSON",
+    )
+    _add_var_argument(sp_create_parser)
+
+    # store
+    sp_store_parser: ArgumentParser = sp_verbs.add_parser(
+        "store",
+        help="Write the service-principal client id / secret to a Databricks secret scope",
+        parents=[_GLOBAL],
+    )
+    sp_store_parser.add_argument(
+        "-c", "--config", type=str, metavar="FILE",
+        help="Config file; its service_principals block provides default scope + key names",
+    )
+    sp_store_parser.add_argument("--client-id", type=str, required=True, help="Service-principal application (client) id")
+    sp_store_parser.add_argument("--client-secret", type=str, required=True, help="Service-principal OAuth client secret")
+    sp_store_parser.add_argument("--scope", type=str, default=None, help="Secret scope (default: from config)")
+    sp_store_parser.add_argument("--client-id-key", type=str, default=None, help="Secret key for the client id (default: from config)")
+    sp_store_parser.add_argument("--client-secret-key", type=str, default=None, help="Secret key for the client secret (default: from config)")
+    _add_var_argument(sp_store_parser)
+
+    # grant
+    sp_grant_parser: ArgumentParser = sp_verbs.add_parser(
+        "grant",
+        help="Grant the service principal read/execute access to all config resources",
+        parents=[_GLOBAL],
+    )
+    sp_grant_parser.add_argument(
+        "-c", "--config", type=str, required=True, metavar="FILE",
+        help="Config file whose resources are granted to the service principal",
+    )
+    sp_grant_parser.add_argument(
+        "--principal", "--client-id", dest="principal", type=str, default=None,
+        help="Grantee client id (default: config service_principals.client_id)",
+    )
+    sp_grant_parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the grants that would be applied without applying them",
+    )
+    _add_var_argument(sp_grant_parser)
+
     chat_parser: ArgumentParser = subparsers.add_parser(
         "chat",
         help="Interactive chat with the DAO AI system",
@@ -2406,6 +2499,148 @@ def handle_graph_command(options: Namespace) -> None:
         sys.exit(1)
     app = create_dao_ai_graph(config)
     save_image(app, options.output)
+
+
+def _load_sp_config(options: Namespace) -> "AppConfig | None":
+    """Load the config for a service-principal command (``-c`` optional).
+
+    Uses ``initialize=False`` — SP commands only read declared resources /
+    service_principals, they don't need the graph materialized.
+    """
+    config_path = getattr(options, "config", None)
+    if not config_path:
+        return None
+    try:
+        return AppConfig.from_file(
+            config_path,
+            params=_parse_var_args(getattr(options, "var", None)),
+            initialize=False,
+        )
+    except ConfigVariableError as e:
+        _print_config_variable_error(e)
+        sys.exit(1)
+
+
+def handle_service_principal_command(options: Namespace) -> None:
+    """Dispatch ``dao-ai service-principal <create|store|grant>``."""
+    from databricks.sdk import WorkspaceClient
+
+    from dao_ai import service_principal as sp
+
+    _apply_profile_context(getattr(options, "profile", None))
+    config = _load_sp_config(options)
+
+    match options.subcommand:
+        case "create":
+            _handle_sp_create(options, config, sp, WorkspaceClient)
+        case "store":
+            _handle_sp_store(options, config, sp, WorkspaceClient)
+        case "grant":
+            _handle_sp_grant(options, config, sp, WorkspaceClient)
+        case _:
+            logger.error(f"Unknown service-principal sub-command: {options.subcommand}")
+            sys.exit(1)
+
+
+def _handle_sp_create(options, config, sp, WorkspaceClient) -> None:
+    display_name: Optional[str] = options.name
+    if not display_name:
+        if config is not None and config.app is not None and config.app.name:
+            display_name = f"{config.app.name}-sp"
+        else:
+            logger.error(
+                "No service-principal name. Pass --name, or -c a config with an app.name."
+            )
+            sys.exit(1)
+
+    w = WorkspaceClient()
+    result = sp.create(w, display_name=display_name, lifetime=options.lifetime)
+
+    if options.json:
+        print(
+            json.dumps(
+                {
+                    "display_name": result.display_name,
+                    "client_id": result.client_id,
+                    "client_secret": result.client_secret,
+                    "reused": result.reused,
+                },
+                indent=2,
+            )
+        )
+        return
+
+    verb = "Reused" if result.reused else "Created"
+    print(f"{verb} service principal: {result.display_name}")
+    print(f"  client_id:     {result.client_id}")
+    print(f"  client_secret: {result.client_secret}")
+    print("\n⚠️  The client secret is shown only once — copy it now.")
+    print("\nStore it in a secret scope with:")
+    print(
+        f"  dao-ai sp store -c <config> "
+        f"--client-id {result.client_id} --client-secret <secret>"
+    )
+
+
+def _handle_sp_store(options, config, sp, WorkspaceClient) -> None:
+    scope, cid_key, csec_key = sp.resolve_secret_target(
+        config if config is not None else _empty_config(),
+        scope_override=options.scope,
+        client_id_key_override=options.client_id_key,
+        client_secret_key_override=options.client_secret_key,
+    )
+    if not scope:
+        logger.error(
+            "No secret scope. Pass --scope, or -c a config whose service_principals "
+            "reference a secret scope."
+        )
+        sys.exit(1)
+
+    w = WorkspaceClient()
+    sp.store(
+        w,
+        scope=scope,
+        client_id_key=cid_key,
+        client_secret_key=csec_key,
+        client_id=options.client_id,
+        client_secret=options.client_secret,
+    )
+    print(f"Stored credentials in scope '{scope}':")
+    print(f"  {cid_key}   = <client id>")
+    print(f"  {csec_key} = <client secret>")
+
+
+def _handle_sp_grant(options, config, sp, WorkspaceClient) -> None:
+    if config is None:
+        logger.error("grant requires -c/--config.")
+        sys.exit(1)
+
+    principal = sp.resolve_principal_from_config(config, override=options.principal)
+    if not principal:
+        logger.error(
+            "No grantee. Pass --principal <client-id>, or -c a config whose "
+            "service_principals define a client_id."
+        )
+        sys.exit(1)
+
+    w = WorkspaceClient()
+    plan = sp.grant(w, principal=principal, config=config, dry_run=options.dry_run)
+
+    header = "Would grant" if options.dry_run else "Granted"
+    print(f"{header} to principal {plan.principal}:")
+    if not plan.grants:
+        print("  (no grantable resources found in config)")
+        return
+    for g in plan.grants:
+        target = f"{g.securable_type}:{g.target}" if g.securable_type else g.target
+        print(f"  [{g.kind}] {target} -> {', '.join(g.privileges)}")
+
+
+def _empty_config() -> "AppConfig":
+    """A minimal AppConfig so resolve_secret_target can run without a -c file."""
+    from dao_ai.config import AppConfig
+
+    return AppConfig()
 
 
 def handle_monitor_command(options: Namespace) -> None:
@@ -4320,6 +4555,8 @@ def main() -> None:
             handle_workflow_command(options)
         case "monitor":
             handle_monitor_command(options)
+        case "service-principal" | "sp":
+            handle_service_principal_command(options)
         case "chat":
             handle_chat_command(options)
         case "mcp":

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -1556,21 +1556,24 @@ Examples:
 Manage the service principal a dao-ai agent runs as.
 
 Sub-commands:
-  create  Create (or reuse) a workspace service principal and mint an OAuth
-          secret. Prints the client id + one-time secret.
-  store   Write the client id / secret into a Databricks secret scope.
-  grant   Grant the service principal the read/execute privileges an agent
-          needs on every resource declared in the config (catalog, schema,
-          table, function, vector index, warehouse, genie room, ...).
+  provision  One shot: create the SP, store its secret to the config's scope,
+             and grant it every resource in the config. The secret is never
+             printed. This is the easiest way to make a config runnable.
+  create     Create (or reuse) a workspace service principal and mint an OAuth
+             secret. Prints the client id + one-time secret.
+  store      Write the client id / secret into a Databricks secret scope.
+  grant      Grant the service principal the read/execute privileges an agent
+             needs on every resource declared in the config (catalog, schema,
+             table, function, vector index, warehouse, genie room, ...).
 
-All three read the config (-c) for defaults; explicit flags override.
+All read the config (-c) for defaults; explicit flags override.
         """,
         epilog="""
 Examples:
-  dao-ai sp create -c config/model_config.yaml                      # name derived from app.name
-  dao-ai sp create -c config/model_config.yaml --name my-agent-sp   # explicit name
+  dao-ai sp provision -c config/model_config.yaml                   # create + store + grant, one step
+  dao-ai sp provision -c config/model_config.yaml --no-grant        # just create + store the secret
+  dao-ai sp create -c config/model_config.yaml --name my-agent-sp   # granular: create only
   dao-ai sp store  -c config/model_config.yaml --client-id ID --client-secret SECRET
-  dao-ai sp grant  -c config/model_config.yaml                      # principal from config
   dao-ai sp grant  -c config/model_config.yaml --dry-run            # print grants, apply nothing
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -1637,6 +1640,39 @@ Examples:
         help="Print the grants that would be applied without applying them",
     )
     _add_var_argument(sp_grant_parser)
+
+    # provision — one-shot create + store + grant
+    sp_provision_parser: ArgumentParser = sp_verbs.add_parser(
+        "provision",
+        help="One shot: create the SP, store its secret, and grant it all config resources",
+        description="""
+Provision a service principal for a dao-ai config in a single step:
+create (or reuse) the SP, mint an OAuth secret, write it to the config's secret
+scope, and grant the SP read/execute access to every resource in the config.
+
+The client secret is written straight to the secret scope and is never printed.
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_GLOBAL],
+    )
+    sp_provision_parser.add_argument(
+        "-c", "--config", type=str, required=True, metavar="FILE",
+        help="Config to provision the service principal for",
+    )
+    sp_provision_parser.add_argument(
+        "--name", type=str, default=None,
+        help="Service-principal display name (default: <app.name>-sp)",
+    )
+    sp_provision_parser.add_argument(
+        "--scope", type=str, default=None,
+        help="Secret scope for the credentials (default: from config, else app name)",
+    )
+    sp_provision_parser.add_argument("--client-id-key", type=str, default=None, help="Secret key for the client id (default: from config)")
+    sp_provision_parser.add_argument("--client-secret-key", type=str, default=None, help="Secret key for the client secret (default: from config)")
+    sp_provision_parser.add_argument("--lifetime", type=str, default=None, help="OAuth secret lifetime (e.g. 7776000s)")
+    sp_provision_parser.add_argument("--no-store", action="store_true", help="Skip writing the secret to a scope (print it instead)")
+    sp_provision_parser.add_argument("--no-grant", action="store_true", help="Skip granting the config's resources")
+    _add_var_argument(sp_provision_parser)
 
     chat_parser: ArgumentParser = subparsers.add_parser(
         "chat",
@@ -2531,6 +2567,8 @@ def handle_service_principal_command(options: Namespace) -> None:
     config = _load_sp_config(options)
 
     match options.subcommand:
+        case "provision":
+            _handle_sp_provision(options, config, sp, WorkspaceClient)
         case "create":
             _handle_sp_create(options, config, sp, WorkspaceClient)
         case "store":
@@ -2542,16 +2580,53 @@ def handle_service_principal_command(options: Namespace) -> None:
             sys.exit(1)
 
 
+def _sp_display_name(options, config) -> str:
+    """Resolve the SP display name: --name, else <app.name>-sp, else error."""
+    if getattr(options, "name", None):
+        return options.name
+    if config is not None and config.app is not None and config.app.name:
+        return f"{config.app.name}-sp"
+    logger.error(
+        "No service-principal name. Pass --name, or -c a config with an app.name."
+    )
+    sys.exit(1)
+
+
+def _handle_sp_provision(options, config, sp, WorkspaceClient) -> None:
+    if config is None:
+        logger.error("provision requires -c/--config.")
+        sys.exit(1)
+
+    display_name = _sp_display_name(options, config)
+    w = WorkspaceClient()
+    try:
+        result = sp.provision(
+            w,
+            config=config,
+            display_name=display_name,
+            scope=options.scope,
+            client_id_key=options.client_id_key,
+            client_secret_key=options.client_secret_key,
+            lifetime=options.lifetime,
+            do_store=not options.no_store,
+            do_grant=not options.no_grant,
+        )
+    except ValueError as e:
+        logger.error(str(e))
+        sys.exit(1)
+
+    verb = "Reused" if result.reused else "Created"
+    print(f"{verb} service principal: {result.display_name}")
+    print(f"  client_id: {result.client_id}")
+    if result.stored:
+        print(f"  secret stored in scope: {result.stored_scope} (not printed)")
+    if result.grant_plan is not None:
+        print(f"  granted {len(result.grant_plan.grants)} resource(s)")
+    print("\n✓ Service principal is ready for this config.")
+
+
 def _handle_sp_create(options, config, sp, WorkspaceClient) -> None:
-    display_name: Optional[str] = options.name
-    if not display_name:
-        if config is not None and config.app is not None and config.app.name:
-            display_name = f"{config.app.name}-sp"
-        else:
-            logger.error(
-                "No service-principal name. Pass --name, or -c a config with an app.name."
-            )
-            sys.exit(1)
+    display_name = _sp_display_name(options, config)
 
     w = WorkspaceClient()
     result = sp.create(w, display_name=display_name, lifetime=options.lifetime)
@@ -2575,10 +2650,16 @@ def _handle_sp_create(options, config, sp, WorkspaceClient) -> None:
     print(f"  client_id:     {result.client_id}")
     print(f"  client_secret: {result.client_secret}")
     print("\n⚠️  The client secret is shown only once — copy it now.")
+    cfg = getattr(options, "config", None) or "<config>"
     print("\nStore it in a secret scope with:")
     print(
-        f"  dao-ai sp store -c <config> "
+        f"  dao-ai sp store -c {cfg} "
         f"--client-id {result.client_id} --client-secret <secret>"
+    )
+    print(
+        "\nTip: `dao-ai sp provision -c "
+        f"{cfg}` does create + store + grant in one step "
+        "(and never prints the secret)."
     )
 
 

--- a/src/dao_ai/service_principal.py
+++ b/src/dao_ai/service_principal.py
@@ -217,15 +217,17 @@ def provision(
         lifetime: Optional OAuth secret lifetime.
         do_store: Write the credentials to the secret scope (default True).
         do_grant: Grant the SP the config's resources (default True).
+
+    Raises:
+        ValueError: if ``do_store`` is set but the secret scope/keys cannot be
+            resolved. Validated BEFORE creating the service principal so a
+            misconfigured call never leaves an orphaned SP behind.
     """
-    created = create(w, display_name=display_name, lifetime=lifetime)
-
-    result = ProvisionResult(
-        display_name=created.display_name,
-        client_id=created.client_id,
-        reused=created.reused,
-    )
-
+    # Resolve + validate the store target up front — before we create anything —
+    # so an unresolvable config fails fast without orphaning a service principal.
+    resolved_scope: Optional[str] = None
+    cid_key: Optional[str] = None
+    csec_key: Optional[str] = None
     if do_store:
         resolved_scope, cid_key, csec_key = resolve_secret_target(
             config,
@@ -239,6 +241,24 @@ def provision(
                 "Cannot determine a secret scope to store credentials. "
                 "Pass --scope, or add a service_principals block to the config."
             )
+        if not (cid_key and csec_key):
+            raise ValueError(
+                "Cannot determine which secret keys to store the credentials under. "
+                "The config has no service_principals block or client_id/client_secret "
+                "variables to infer them from. Pass --client-id-key and "
+                "--client-secret-key (the keys your config reads its credentials from)."
+            )
+
+    created = create(w, display_name=display_name, lifetime=lifetime)
+
+    result = ProvisionResult(
+        display_name=created.display_name,
+        client_id=created.client_id,
+        reused=created.reused,
+    )
+
+    if do_store:
+        assert resolved_scope and cid_key and csec_key  # validated above
         store(
             w,
             scope=resolved_scope,
@@ -542,21 +562,23 @@ def resolve_secret_target(
     scope_override: Optional[str] = None,
     client_id_key_override: Optional[str] = None,
     client_secret_key_override: Optional[str] = None,
-) -> tuple[Optional[str], str, str]:
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
     """Resolve (scope, client_id_key, client_secret_key) for ``store``.
 
     Prefers explicit overrides, then discovers the secret scope + key names the
-    config actually reads its credentials from, checking three places in order:
+    config actually reads its credentials from, checking two *structural* sources
+    (where the credential's role is unambiguous) in order:
 
-    1. ``service_principals`` block (``client_id`` / ``client_secret`` vars),
-    2. top-level ``variables`` named ``client_id`` / ``client_secret``,
-    3. ``app.environment_vars`` entries pointing at ``{{secrets/scope/KEY}}``
-       (the ``RETAIL_AI_DATABRICKS_CLIENT_ID`` / ``_SECRET`` pattern).
+    1. ``service_principals`` block — its ``client_id`` / ``client_secret`` vars.
+    2. top-level ``variables`` named ``client_id`` / ``client_secret``.
 
-    This matters because most configs wire credentials via ``variables`` /
-    ``environment_vars`` rather than a ``service_principals`` block — resolving
-    only the latter would store the secret under generic key names the agent
-    never reads.
+    We deliberately do NOT try to infer keys from ``app.environment_vars`` by
+    string-matching names like ``*_CLIENT_ID`` — that's a guess, not a fact, and a
+    wrong guess would store the secret under keys the agent never reads. When
+    neither structural source resolves a key, ``None`` is returned for it and the
+    caller must supply ``--client-id-key`` / ``--client-secret-key`` / ``--scope``.
+
+    Returns ``None`` for any component that could not be resolved (no fallbacks).
     """
     scope = scope_override
     client_id_key = client_id_key_override
@@ -573,7 +595,7 @@ def resolve_secret_target(
     def _done() -> bool:
         return bool(scope and client_id_key and client_secret_key)
 
-    # 1. service_principals block
+    # 1. service_principals block (structural — role known by binding)
     if not _done():
         sp: "ServicePrincipalModel"
         for sp in config.service_principals.values():
@@ -581,51 +603,11 @@ def resolve_secret_target(
             if _done():
                 break
 
-    # 2. top-level variables named client_id / client_secret
+    # 2. top-level variables named client_id / client_secret (structural — role known by name)
     if not _done():
         _merge(config.variables.get("client_id"), config.variables.get("client_secret"))
 
-    # 3. app.environment_vars pointing at {{secrets/scope/KEY}}
-    if not _done() and config.app is not None:
-        env_vars = config.app.environment_vars or {}
-        cid_scope, cid_key = _secret_ref_from_env(env_vars, "CLIENT_ID")
-        csec_scope, csec_key = _secret_ref_from_env(env_vars, "CLIENT_SECRET")
-        scope = scope or cid_scope or csec_scope
-        client_id_key = client_id_key or cid_key
-        client_secret_key = client_secret_key or csec_key
-
-    return scope, client_id_key or "sp-client-id", client_secret_key or "sp-client-secret"
-
-
-_SECRET_REF_RE = re.compile(r"\{\{secrets/(?P<scope>[^/]+)/(?P<key>[^}]+)\}\}")
-
-
-def _secret_ref_from_env(
-    env_vars: dict, needle: str
-) -> tuple[Optional[str], Optional[str]]:
-    """Find a ``{{secrets/scope/KEY}}`` env-var value whose KEY contains ``needle``.
-
-    ``needle`` is ``CLIENT_ID`` or ``CLIENT_SECRET`` — matched case-insensitively
-    against the resolved secret key (not the env var name), so
-    ``RETAIL_AI_DATABRICKS_CLIENT_ID`` is picked for ``CLIENT_ID``. Guards against
-    ``CLIENT_ID`` also matching ``CLIENT_SECRET`` by requiring the key NOT contain
-    ``SECRET`` when looking for the id.
-    """
-    want_secret = needle == "CLIENT_SECRET"
-    for value in env_vars.values():
-        if not isinstance(value, str):
-            continue
-        m = _SECRET_REF_RE.search(value)
-        if not m:
-            continue
-        key = m.group("key")
-        key_upper = key.upper()
-        has_secret = "SECRET" in key_upper
-        if want_secret and has_secret:
-            return m.group("scope"), key
-        if not want_secret and "CLIENT_ID" in key_upper and not has_secret:
-            return m.group("scope"), key
-    return None, None
+    return scope, client_id_key, client_secret_key
 
 
 def _secret_ref(value: object) -> tuple[Optional[str], Optional[str]]:

--- a/src/dao_ai/service_principal.py
+++ b/src/dao_ai/service_principal.py
@@ -291,6 +291,10 @@ class Grant:
     target: str  # full name / id
     privileges: Sequence[str]
     securable_type: Optional[str] = None  # for kind == "uc"
+    # Set during apply (not dry-run): True if applied, False if it errored,
+    # None if not attempted (dry-run).
+    applied: Optional[bool] = None
+    error: Optional[str] = None
 
 
 @dataclass
@@ -378,9 +382,14 @@ def build_grant_plan(config: "AppConfig", principal: str) -> GrantPlan:
             plan.grants.append(
                 Grant("experiment", str(value_of(app.experiment.name)), ["CAN_EDIT"])
             )
-        endpoint: Optional[str] = app.endpoint_name or app.name
-        if endpoint:
-            plan.grants.append(Grant("serving_endpoint", endpoint, ["CAN_QUERY"]))
+        # AppModel always populates endpoint_name (defaulting from app.name), so
+        # this grant is planned for every app. It's best-effort: _grant_serving_endpoint
+        # resolves the endpoint by name and skips (no-op) if it isn't deployed, so
+        # Apps-only configs don't error — they simply have nothing to grant here.
+        if app.endpoint_name:
+            plan.grants.append(
+                Grant("serving_endpoint", app.endpoint_name, ["CAN_QUERY"])
+            )
 
     return plan
 
@@ -411,10 +420,13 @@ def grant(
             elif g.kind == "genie":
                 _grant_genie(w, principal, g.target)
             elif g.kind == "experiment":
-                _grant_experiment(principal, g.target)
+                _grant_experiment(w, principal, g.target)
             elif g.kind == "serving_endpoint":
-                _grant_serving_endpoint(principal, g.target)
+                _grant_serving_endpoint(w, principal, g.target)
+            g.applied = True
         except Exception as e:  # noqa: BLE001 — warn-and-continue per resource
+            g.applied = False
+            g.error = str(e)
             logger.warning(
                 "Grant failed — verify the calling identity has GRANT rights",
                 kind=g.kind,
@@ -453,13 +465,17 @@ def _grant_uc(
 
 
 def _grant_warehouse(w: "WorkspaceClient", principal: str, warehouse_id: str) -> None:
-    """Grant CAN_USE on a SQL warehouse to the service principal."""
+    """Grant CAN_USE on a SQL warehouse to the service principal.
+
+    Uses ``update_permissions`` (additive) — NOT ``set_permissions``, which
+    replaces the entire ACL and would strip every other principal's access.
+    """
     from databricks.sdk.service.sql import (
         WarehouseAccessControlRequest,
         WarehousePermissionLevel,
     )
 
-    w.warehouses.set_permissions(
+    w.warehouses.update_permissions(
         warehouse_id=warehouse_id,
         access_control_list=[
             WarehouseAccessControlRequest(
@@ -472,7 +488,11 @@ def _grant_warehouse(w: "WorkspaceClient", principal: str, warehouse_id: str) ->
 
 
 def _grant_genie(w: "WorkspaceClient", principal: str, space_id: str) -> None:
-    """Grant CAN_RUN on a Genie space to the service principal."""
+    """Grant CAN_RUN on a Genie space to the service principal.
+
+    Uses ``permissions.update`` (additive), not ``permissions.set`` (which
+    replaces the whole ACL).
+    """
     from databricks.sdk.service.iam import (
         AccessControlRequest,
         PermissionLevel,
@@ -486,7 +506,7 @@ def _grant_genie(w: "WorkspaceClient", principal: str, space_id: str) -> None:
     else:
         kwargs["group_name"] = principal
 
-    w.permissions.set(
+    w.permissions.update(
         request_object_type="genie",
         request_object_id=space_id,
         access_control_list=[AccessControlRequest(**kwargs)],
@@ -494,38 +514,38 @@ def _grant_genie(w: "WorkspaceClient", principal: str, space_id: str) -> None:
     logger.info("Granted genie CAN_RUN", principal=principal, space_id=space_id)
 
 
-def _grant_experiment(principal: str, experiment_name: str) -> None:
+def _grant_experiment(w: "WorkspaceClient", principal: str, experiment_name: str) -> None:
     """Grant CAN_EDIT on an MLflow experiment (reuses the provider helper)."""
-    from databricks.sdk import WorkspaceClient
-
     from dao_ai.providers.databricks import (
         _grant_experiment_permissions_to_principal,
     )
 
-    w = WorkspaceClient()
     experiment = w.experiments.get_by_name(experiment_name)
     exp_id = experiment.experiment.experiment_id if experiment.experiment else None
     if exp_id:
         _grant_experiment_permissions_to_principal(principal, exp_id)
 
 
-def _grant_serving_endpoint(principal: str, endpoint_name: str) -> None:
-    """Grant CAN_QUERY on a Model Serving endpoint (best-effort; skip if absent)."""
-    from databricks.sdk import WorkspaceClient
+def _grant_serving_endpoint(w: "WorkspaceClient", principal: str, endpoint_name: str) -> None:
+    """Grant CAN_QUERY on a Model Serving endpoint (best-effort; skip if absent).
+
+    Uses ``update_permissions`` (additive), and resolves the endpoint's id from
+    its name (``set/update_permissions`` key on the id, not the name).
+    """
     from databricks.sdk.service.serving import (
         ServingEndpointAccessControlRequest,
         ServingEndpointPermissionLevel,
     )
 
-    w = WorkspaceClient()
     try:
-        w.serving_endpoints.get(name=endpoint_name)
+        endpoint = w.serving_endpoints.get(name=endpoint_name)
     except Exception:  # noqa: BLE001 — endpoint not deployed yet; skip quietly
         logger.debug("Serving endpoint not found; skipping grant", endpoint=endpoint_name)
         return
 
-    w.serving_endpoints.set_permissions(
-        serving_endpoint_id=endpoint_name,
+    endpoint_id = endpoint.id or endpoint_name
+    w.serving_endpoints.update_permissions(
+        serving_endpoint_id=endpoint_id,
         access_control_list=[
             ServingEndpointAccessControlRequest(
                 service_principal_name=principal,

--- a/src/dao_ai/service_principal.py
+++ b/src/dao_ai/service_principal.py
@@ -183,6 +183,8 @@ class ProvisionResult:
     client_id: str
     reused: bool
     stored_scope: Optional[str] = None
+    stored_client_id_key: Optional[str] = None
+    stored_client_secret_key: Optional[str] = None
     stored: bool = False
     grant_plan: Optional["GrantPlan"] = None
 
@@ -246,6 +248,8 @@ def provision(
             client_secret=created.client_secret,
         )
         result.stored_scope = resolved_scope
+        result.stored_client_id_key = cid_key
+        result.stored_client_secret_key = csec_key
         result.stored = True
 
     if do_grant:
@@ -541,25 +545,87 @@ def resolve_secret_target(
 ) -> tuple[Optional[str], str, str]:
     """Resolve (scope, client_id_key, client_secret_key) for ``store``.
 
-    Prefers explicit overrides, then introspects the config's service-principal
-    ``client_id`` / ``client_secret`` variables for their secret scope + key.
+    Prefers explicit overrides, then discovers the secret scope + key names the
+    config actually reads its credentials from, checking three places in order:
+
+    1. ``service_principals`` block (``client_id`` / ``client_secret`` vars),
+    2. top-level ``variables`` named ``client_id`` / ``client_secret``,
+    3. ``app.environment_vars`` entries pointing at ``{{secrets/scope/KEY}}``
+       (the ``RETAIL_AI_DATABRICKS_CLIENT_ID`` / ``_SECRET`` pattern).
+
+    This matters because most configs wire credentials via ``variables`` /
+    ``environment_vars`` rather than a ``service_principals`` block — resolving
+    only the latter would store the secret under generic key names the agent
+    never reads.
     """
     scope = scope_override
     client_id_key = client_id_key_override
     client_secret_key = client_secret_key_override
 
-    if not (scope and client_id_key and client_secret_key):
+    def _merge(cid_ref: object, csec_ref: object) -> None:
+        nonlocal scope, client_id_key, client_secret_key
+        cid_scope, cid_key = _secret_ref(cid_ref)
+        csec_scope, csec_key = _secret_ref(csec_ref)
+        scope = scope or cid_scope or csec_scope
+        client_id_key = client_id_key or cid_key
+        client_secret_key = client_secret_key or csec_key
+
+    def _done() -> bool:
+        return bool(scope and client_id_key and client_secret_key)
+
+    # 1. service_principals block
+    if not _done():
         sp: "ServicePrincipalModel"
         for sp in config.service_principals.values():
-            cid_scope, cid_key = _secret_ref(sp.client_id)
-            csec_scope, csec_key = _secret_ref(sp.client_secret)
-            scope = scope or cid_scope or csec_scope
-            client_id_key = client_id_key or cid_key
-            client_secret_key = client_secret_key or csec_key
-            if scope and client_id_key and client_secret_key:
+            _merge(sp.client_id, sp.client_secret)
+            if _done():
                 break
 
+    # 2. top-level variables named client_id / client_secret
+    if not _done():
+        _merge(config.variables.get("client_id"), config.variables.get("client_secret"))
+
+    # 3. app.environment_vars pointing at {{secrets/scope/KEY}}
+    if not _done() and config.app is not None:
+        env_vars = config.app.environment_vars or {}
+        cid_scope, cid_key = _secret_ref_from_env(env_vars, "CLIENT_ID")
+        csec_scope, csec_key = _secret_ref_from_env(env_vars, "CLIENT_SECRET")
+        scope = scope or cid_scope or csec_scope
+        client_id_key = client_id_key or cid_key
+        client_secret_key = client_secret_key or csec_key
+
     return scope, client_id_key or "sp-client-id", client_secret_key or "sp-client-secret"
+
+
+_SECRET_REF_RE = re.compile(r"\{\{secrets/(?P<scope>[^/]+)/(?P<key>[^}]+)\}\}")
+
+
+def _secret_ref_from_env(
+    env_vars: dict, needle: str
+) -> tuple[Optional[str], Optional[str]]:
+    """Find a ``{{secrets/scope/KEY}}`` env-var value whose KEY contains ``needle``.
+
+    ``needle`` is ``CLIENT_ID`` or ``CLIENT_SECRET`` — matched case-insensitively
+    against the resolved secret key (not the env var name), so
+    ``RETAIL_AI_DATABRICKS_CLIENT_ID`` is picked for ``CLIENT_ID``. Guards against
+    ``CLIENT_ID`` also matching ``CLIENT_SECRET`` by requiring the key NOT contain
+    ``SECRET`` when looking for the id.
+    """
+    want_secret = needle == "CLIENT_SECRET"
+    for value in env_vars.values():
+        if not isinstance(value, str):
+            continue
+        m = _SECRET_REF_RE.search(value)
+        if not m:
+            continue
+        key = m.group("key")
+        key_upper = key.upper()
+        has_secret = "SECRET" in key_upper
+        if want_secret and has_secret:
+            return m.group("scope"), key
+        if not want_secret and "CLIENT_ID" in key_upper and not has_secret:
+            return m.group("scope"), key
+    return None, None
 
 
 def _secret_ref(value: object) -> tuple[Optional[str], Optional[str]]:

--- a/src/dao_ai/service_principal.py
+++ b/src/dao_ai/service_principal.py
@@ -171,6 +171,90 @@ def _ensure_scope(w: "WorkspaceClient", scope: str) -> None:
 
 
 # =============================================================================
+# provision — one-shot create + store + grant
+# =============================================================================
+
+
+@dataclass
+class ProvisionResult:
+    """Outcome of :func:`provision`. The secret is deliberately NOT included."""
+
+    display_name: str
+    client_id: str
+    reused: bool
+    stored_scope: Optional[str] = None
+    stored: bool = False
+    grant_plan: Optional["GrantPlan"] = None
+
+
+def provision(
+    w: "WorkspaceClient",
+    *,
+    config: "AppConfig",
+    display_name: str,
+    scope: Optional[str] = None,
+    client_id_key: Optional[str] = None,
+    client_secret_key: Optional[str] = None,
+    lifetime: Optional[str] = None,
+    do_store: bool = True,
+    do_grant: bool = True,
+) -> ProvisionResult:
+    """Create an SP, store its secret, and grant it the config's resources — one shot.
+
+    The freshly-minted client secret is written straight to the secret scope and is
+    never returned or printed. This is the recommended path to make a config's
+    declared service principal usable end-to-end.
+
+    Args:
+        w: Workspace client (profile already applied by the caller).
+        config: The AppConfig being provisioned for.
+        display_name: Service-principal display name.
+        scope / client_id_key / client_secret_key: Secret target. Resolved from the
+            config's service_principals block when omitted; scope falls back to a
+            name derived from the config (see :func:`default_scope_from_config`).
+        lifetime: Optional OAuth secret lifetime.
+        do_store: Write the credentials to the secret scope (default True).
+        do_grant: Grant the SP the config's resources (default True).
+    """
+    created = create(w, display_name=display_name, lifetime=lifetime)
+
+    result = ProvisionResult(
+        display_name=created.display_name,
+        client_id=created.client_id,
+        reused=created.reused,
+    )
+
+    if do_store:
+        resolved_scope, cid_key, csec_key = resolve_secret_target(
+            config,
+            scope_override=scope,
+            client_id_key_override=client_id_key,
+            client_secret_key_override=client_secret_key,
+        )
+        resolved_scope = resolved_scope or default_scope_from_config(config)
+        if not resolved_scope:
+            raise ValueError(
+                "Cannot determine a secret scope to store credentials. "
+                "Pass --scope, or add a service_principals block to the config."
+            )
+        store(
+            w,
+            scope=resolved_scope,
+            client_id_key=cid_key,
+            client_secret_key=csec_key,
+            client_id=created.client_id,
+            client_secret=created.client_secret,
+        )
+        result.stored_scope = resolved_scope
+        result.stored = True
+
+    if do_grant:
+        result.grant_plan = grant(w, principal=created.client_id, config=config)
+
+    return result
+
+
+# =============================================================================
 # grant
 # =============================================================================
 
@@ -494,4 +578,17 @@ def _secret_ref(value: object) -> tuple[Optional[str], Optional[str]]:
             if isinstance(option, SecretVariableModel):
                 return option.scope, option.secret
     return None, None
-    return None, None
+
+
+def default_scope_from_config(config: "AppConfig") -> Optional[str]:
+    """Derive a fallback secret scope when the config has no service_principals block.
+
+    Prefers the app name, then the first schema's catalog — so ``provision`` works
+    on configs that never declared a service principal.
+    """
+    if config.app is not None and config.app.name:
+        return config.app.name
+    for schema in config.schemas.values():
+        if schema.catalog_name:
+            return str(schema.catalog_name)
+    return None

--- a/src/dao_ai/service_principal.py
+++ b/src/dao_ai/service_principal.py
@@ -1,0 +1,497 @@
+"""Service-principal lifecycle helpers for the ``dao-ai service-principal`` CLI.
+
+Three operations, all workspace-level (no AccountClient needed):
+
+* :func:`create` — create (or reuse) a workspace service principal and mint an
+  OAuth secret. Returns the ``application_id`` (client id) + the one-time secret.
+* :func:`store` — write client id / secret into a Databricks secret scope.
+* :func:`grant` — walk an :class:`~dao_ai.config.AppConfig` and grant the service
+  principal the read/execute privileges an agent runtime needs on every declared
+  resource (catalog, schema, table, function, vector index, warehouse, genie room,
+  experiment, serving endpoint).
+
+The grant path reuses the same idempotent, warn-and-continue Unity Catalog
+permissions REST call dao-ai already uses at deploy time
+(``PATCH /api/2.1/unity-catalog/permissions/{securable_type}/{full_name}``).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Optional, Sequence
+
+from loguru import logger
+
+from dao_ai.config import value_of
+
+if TYPE_CHECKING:
+    from databricks.sdk import WorkspaceClient
+
+    from dao_ai.config import (
+        AiSearchVectorStoreModel,
+        AppConfig,
+        FunctionModel,
+        GenieRoomModel,
+        SchemaModel,
+        ServicePrincipalModel,
+        TableModel,
+        WarehouseModel,
+    )
+
+
+_UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+def _looks_like_uuid(value: str) -> bool:
+    """Return True if ``value`` is a UUID (a service-principal application id)."""
+    return bool(_UUID_RE.match(value.strip()))
+
+
+# =============================================================================
+# create
+# =============================================================================
+
+
+@dataclass
+class CreatedServicePrincipal:
+    """Result of :func:`create`. ``client_secret`` is shown only once."""
+
+    display_name: str
+    client_id: str  # application_id (UUID) — the grantee principal
+    sp_id: str  # numeric id, used to mint OAuth secrets
+    client_secret: Optional[str] = None  # None when an existing SP was reused
+    reused: bool = False
+
+
+def create(
+    w: "WorkspaceClient",
+    *,
+    display_name: str,
+    lifetime: Optional[str] = None,
+) -> CreatedServicePrincipal:
+    """Create (or reuse) a workspace service principal and mint an OAuth secret.
+
+    Idempotent on ``display_name``: if a service principal with the same display
+    name already exists it is reused (and a fresh secret is still minted, so the
+    caller always gets usable credentials).
+
+    Args:
+        w: Workspace client (profile already applied by the caller).
+        display_name: Display name for the service principal.
+        lifetime: Optional OAuth secret lifetime (e.g. ``"7776000s"``). Defaults
+            to the workspace maximum when omitted.
+
+    Returns:
+        The created/reused principal plus the one-time client secret.
+    """
+    existing = next(
+        (
+            sp
+            for sp in w.service_principals.list(
+                filter=f'displayName eq "{display_name}"'
+            )
+            if sp.display_name == display_name
+        ),
+        None,
+    )
+
+    if existing is not None:
+        logger.info(
+            "Reusing existing service principal",
+            display_name=display_name,
+            application_id=existing.application_id,
+        )
+        sp = existing
+        reused = True
+    else:
+        sp = w.service_principals.create(display_name=display_name, active=True)
+        logger.info(
+            "Created service principal",
+            display_name=display_name,
+            application_id=sp.application_id,
+        )
+        reused = False
+
+    secret_resp = w.service_principal_secrets_proxy.create(
+        service_principal_id=str(sp.id),
+        **({"lifetime": lifetime} if lifetime else {}),
+    )
+
+    return CreatedServicePrincipal(
+        display_name=display_name,
+        client_id=sp.application_id,
+        sp_id=str(sp.id),
+        client_secret=secret_resp.secret,
+        reused=reused,
+    )
+
+
+# =============================================================================
+# store
+# =============================================================================
+
+
+def store(
+    w: "WorkspaceClient",
+    *,
+    scope: str,
+    client_id_key: str,
+    client_secret_key: str,
+    client_id: str,
+    client_secret: str,
+) -> None:
+    """Write the service-principal credentials into a Databricks secret scope.
+
+    Creates the scope if it does not already exist (idempotent).
+    """
+    _ensure_scope(w, scope)
+    w.secrets.put_secret(scope=scope, key=client_id_key, string_value=client_id)
+    w.secrets.put_secret(scope=scope, key=client_secret_key, string_value=client_secret)
+    logger.info(
+        "Stored service-principal credentials",
+        scope=scope,
+        client_id_key=client_id_key,
+        client_secret_key=client_secret_key,
+    )
+
+
+def _ensure_scope(w: "WorkspaceClient", scope: str) -> None:
+    """Create a secret scope, ignoring the error if it already exists."""
+    try:
+        w.secrets.create_scope(scope=scope)
+        logger.info("Created secret scope", scope=scope)
+    except Exception as e:  # noqa: BLE001 — SDK raises a generic error on dup
+        if "RESOURCE_ALREADY_EXISTS" in str(e) or "already exists" in str(e).lower():
+            logger.debug("Secret scope already exists", scope=scope)
+        else:
+            raise
+
+
+# =============================================================================
+# grant
+# =============================================================================
+
+
+@dataclass
+class Grant:
+    """A single intended permission grant (used for dry-run reporting)."""
+
+    kind: str  # "uc" | "warehouse" | "genie" | "experiment" | "serving_endpoint"
+    target: str  # full name / id
+    privileges: Sequence[str]
+    securable_type: Optional[str] = None  # for kind == "uc"
+
+
+@dataclass
+class GrantPlan:
+    """The full set of grants a :func:`grant` call will (or did) apply."""
+
+    principal: str
+    grants: list[Grant] = field(default_factory=list)
+
+
+def build_grant_plan(config: "AppConfig", principal: str) -> GrantPlan:
+    """Walk an AppConfig and compute the read/execute grants for ``principal``.
+
+    Pure (no side effects) so it can back both ``--dry-run`` and the real apply.
+    De-dupes catalogs and schemas across every resource that references them.
+    """
+    plan = GrantPlan(principal=principal)
+    catalogs: set[str] = set()
+    schemas: set[str] = set()
+
+    def _add_schema(catalog_name: str, schema_name: str) -> None:
+        if catalog_name and catalog_name not in catalogs:
+            catalogs.add(catalog_name)
+            plan.grants.append(Grant("uc", catalog_name, ["USE_CATALOG"], "catalog"))
+        full = f"{catalog_name}.{schema_name}"
+        if catalog_name and schema_name and full not in schemas:
+            schemas.add(full)
+            plan.grants.append(
+                Grant("uc", full, ["USE_SCHEMA", "SELECT", "EXECUTE"], "schema")
+            )
+
+    # Top-level schemas
+    schema: "SchemaModel"
+    for schema in config.schemas.values():
+        _add_schema(schema.catalog_name, schema.schema_name)
+
+    resources = config.resources
+    if resources is not None:
+        # Tables → SELECT (+ ensure their schema is granted)
+        table: "TableModel"
+        for table in resources.tables.values():
+            if table.schema_model is not None:
+                _add_schema(
+                    table.schema_model.catalog_name, table.schema_model.schema_name
+                )
+            if table.full_name and table.full_name.count(".") == 2:
+                plan.grants.append(Grant("uc", table.full_name, ["SELECT"], "table"))
+
+        # UC functions → EXECUTE
+        func: "FunctionModel"
+        for func in resources.functions.values():
+            if func.schema_model is not None:
+                _add_schema(
+                    func.schema_model.catalog_name, func.schema_model.schema_name
+                )
+            if func.full_name and func.full_name.count(".") == 2:
+                plan.grants.append(Grant("uc", func.full_name, ["EXECUTE"], "function"))
+
+        # Vector-search indexes → SELECT on the backing UC index (a table securable)
+        store_model: "AiSearchVectorStoreModel"
+        for store_model in resources.vector_stores.values():
+            index = store_model.index
+            index_name = value_of(index.full_name) if index is not None else None
+            if index_name and str(index_name).count(".") == 2:
+                plan.grants.append(Grant("uc", str(index_name), ["SELECT"], "table"))
+
+        # Warehouses → CAN_USE (workspace permission, not UC)
+        warehouse: "WarehouseModel"
+        for warehouse in resources.warehouses.values():
+            wid = value_of(warehouse.warehouse_id) if warehouse.warehouse_id else None
+            if wid:
+                plan.grants.append(Grant("warehouse", str(wid), ["CAN_USE"]))
+
+        # Genie rooms → CAN_RUN (workspace permission)
+        room: "GenieRoomModel"
+        for room in resources.genie_rooms.values():
+            space_id = value_of(room.space_id) if room.space_id else None
+            if space_id:
+                plan.grants.append(Grant("genie", str(space_id), ["CAN_RUN"]))
+
+    # Experiment + serving endpoint (only if declared on the app)
+    app = config.app
+    if app is not None:
+        if app.experiment is not None and app.experiment.name:
+            plan.grants.append(
+                Grant("experiment", str(value_of(app.experiment.name)), ["CAN_EDIT"])
+            )
+        endpoint: Optional[str] = app.endpoint_name or app.name
+        if endpoint:
+            plan.grants.append(Grant("serving_endpoint", endpoint, ["CAN_QUERY"]))
+
+    return plan
+
+
+def grant(
+    w: "WorkspaceClient",
+    *,
+    principal: str,
+    config: "AppConfig",
+    dry_run: bool = False,
+) -> GrantPlan:
+    """Grant ``principal`` read/execute access to every resource in ``config``.
+
+    Returns the :class:`GrantPlan`. When ``dry_run`` is True nothing is applied.
+    Individual failures warn-and-continue (consistent with deploy-time granting).
+    """
+    plan = build_grant_plan(config, principal)
+
+    if dry_run:
+        return plan
+
+    for g in plan.grants:
+        try:
+            if g.kind == "uc":
+                _grant_uc(w, principal, g.securable_type, g.target, g.privileges)
+            elif g.kind == "warehouse":
+                _grant_warehouse(w, principal, g.target)
+            elif g.kind == "genie":
+                _grant_genie(w, principal, g.target)
+            elif g.kind == "experiment":
+                _grant_experiment(principal, g.target)
+            elif g.kind == "serving_endpoint":
+                _grant_serving_endpoint(principal, g.target)
+        except Exception as e:  # noqa: BLE001 — warn-and-continue per resource
+            logger.warning(
+                "Grant failed — verify the calling identity has GRANT rights",
+                kind=g.kind,
+                target=g.target,
+                error=str(e),
+            )
+
+    return plan
+
+
+def _grant_uc(
+    w: "WorkspaceClient",
+    principal: str,
+    securable_type: str,
+    full_name: str,
+    privileges: Sequence[str],
+) -> None:
+    """Grant UC privileges via the raw REST permissions endpoint (idempotent).
+
+    Mirrors ``_grant_uc_trace_table_permissions_to_principal`` in
+    ``providers/databricks.py`` — lowercase securable type works across SDK
+    versions where the typed ``grants.update`` serializes the enum incorrectly.
+    """
+    w.api_client.do(
+        "PATCH",
+        f"/api/2.1/unity-catalog/permissions/{securable_type}/{full_name}",
+        body={"changes": [{"principal": principal, "add": list(privileges)}]},
+    )
+    logger.info(
+        "Granted UC privileges",
+        principal=principal,
+        securable_type=securable_type,
+        full_name=full_name,
+        privileges=list(privileges),
+    )
+
+
+def _grant_warehouse(w: "WorkspaceClient", principal: str, warehouse_id: str) -> None:
+    """Grant CAN_USE on a SQL warehouse to the service principal."""
+    from databricks.sdk.service.sql import (
+        WarehouseAccessControlRequest,
+        WarehousePermissionLevel,
+    )
+
+    w.warehouses.set_permissions(
+        warehouse_id=warehouse_id,
+        access_control_list=[
+            WarehouseAccessControlRequest(
+                service_principal_name=principal,
+                permission_level=WarehousePermissionLevel.CAN_USE,
+            )
+        ],
+    )
+    logger.info("Granted warehouse CAN_USE", principal=principal, warehouse_id=warehouse_id)
+
+
+def _grant_genie(w: "WorkspaceClient", principal: str, space_id: str) -> None:
+    """Grant CAN_RUN on a Genie space to the service principal."""
+    from databricks.sdk.service.iam import (
+        AccessControlRequest,
+        PermissionLevel,
+    )
+
+    kwargs = {"permission_level": PermissionLevel.CAN_RUN}
+    if _looks_like_uuid(principal):
+        kwargs["service_principal_name"] = principal
+    elif "@" in principal:
+        kwargs["user_name"] = principal
+    else:
+        kwargs["group_name"] = principal
+
+    w.permissions.set(
+        request_object_type="genie",
+        request_object_id=space_id,
+        access_control_list=[AccessControlRequest(**kwargs)],
+    )
+    logger.info("Granted genie CAN_RUN", principal=principal, space_id=space_id)
+
+
+def _grant_experiment(principal: str, experiment_name: str) -> None:
+    """Grant CAN_EDIT on an MLflow experiment (reuses the provider helper)."""
+    from databricks.sdk import WorkspaceClient
+
+    from dao_ai.providers.databricks import (
+        _grant_experiment_permissions_to_principal,
+    )
+
+    w = WorkspaceClient()
+    experiment = w.experiments.get_by_name(experiment_name)
+    exp_id = experiment.experiment.experiment_id if experiment.experiment else None
+    if exp_id:
+        _grant_experiment_permissions_to_principal(principal, exp_id)
+
+
+def _grant_serving_endpoint(principal: str, endpoint_name: str) -> None:
+    """Grant CAN_QUERY on a Model Serving endpoint (best-effort; skip if absent)."""
+    from databricks.sdk import WorkspaceClient
+    from databricks.sdk.service.serving import (
+        ServingEndpointAccessControlRequest,
+        ServingEndpointPermissionLevel,
+    )
+
+    w = WorkspaceClient()
+    try:
+        w.serving_endpoints.get(name=endpoint_name)
+    except Exception:  # noqa: BLE001 — endpoint not deployed yet; skip quietly
+        logger.debug("Serving endpoint not found; skipping grant", endpoint=endpoint_name)
+        return
+
+    w.serving_endpoints.set_permissions(
+        serving_endpoint_id=endpoint_name,
+        access_control_list=[
+            ServingEndpointAccessControlRequest(
+                service_principal_name=principal,
+                permission_level=ServingEndpointPermissionLevel.CAN_QUERY,
+            )
+        ],
+    )
+    logger.info("Granted serving endpoint CAN_QUERY", principal=principal, endpoint=endpoint_name)
+
+
+# =============================================================================
+# config extraction helpers
+# =============================================================================
+
+
+def resolve_principal_from_config(
+    config: "AppConfig", override: Optional[str] = None
+) -> Optional[str]:
+    """Resolve the grantee client id: explicit override, else config service principal."""
+    if override:
+        return override
+    sp: "ServicePrincipalModel"
+    for sp in config.service_principals.values():
+        if sp.client_id is not None:
+            client_id = value_of(sp.client_id)
+            if client_id:
+                return str(client_id)
+    return None
+
+
+def resolve_secret_target(
+    config: "AppConfig",
+    *,
+    scope_override: Optional[str] = None,
+    client_id_key_override: Optional[str] = None,
+    client_secret_key_override: Optional[str] = None,
+) -> tuple[Optional[str], str, str]:
+    """Resolve (scope, client_id_key, client_secret_key) for ``store``.
+
+    Prefers explicit overrides, then introspects the config's service-principal
+    ``client_id`` / ``client_secret`` variables for their secret scope + key.
+    """
+    scope = scope_override
+    client_id_key = client_id_key_override
+    client_secret_key = client_secret_key_override
+
+    if not (scope and client_id_key and client_secret_key):
+        sp: "ServicePrincipalModel"
+        for sp in config.service_principals.values():
+            cid_scope, cid_key = _secret_ref(sp.client_id)
+            csec_scope, csec_key = _secret_ref(sp.client_secret)
+            scope = scope or cid_scope or csec_scope
+            client_id_key = client_id_key or cid_key
+            client_secret_key = client_secret_key or csec_key
+            if scope and client_id_key and client_secret_key:
+                break
+
+    return scope, client_id_key or "sp-client-id", client_secret_key or "sp-client-secret"
+
+
+def _secret_ref(value: object) -> tuple[Optional[str], Optional[str]]:
+    """Extract (scope, key) from a secret-backed variable, if it is one.
+
+    ``value`` is an ``AnyVariable`` union: a literal, a ``SecretVariableModel``
+    (has ``scope`` + ``secret``), or a ``CompositeVariableModel`` (has ``options``
+    listing candidate resolutions). Narrow with isinstance rather than duck-typing.
+    """
+    from dao_ai.config import CompositeVariableModel, SecretVariableModel
+
+    if isinstance(value, SecretVariableModel):
+        return value.scope, value.secret
+    if isinstance(value, CompositeVariableModel):
+        for option in value.options or []:
+            if isinstance(option, SecretVariableModel):
+                return option.scope, option.secret
+    return None, None
+    return None, None

--- a/tests/dao_ai/test_service_principal.py
+++ b/tests/dao_ai/test_service_principal.py
@@ -320,28 +320,57 @@ def test_provision_end_to_end_stores_and_grants() -> None:
     assert w.api_client.do.called
 
 
-def test_provision_derives_scope_when_no_sp_block() -> None:
-    from dao_ai.config import AgentModel, InferenceEndpointModel
+def _appmodel_no_sp(name: str = "my-agent"):
+    from dao_ai.config import AgentModel, AppModel, InferenceEndpointModel
+
+    return AppModel(
+        name=name,
+        agents=[
+            AgentModel(
+                name="a",
+                description="d",
+                model=InferenceEndpointModel(name="databricks-gpt-5-4-mini"),
+            )
+        ],
+    )
+
+
+def test_provision_without_sp_block_requires_explicit_keys() -> None:
+    """No service_principals block + no key overrides → error, never guess keys."""
+    import pytest
 
     w = MagicMock()
     w.service_principals.list.return_value = []
     w.service_principals.create.return_value = MagicMock(id="9", application_id=PRINCIPAL)
     w.service_principal_secrets_proxy.create.return_value = MagicMock(secret="x")
 
-    config = AppConfig(
-        app=AppModel(
-            name="my-agent",
-            agents=[
-                AgentModel(
-                    name="a",
-                    description="d",
-                    model=InferenceEndpointModel(name="databricks-gpt-5-4-mini"),
-                )
-            ],
-        )
+    config = AppConfig(app=_appmodel_no_sp())
+    with pytest.raises(ValueError, match="which secret keys"):
+        provision(w, config=config, display_name="my-sp")
+    # fail-fast: validated before creating anything, so no orphaned SP
+    w.service_principals.create.assert_not_called()
+
+
+def test_provision_without_sp_block_succeeds_with_explicit_keys() -> None:
+    """Explicit --scope/--*-key overrides make provision work on any config."""
+    w = MagicMock()
+    w.service_principals.list.return_value = []
+    w.service_principals.create.return_value = MagicMock(id="9", application_id=PRINCIPAL)
+    w.service_principal_secrets_proxy.create.return_value = MagicMock(secret="x")
+
+    config = AppConfig(app=_appmodel_no_sp())
+    result = provision(
+        w,
+        config=config,
+        display_name="my-sp",
+        scope="my-scope",
+        client_id_key="CID",
+        client_secret_key="CSEC",
     )
-    result = provision(w, config=config, display_name="my-sp")
-    assert result.stored_scope == "my-agent"  # derived from app name
+    assert result.stored is True
+    assert result.stored_scope == "my-scope"
+    put = {c.kwargs["key"] for c in w.secrets.put_secret.call_args_list}
+    assert put == {"CID", "CSEC"}
 
 
 def test_provision_no_store_no_grant_flags() -> None:
@@ -383,8 +412,8 @@ def test_resolve_secret_target_from_variables_block() -> None:
     assert csec_key == "RETAIL_AI_CLIENT_SECRET"
 
 
-def test_resolve_secret_target_from_environment_vars() -> None:
-    """Configs that only reference secrets via app.environment_vars {{secrets/...}}."""
+def test_resolve_secret_target_does_not_guess_from_environment_vars() -> None:
+    """environment_vars is NOT string-matched to infer keys — that would be a guess."""
     from dao_ai.config import AgentModel, AppModel, InferenceEndpointModel
 
     config = AppConfig(
@@ -400,14 +429,13 @@ def test_resolve_secret_target_from_environment_vars() -> None:
             environment_vars={
                 "RETAIL_AI_DATABRICKS_CLIENT_ID": "{{secrets/rcg/RETAIL_AI_DATABRICKS_CLIENT_ID}}",
                 "RETAIL_AI_DATABRICKS_CLIENT_SECRET": "{{secrets/rcg/RETAIL_AI_DATABRICKS_CLIENT_SECRET}}",
-                "DATABRICKS_HOST": "https://example.databricks.com",
             },
         )
     )
+    # No service_principals block and no client_id/client_secret variables → unresolved.
     scope, cid_key, csec_key = resolve_secret_target(config)
-    assert scope == "rcg"
-    assert cid_key == "RETAIL_AI_DATABRICKS_CLIENT_ID"  # not the _SECRET one
-    assert csec_key == "RETAIL_AI_DATABRICKS_CLIENT_SECRET"
+    assert cid_key is None
+    assert csec_key is None
 
 
 def test_resolve_secret_target_override_wins() -> None:

--- a/tests/dao_ai/test_service_principal.py
+++ b/tests/dao_ai/test_service_principal.py
@@ -1,0 +1,277 @@
+"""Unit tests for the ``dao-ai service-principal`` helpers.
+
+Cover the pure grant-plan resource walk + privilege mapping, the create/store
+SDK call shapes (mocked WorkspaceClient), and principal/secret resolution.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from dao_ai.config import (
+    AppConfig,
+    AppModel,
+    FunctionModel,
+    SchemaModel,
+    SecretVariableModel,
+    ServicePrincipalModel,
+    TableModel,
+    WarehouseModel,
+)
+from dao_ai.service_principal import (
+    build_grant_plan,
+    create,
+    grant,
+    resolve_principal_from_config,
+    resolve_secret_target,
+    store,
+)
+
+PRINCIPAL = "11111111-1111-1111-1111-111111111111"
+
+
+def _schema() -> SchemaModel:
+    return SchemaModel(catalog_name="cat", schema_name="sch")
+
+
+# =============================================================================
+# build_grant_plan — resource walk + privilege mapping
+# =============================================================================
+
+
+def test_grant_plan_schema_catalog_privileges() -> None:
+    config = AppConfig(schemas={"s": _schema()})
+    plan = build_grant_plan(config, PRINCIPAL)
+
+    by_target = {(g.securable_type, g.target): g for g in plan.grants}
+    assert ("catalog", "cat") in by_target
+    assert by_target[("catalog", "cat")].privileges == ["USE_CATALOG"]
+    assert ("schema", "cat.sch") in by_target
+    assert by_target[("schema", "cat.sch")].privileges == ["USE_SCHEMA", "SELECT", "EXECUTE"]
+
+
+def test_grant_plan_table_and_function_privileges() -> None:
+    from dao_ai.config import ResourcesModel
+
+    schema = _schema()
+    config = AppConfig(
+        schemas={"s": schema},
+        resources=ResourcesModel(
+            tables={"t": TableModel(schema=schema, name="products")},
+            functions={"f": FunctionModel(schema=schema, name="find_x")},
+        ),
+    )
+    plan = build_grant_plan(config, PRINCIPAL)
+    mapping = {(g.securable_type, g.target): list(g.privileges) for g in plan.grants}
+
+    assert mapping[("table", "cat.sch.products")] == ["SELECT"]
+    assert mapping[("function", "cat.sch.find_x")] == ["EXECUTE"]
+
+
+def test_grant_plan_dedupes_catalog_and_schema() -> None:
+    from dao_ai.config import ResourcesModel
+
+    schema = _schema()
+    config = AppConfig(
+        schemas={"s": schema},
+        resources=ResourcesModel(
+            tables={
+                "a": TableModel(schema=schema, name="one"),
+                "b": TableModel(schema=schema, name="two"),
+            },
+        ),
+    )
+    plan = build_grant_plan(config, PRINCIPAL)
+    catalogs = [g for g in plan.grants if g.securable_type == "catalog"]
+    schemas = [g for g in plan.grants if g.securable_type == "schema"]
+    assert len(catalogs) == 1  # deduped even though two tables share it
+    assert len(schemas) == 1
+
+
+def test_grant_plan_warehouse_and_serving_endpoint() -> None:
+    from dao_ai.config import ResourcesModel
+
+    from dao_ai.config import AgentModel, InferenceEndpointModel
+
+    config = AppConfig(
+        resources=ResourcesModel(
+            warehouses={"w": WarehouseModel(warehouse_id="wh-123")},
+        ),
+        app=AppModel(
+            name="my-agent",
+            endpoint_name="my_agent_ep",
+            agents=[
+                AgentModel(
+                    name="a",
+                    description="d",
+                    model=InferenceEndpointModel(name="databricks-gpt-5-4-mini"),
+                )
+            ],
+        ),
+    )
+    plan = build_grant_plan(config, PRINCIPAL)
+    kinds = {g.kind: g for g in plan.grants}
+
+    assert kinds["warehouse"].target == "wh-123"
+    assert kinds["warehouse"].privileges == ["CAN_USE"]
+    assert kinds["serving_endpoint"].target == "my_agent_ep"
+    assert kinds["serving_endpoint"].privileges == ["CAN_QUERY"]
+
+
+def test_grant_plan_empty_config_yields_nothing() -> None:
+    plan = build_grant_plan(AppConfig(), PRINCIPAL)
+    assert plan.grants == []
+    assert plan.principal == PRINCIPAL
+
+
+# =============================================================================
+# grant — dry-run applies nothing; real run issues UC PATCH
+# =============================================================================
+
+
+def test_grant_dry_run_makes_no_sdk_calls() -> None:
+    w = MagicMock()
+    config = AppConfig(schemas={"s": _schema()})
+    plan = grant(w, principal=PRINCIPAL, config=config, dry_run=True)
+
+    assert plan.grants  # a plan was produced
+    w.api_client.do.assert_not_called()
+
+
+def test_grant_applies_uc_patch_for_schema() -> None:
+    w = MagicMock()
+    config = AppConfig(schemas={"s": _schema()})
+    grant(w, principal=PRINCIPAL, config=config, dry_run=False)
+
+    # catalog USE_CATALOG + schema USE_SCHEMA/SELECT/EXECUTE via PATCH
+    calls = w.api_client.do.call_args_list
+    patched = {
+        c.args[1]: c.kwargs["body"]["changes"][0]
+        for c in calls
+        if c.args[0] == "PATCH"
+    }
+    assert "/api/2.1/unity-catalog/permissions/catalog/cat" in patched
+    schema_body = patched["/api/2.1/unity-catalog/permissions/schema/cat.sch"]
+    assert schema_body["principal"] == PRINCIPAL
+    assert schema_body["add"] == ["USE_SCHEMA", "SELECT", "EXECUTE"]
+
+
+def test_grant_continues_after_a_failure() -> None:
+    w = MagicMock()
+    # First PATCH raises; the walk should warn-and-continue to the rest.
+    w.api_client.do.side_effect = [RuntimeError("no GRANT rights"), None, None, None]
+    config = AppConfig(schemas={"s": _schema()})
+    grant(w, principal=PRINCIPAL, config=config, dry_run=False)
+    assert w.api_client.do.call_count >= 2  # did not abort on the first failure
+
+
+# =============================================================================
+# create / store — SDK call shapes
+# =============================================================================
+
+
+def test_create_new_service_principal_mints_secret() -> None:
+    w = MagicMock()
+    w.service_principals.list.return_value = []  # none existing
+    w.service_principals.create.return_value = MagicMock(
+        id="42", application_id=PRINCIPAL
+    )
+    w.service_principal_secrets_proxy.create.return_value = MagicMock(secret="sekret")
+
+    result = create(w, display_name="my-sp")
+
+    w.service_principals.create.assert_called_once()
+    w.service_principal_secrets_proxy.create.assert_called_once_with(
+        service_principal_id="42"
+    )
+    assert result.client_id == PRINCIPAL
+    assert result.client_secret == "sekret"
+    assert result.reused is False
+
+
+def test_create_reuses_existing_service_principal() -> None:
+    w = MagicMock()
+    w.service_principals.list.return_value = [
+        MagicMock(id="7", application_id=PRINCIPAL, display_name="my-sp")
+    ]
+    w.service_principal_secrets_proxy.create.return_value = MagicMock(secret="fresh")
+
+    result = create(w, display_name="my-sp")
+
+    w.service_principals.create.assert_not_called()
+    assert result.reused is True
+    assert result.client_secret == "fresh"  # a fresh secret is still minted
+
+
+def test_store_creates_scope_and_puts_secrets() -> None:
+    w = MagicMock()
+    store(
+        w,
+        scope="myscope",
+        client_id_key="CID",
+        client_secret_key="CSEC",
+        client_id="the-id",
+        client_secret="the-secret",
+    )
+    w.secrets.create_scope.assert_called_once_with(scope="myscope")
+    put_calls = {c.kwargs["key"]: c.kwargs["string_value"] for c in w.secrets.put_secret.call_args_list}
+    assert put_calls == {"CID": "the-id", "CSEC": "the-secret"}
+
+
+def test_store_tolerates_existing_scope() -> None:
+    w = MagicMock()
+    w.secrets.create_scope.side_effect = RuntimeError("RESOURCE_ALREADY_EXISTS: scope")
+    store(
+        w,
+        scope="s",
+        client_id_key="a",
+        client_secret_key="b",
+        client_id="x",
+        client_secret="y",
+    )
+    assert w.secrets.put_secret.call_count == 2  # proceeded despite the scope error
+
+
+# =============================================================================
+# principal / secret-target resolution
+# =============================================================================
+
+
+def test_resolve_principal_prefers_override() -> None:
+    config = AppConfig(
+        service_principals={
+            "sp": ServicePrincipalModel(client_id="from-config", client_secret="x")
+        }
+    )
+    assert resolve_principal_from_config(config, override="from-flag") == "from-flag"
+    assert resolve_principal_from_config(config) == "from-config"
+
+
+def test_resolve_secret_target_reads_scope_from_config() -> None:
+    config = AppConfig(
+        service_principals={
+            "sp": ServicePrincipalModel(
+                client_id=SecretVariableModel(scope="myscope", secret="CID"),
+                client_secret=SecretVariableModel(scope="myscope", secret="CSEC"),
+            )
+        }
+    )
+    scope, cid_key, csec_key = resolve_secret_target(config)
+    assert scope == "myscope"
+    assert cid_key == "CID"
+    assert csec_key == "CSEC"
+
+
+def test_resolve_secret_target_override_wins() -> None:
+    config = AppConfig(
+        service_principals={
+            "sp": ServicePrincipalModel(
+                client_id=SecretVariableModel(scope="cfg", secret="CID"),
+                client_secret=SecretVariableModel(scope="cfg", secret="CSEC"),
+            )
+        }
+    )
+    scope, cid_key, csec_key = resolve_secret_target(
+        config, scope_override="flag-scope"
+    )
+    assert scope == "flag-scope"  # override wins over config

--- a/tests/dao_ai/test_service_principal.py
+++ b/tests/dao_ai/test_service_principal.py
@@ -363,6 +363,53 @@ def test_provision_no_store_no_grant_flags() -> None:
     w.api_client.do.assert_not_called()
 
 
+def test_resolve_secret_target_from_variables_block() -> None:
+    """Configs that wire creds via top-level `variables:` (no service_principals)."""
+    from dao_ai.config import CompositeVariableModel, SecretVariableModel
+
+    config = AppConfig(
+        variables={
+            "client_id": CompositeVariableModel(
+                options=[SecretVariableModel(scope="rcg", secret="RETAIL_AI_CLIENT_ID")]
+            ),
+            "client_secret": CompositeVariableModel(
+                options=[SecretVariableModel(scope="rcg", secret="RETAIL_AI_CLIENT_SECRET")]
+            ),
+        }
+    )
+    scope, cid_key, csec_key = resolve_secret_target(config)
+    assert scope == "rcg"
+    assert cid_key == "RETAIL_AI_CLIENT_ID"
+    assert csec_key == "RETAIL_AI_CLIENT_SECRET"
+
+
+def test_resolve_secret_target_from_environment_vars() -> None:
+    """Configs that only reference secrets via app.environment_vars {{secrets/...}}."""
+    from dao_ai.config import AgentModel, AppModel, InferenceEndpointModel
+
+    config = AppConfig(
+        app=AppModel(
+            name="hw",
+            agents=[
+                AgentModel(
+                    name="a",
+                    description="d",
+                    model=InferenceEndpointModel(name="databricks-gpt-5-4-mini"),
+                )
+            ],
+            environment_vars={
+                "RETAIL_AI_DATABRICKS_CLIENT_ID": "{{secrets/rcg/RETAIL_AI_DATABRICKS_CLIENT_ID}}",
+                "RETAIL_AI_DATABRICKS_CLIENT_SECRET": "{{secrets/rcg/RETAIL_AI_DATABRICKS_CLIENT_SECRET}}",
+                "DATABRICKS_HOST": "https://example.databricks.com",
+            },
+        )
+    )
+    scope, cid_key, csec_key = resolve_secret_target(config)
+    assert scope == "rcg"
+    assert cid_key == "RETAIL_AI_DATABRICKS_CLIENT_ID"  # not the _SECRET one
+    assert csec_key == "RETAIL_AI_DATABRICKS_CLIENT_SECRET"
+
+
 def test_resolve_secret_target_override_wins() -> None:
     config = AppConfig(
         service_principals={

--- a/tests/dao_ai/test_service_principal.py
+++ b/tests/dao_ai/test_service_principal.py
@@ -158,13 +158,97 @@ def test_grant_applies_uc_patch_for_schema() -> None:
     assert schema_body["add"] == ["USE_SCHEMA", "SELECT", "EXECUTE"]
 
 
-def test_grant_continues_after_a_failure() -> None:
+def test_grant_continues_after_a_failure_and_tracks_status() -> None:
     w = MagicMock()
     # First PATCH raises; the walk should warn-and-continue to the rest.
     w.api_client.do.side_effect = [RuntimeError("no GRANT rights"), None, None, None]
     config = AppConfig(schemas={"s": _schema()})
-    grant(w, principal=PRINCIPAL, config=config, dry_run=False)
+    plan = grant(w, principal=PRINCIPAL, config=config, dry_run=False)
     assert w.api_client.do.call_count >= 2  # did not abort on the first failure
+    # per-grant status is tracked: the first is failed, later ones applied
+    assert plan.grants[0].applied is False
+    assert plan.grants[0].error
+    assert any(g.applied is True for g in plan.grants[1:])
+
+
+def test_grant_warehouse_uses_additive_update_not_set() -> None:
+    """set_permissions REPLACES the whole ACL — grant must use update_permissions."""
+    from dao_ai.config import ResourcesModel, WarehouseModel
+
+    w = MagicMock()
+    config = AppConfig(
+        resources=ResourcesModel(warehouses={"w": WarehouseModel(warehouse_id="wh-1")})
+    )
+    grant(w, principal=PRINCIPAL, config=config, dry_run=False)
+    w.warehouses.update_permissions.assert_called_once()
+    w.warehouses.set_permissions.assert_not_called()  # never the destructive variant
+
+
+def test_grant_genie_uses_additive_update_not_set() -> None:
+    from dao_ai.config import GenieRoomModel, ResourcesModel
+
+    w = MagicMock()
+    config = AppConfig(
+        resources=ResourcesModel(
+            genie_rooms={"g": GenieRoomModel(space_id="01f0space")}
+        )
+    )
+    grant(w, principal=PRINCIPAL, config=config, dry_run=False)
+    w.permissions.update.assert_called_once()
+    w.permissions.set.assert_not_called()
+
+
+def test_grant_serving_endpoint_uses_resolved_id_and_additive_update() -> None:
+    from dao_ai.config import AgentModel, AppModel, InferenceEndpointModel
+
+    w = MagicMock()
+    # get(name=...) returns an endpoint whose id differs from its name
+    w.serving_endpoints.get.return_value = MagicMock(id="ep-internal-id")
+    config = AppConfig(
+        app=AppModel(
+            name="my-agent",
+            endpoint_name="my_agent_ep",
+            agents=[
+                AgentModel(
+                    name="a",
+                    description="d",
+                    model=InferenceEndpointModel(name="databricks-gpt-5-4-mini"),
+                )
+            ],
+        )
+    )
+    grant(w, principal=PRINCIPAL, config=config, dry_run=False)
+    w.serving_endpoints.set_permissions.assert_not_called()
+    w.serving_endpoints.update_permissions.assert_called_once()
+    # keyed on the resolved id, not the endpoint name
+    assert w.serving_endpoints.update_permissions.call_args.kwargs["serving_endpoint_id"] == "ep-internal-id"
+
+
+def test_grant_serving_endpoint_skips_when_endpoint_absent() -> None:
+    """The serving grant is best-effort: if the endpoint isn't deployed, skip it
+    (no update_permissions) rather than erroring — AppModel always populates
+    endpoint_name (defaulting from name), so existence is checked at apply time."""
+    from dao_ai.config import AgentModel, AppModel, InferenceEndpointModel
+
+    w = MagicMock()
+    w.serving_endpoints.get.side_effect = RuntimeError("RESOURCE_DOES_NOT_EXIST")
+    config = AppConfig(
+        app=AppModel(
+            name="apps-only",
+            agents=[
+                AgentModel(
+                    name="a",
+                    description="d",
+                    model=InferenceEndpointModel(name="databricks-gpt-5-4-mini"),
+                )
+            ],
+        )
+    )
+    plan = grant(w, principal=PRINCIPAL, config=config, dry_run=False)
+    # planned, but not applied (endpoint absent) — and never the destructive set
+    assert any(g.kind == "serving_endpoint" for g in plan.grants)
+    w.serving_endpoints.update_permissions.assert_not_called()
+    w.serving_endpoints.set_permissions.assert_not_called()
 
 
 # =============================================================================

--- a/tests/dao_ai/test_service_principal.py
+++ b/tests/dao_ai/test_service_principal.py
@@ -21,7 +21,9 @@ from dao_ai.config import (
 from dao_ai.service_principal import (
     build_grant_plan,
     create,
+    default_scope_from_config,
     grant,
+    provision,
     resolve_principal_from_config,
     resolve_secret_target,
     store,
@@ -260,6 +262,105 @@ def test_resolve_secret_target_reads_scope_from_config() -> None:
     assert scope == "myscope"
     assert cid_key == "CID"
     assert csec_key == "CSEC"
+
+
+def test_default_scope_prefers_app_name() -> None:
+    from dao_ai.config import AgentModel, InferenceEndpointModel
+
+    config = AppConfig(
+        app=AppModel(
+            name="my-agent",
+            agents=[
+                AgentModel(
+                    name="a",
+                    description="d",
+                    model=InferenceEndpointModel(name="databricks-gpt-5-4-mini"),
+                )
+            ],
+        )
+    )
+    assert default_scope_from_config(config) == "my-agent"
+
+
+def test_default_scope_falls_back_to_catalog() -> None:
+    config = AppConfig(schemas={"s": _schema()})
+    assert default_scope_from_config(config) == "cat"
+
+
+# =============================================================================
+# provision — one-shot create + store + grant
+# =============================================================================
+
+
+def test_provision_end_to_end_stores_and_grants() -> None:
+    w = MagicMock()
+    w.service_principals.list.return_value = []
+    w.service_principals.create.return_value = MagicMock(id="9", application_id=PRINCIPAL)
+    w.service_principal_secrets_proxy.create.return_value = MagicMock(secret="s3cr3t")
+
+    config = AppConfig(
+        schemas={"s": _schema()},
+        service_principals={
+            "sp": ServicePrincipalModel(
+                client_id=SecretVariableModel(scope="myscope", secret="CID"),
+                client_secret=SecretVariableModel(scope="myscope", secret="CSEC"),
+            )
+        },
+    )
+    result = provision(w, config=config, display_name="my-sp")
+
+    # secret written to the config's scope, never surfaced on the result
+    assert result.stored is True
+    assert result.stored_scope == "myscope"
+    assert not hasattr(result, "client_secret")
+    put_keys = {c.kwargs["key"] for c in w.secrets.put_secret.call_args_list}
+    assert put_keys == {"CID", "CSEC"}
+    # granted the schema (UC PATCH issued)
+    assert result.grant_plan is not None and result.grant_plan.grants
+    assert w.api_client.do.called
+
+
+def test_provision_derives_scope_when_no_sp_block() -> None:
+    from dao_ai.config import AgentModel, InferenceEndpointModel
+
+    w = MagicMock()
+    w.service_principals.list.return_value = []
+    w.service_principals.create.return_value = MagicMock(id="9", application_id=PRINCIPAL)
+    w.service_principal_secrets_proxy.create.return_value = MagicMock(secret="x")
+
+    config = AppConfig(
+        app=AppModel(
+            name="my-agent",
+            agents=[
+                AgentModel(
+                    name="a",
+                    description="d",
+                    model=InferenceEndpointModel(name="databricks-gpt-5-4-mini"),
+                )
+            ],
+        )
+    )
+    result = provision(w, config=config, display_name="my-sp")
+    assert result.stored_scope == "my-agent"  # derived from app name
+
+
+def test_provision_no_store_no_grant_flags() -> None:
+    w = MagicMock()
+    w.service_principals.list.return_value = []
+    w.service_principals.create.return_value = MagicMock(id="9", application_id=PRINCIPAL)
+    w.service_principal_secrets_proxy.create.return_value = MagicMock(secret="x")
+
+    result = provision(
+        w,
+        config=AppConfig(schemas={"s": _schema()}),
+        display_name="my-sp",
+        do_store=False,
+        do_grant=False,
+    )
+    assert result.stored is False
+    assert result.grant_plan is None
+    w.secrets.put_secret.assert_not_called()
+    w.api_client.do.assert_not_called()
 
 
 def test_resolve_secret_target_override_wins() -> None:


### PR DESCRIPTION
## Summary

Adds a `service-principal` CLI command group (alias `sp`) that makes provisioning the service principal for a dao-ai config a one-liner. Config-driven with flag overrides.

| Command | What it does |
|---|---|
| **`provision`** | **One shot: create (or reuse) the SP, mint a secret, write it to the config's scope, and grant every config resource — the secret is never printed.** The easiest way to make a config runnable. |
| `create` | Create/reuse a workspace SP and mint an OAuth secret; prints `client_id` + one-time secret. Name defaults to `<app.name>-sp`. |
| `store` | Write `client_id`/`client_secret` into a secret scope; scope + key names default from the config. |
| `grant` | Grant the SP read/execute on every declared resource. `--dry-run` prints the plan. |

### The one-command path
```
dao-ai sp provision -c config/model_config.yaml
  → creates <app.name>-sp
  → writes creds to the config's secret scope (secret never printed)
  → grants catalog/schema/table/function/vector-index/warehouse/genie/experiment/endpoint
```
`--no-store` / `--no-grant` opt out of steps; `--name`/`--scope`/`--principal` override. When a config has no `service_principals` block, the scope is derived from the app name (or catalog).

### `grant` privilege mapping
catalog `USE_CATALOG` · schema `USE_SCHEMA/SELECT/EXECUTE` · table `SELECT` · UC function `EXECUTE` · vector-search index `SELECT` · warehouse `CAN_USE` · genie room `CAN_RUN` · experiment `CAN_EDIT` · serving endpoint `CAN_QUERY`. De-duped; failures warn-and-continue.

## Implementation
- **New module `src/dao_ai/service_principal.py`** — pure `build_grant_plan` (backs `--dry-run` and apply), `create`/`store`/`grant`/`provision` orchestrator, and principal/secret/scope resolution. **Strong-typed throughout (no `getattr`/`hasattr`).** Reuses the idempotent UC PATCH permissions call dao-ai uses at deploy time. SP + OAuth-secret creation are workspace-level (no AccountClient).
- **`cli.py`** — new parser group mirroring the `monitor`/`trace` pattern.

## Verification
- **20 unit tests** (mocked `WorkspaceClient`): grant-plan resource/privilege mapping + dedup, dry-run, create/store call shapes, provision end-to-end (stores + grants, secret never surfaced), scope derivation, `--no-store`/`--no-grant`, resolution precedence.
- **Live on fevm**: `sp provision` created an SP, stored the secret under the config's own key names (verified via `secrets list-secrets`), and granted 30 resources (catalog grant confirmed via the UC permissions API). Standalone create/store/grant also verified. All test SPs + scopes cleaned up.

## Notes / follow-ups (separate)
- Pending temperature regression across ~28 example configs is still its own tracked follow-up.
- Possible future: `grant --revoke` / SP teardown.

This pull request and its description were written by Isaac.