### PR TITLE
docs: MkDocs Material site + gh-pages publish workflow for 0.2.x

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -1,0 +1,32 @@
+name: Publish docs 📚 to GitHub Pages
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  deploy-docs:
+    name: Build and deploy MkDocs site
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # required for mkdocs gh-deploy to push to the gh-pages branch
+
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      with:
+        fetch-depth: 0  # full history so `mkdocs gh-deploy` can commit to gh-pages
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      with:
+        python-version: "3.11"
+    - name: Install uv
+      uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+      with:
+        version: "0.11.1"
+    - name: Install docs dependencies
+      run: uv pip install --system ".[docs]"
+    - name: Build site (strict)
+      run: mkdocs build --strict
+    - name: Deploy to gh-pages
+      run: mkdocs gh-deploy --force --no-history

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ schemas:
     schema_name: my_schema          # Replace with your schema name
 
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-gpt-5-4-mini  # The AI model to use
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -258,12 +258,12 @@ You can mix a cohort with regular single-target handoffs on the same source (age
 
 ![Parallel fan-out orchestration pattern: a source agent fires multiple handoff tools in a single LLM turn; LangGraph runs the siblings concurrently in one superstep and the join reducer runs exactly once](images/parallel-fan-out-pattern.png)
 
-See [`examples/13_orchestration/parallel_fan_out_pattern.yaml`](../examples/13_orchestration/parallel_fan_out_pattern.yaml) for a complete deployable example.
+See [`examples/13_orchestration/parallel_fan_out_pattern.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/13_orchestration/parallel_fan_out_pattern.yaml) for a complete deployable example.
 
 ---
 
 ## Navigation
 
 - [← Previous: Why DAO?](why-dao.md)
-- [↑ Back to Documentation Index](../README.md#-documentation)
+- [↑ Back to Documentation Index](https://github.com/natefleming/dao-ai/blob/main/README.md#-documentation)
 - [Next: Key Capabilities →](key-capabilities.md)

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -20,7 +20,7 @@ verification research captured in the vault
 2. [Config](#config)
 3. [Call flow diagrams](#call-flow-diagrams)
 4. [Receipt schema](#receipt-schema)
-5. [MLflow span attributes](#mlflow-span-attributes)
+5. [MLflow span attributes](#mlflow-span-attributes-events)
 6. [`AuditToolkit` — self-service audit queries for agents](#audittoolkit)
 7. [Sensitive data handling](#sensitive-data-handling)
 8. [Deployment](#deployment)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -437,7 +437,7 @@ The `dao-ai trace` group manages MLflow experiments and UC trace destinations.
 
 ### `dao-ai trace link`
 
-`dao-ai trace link` attaches an MLflow experiment to its Unity Catalog trace destination declared under `app.trace_location`. Run it as an explicit step **between** `databricks bundle deploy` and `databricks bundle run` — see the [background above](#linking-the-uc-trace-destination--run-dao-ai-trace-link-between-deploy-and-run) for why the app's runtime attempt is unreliable.
+`dao-ai trace link` attaches an MLflow experiment to its Unity Catalog trace destination declared under `app.trace_location`. Run it as an explicit step **between** `databricks bundle deploy` and `databricks bundle run` — see the [background above](#linking-the-uc-trace-destination-run-dao-ai-trace-link-between-deploy-and-run) for why the app's runtime attempt is unreliable.
 
 ```bash
 databricks bundle deploy --target dev -p <profile>
@@ -1020,6 +1020,6 @@ The deploy-model v2 release removed several commands and renamed others. Use thi
 ## Navigation
 
 - [← Previous: Examples](examples.md)
-- [↑ Back to Documentation Index](../README.md#-documentation)
+- [↑ Back to Documentation Index](https://github.com/natefleming/dao-ai/blob/main/README.md#-documentation)
 - [Next: Python API →](python-api.md)
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -1012,8 +1012,8 @@ shared connection pool.
 **Governance** — because `type: sql` inherits the base tool model, it composes with
 `human_in_the_loop:` and `audit:` (e.g. gate a mutating `UPDATE`/`DELETE` behind
 human approval with a signed audit receipt). See
-[`examples/99_complete_applications/hardware_store/hardware_store_lakebase.yaml`](../examples/99_complete_applications/hardware_store/hardware_store_lakebase.yaml)
-and [`examples/14_basic_tools/sql_tool_example.yaml`](../examples/14_basic_tools/sql_tool_example.yaml).
+[`examples/99_complete_applications/hardware_store/hardware_store_lakebase.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/99_complete_applications/hardware_store/hardware_store_lakebase.yaml)
+and [`examples/14_basic_tools/sql_tool_example.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/14_basic_tools/sql_tool_example.yaml).
 
 ## First-Class Agent Tools
 
@@ -1092,14 +1092,14 @@ tools:
 
 ### `type: a2a` — call an external A2A agent
 
-See [`examples/99_complete_applications/procurement_supplier_a2a/README.md`](../examples/99_complete_applications/procurement_supplier_a2a/README.md) for the full A2A protocol example. Available since v0.1.80.
+See [`examples/99_complete_applications/procurement_supplier_a2a/README.md`](https://github.com/natefleming/dao-ai/blob/main/examples/99_complete_applications/procurement_supplier_a2a/README.md) for the full A2A protocol example. Available since v0.1.80.
 
 ### See Also
 
-- [`examples/10_agent_integrations/app_first_class.yaml`](../examples/10_agent_integrations/app_first_class.yaml)
-- [`examples/10_agent_integrations/serving_endpoint_first_class.yaml`](../examples/10_agent_integrations/serving_endpoint_first_class.yaml)
-- [`examples/10_agent_integrations/README.md`](../examples/10_agent_integrations/README.md) — routing matrix and migration notes
-- [`examples/99_complete_applications/procurement_supplier_a2a/`](../examples/99_complete_applications/procurement_supplier_a2a/) — end-to-end A2A example
+- [`examples/10_agent_integrations/app_first_class.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/10_agent_integrations/app_first_class.yaml)
+- [`examples/10_agent_integrations/serving_endpoint_first_class.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/10_agent_integrations/serving_endpoint_first_class.yaml)
+- [`examples/10_agent_integrations/README.md`](https://github.com/natefleming/dao-ai/blob/main/examples/10_agent_integrations/README.md) — routing matrix and migration notes
+- [`examples/99_complete_applications/procurement_supplier_a2a/`](https://github.com/natefleming/dao-ai/tree/main/examples/99_complete_applications/procurement_supplier_a2a/) — end-to-end A2A example
 
 ---
 
@@ -1167,8 +1167,8 @@ environment (it is on Apps/MS deploys).
 
 ### See Also
 
-- [`examples/10_agent_integrations/genie_agent_model.yaml`](../examples/10_agent_integrations/genie_agent_model.yaml)
-- [`examples/10_agent_integrations/genie_agent_model_obo.yaml`](../examples/10_agent_integrations/genie_agent_model_obo.yaml) — OBO + deployable App
+- [`examples/10_agent_integrations/genie_agent_model.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/10_agent_integrations/genie_agent_model.yaml)
+- [`examples/10_agent_integrations/genie_agent_model_obo.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/10_agent_integrations/genie_agent_model_obo.yaml) — OBO + deployable App
 
 ---
 
@@ -1259,8 +1259,8 @@ include_tools: ["execute_query", "list_tables"]  # Only these 2
 
 ### See Also
 
-- Full examples: [`examples/02_mcp/filtered_mcp.yaml`](../examples/02_mcp/filtered_mcp.yaml)
-- MCP documentation: [`examples/02_mcp/README.md`](../examples/02_mcp/README.md#pattern-4-filtered-mcp-tool-selection)
+- Full examples: [`examples/02_mcp/filtered_mcp.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/02_mcp/filtered_mcp.yaml)
+- MCP documentation: [`examples/02_mcp/README.md`](https://github.com/natefleming/dao-ai/blob/main/examples/02_mcp/README.md#pattern-4-filtered-mcp-tool-selection)
 
 ---
 
@@ -1390,14 +1390,14 @@ subagents:
 
 ### See Also
 
-- Full example: [`examples/12_middleware/deepagents_middleware.yaml`](../examples/12_middleware/deepagents_middleware.yaml)
-- Middleware examples: [`examples/12_middleware/README.md`](../examples/12_middleware/README.md)
+- Full example: [`examples/12_middleware/deepagents_middleware.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/12_middleware/deepagents_middleware.yaml)
+- Middleware examples: [`examples/12_middleware/README.md`](https://github.com/natefleming/dao-ai/blob/main/examples/12_middleware/README.md)
 
 ---
 
 ## Navigation
 
 - [← Previous: Key Capabilities](key-capabilities.md)
-- [↑ Back to Documentation Index](../README.md#-documentation)
+- [↑ Back to Documentation Index](https://github.com/natefleming/dao-ai/blob/main/README.md#-documentation)
 - [Next: Examples →](examples.md)
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -176,7 +176,7 @@ Example:
 
 ```yaml
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-gpt-5-4-mini
       temperature: 0.7
@@ -339,5 +339,5 @@ Thank you for contributing to DAO! 🎉
 ## Navigation
 
 - [← Previous: FAQ](faq.md)
-- [↑ Back to Documentation Index](../README.md#-documentation)
+- [↑ Back to Documentation Index](https://github.com/natefleming/dao-ai/blob/main/README.md#-documentation)
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -21,50 +21,50 @@ Start at `01_getting_started` if you're new, or jump directly to the category th
 
 ### 🆕 New to DAO AI?
 **Start here:**
-- [`01_getting_started/minimal.yaml`](../examples/01_getting_started/minimal.yaml) - Simplest possible agent
-- [`04_genie/genie_basic.yaml`](../examples/04_genie/genie_basic.yaml) - Natural language to SQL
+- [`01_getting_started/minimal.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/01_getting_started/minimal.yaml) - Simplest possible agent
+- [`04_genie/genie_basic.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/04_genie/genie_basic.yaml) - Natural language to SQL
 
 ### 🔧 Need Specific Tools?
 **Explore:**
-- [`02_mcp/`](../examples/02_mcp/) - JIRA, managed/external/custom MCP integrations
-- [`10_agent_integrations/`](../examples/10_agent_integrations/) - Agent Bricks, Kasal, external agent platforms
-- [`14_basic_tools/`](../examples/14_basic_tools/) - SQL execution, Slack, and basic tool patterns
+- [`02_mcp/`](https://github.com/natefleming/dao-ai/tree/main/examples/02_mcp/) - JIRA, managed/external/custom MCP integrations
+- [`10_agent_integrations/`](https://github.com/natefleming/dao-ai/tree/main/examples/10_agent_integrations/) - Agent Bricks, Kasal, external agent platforms
+- [`14_basic_tools/`](https://github.com/natefleming/dao-ai/tree/main/examples/14_basic_tools/) - SQL execution, Slack, and basic tool patterns
 
 ### ⚡ Optimizing Performance?
 **Check out:**
-- [`04_genie/`](../examples/04_genie/) - LRU and semantic caching strategies
+- [`04_genie/`](https://github.com/natefleming/dao-ai/tree/main/examples/04_genie/) - LRU and semantic caching strategies
 
 ### 💾 Managing State?
 **See:**
-- [`05_memory/`](../examples/05_memory/) - Conversation history and persistence
+- [`05_memory/`](https://github.com/natefleming/dao-ai/tree/main/examples/05_memory/) - Conversation history and persistence
 
 ### 🛡️ Production Ready?
 **Essential patterns:**
-- [`06_on_behalf_of_user/`](../examples/06_on_behalf_of_user/) - User-level authentication and access control
-- [`07_human_in_the_loop/`](../examples/07_human_in_the_loop/) - Approval workflows
-- [`08_guardrails/`](../examples/08_guardrails/) - Safety and compliance
-- [`09_structured_output/`](../examples/09_structured_output/) - Enforce JSON schemas
-- [`11_prompt_engineering/`](../examples/11_prompt_engineering/) - Prompt management and optimization
+- [`06_on_behalf_of_user/`](https://github.com/natefleming/dao-ai/tree/main/examples/06_on_behalf_of_user/) - User-level authentication and access control
+- [`07_human_in_the_loop/`](https://github.com/natefleming/dao-ai/tree/main/examples/07_human_in_the_loop/) - Approval workflows
+- [`08_guardrails/`](https://github.com/natefleming/dao-ai/tree/main/examples/08_guardrails/) - Safety and compliance
+- [`09_structured_output/`](https://github.com/natefleming/dao-ai/tree/main/examples/09_structured_output/) - Enforce JSON schemas
+- [`11_prompt_engineering/`](https://github.com/natefleming/dao-ai/tree/main/examples/11_prompt_engineering/) - Prompt management and optimization
 
 ### 🛡️ Need Validation & Monitoring?
 **Middleware patterns:**
-- [`12_middleware/`](../examples/12_middleware/) - Input validation, logging, performance monitoring
+- [`12_middleware/`](https://github.com/natefleming/dao-ai/tree/main/examples/12_middleware/) - Input validation, logging, performance monitoring
 
 ### 📊 Visualizations?
 **Charts and graphs:**
-- [`17_visualization/`](../examples/17_visualization/) - Vega-Lite chart generation via `custom_outputs`
+- [`17_visualization/`](https://github.com/natefleming/dao-ai/tree/main/examples/17_visualization/) - Vega-Lite chart generation via `custom_outputs`
 
 ### ⏱️ Background Tasks?
 **Background kickoff + poll/stream retrieval (deep research, multi-tool workflows):**
-- [`18_background_agents/`](../examples/18_background_agents/) - OpenAI Responses API–compatible `/v1/responses` on Apps + `background=true` on Model Serving, backed by Lakebase
+- [`18_background_agents/`](https://github.com/natefleming/dao-ai/tree/main/examples/18_background_agents/) - OpenAI Responses API–compatible `/v1/responses` on Apps + `background=true` on Model Serving, backed by Lakebase
 
 ### 🔎 Retrieval from Lakebase Postgres?
 **ANN / BM25 / hybrid RRF over a Lakebase table (as a sibling of `ai_search`):**
-- [`20_lakebase_search/`](../examples/20_lakebase_search/) - `type: lakebase_search` using the `lakebase_vector` + `lakebase_text` extensions, with filter-operator coverage and a UC OTEL `trace_location` example
+- [`20_lakebase_search/`](https://github.com/natefleming/dao-ai/tree/main/examples/20_lakebase_search/) - `type: lakebase_search` using the `lakebase_vector` + `lakebase_text` extensions, with filter-operator coverage and a UC OTEL `trace_location` example
 
 ### 🏗️ Complete Solutions?
 **Full applications:**
-- [`99_complete_applications/`](../examples/99_complete_applications/) - Executive assistant, research agent, reservation system
+- [`99_complete_applications/`](https://github.com/natefleming/dao-ai/tree/main/examples/99_complete_applications/) - Executive assistant, research agent, reservation system
 
 ---
 
@@ -94,7 +94,7 @@ dao-ai agent up -c examples/07_human_in_the_loop/human_in_the_loop.yaml
 
 ## 📂 Directory Guide
 
-### 01. Getting Started [📖 README](../examples/01_getting_started/README.md)
+### 01. Getting Started [📖 README](https://github.com/natefleming/dao-ai/blob/main/examples/01_getting_started/README.md)
 
 Foundation concepts for beginners.
 
@@ -108,7 +108,7 @@ Foundation concepts for beginners.
 
 ---
 
-### 02. MCP [📖 README](../examples/02_mcp/README.md)
+### 02. MCP [📖 README](https://github.com/natefleming/dao-ai/blob/main/examples/02_mcp/README.md)
 
 Integrate external services and Databricks capabilities via the Model Context Protocol.
 
@@ -124,7 +124,7 @@ Integrate external services and Databricks capabilities via the Model Context Pr
 
 ---
 
-### 03. Caching [📖 README](../examples/04_genie/README.md)
+### 03. Caching [📖 README](https://github.com/natefleming/dao-ai/blob/main/examples/04_genie/README.md)
 
 Improve performance and reduce costs through intelligent caching.
 
@@ -139,7 +139,7 @@ Improve performance and reduce costs through intelligent caching.
 
 ---
 
-### 05. Memory [📖 README](../examples/05_memory/README.md)
+### 05. Memory [📖 README](https://github.com/natefleming/dao-ai/blob/main/examples/05_memory/README.md)
 
 Persistent state management and long-term memory for multi-turn conversations.
 
@@ -157,7 +157,7 @@ All examples support the optional `extraction` config block for long-term memory
 
 ---
 
-### 06. On-Behalf-Of User [📖 README](../examples/06_on_behalf_of_user/README.md)
+### 06. On-Behalf-Of User [📖 README](https://github.com/natefleming/dao-ai/blob/main/examples/06_on_behalf_of_user/README.md)
 
 User-level authentication and access control with Unity Catalog.
 
@@ -170,7 +170,7 @@ User-level authentication and access control with Unity Catalog.
 
 ---
 
-### 07. Human-in-the-Loop [📖 README](../examples/07_human_in_the_loop/README.md)
+### 07. Human-in-the-Loop [📖 README](https://github.com/natefleming/dao-ai/blob/main/examples/07_human_in_the_loop/README.md)
 
 Approval workflows for sensitive operations.
 
@@ -183,7 +183,7 @@ Approval workflows for sensitive operations.
 
 ---
 
-### 08. Guardrails [📖 README](../examples/08_guardrails/README.md)
+### 08. Guardrails [📖 README](https://github.com/natefleming/dao-ai/blob/main/examples/08_guardrails/README.md)
 
 Automated safety and validation using MLflow judges (`mlflow.genai.judges.make_judge`). The prompt determines the evaluation type -- tone, completeness, veracity/groundedness, or any custom criteria. Tool context from the conversation is automatically extracted for veracity checks.
 
@@ -197,7 +197,7 @@ Automated safety and validation using MLflow judges (`mlflow.genai.judges.make_j
 
 ---
 
-### 09. Structured Output [📖 README](../examples/09_structured_output/README.md)
+### 09. Structured Output [📖 README](https://github.com/natefleming/dao-ai/blob/main/examples/09_structured_output/README.md)
 
 Enforce response format with JSON schema.
 
@@ -210,7 +210,7 @@ Enforce response format with JSON schema.
 
 ---
 
-### 10. Agent Integrations [📖 README](../examples/10_agent_integrations/README.md)
+### 10. Agent Integrations [📖 README](https://github.com/natefleming/dao-ai/blob/main/examples/10_agent_integrations/README.md)
 
 Call another agent as a tool using the first-class `type: app`, `type: serving_endpoint`, and `type: a2a` function types.
 
@@ -240,7 +240,7 @@ Call another agent as a tool using the first-class `type: app`, `type: serving_e
 
 ---
 
-### 11. Prompt Engineering [📖 README](../examples/11_prompt_engineering/README.md)
+### 11. Prompt Engineering [📖 README](https://github.com/natefleming/dao-ai/blob/main/examples/11_prompt_engineering/README.md)
 
 Define reusable prompts as first-class config objects and share them across agents.
 
@@ -326,7 +326,7 @@ enterprise_coordinator:
 
 ---
 
-### 12. Middleware [📖 README](../examples/12_middleware/README.md)
+### 12. Middleware [📖 README](https://github.com/natefleming/dao-ai/blob/main/examples/12_middleware/README.md)
 
 Cross-cutting concerns for production agents: validation, logging, monitoring, limits, retries, and privacy.
 
@@ -372,14 +372,14 @@ agents:
 ```
 
 **Real-World Example:**  
-The hardware store application uses store number validation to ensure users provide their store location for inventory lookups. See [`99_complete_applications/hardware_store/hardware_store.yaml`](../examples/99_complete_applications/hardware_store/hardware_store.yaml).
+The hardware store application uses store number validation to ensure users provide their store location for inventory lookups. See [`99_complete_applications/hardware_store/hardware_store.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/99_complete_applications/hardware_store/hardware_store.yaml).
 
 **Prerequisites:** Basic understanding of agents and prompts  
 **Next:** Learn multi-agent coordination in `13_orchestration/`
 
 ---
 
-### 13. Orchestration [📖 README](../examples/13_orchestration/README.md)
+### 13. Orchestration [📖 README](https://github.com/natefleming/dao-ai/blob/main/examples/13_orchestration/README.md)
 
 Multi-agent coordination patterns.
 
@@ -394,7 +394,7 @@ Multi-agent coordination patterns.
 
 ---
 
-### 14. Basic Tools [📖 README](../examples/14_basic_tools/README.md)
+### 14. Basic Tools [📖 README](https://github.com/natefleming/dao-ai/blob/main/examples/14_basic_tools/README.md)
 
 Simple tool integrations for SQL and data operations.
 
@@ -407,7 +407,7 @@ Simple tool integrations for SQL and data operations.
 
 ---
 
-### 15. Complete Applications [📖 README](../examples/99_complete_applications/README.md)
+### 15. Complete Applications [📖 README](https://github.com/natefleming/dao-ai/blob/main/examples/99_complete_applications/README.md)
 
 Full-featured, production-ready agent applications.
 
@@ -424,7 +424,7 @@ Full-featured, production-ready agent applications.
 
 ---
 
-### 18. Visualization [📖 README](../examples/17_visualization/README.md)
+### 18. Visualization [📖 README](https://github.com/natefleming/dao-ai/blob/main/examples/17_visualization/README.md)
 
 Generate Vega-Lite chart specs from structured data, delivered to clients via `custom_outputs.visualizations`.
 
@@ -481,6 +481,6 @@ See [Contributing Guide](contributing.md) for details.
 ## Navigation
 
 - [← Previous: Configuration Reference](configuration-reference.md)
-- [↑ Back to Documentation Index](../README.md#-documentation)
+- [↑ Back to Documentation Index](https://github.com/natefleming/dao-ai/blob/main/README.md#-documentation)
 - [Next: CLI Reference →](cli-reference.md)
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -34,7 +34,7 @@
 - [How do I orchestrate a parallel fan-out pattern?](#how-do-i-orchestrate-a-parallel-fan-out-pattern)
 - [How do I add guardrails to my agent?](#how-do-i-add-guardrails-to-my-agent)
 - [How do I add tools to my agent (UC functions, REST, MCP)?](#how-do-i-add-tools-to-my-agent-uc-functions-rest-mcp)
-- [How do I do RAG / AI Search with reranking?](#how-do-i-do-rag--ai-search-with-reranking)
+- [How do I do RAG / AI Search with reranking?](#how-do-i-do-rag-ai-search-with-reranking)
 - [How do I run long-running tasks?](#how-do-i-run-long-running-tasks)
 
 **MLflow Tracing & Monitoring**
@@ -84,7 +84,7 @@ Benefits:
 
 Most users stick to YAML and use pre-built tools.
 
-**Learn more:** [`docs/python-api.md`](python-api.md) · [`examples/01_getting_started/minimal.yaml`](../examples/01_getting_started/minimal.yaml)
+**Learn more:** [`docs/python-api.md`](python-api.md) · [`examples/01_getting_started/minimal.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/01_getting_started/minimal.yaml)
 
 ### Can I test locally before deploying?
 
@@ -105,7 +105,7 @@ print(response["messages"][-1].content)
 
 See [Lab 1 — Your First DAO-AI Agent](https://github.com/natefleming/dao-ai-workshop/tree/main/L100-foundations/lab-01-first-agent) for the shortest end-to-end example.
 
-**Learn more:** [`docs/python-api.md`](python-api.md) · [`examples/01_getting_started/`](../examples/01_getting_started/)
+**Learn more:** [`docs/python-api.md`](python-api.md) · [`examples/01_getting_started/`](https://github.com/natefleming/dao-ai/tree/main/examples/01_getting_started/)
 
 ### What's the learning curve?
 
@@ -115,17 +115,17 @@ See [Lab 1 — Your First DAO-AI Agent](https://github.com/natefleming/dao-ai-wo
 
 **If you're a business user:** Consider starting with [DAO AI Builder](https://github.com/natefleming/dao-ai-builder) (visual interface).
 
-**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`docs/examples.md`](examples.md) · [`examples/01_getting_started/`](../examples/01_getting_started/)
+**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`docs/examples.md`](examples.md) · [`examples/01_getting_started/`](https://github.com/natefleming/dao-ai/tree/main/examples/01_getting_started/)
 
 ### How do I get help?
 
-1. Check the [`examples/`](../examples/) directory for working examples
+1. Check the [`examples/`](https://github.com/natefleming/dao-ai/tree/main/examples/) directory for working examples
 2. Run through the [dao-ai-workshop](https://github.com/natefleming/dao-ai-workshop) — 25 self-paced labs covering every framework feature, each with a runnable notebook + YAML
-3. Review the documentation for detailed explanations — see the [docs index in the top-level README](../README.md#-documentation)
+3. Review the documentation for detailed explanations — see the [docs index in the top-level README](https://github.com/natefleming/dao-ai/blob/main/README.md#-documentation)
 4. Read the [Configuration Reference](configuration-reference.md) section
 5. Open an issue on GitHub
 
-**Learn more:** [`docs/examples.md`](examples.md) · [`examples/README.md`](../examples/README.md)
+**Learn more:** [`docs/examples.md`](examples.md) · [`examples/README.md`](https://github.com/natefleming/dao-ai/blob/main/examples/README.md)
 
 ## Deployment Questions
 
@@ -164,7 +164,7 @@ variables:
       - env: MY_API_KEY
 ```
 
-**Learn more:** [`docs/configuration-reference.md`](configuration-reference.md#dynamic-configuration-with-anyvariable) · [`examples/01_getting_started/`](../examples/01_getting_started/)
+**Learn more:** [`docs/configuration-reference.md`](configuration-reference.md#dynamic-configuration-with-anyvariable) · [`examples/01_getting_started/`](https://github.com/natefleming/dao-ai/tree/main/examples/01_getting_started/)
 
 ### How do I update a deployed agent?
 
@@ -221,7 +221,7 @@ databricks bundle run <app-name>
 4. **Monitor MLflow traces** to identify bottlenecks — see [Lab 24 — UC OTEL Trace Tables](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-24-uc-trace-location) for durable trace storage
 5. **Use appropriate model sizes** (larger models = slower but more accurate)
 
-**Learn more:** [`docs/genie_context_aware_cache_prompt_history.md`](genie_context_aware_cache_prompt_history.md) · [`examples/04_genie/`](../examples/04_genie/) · [`examples/03_reranking/`](../examples/03_reranking/)
+**Learn more:** [`docs/genie_context_aware_cache_prompt_history.md`](genie_context_aware_cache_prompt_history.md) · [`examples/04_genie/`](https://github.com/natefleming/dao-ai/tree/main/examples/04_genie/) · [`examples/03_reranking/`](https://github.com/natefleming/dao-ai/tree/main/examples/03_reranking/)
 
 ### What's the typical latency?
 
@@ -242,7 +242,7 @@ Latency depends on your configuration:
 4. **Set TTLs appropriately** to balance freshness vs. cache hits
 5. **Monitor usage** with MLflow tracking
 
-**Learn more:** [`docs/genie_context_aware_cache_prompt_history.md`](genie_context_aware_cache_prompt_history.md) · [`examples/04_genie/genie_context_aware_cache.yaml`](../examples/04_genie/genie_context_aware_cache.yaml)
+**Learn more:** [`docs/genie_context_aware_cache_prompt_history.md`](genie_context_aware_cache_prompt_history.md) · [`examples/04_genie/genie_context_aware_cache.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/04_genie/genie_context_aware_cache.yaml)
 
 ## Configuration Questions
 
@@ -255,9 +255,9 @@ Rule of thumb:
 - Should the value travel with the bundle (catalog name, schema, app name)? Use `parameters:`.
 - Should the value be read from the deployed environment or Databricks Secrets each time the agent runs (credentials, hostnames)? Use `variables:`.
 
-See [Parameters vs Variables](configuration-reference.md#parameters-vs-variables---the-lifecycle-distinction) for the full comparison table.
+See [Parameters vs Variables](configuration-reference.md#parameters-vs-variables-the-lifecycle-distinction) for the full comparison table.
 
-**Learn more:** [`docs/configuration-reference.md`](configuration-reference.md) · [`examples/01_getting_started/`](../examples/01_getting_started/)
+**Learn more:** [`docs/configuration-reference.md`](configuration-reference.md) · [`examples/01_getting_started/`](https://github.com/natefleming/dao-ai/tree/main/examples/01_getting_started/)
 
 ### What happens if I use `${var.NAME}` without declaring it?
 
@@ -265,7 +265,7 @@ If your YAML has a `parameters:` block, any `${var.NAME}` reference not declared
 
 If your YAML has no `parameters:` block at all, the undeclared-name check is skipped and the reference falls through to the inline `:-default` or the "missing required" error.
 
-**Learn more:** [`docs/configuration-reference.md`](configuration-reference.md#parameters)
+**Learn more:** [`docs/configuration-reference.md`](configuration-reference.md#parameters-load-time-substitution)
 
 ### Can I use a parameter to choose which secret to load?
 
@@ -310,7 +310,7 @@ resources:
 
 See [Lab 20 — A2A: HITL + OBO](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-20-a2a-hitl-obo) for the canonical end-to-end demonstration (approve/edit/reject over A2A with OBO). [Lab 10 — Human in the Loop](https://github.com/natefleming/dao-ai-workshop/tree/main/L200-real-agents/lab-10-hitl) covers the standalone HITL primitive that OBO commonly runs alongside.
 
-**Learn more:** [`docs/a2a_protocol.md`](a2a_protocol.md) · [`examples/06_on_behalf_of_user/`](../examples/06_on_behalf_of_user/) · [`examples/07_human_in_the_loop/`](../examples/07_human_in_the_loop/) · [`examples/19_a2a_protocol/a2a_hitl_obo.yaml`](../examples/19_a2a_protocol/a2a_hitl_obo.yaml)
+**Learn more:** [`docs/a2a_protocol.md`](a2a_protocol.md) · [`examples/06_on_behalf_of_user/`](https://github.com/natefleming/dao-ai/tree/main/examples/06_on_behalf_of_user/) · [`examples/07_human_in_the_loop/`](https://github.com/natefleming/dao-ai/tree/main/examples/07_human_in_the_loop/) · [`examples/19_a2a_protocol/a2a_hitl_obo.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/19_a2a_protocol/a2a_hitl_obo.yaml)
 
 ### How do I add human-in-the-loop approval to my tool calls?
 
@@ -336,7 +336,7 @@ tools:
 
 See [Lab 10 — Human in the Loop](https://github.com/natefleming/dao-ai-workshop/tree/main/L200-real-agents/lab-10-hitl) for the standalone primitive and [Lab 20 — A2A: HITL + OBO](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-20-a2a-hitl-obo) for HITL over the A2A protocol (approve/edit/reject via DataPart resume, SSE streaming).
 
-**Learn more:** [`examples/07_human_in_the_loop/`](../examples/07_human_in_the_loop/) · [`examples/19_a2a_protocol/a2a_hitl_obo.yaml`](../examples/19_a2a_protocol/a2a_hitl_obo.yaml) · [`docs/a2a_protocol.md`](a2a_protocol.md)
+**Learn more:** [`examples/07_human_in_the_loop/`](https://github.com/natefleming/dao-ai/tree/main/examples/07_human_in_the_loop/) · [`examples/19_a2a_protocol/a2a_hitl_obo.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/19_a2a_protocol/a2a_hitl_obo.yaml) · [`docs/a2a_protocol.md`](a2a_protocol.md)
 
 ### How do I use Genie with dao-ai?
 
@@ -366,7 +366,7 @@ agents:
 
 Create the Genie Space in the workspace UI first and copy its ID from the URL. See [Lab 3 — NL Analytics with Genie](https://github.com/natefleming/dao-ai-workshop/tree/main/L100-foundations/lab-03-genie) for the walkthrough, [Lab 12 — Genie Context-Aware Caching](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-12-genie-caching) for layering L1/L2 cache over the same tool, and [Lab 16 — Declarative Genie Space Provisioning](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-16-genie-provisioning) for provisioning the Space itself from YAML instead of the UI.
 
-**Learn more:** [`docs/genie_context_aware_cache_prompt_history.md`](genie_context_aware_cache_prompt_history.md) · [`examples/04_genie/`](../examples/04_genie/) (basic, context-aware cache, threshold optimization)
+**Learn more:** [`docs/genie_context_aware_cache_prompt_history.md`](genie_context_aware_cache_prompt_history.md) · [`examples/04_genie/`](https://github.com/natefleming/dao-ai/tree/main/examples/04_genie/) (basic, context-aware cache, threshold optimization)
 
 ### How do I use Unity AI Gateway?
 
@@ -386,9 +386,9 @@ resources:
 - `ai_gateway: true` is incompatible with `use_responses_api: true` on the same resource (the AI Gateway path exposes chat-completions only). dao-ai raises a validation error if both are set.
 - OBO (`on_behalf_of_user: true`) + `ai_gateway: true` is permitted but relatively new — verify end-to-end trace propagation in your workspace before shipping.
 
-Canonical example: [`examples/01_getting_started/ai_gateway.yaml`](../examples/01_getting_started/ai_gateway.yaml). Also used across `examples/99_complete_applications/commerce/`.
+Canonical example: [`examples/01_getting_started/ai_gateway.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/01_getting_started/ai_gateway.yaml). Also used across `examples/99_complete_applications/commerce/`.
 
-**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`examples/99_complete_applications/commerce/commerce_supervisor.yaml`](../examples/99_complete_applications/commerce/commerce_supervisor.yaml)
+**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`examples/99_complete_applications/commerce/commerce_supervisor.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/99_complete_applications/commerce/commerce_supervisor.yaml)
 
 ### How do I define reusable prompts?
 
@@ -419,7 +419,7 @@ agents:
 
 See [Lab 8 — Production Prompts and Guardrails](https://github.com/natefleming/dao-ai-workshop/tree/main/L200-real-agents/lab-08-prompts-guardrails). The lab walks from an inline-string prompt (`01_inline_support.yaml`) → a reusable `PromptModel` (`02_support_with_managed_prompts.yaml`) → the same setup with an added judge guardrail (`03_support_with_guardrails.yaml`).
 
-**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`examples/11_prompt_engineering/`](../examples/11_prompt_engineering/)
+**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`examples/11_prompt_engineering/`](https://github.com/natefleming/dao-ai/tree/main/examples/11_prompt_engineering/)
 
 ### How do I give my agent persistent memory / chat history?
 
@@ -455,7 +455,7 @@ app:
 
 See [Lab 7 — Persistent Memory + Chat Summarization](https://github.com/natefleming/dao-ai-workshop/tree/main/L200-real-agents/lab-07-memory) for the runnable walkthrough.
 
-**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`examples/05_memory/`](../examples/05_memory/) (in-memory, Lakebase, conversation-summarization variants)
+**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`examples/05_memory/`](https://github.com/natefleming/dao-ai/tree/main/examples/05_memory/) (in-memory, Lakebase, conversation-summarization variants)
 
 ### How do I orchestrate multiple agents?
 
@@ -482,7 +482,7 @@ orchestration:
 
 See [Lab 9 — Multi-agent Orchestration](https://github.com/natefleming/dao-ai-workshop/tree/main/L200-real-agents/lab-09-orchestration) for supervisor + swarm side by side, [Lab 17 — Deep Agent Orchestration](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-17-deep-agents) for the planning + Skills pattern, and [Lab 18 — Skills-only Deep Agent](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-18-skills-only-deep-agent) for the minimum-viable deep agent (zero sub-agents, one Skill).
 
-**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`docs/architecture.md`](architecture.md) · [`examples/13_orchestration/`](../examples/13_orchestration/) (deep-agent patterns) · [`examples/99_complete_applications/commerce/`](../examples/99_complete_applications/commerce/) and [`commerce_swarm/`](../examples/99_complete_applications/commerce/)
+**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`docs/architecture.md`](architecture.md) · [`examples/13_orchestration/`](https://github.com/natefleming/dao-ai/tree/main/examples/13_orchestration/) (deep-agent patterns) · [`examples/99_complete_applications/commerce/`](https://github.com/natefleming/dao-ai/tree/main/examples/99_complete_applications/commerce/) and [`commerce_swarm/`](https://github.com/natefleming/dao-ai/tree/main/examples/99_complete_applications/commerce/)
 
 ### How do I orchestrate a parallel fan-out pattern?
 
@@ -550,10 +550,10 @@ in a single turn" when that's the intent. If the LLM invokes only a subset,
 that's a valid degenerate case — only those siblings run, then the join.
 If it invokes zero, the source terminates and the join does not run.
 
-See [`examples/13_orchestration/parallel_fan_out_pattern.yaml`](../examples/13_orchestration/parallel_fan_out_pattern.yaml)
+See [`examples/13_orchestration/parallel_fan_out_pattern.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/13_orchestration/parallel_fan_out_pattern.yaml)
 for a complete deployable example.
 
-**Learn more:** [`examples/13_orchestration/`](../examples/13_orchestration/) · [`docs/key-capabilities.md`](key-capabilities.md)
+**Learn more:** [`examples/13_orchestration/`](https://github.com/natefleming/dao-ai/tree/main/examples/13_orchestration/) · [`docs/key-capabilities.md`](key-capabilities.md)
 
 ### How do I add guardrails to my agent?
 
@@ -577,7 +577,7 @@ Wire the guardrail(s) into an agent via `agents.<name>.guardrails: [...]`. Faile
 
 See [Lab 8 — Production Prompts and Guardrails](https://github.com/natefleming/dao-ai-workshop/tree/main/L200-real-agents/lab-08-prompts-guardrails) — the third YAML (`03_support_with_guardrails.yaml`) adds a judge guardrail to the prompts flow.
 
-**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`examples/08_guardrails/`](../examples/08_guardrails/)
+**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`examples/08_guardrails/`](https://github.com/natefleming/dao-ai/tree/main/examples/08_guardrails/)
 
 ### How do I add tools to my agent (UC functions, REST, MCP)?
 
@@ -628,7 +628,7 @@ MCP tools live under `tools:` (not `resources:`). Each tool has `name:` + `funct
 
 See the workshop's tool-grounding progression: [Lab 2 — Grounding with Unity Catalog Tools](https://github.com/natefleming/dao-ai-workshop/tree/main/L100-foundations/lab-02-uc-tools) → [Lab 4 — Schema-wide Tool Discovery with MCP](https://github.com/natefleming/dao-ai-workshop/tree/main/L100-foundations/lab-04-mcp) → [Lab 5 — External Integrations via REST](https://github.com/natefleming/dao-ai-workshop/tree/main/L200-real-agents/lab-05-rest).
 
-**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`docs/mcp_server.md`](mcp_server.md) · [`examples/14_basic_tools/`](../examples/14_basic_tools/) (REST, Slack) · [`examples/02_mcp/`](../examples/02_mcp/) (custom / external / filtered MCP)
+**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`docs/mcp_server.md`](mcp_server.md) · [`examples/14_basic_tools/`](https://github.com/natefleming/dao-ai/tree/main/examples/14_basic_tools/) (REST, Slack) · [`examples/02_mcp/`](https://github.com/natefleming/dao-ai/tree/main/examples/02_mcp/) (custom / external / filtered MCP)
 
 ### How do I do RAG / AI Search with reranking?
 
@@ -660,7 +660,7 @@ Reference the retriever from an `agents:` block (`agents.<name>.retrievers: [*kb
 
 For filter-heavy queries (*"Milwaukee power tools under $100"*), layer an **instructed retriever** on top: query decomposition into structured filters + a residual semantic query, then LLM-based rerank with natural-language instructions. See [Lab 6 — Knowledge-base Retrieval with AI Search](https://github.com/natefleming/dao-ai-workshop/tree/main/L200-real-agents/lab-06-vector-search) for the base pattern and [Lab 11 — Instructed Retrieval](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-11-instructed-retrieval) for the filter-decomposition variant.
 
-**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`examples/03_reranking/`](../examples/03_reranking/) · [`examples/15_instructed_retriever/`](../examples/15_instructed_retriever/)
+**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`examples/03_reranking/`](https://github.com/natefleming/dao-ai/tree/main/examples/03_reranking/) · [`examples/15_instructed_retriever/`](https://github.com/natefleming/dao-ai/tree/main/examples/15_instructed_retriever/)
 
 ### How do I use Lakebase Postgres as the retrieval backend instead of AI Search?
 
@@ -712,7 +712,7 @@ backfill_embeddings(retriever.vector_store)
 
 When to reach for `lakebase_search`: your source of truth already lives in Postgres, you want hybrid ANN + BM25 in a single call without a separate vector index, or you want to share auth + connection pooling with existing Lakebase workloads. The retriever exposes the same `filters:` and `rerank:` shape `ai_search` uses, so agent code doesn't change when you switch backends.
 
-**Learn more:** [`examples/20_lakebase_search/`](../examples/20_lakebase_search/) · [Lab 11 — Lakebase Search Retrieval](https://github.com/natefleming/dao-ai-workshop/tree/main/L200-real-agents/lab-11-lakebase-search)
+**Learn more:** [`examples/20_lakebase_search/`](https://github.com/natefleming/dao-ai/tree/main/examples/20_lakebase_search/) · [Lab 11 — Lakebase Search Retrieval](https://github.com/natefleming/dao-ai-workshop/tree/main/L200-real-agents/lab-11-lakebase-search)
 
 ### How do I run long-running tasks?
 
@@ -738,7 +738,7 @@ Clients then use any OpenAI-compatible SDK against the deployed app's `/response
 
 See [Lab 15 — Background Agents](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-15-background) for the runnable walkthrough.
 
-**Learn more:** [`docs/background_agents.md`](background_agents.md) · [`examples/18_background_agents/background_research.yaml`](../examples/18_background_agents/background_research.yaml) · [`examples/19_a2a_protocol/a2a_background.yaml`](../examples/19_a2a_protocol/a2a_background.yaml) (background over A2A)
+**Learn more:** [`docs/background_agents.md`](background_agents.md) · [`examples/18_background_agents/background_research.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/18_background_agents/background_research.yaml) · [`examples/19_a2a_protocol/a2a_background.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/19_a2a_protocol/a2a_background.yaml) (background over A2A)
 
 ---
 
@@ -778,7 +778,7 @@ The `dao-ai trace link` step is idempotent — safe on every deploy — but load
 
 See [Lab 24 — UC OTEL Trace Tables](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-24-uc-trace-location) for the walkthrough. **Note:** in-process notebook usage of the same config additionally needs `mlflow.langchain.autolog(run_tracer_inline=True)` + `dao_ai.logging.suppress_autolog_context_warnings()` — the deploy runtime does both automatically at boot, but the notebook flow must do them explicitly.
 
-**Learn more:** [`docs/configuration-reference.md`](configuration-reference.md) · [`examples/99_complete_applications/hardware_store/hardware_store.yaml`](../examples/99_complete_applications/hardware_store/hardware_store.yaml)
+**Learn more:** [`docs/configuration-reference.md`](configuration-reference.md) · [`examples/99_complete_applications/hardware_store/hardware_store.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/99_complete_applications/hardware_store/hardware_store.yaml)
 
 ### What extra permissions does Model Serving need for `trace_location`?
 
@@ -818,7 +818,7 @@ app:
 
 Precedence: `id` wins if both are set. When the whole `experiment:` block is omitted, dao-ai auto-creates `/Users/<deployer_email>/<app.name>` — fine for solo development but not what you want if a team shares one experiment (or if the experiment is pre-provisioned by an admin with tighter ACLs).
 
-The canonical worked example is [`examples/99_complete_applications/hardware_store/hardware_store.yaml`](../examples/99_complete_applications/hardware_store/hardware_store.yaml).
+The canonical worked example is [`examples/99_complete_applications/hardware_store/hardware_store.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/99_complete_applications/hardware_store/hardware_store.yaml).
 
 **Learn more:** [`docs/configuration-reference.md`](configuration-reference.md)
 
@@ -846,7 +846,7 @@ Monitoring is **independent** of `trace_location:` — it works over MLflow's de
 
 See [Lab 23 — Production Monitoring with Registered Scorers](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-23-production-monitoring) for the runtime side. For adjacent evaluation surfaces, [Lab 22 — Offline Evaluation](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-22-offline-evaluation) covers `mlflow.genai.evaluate()` on curated datasets, and [Lab 21 — User Feedback](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-21-feedback) covers attaching thumbs-up/thumbs-down assessments to live traces.
 
-**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`examples/08_guardrails/`](../examples/08_guardrails/)
+**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`examples/08_guardrails/`](https://github.com/natefleming/dao-ai/tree/main/examples/08_guardrails/)
 
 ---
 
@@ -877,7 +877,7 @@ For context-aware cache:
 
 See [Lab 12](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-12-genie-caching) for the reference config that pairs L1 (LRU exact-match) with L2 (embedding-similarity) over a Genie tool.
 
-**Learn more:** [`docs/genie_context_aware_cache_prompt_history.md`](genie_context_aware_cache_prompt_history.md) · [`examples/04_genie/`](../examples/04_genie/)
+**Learn more:** [`docs/genie_context_aware_cache_prompt_history.md`](genie_context_aware_cache_prompt_history.md) · [`examples/04_genie/`](https://github.com/natefleming/dao-ai/tree/main/examples/04_genie/)
 
 ### Deployment fails
 
@@ -897,7 +897,7 @@ Common issues:
 4. **Check model size**: Consider using smaller/faster models
 5. **Review middleware**: Disable unnecessary validation in dev
 
-**Learn more:** [`docs/architecture.md`](architecture.md) · [`examples/04_genie/`](../examples/04_genie/) · [`examples/03_reranking/`](../examples/03_reranking/)
+**Learn more:** [`docs/architecture.md`](architecture.md) · [`examples/04_genie/`](https://github.com/natefleming/dao-ai/tree/main/examples/04_genie/) · [`examples/03_reranking/`](https://github.com/natefleming/dao-ai/tree/main/examples/03_reranking/)
 
 ## Platform-Specific Questions
 
@@ -909,7 +909,7 @@ See the detailed comparison in [Why DAO?](why-dao.md#comparing-databricks-ai-age
 - **DAO**: Code-first, Git-native, advanced features (caching, middleware)
 - **Agent Bricks**: GUI-based, automated optimization, rapid prototyping
 
-**Learn more:** [`docs/why-dao.md`](why-dao.md) · [`examples/10_agent_integrations/agent_bricks.yaml`](../examples/10_agent_integrations/agent_bricks.yaml)
+**Learn more:** [`docs/why-dao.md`](why-dao.md) · [`examples/10_agent_integrations/agent_bricks.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/10_agent_integrations/agent_bricks.yaml)
 
 ### Can I use DAO with Agent Bricks or Kasal?
 
@@ -917,7 +917,7 @@ Yes! All three platforms can interoperate via **agent endpoints**. Deploy agents
 
 See [Using All Three Together](why-dao.md#using-all-three-together) for examples.
 
-**Learn more:** [`docs/why-dao.md`](why-dao.md) · [`examples/10_agent_integrations/`](../examples/10_agent_integrations/) (A2A, Agent Bricks, external agents)
+**Learn more:** [`docs/why-dao.md`](why-dao.md) · [`examples/10_agent_integrations/`](https://github.com/natefleming/dao-ai/tree/main/examples/10_agent_integrations/) (A2A, Agent Bricks, external agents)
 
 ### Does DAO work with external LLMs?
 
@@ -927,7 +927,7 @@ Yes! DAO supports:
 - Anthropic models (via Databricks endpoints)
 - Custom model endpoints
 
-**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`examples/01_getting_started/`](../examples/01_getting_started/)
+**Learn more:** [`docs/key-capabilities.md`](key-capabilities.md) · [`examples/01_getting_started/`](https://github.com/natefleming/dao-ai/tree/main/examples/01_getting_started/)
 
 ### How do I migrate from LangChain code to DAO?
 
@@ -938,7 +938,7 @@ Yes! DAO supports:
 5. **Set up orchestration**: Choose Supervisor or Swarm pattern
 6. **Test**: Validate and test locally before deploying
 
-Need help? Check the [`examples/`](../examples/) directory, or work through [Lab 13 — Programmatic Construction](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-13-programmatic), which builds the same `AppConfig` in pure Python instead of YAML — closest to the LangChain-code mental model.
+Need help? Check the [`examples/`](https://github.com/natefleming/dao-ai/tree/main/examples/) directory, or work through [Lab 13 — Programmatic Construction](https://github.com/natefleming/dao-ai-workshop/tree/main/L300-advanced/lab-13-programmatic), which builds the same `AppConfig` in pure Python instead of YAML — closest to the LangChain-code mental model.
 
 **Learn more:** [`docs/python-api.md`](python-api.md) · [`docs/architecture.md`](architecture.md)
 
@@ -947,6 +947,6 @@ Need help? Check the [`examples/`](../examples/) directory, or work through [Lab
 ## Navigation
 
 - [← Previous: Python API](python-api.md)
-- [↑ Back to Documentation Index](../README.md#-documentation)
+- [↑ Back to Documentation Index](https://github.com/natefleming/dao-ai/blob/main/README.md#-documentation)
 - [Next: Contributing →](contributing.md)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,49 @@
+# DAO: Declarative Agent Orchestration
+
+**Production-grade AI agents defined in YAML, powered by LangGraph, deployed on Databricks.**
+
+DAO is an **infrastructure-as-code framework** for building, deploying, and managing
+multi-agent AI systems. Instead of writing boilerplate Python to wire up agents, tools,
+and orchestration, you define everything declaratively in YAML configuration files.
+
+```yaml
+# Define an agent in 10 lines of YAML
+agents:
+  product_expert:
+    name: product_expert
+    model: *claude_sonnet
+    tools:
+      - *ai_search_tool
+      - *genie_tool
+    prompt: |
+      You are a product expert. Answer questions about inventory and pricing.
+```
+
+## Getting started
+
+- [**Why DAO?**](why-dao.md) — what DAO is and how it compares to other platforms.
+- [**Architecture**](architecture.md) — how DAO works under the hood.
+- [**Key Capabilities**](key-capabilities.md) — 20 features for production agents.
+
+## Reference
+
+- [**Configuration Reference**](configuration-reference.md) — the complete YAML schema.
+- [**CLI Reference**](cli-reference.md) — the `dao-ai` command-line interface.
+- [**Python API**](python-api.md) — programmatic usage and customization.
+
+## Guides
+
+- [**Examples**](examples.md) — ready-to-use example configurations.
+- [**MCP Server**](mcp_server.md) — expose a dao-ai agent as a single MCP tool.
+- [**A2A Protocol**](a2a_protocol.md) — Google Agent2Agent endpoints on every Apps deployment.
+- [**Background Agents**](background_agents.md) — kickoff / poll / cancel for multi-minute runs.
+- [**Auditable Tool Invocations**](audit.md) — tamper-evident approval receipts and audit-trail queries.
+
+## Visual configuration studio
+
+Prefer a visual interface?
+[**DAO AI Builder**](https://github.com/natefleming/dao-ai-builder) is a React web app that
+provides a graphical interface for creating and editing DAO configurations — explore
+capabilities, learn the configuration structure with guided forms, and build agents without
+writing YAML by hand. It generates valid configurations that work seamlessly with this
+framework.

--- a/docs/key-capabilities.md
+++ b/docs/key-capabilities.md
@@ -215,8 +215,8 @@ Cache parameter field renames on `type: genie`:
 **Supported resources:**
 ```yaml
 resources:
-  # LLMs - use caller's permissions for model access
-  llms:
+  # Models - use caller's permissions for model access
+  models:
     claude: &claude
       name: databricks-claude-3-7-sonnet
       on_behalf_of_user: true      # Inherits caller's model access
@@ -455,7 +455,7 @@ genie_tool:
 
 *(AI Search is the current Databricks name; older docs and configs may still call it Vector Search — dao-ai accepts both.)*
 
-> **`lakebase_search` parity (Stage 2, PR A):** the same `rerank` field with identical semantics is now available on `LakebaseRetrieverModel`. Set `rerank: true` for the default FlashRank model or provide a full `RerankParametersModel` — applies uniformly to the retriever's ANN, BM25, or HYBRID output. See [examples/20_lakebase_search/reranked.yaml](../examples/20_lakebase_search/reranked.yaml).
+> **`lakebase_search` parity (Stage 2, PR A):** the same `rerank` field with identical semantics is now available on `LakebaseRetrieverModel`. Set `rerank: true` for the default FlashRank model or provide a full `RerankParametersModel` — applies uniformly to the retriever's ANN, BM25, or HYBRID output. See [examples/20_lakebase_search/reranked.yaml](https://github.com/natefleming/dao-ai/blob/main/examples/20_lakebase_search/reranked.yaml).
 
 **The problem:** AI Search (semantic similarity) is fast but sometimes returns loosely related results. It's like a librarian who quickly grabs 50 books that *might* be relevant.
 
@@ -527,7 +527,7 @@ rerank:
 > → parallel search → RRF merge → instruction rerank → verifier retry loop)
 > is shared via `dao_ai.tools.instructed_pipeline` — both retrievers pass a
 > backend adapter callable. See
-> [examples/20_lakebase_search/instructed.yaml](../examples/20_lakebase_search/instructed.yaml).
+> [examples/20_lakebase_search/instructed.yaml](https://github.com/natefleming/dao-ai/blob/main/examples/20_lakebase_search/instructed.yaml).
 
 **The problem:** Standard AI Search ignores metadata constraints entirely. When a user asks "Milwaukee power drills under $200 from last month", semantic similarity alone can't enforce brand, price, or recency constraints. Queries with multiple intents or exclusions ("cordless tools excluding DeWalt") fare even worse.
 
@@ -648,7 +648,7 @@ instructed:
 
 **Fallback behavior:** If decomposition fails (LLM error, parsing error), the system automatically falls back to standard single-query search, ensuring robustness in production.
 
-**Example configurations:** See [`examples/15_instructed_retriever/`](../examples/15_instructed_retriever/) for complete working examples including basic instructed retrieval and the full pipeline with router and verifier.
+**Example configurations:** See [`examples/15_instructed_retriever/`](https://github.com/natefleming/dao-ai/tree/main/examples/15_instructed_retriever/) for complete working examples including basic instructed retrieval and the full pipeline with router and verifier.
 
 ## 6. Human-in-the-Loop Approvals
 
@@ -1557,8 +1557,8 @@ agents:
 6. **Security first**: Mask PII and sensitive data in logs
 
 **Example configurations:**
-- See [`examples/12_middleware/`](../examples/12_middleware/) for complete examples
-- See [`examples/99_complete_applications/hardware_store/hardware_store.yaml`](../examples/99_complete_applications/hardware_store/hardware_store.yaml) for production usage
+- See [`examples/12_middleware/`](https://github.com/natefleming/dao-ai/tree/main/examples/12_middleware/) for complete examples
+- See [`examples/99_complete_applications/hardware_store/hardware_store.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/99_complete_applications/hardware_store/hardware_store.yaml) for production usage
 
 ---
 
@@ -1719,7 +1719,7 @@ schemas:
     schema_name: agents
 
 resources:
-  llms:
+  models:
     default_llm: &default_llm
       name: databricks-claude-sonnet-4
       temperature: 0.1
@@ -1900,8 +1900,8 @@ middleware:
 | Production file storage on Databricks | `create_filesystem_middleware` with `backend_type: volume` |
 
 **Example configurations:**
-- See [`examples/12_middleware/deepagents_middleware.yaml`](../examples/12_middleware/deepagents_middleware.yaml) for a complete example
-- See [`examples/12_middleware/README.md`](../examples/12_middleware/README.md) for all middleware examples
+- See [`examples/12_middleware/deepagents_middleware.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/12_middleware/deepagents_middleware.yaml) for a complete example
+- See [`examples/12_middleware/README.md`](https://github.com/natefleming/dao-ai/blob/main/examples/12_middleware/README.md) for all middleware examples
 
 ### Deep Agent Orchestration (alternative to middleware)
 
@@ -1944,7 +1944,7 @@ app:
   agent that already participates in a swarm or supervisor graph.
 
 The two are mutually exclusive for a given graph — you don't need both at
-once. See [`examples/13_orchestration/deep_agent_*.yaml`](../examples/13_orchestration/) for working examples and the full pattern comparison.
+once. See [`examples/13_orchestration/deep_agent_*.yaml`](https://github.com/natefleming/dao-ai/tree/main/examples/13_orchestration/) for working examples and the full pattern comparison.
 
 ---
 
@@ -2006,7 +2006,7 @@ Each visualization in `custom_outputs.visualizations` has this shape:
 The client matches `message_id` to the response output item `id` and renders
 the spec using [vega-embed](https://github.com/vega/vega-embed).
 
-**Example configuration:** See [`examples/17_visualization/`](../examples/17_visualization/)
+**Example configuration:** See [`examples/17_visualization/`](https://github.com/natefleming/dao-ai/tree/main/examples/17_visualization/)
 
 ---
 
@@ -2075,7 +2075,7 @@ for architecture diagrams, Lakebase schema, streaming retrieve + cursor
 resumption, cancel semantics, connection-pool OAuth refresh, and the
 end-to-end demo notebook.
 
-**Example configuration:** See [`examples/18_background_agents/`](../examples/18_background_agents/)
+**Example configuration:** See [`examples/18_background_agents/`](https://github.com/natefleming/dao-ai/tree/main/examples/18_background_agents/)
 
 ---
 
@@ -2125,8 +2125,8 @@ app:
   the wire mappings, configuration surface, HITL/OBO semantics, task
   store selection, and scope of v0.3 compliance.
 
-**Example:** [`examples/19_a2a_protocol/a2a_minimal.yaml`](../examples/19_a2a_protocol/a2a_minimal.yaml)
-is a deploy-ready, dependency-free A2A agent; [`examples/19_a2a_protocol/client/client.py`](../examples/19_a2a_protocol/client/client.py)
+**Example:** [`examples/19_a2a_protocol/a2a_minimal.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/19_a2a_protocol/a2a_minimal.yaml)
+is a deploy-ready, dependency-free A2A agent; [`examples/19_a2a_protocol/client/client.py`](https://github.com/natefleming/dao-ai/blob/main/examples/19_a2a_protocol/client/client.py)
 is an end-to-end Python A2A client that exercises agent card, message/send,
 message/stream, and HITL resume.
 
@@ -2139,6 +2139,6 @@ message/stream, and HITL resume.
 ## Navigation
 
 - [← Previous: Architecture](architecture.md)
-- [↑ Back to Documentation Index](../README.md#-documentation)
+- [↑ Back to Documentation Index](https://github.com/natefleming/dao-ai/blob/main/README.md#-documentation)
 - [Next: Configuration Reference →](configuration-reference.md)
 

--- a/docs/lakebase.md
+++ b/docs/lakebase.md
@@ -183,10 +183,10 @@ docs = tool.invoke({"query": "How do I reset my password?"})
 
 | Example | Demonstrates |
 |---|---|
-| [`examples/20_lakebase_search/ann_only.yaml`](../examples/20_lakebase_search/ann_only.yaml) | Minimal ANN — no tsvector column required. |
-| [`examples/20_lakebase_search/bm25_only.yaml`](../examples/20_lakebase_search/bm25_only.yaml) | BM25 only — exact-term lookup (SKUs, error codes). |
-| [`examples/20_lakebase_search/hybrid_rrf.yaml`](../examples/20_lakebase_search/hybrid_rrf.yaml) | ANN + BM25 fused via RRF. |
-| [`examples/20_lakebase_search/reranked.yaml`](../examples/20_lakebase_search/reranked.yaml) | HYBRID + FlashRank cross-encoder rerank. |
-| [`examples/20_lakebase_search/filters_and_traces.yaml`](../examples/20_lakebase_search/filters_and_traces.yaml) | Static filters + MLflow `trace_location`. |
-| [`examples/20_lakebase_search/dynamic_schema.yaml`](../examples/20_lakebase_search/dynamic_schema.yaml) | Hand-declared `ColumnInfo` for per-column filter narrowing. |
-| [`examples/20_lakebase_search/instructed.yaml`](../examples/20_lakebase_search/instructed.yaml) | Full instructed retrieval pipeline (decompose → parallel → RRF → LLM rerank → verify). |
+| [`examples/20_lakebase_search/ann_only.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/20_lakebase_search/ann_only.yaml) | Minimal ANN — no tsvector column required. |
+| [`examples/20_lakebase_search/bm25_only.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/20_lakebase_search/bm25_only.yaml) | BM25 only — exact-term lookup (SKUs, error codes). |
+| [`examples/20_lakebase_search/hybrid_rrf.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/20_lakebase_search/hybrid_rrf.yaml) | ANN + BM25 fused via RRF. |
+| [`examples/20_lakebase_search/reranked.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/20_lakebase_search/reranked.yaml) | HYBRID + FlashRank cross-encoder rerank. |
+| [`examples/20_lakebase_search/filters_and_traces.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/20_lakebase_search/filters_and_traces.yaml) | Static filters + MLflow `trace_location`. |
+| [`examples/20_lakebase_search/dynamic_schema.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/20_lakebase_search/dynamic_schema.yaml) | Hand-declared `ColumnInfo` for per-column filter narrowing. |
+| [`examples/20_lakebase_search/instructed.yaml`](https://github.com/natefleming/dao-ai/blob/main/examples/20_lakebase_search/instructed.yaml) | Full instructed retrieval pipeline (decompose → parallel → RRF → LLM rerank → verify). |

--- a/docs/mcp_server.md
+++ b/docs/mcp_server.md
@@ -33,7 +33,7 @@ function calls run as the caller, not as the App's service principal.
 > **Migrating from an older release?** The MCP server was rewritten to
 > an agent-as-tool model in PR #154 (one MCP tool per app instead of
 > per-tool fan-out). See the "agent-as-tool refactor" entry in
-> [`CHANGELOG.md`](../CHANGELOG.md) for the full set of removed modules
+> [`CHANGELOG.md`](https://github.com/natefleming/dao-ai/blob/main/CHANGELOG.md) for the full set of removed modules
 > (`dao_ai.mcp.service`, `dao_ai.mcp.adapters/`, `AppModel.mcp_only`)
 > and the requirement that `config.app.name` is now mandatory.
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -101,7 +101,7 @@ tools = config.find_tools()
 vector_stores = config.resources.vector_stores
 
 # Access other resources
-llms = config.resources.llms
+models = config.resources.models  # `.llms` is a deprecated alias
 warehouses = config.resources.warehouses
 databases = config.resources.databases
 ```
@@ -339,7 +339,7 @@ positive = traces[has_pos]
 ```
 
 For SQL-side analysis, see
-[`notebooks/07_feedback_demo.py`](../notebooks/07_feedback_demo.py) — it
+[`notebooks/07_feedback_demo.py`](https://github.com/natefleming/dao-ai/blob/main/notebooks/07_feedback_demo.py) — it
 registers `mlflow.search_traces` results as a Spark temp view and
 demonstrates `LATERAL VIEW EXPLODE(assessments)` queries for daily
 up/down volume and feedback-by-trace.
@@ -349,6 +349,6 @@ up/down volume and feedback-by-trace.
 ## Navigation
 
 - [← Previous: CLI Reference](cli-reference.md)
-- [↑ Back to Documentation Index](../README.md#-documentation)
+- [↑ Back to Documentation Index](https://github.com/natefleming/dao-ai/blob/main/README.md#-documentation)
 - [Next: FAQ →](faq.md)
 

--- a/docs/why-dao.md
+++ b/docs/why-dao.md
@@ -166,6 +166,6 @@ tools:
 
 ## Navigation
 
-- [↑ Back to Documentation Index](../README.md#-documentation)
+- [↑ Back to Documentation Index](https://github.com/natefleming/dao-ai/blob/main/README.md#-documentation)
 - [Next: Architecture →](architecture.md)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,110 @@
+site_name: dao-ai
+site_description: Declarative Agent Orchestration — production-grade multi-agent AI systems defined in YAML, deployed on Databricks.
+site_author: Nate Fleming
+site_url: https://natefleming.github.io/dao-ai
+
+# Repository
+repo_name: natefleming/dao-ai
+repo_url: https://github.com/natefleming/dao-ai
+edit_uri: edit/main/docs/
+
+# Configuration
+theme:
+  name: material
+  palette:
+    # Palette toggle for light mode
+    - scheme: default
+      primary: black
+      accent: red
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Palette toggle for dark mode
+    - scheme: slate
+      primary: black
+      accent: red
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.instant
+    - navigation.tracking
+    - search.highlight
+    - search.share
+    - search.suggest
+    - toc.follow
+    - content.code.copy
+    - content.code.annotate
+    - content.action.edit
+  icon:
+    repo: fontawesome/brands/github
+
+# Extensions
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - admonition
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+
+# Empty per-application stub dirs not yet wired into the nav
+exclude_docs: |
+  hardware_store/
+  quick_serve_restaurant/
+
+# Plugins
+plugins:
+  - search
+
+# Navigation
+nav:
+  - Home: index.md
+  - Concepts:
+    - Why DAO?: why-dao.md
+    - Architecture: architecture.md
+    - Key Capabilities: key-capabilities.md
+  - Reference:
+    - Configuration Reference: configuration-reference.md
+    - CLI Reference: cli-reference.md
+    - Python API: python-api.md
+  - Guides:
+    - Examples: examples.md
+    - MCP Server: mcp_server.md
+    - MCP Callbacks: mcp-callbacks.md
+    - A2A Protocol: a2a_protocol.md
+    - Background Agents: background_agents.md
+    - Auditable Tool Invocations: audit.md
+    - Lakebase: lakebase.md
+    - MLflow Tracing: mlflow-tracing.md
+    - Genie Context-Aware Cache: genie_context_aware_cache_prompt_history.md
+  - FAQ: faq.md
+  - Contributing: contributing.md
+
+# Extra
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/natefleming/dao-ai


### PR DESCRIPTION
## Context

Getting the docs release-ready for the first `0.2.x`. The source docs were already accurate for 0.2.4 (version consistent, CLI reference matches `dao-ai --help`, install extras match `pyproject.toml`). The gap was **publishing**: the `gh-pages` site was ~14 months stale (still branded "Retail AI Documentation", ~1,750 commits behind), and there was no `mkdocs.yml` or deploy workflow on `main` even though the `[docs]` extra was declared.

## Changes

- **`mkdocs.yml`** (new) — Material theme with correct dao-ai branding/URLs, nav over the current flat `docs/`, native mermaid via pymdownx superfences (no `mermaid2` plugin), empty stub dirs excluded.
- **`docs/index.md`** (new) — purpose-built site home page (avoids README-relative-link breakage under `--strict`).
- **`.github/workflows/publish-docs.yaml`** (new) — `mkdocs build --strict` + `mkdocs gh-deploy --force` on GitHub `release: published` (+ `workflow_dispatch`), matching `publish-to-pypi.yaml`'s SHA-pinned/uv style.
- **121 cross-tree links** rewritten to absolute GitHub URLs (`blob/main` for files, `tree/main` for dirs). These `../examples/…`, `../README.md`, `../CHANGELOG.md` links work on GitHub but 404 on the published site, since MkDocs only publishes `docs/`. Absolute URLs are correct in both contexts.
- **5 broken/truncated in-page anchors** fixed (GitHub keeps double-hyphens from `/`, `—`, `+`; MkDocs collapses to single).
- **`resources.models` canonical naming** — example snippets updated off the deprecated `llms` alias in README + 4 docs (alias still valid).

## Verification

- `uv pip install ".[docs]" && uv run mkdocs build --strict` → **exits 0, zero warnings**.
- All 17 nav pages, mermaid diagrams, and rewritten links render in the built HTML; in-docs link checker reports 0 broken.

## One-time follow-up after merge

The first workflow run (on a release) creates/overwrites `gh-pages`. Set **GitHub Pages → Source = `gh-pages` branch** in repo settings so the fresh site replaces the stale "Retail AI" snapshot at https://natefleming.github.io/dao-ai.

This pull request and its description were written by Isaac.