### PR TITLE
fix(notebooks): 06_background_agents — app-scoped token auth + live-streamed output

### DIFF
--- a/notebooks/06_background_agents.py
+++ b/notebooks/06_background_agents.py
@@ -14,8 +14,14 @@
 # MAGIC ### Client note
 # MAGIC The app exposes OpenAI Responses API–compatible routes under `/v1`
 # MAGIC (`POST /v1/responses`, `GET /v1/responses/{id}`, `POST /v1/responses/{id}/cancel`).
-# MAGIC We resolve the app's URL + an OAuth token *from the app name* via the
-# MAGIC Databricks SDK, then point the stock `OpenAI` client at `{app_url}/v1`.
+# MAGIC We resolve the app's URL from the app name via the Databricks SDK, then point
+# MAGIC the stock `OpenAI` client at `{app_url}/v1`.
+# MAGIC
+# MAGIC > **Auth:** the Databricks Apps front door only accepts an OAuth access token
+# MAGIC > *audience-scoped to the app's `oauth2_app_client_id`*. The notebook's ambient
+# MAGIC > credential is not app-scoped and gets a bare `401`, so we exchange the notebook
+# MAGIC > token for an app-scoped one via `POST {host}/oidc/v1/token` (token-exchange
+# MAGIC > grant). See Databricks docs: *dev-tools/databricks-apps/connect-local*.
 # MAGIC
 # MAGIC > The `databricks-openai` `DatabricksOpenAI` client with `model="apps/<name>"`
 # MAGIC > routes `responses.create` to the app, but its base URL omits the `/v1`
@@ -91,13 +97,45 @@ else:
 
 import time
 
+import requests
 from databricks.sdk import WorkspaceClient
 from openai import OpenAI, Stream
 from openai.types.responses import Response, ResponseStreamEvent
 
 w = WorkspaceClient()
-app_url: str = w.apps.get(app_name).url.rstrip("/")
-token: str = w.config.authenticate()["Authorization"].removeprefix("Bearer ")
+app = w.apps.get(app_name)
+app_url: str = app.url.rstrip("/")
+
+# The Databricks Apps front door (*.databricksapps.com) only accepts an OAuth
+# access token that is audience-scoped to the app's client id. The notebook's
+# ambient credential is NOT scoped to the app, so we exchange it for an
+# app-scoped token via /oidc/v1/token (the documented Apps auth recipe).
+app_client_id: str | None = app.oauth2_app_client_id
+if not app_client_id:
+    raise RuntimeError(
+        f"App {app_name!r} has no oauth2_app_client_id; cannot mint an "
+        "app-scoped token. Ensure the app is fully deployed."
+    )
+
+host: str = w.config.host.rstrip("/")
+notebook_token: str = (
+    dbutils.notebook.entry_point.getDbutils()
+    .notebook()
+    .getContext()
+    .apiToken()
+    .get()
+)
+token: str = requests.post(
+    f"{host}/oidc/v1/token",
+    data={
+        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "subject_token": notebook_token,
+        "subject_token_type": "urn:databricks:params:oauth:token-type:personal-access-token",
+        "requested_token_type": "urn:ietf:params:oauth:token-type:access_token",
+        "scope": "all-apis",
+        "audience": app_client_id,
+    },
+).json()["access_token"]
 
 client = OpenAI(base_url=f"{app_url}/v1", api_key=token)
 print("App URL:", app_url)
@@ -202,26 +240,24 @@ for event in retrieve_stream:
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## 4. Stream the agent's output (`DatabricksOpenAI`)
+# MAGIC ## 4. Stream the agent's output
 # MAGIC
-# MAGIC The `OpenAI(/v1)` client above is best for the background lifecycle
-# MAGIC (kickoff/poll/cancel). To stream the agent's **output** as it is produced,
-# MAGIC use `DatabricksOpenAI` with `model="apps/<app-name>"` — it resolves the app
-# MAGIC by name (OAuth) and streams the synchronous run's events. We accumulate
-# MAGIC `output_text.delta` events (token deltas) and fall back to the text on a
-# MAGIC final `output_item.done` event for agents that emit output in one piece.
+# MAGIC The same `OpenAI(/v1)` client streams the agent's **output** as it is
+# MAGIC produced — pass `stream=True` with `background=False` so the run executes
+# MAGIC synchronously and emits token deltas (rather than a single background
+# MAGIC status event). We accumulate `output_text.delta` events (token deltas) and
+# MAGIC fall back to the text on a final `output_item.done` event for agents that
+# MAGIC emit output in one piece.
 
 # COMMAND ----------
 
-from databricks_openai import DatabricksOpenAI
 from openai.types.responses import ResponseOutputMessage
 
-dbx_client = DatabricksOpenAI(workspace_client=w)
-
-stream: Stream[ResponseStreamEvent] = dbx_client.responses.create(
-    model=f"apps/{app_name}",
+stream: Stream[ResponseStreamEvent] = client.responses.create(
+    model=app_name,
     input=messages("Give me 3 quick tips for using Databricks Lakebase."),
     stream=True,
+    background=False,
     extra_body=custom_inputs("nb_bg_stream_output_1"),
 )
 

--- a/notebooks/06_background_agents.py
+++ b/notebooks/06_background_agents.py
@@ -240,10 +240,10 @@ streamed_text: str = ""
 saw_delta: bool = False
 event: ResponseStreamEvent
 for event in retrieve_stream:
-    print(f"  event: {event.type}")
     if event.type == "response.output_text.delta":
         streamed_text += event.delta
         saw_delta = True
+        print(event.delta, end="", flush=True)  # render tokens as they arrive
     elif (
         not saw_delta
         and event.type == "response.output_item.done"
@@ -253,8 +253,9 @@ for event in retrieve_stream:
         for part in event.item.content:
             if part.type == "output_text":
                 streamed_text += part.text
+                print(part.text, end="", flush=True)
 
-print(f"\nstreamed output:\n{streamed_text}")
+print()  # trailing newline after the streamed output
 
 # COMMAND ----------
 
@@ -284,10 +285,10 @@ streamed_text: str = ""
 saw_delta: bool = False
 event: ResponseStreamEvent
 for event in stream:
-    print(f"  event: {event.type}")
     if event.type == "response.output_text.delta":
         streamed_text += event.delta
         saw_delta = True
+        print(event.delta, end="", flush=True)  # render tokens as they arrive
     elif (
         not saw_delta
         and event.type == "response.output_item.done"
@@ -297,5 +298,6 @@ for event in stream:
         for part in event.item.content:
             if part.type == "output_text":
                 streamed_text += part.text
+                print(part.text, end="", flush=True)
 
-print(f"\nstreamed output:\n{streamed_text}")
+print()  # trailing newline after the streamed output

--- a/notebooks/06_background_agents.py
+++ b/notebooks/06_background_agents.py
@@ -221,21 +221,40 @@ print(f"retrieve-after-cancel: status={after.status}")
 
 # COMMAND ----------
 
-kickoff = client.responses.create(
+from openai.types.responses import ResponseOutputMessage
+
+kickoff: Response = client.responses.create(
     model=app_name,
     input=messages("List 10 things Databricks Lakebase is good for."),
     background=True,
     extra_body=custom_inputs("nb_bg_stream_1"),
 )
-response_id = kickoff.id
+response_id: str = kickoff.id
 print(f"kickoff id={response_id}")
 
-event: ResponseStreamEvent
 retrieve_stream: Stream[ResponseStreamEvent] = client.responses.retrieve(
     response_id, stream=True, starting_after=0
 )
+
+streamed_text: str = ""
+saw_delta: bool = False
+event: ResponseStreamEvent
 for event in retrieve_stream:
     print(f"  event: {event.type}")
+    if event.type == "response.output_text.delta":
+        streamed_text += event.delta
+        saw_delta = True
+    elif (
+        not saw_delta
+        and event.type == "response.output_item.done"
+        and isinstance(event.item, ResponseOutputMessage)
+    ):
+        # Fallback for agents that emit output in one piece (no token deltas).
+        for part in event.item.content:
+            if part.type == "output_text":
+                streamed_text += part.text
+
+print(f"\nstreamed output:\n{streamed_text}")
 
 # COMMAND ----------
 
@@ -262,12 +281,19 @@ stream: Stream[ResponseStreamEvent] = client.responses.create(
 )
 
 streamed_text: str = ""
+saw_delta: bool = False
 event: ResponseStreamEvent
 for event in stream:
     print(f"  event: {event.type}")
     if event.type == "response.output_text.delta":
         streamed_text += event.delta
-    elif event.type == "response.output_item.done" and isinstance(event.item, ResponseOutputMessage):
+        saw_delta = True
+    elif (
+        not saw_delta
+        and event.type == "response.output_item.done"
+        and isinstance(event.item, ResponseOutputMessage)
+    ):
+        # Fallback for agents that emit output in one piece (no token deltas).
         for part in event.item.content:
             if part.type == "output_text":
                 streamed_text += part.text


### PR DESCRIPTION
## Problem

Running `notebooks/06_background_agents.py` against a background-enabled dao-ai
App from a serverless notebook failed at the kickoff cell:

```
kickoff = client.responses.create(model=app_name, ..., background=True)
# AuthenticationError: Error code: 401 - {}
```

## Root cause

The notebook built a bare `OpenAI` client pointed at the Databricks Apps front
door (`{app_url}/v1`) and authenticated with `w.config.authenticate()`. In a
serverless notebook that returns the runtime's **ambient** token, which is
**not audience-scoped to the app**. The Apps front door only accepts an OAuth
access token scoped to the app's `oauth2_app_client_id`, so it rejected the
request with a bare `401` **before it reached app code**.

The empty-body `401` raised *at* `.create()` (not during polling) is the tell —
a downstream OBO/tool 401 would surface later during `retrieve()`, since
`background=True` returns immediately.

## Fix

1. **App-scoped token exchange.** Exchange the notebook's internal `apiToken()`
   for an app-audience-scoped OAuth token via `POST {host}/oidc/v1/token` (the
   documented Databricks Apps auth recipe), keyed on `app.oauth2_app_client_id`,
   and use it as the client's `api_key`.

2. **Single client for the whole lifecycle.** Switched the streaming section off
   `DatabricksOpenAI` (whose `_validate_oauth_for_apps` gate also fails under
   ambient notebook auth, and whose base URL omits `/v1` so retrieve/cancel 404)
   to the same app-scoped `OpenAI(/v1)` client with `stream=True,
   background=False`. Kickoff/poll/cancel/stream now run through one client.

3. **Stream text, rendered live.** Section 3 now accumulates and prints the
   streamed output. Both streaming sections print each `output_text.delta` as it
   arrives (`print(delta, end="", flush=True)`) so tokens render incrementally.

4. **Double-count guard.** The app emits both full token deltas *and* a final
   `output_item.done` carrying the complete text; the `done`-item is now a
   fallback used only when no deltas arrived (previously it double-counted ~2x).

Strong typehints applied throughout the touched cells.

## Verification

Verified live on **fevm** (serverless v5, `background-dao` app):

- Full notebook job run → **SUCCESS**
- Kickoff → poll → `completed` (3068 chars)
- Cancel → `cancelled`
- Section 3 retrieve-stream → single clean copy (~3298 chars)
- Section 4 create-stream → 172 deltas rendered incrementally over a ~7s stream
  (first delta 5.05s, last 12.22s)

This pull request and its description were written by Isaac.