### PR TITLE
docs: brand imagery, Deploy rewrite (up→build/sync/start), + DAO AI Workshop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,28 @@
-# DAO: Declarative Agent Orchestration
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/images/brand/logo-lockup-tagline.png">
+    <img src="docs/images/brand/logo-lockup-tagline-lightbg.png" width="480" alt="DAO-ai — Orchestrate. Collaborate. Automate.">
+  </picture>
+</p>
 
-[![Version](https://img.shields.io/badge/version-0.2.4-blue.svg)](CHANGELOG.md)
-[![Python](https://img.shields.io/badge/python-3.11+-green.svg)](https://www.python.org/)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+<p align="center">
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.2.4-blue.svg" alt="Version"></a>
+  <a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.11+-green.svg" alt="Python"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
+</p>
 
-**Production-grade AI agents defined in YAML, powered by LangGraph, deployed on Databricks.**
+<p align="center">
+  <img src="docs/images/hero/main-hero-panel.png" width="640" alt="DAO-ai orchestrator directing a team of specialist agents — researcher, planner, coder, writer, executor">
+</p>
+
+<p align="center"><strong>Production-grade AI agents defined in YAML, powered by LangGraph, deployed on Databricks.</strong></p>
+
+<p align="center">
+  <img src="docs/images/banners/yaml-first.png" height="76" alt="YAML First — configure everything with simple YAML">
+  <img src="docs/images/banners/python-powered.png" height="76" alt="Python Powered — built for developers, by developers">
+  <img src="docs/images/banners/modular-extensible.png" height="76" alt="Modular & Extensible — add your own agents, tools, and capabilities">
+  <img src="docs/images/banners/observability.png" height="76" alt="Observability Built-in — logs, traces, and metrics out of the box">
+</p>
 
 DAO is an **infrastructure-as-code framework** for building, deploying, and managing multi-agent AI systems. Instead of writing boilerplate Python code to wire up agents, tools, and orchestration, you define everything declaratively in YAML configuration files.
 
@@ -20,6 +38,17 @@ agents:
     prompt: |
       You are a product expert. Answer questions about inventory and pricing.
 ```
+
+### 🎓 Learn DAO: Hands-on Workshop
+
+New to DAO? Start with the **[DAO AI Workshop](https://github.com/natefleming/dao-ai-workshop)** — a self-paced, hands-on workshop that takes you from zero to a deployed, governed multi-agent system. Designed for solution architects, data engineers, and analysts, it's organized as **L100 → L200 → L300** with lectures and lab notebooks covering:
+
+- **Tool use** — Unity Catalog SQL functions and managed MCP servers
+- **NL-to-SQL** with Genie Spaces
+- **Vector search**, memory, and chat-history summarization
+- **Prompts + guardrails** and multi-agent orchestration
+
+By the end you'll have built, tested, and deployed a multi-agent system — all defined in YAML and running as a Databricks App.
 
 ### 🎨 Visual Configuration Studio
 
@@ -65,6 +94,10 @@ DAO AI Builder generates valid YAML configurations that work seamlessly with thi
 ---
 
 ## Quick Start
+
+<p align="center">
+  <img src="docs/images/banners/terminal-banner.png" width="560" alt="dao-ai — Orchestrate intelligence. Empower builders. Ship the future.">
+</p>
 
 ### Prerequisites
 
@@ -418,6 +451,8 @@ Full reference: [Parameters (Load-Time Substitution)](docs/configuration-referen
 
 ## Key Features at a Glance
 
+<a href="docs/key-capabilities.md"><img src="docs/images/stickers/team-of-agents.png" align="right" width="120" alt="Team of agents"></a>
+
 DAO provides powerful capabilities for building production-ready AI agents:
 
 | Feature | Description |
@@ -590,6 +625,8 @@ The CLI automatically:
 ---
 
 ## Contributing
+
+<a href="docs/contributing.md"><img src="docs/images/stickers/lets-build.png" align="right" width="110" alt="Let's build"></a>
 
 We welcome contributions! See the [Contributing Guide](docs/contributing.md) for details on:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,7 @@
 # Architecture
 
+<img src="images/mascots/yaml-scroll.png" align="right" width="130" alt="DAO-ai mascot holding an agents.yaml scroll">
+
 ## How It Works (Simple Explanation)
 
 Think of DAO as a three-layer cake:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -139,6 +139,11 @@ dao-ai agent start -c config/my_config.yaml --profile fevm
   **does not re-sync or rebuild** — it errors if nothing is synced. Re-run it any
   time to restart an app or re-execute a model_serving/workflow job.
 
+> If `app.trace_location` is set, run `dao-ai trace link` **between `sync` and
+> `start`** — otherwise traces silently drop (`TABLE_DOES_NOT_EXIST`) on re-deploys.
+> See [Linking the UC trace destination](#linking-the-uc-trace-destination-run-dao-ai-trace-link-between-deploy-and-run).
+> The one-command `up` path does this linking for you.
+
 To ship the **local dao-ai wheel** instead of the published PyPI package, add
 `--development` on `build` (or on `sync`, which can auto-build):
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -64,34 +64,87 @@ dao-ai graph -c config/my_config.yaml -o workflow.png --param catalog=main
 
 ## Deploy
 
-`dao-ai agent sync` deploys the agent using its staged bundle (the default path;
-it auto-generates the bundle first if nothing is staged). Pass `--mode model_serving`
-to deploy directly to Databricks Model Serving (no bundle). All paths call
-`AppConfig.create_agent()` + `deploy_agent()` in-process: for Model Serving it
-registers the MLflow model and creates the serving endpoint (`agents.deploy`); for
-Apps it uploads the config + source and drives the Apps REST API. Auto-links the UC
-trace destination and auto-grants the runtime service principal the trace-write
-permissions (gated on `app.manage_permissions`).
+Deploying an agent follows one lifecycle — **`build → sync → start`** — whether you
+run it as three explicit steps or let a single command do all three. Start with the
+one-command path and reach for the granular verbs only when you need them.
 
-For the bundle-less SDK fast-path (no bundle written to disk), use `agent up --direct`
-(apps/mcp only) — `--direct` is an `up`-only flag.
+All deploy paths call `AppConfig.create_agent()` + `deploy_agent()` in-process: for
+Model Serving it registers the MLflow model and creates the serving endpoint
+(`agents.deploy`); for Apps it uploads the config + source and drives the Apps REST
+API. Every path auto-links the UC trace destination and auto-grants the runtime
+service principal the trace-write permissions (gated on `app.manage_permissions`).
+
+### Start here: `up` — build, sync, and start in one command
+
+`dao-ai agent up` is the fast path to a live agent. It **builds** the bundle (if
+nothing is staged), **syncs** it to the workspace, links the trace destination, then
+**starts** it — the whole `build → sync → start` lifecycle in one idempotent command.
+This is what you want most of the time.
 
 ```bash
-# Deploy to Model Serving (SDK path, no bundle)
-dao-ai agent sync -c config/my_config.yaml --mode model_serving --profile fevm
+# Bring up a Databricks App (default mode) — build → sync → start
+dao-ai agent up -c config/my_config.yaml --profile fevm
 
-# Deploy as a Databricks App (bundle path, default)
-dao-ai agent sync -c config/my_config.yaml --mode apps --profile fevm
+# Bring up the MCP-server App
+dao-ai agent up -c config/my_config.yaml --mode mcp --profile fevm
 
-# Bring up as Apps via SDK directly (no bundle on disk — fast iteration)
+# Bring up on Model Serving (builds a thin deploy-agent Job, runs it to
+# register the model + create the endpoint)
+dao-ai agent up -c config/my_config.yaml --mode model_serving --profile fevm
+```
+
+`up` is safe to re-run: an unchanged config **skips the build** (content
+fingerprint) and the sync is **convergent**, so re-running never duplicates the
+bundle. The `start` step always executes — an app restarts, a model_serving job
+re-runs and registers a new model version — which is `start` doing its job.
+
+#### The `--direct` option — skip the bundle on disk
+
+Add `--direct` to `up` to go straight through the SDK **without writing a bundle to
+disk**. There is no staged artifact to inspect or hand-edit — dao-ai calls
+`create_agent`/`deploy_agent` directly. It works for **all three modes** (`apps`,
+`mcp`, `model_serving`) and inherently syncs and starts. Use it for fast iteration
+when you don't need an auditable bundle artifact. `--direct` is an **`up`-only** flag
+(it has no meaning on `build`/`sync`/`start`, which are defined by the bundle they act
+on).
+
+```bash
+# Bring up as an App via the SDK directly — no bundle on disk (fast iteration)
 dao-ai agent up -c config/my_config.yaml --mode apps --direct --profile fevm
+```
 
-# Deploy MCP server App
-dao-ai agent sync -c config/my_config.yaml --mode mcp --profile fevm
+### The granular lifecycle: `build → sync → start`
 
-# Ship the local dao-ai wheel instead of the published PyPI package
+When you want to inspect or hand-edit the bundle before it ships — or run the
+CI-style **build once, sync once, start N times** flow — drive the three steps
+yourself, in order:
+
+```bash
+# 1. build — stage the bundle to disk (inspect / hand-edit before shipping)
+dao-ai agent build -c config/my_config.yaml --profile fevm
+
+# 2. sync — push the staged bundle to the workspace (does NOT start it)
+dao-ai agent sync -c config/my_config.yaml --profile fevm
+
+# 3. start — make the synced bundle live (no re-sync; starts/restarts the app)
+dao-ai agent start -c config/my_config.yaml --profile fevm
+```
+
+- **`build`** stages the bundle and does nothing else. `sync` will auto-build first
+  if nothing is staged, so step 1 is optional unless you want to hand-edit.
+- **`sync`** pushes to the workspace but **does not start** the app (it runs
+  `databricks bundle deploy`). A `sync` that failed on a transient error is safe to
+  retry on its own — no rebuild.
+- **`start`** makes the synced bundle live (`databricks bundle run <app>`), and
+  **does not re-sync or rebuild** — it errors if nothing is synced. Re-run it any
+  time to restart an app or re-execute a model_serving/workflow job.
+
+To ship the **local dao-ai wheel** instead of the published PyPI package, add
+`--development` on `build` (or on `sync`, which can auto-build):
+
+```bash
 dao-ai agent build -c config/my_config.yaml --development --profile fevm
-dao-ai agent sync   -c config/my_config.yaml --profile fevm
+dao-ai agent sync  -c config/my_config.yaml --profile fevm
 ```
 
 Mode resolution: `--mode` flag wins; default is `apps`.
@@ -106,9 +159,13 @@ so this local stack never ships to the deployed endpoint.
 
 **When to use which:**
 
-- **`dao-ai agent sync --mode model_serving`** — deploy to Model Serving (SDK, no bundle). Best for iterating on the serving endpoint.
-- **`dao-ai agent sync --mode apps` / `--mode mcp`** — deploy Apps or MCP bundle. Generates on first run if unstaged; ships staged bundle if already generated.
-- **`dao-ai agent up --direct`** — bring up Apps/MCP via SDK without writing a bundle (fast iteration when you don't need an auditable bundle artifact). `--direct` is an `up`-only flag.
+- **`dao-ai agent up`** — the one-command path (`build → sync → start`). Reach for
+  this first for any mode: `apps` (default), `mcp`, or `model_serving`.
+- **`dao-ai agent up --direct`** — same, but SDK-direct with no bundle on disk. Best
+  for fast iteration when you don't need an auditable bundle artifact.
+- **`dao-ai agent build → sync → start`** — the granular flow. Use it to inspect or
+  hand-edit the staged bundle before shipping, or for the CI pattern *build once,
+  sync once, start N times*.
 - **`dao-ai workflow`** — provision the full backing infra (schemas,
   Vector Search, Lakebase, Genie, UC functions) *and* deploy the agent, as a
   multi-task Databricks Job. The job's deploy step runs the same

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,7 @@
 # Contributing to DAO
 
+<img src="images/stickers/lets-build.png" align="right" width="120" alt="Let's build">
+
 Thank you for your interest in contributing to DAO! This guide will help you get started.
 
 ## Project Structure

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,7 @@
 # Frequently Asked Questions (FAQ)
 
+<img src="images/mascots/heart-thumbs-up.png" align="right" width="120" alt="DAO-ai mascot giving a friendly thumbs up">
+
 ## Contents
 
 **General**

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,19 @@
+<p align="center">
+  <img src="images/brand/logo-lockup-tagline.png#only-dark" width="460" alt="DAO-ai — Orchestrate. Collaborate. Automate.">
+  <img src="images/brand/logo-lockup-tagline-lightbg.png#only-light" width="460" alt="DAO-ai — Orchestrate. Collaborate. Automate.">
+</p>
+
+<p align="center">
+  <img src="images/hero/main-hero-panel.png" width="620" alt="DAO-ai orchestrator directing a team of specialist agents — researcher, planner, coder, writer, executor">
+</p>
+
 # DAO: Declarative Agent Orchestration
 
 **Production-grade AI agents defined in YAML, powered by LangGraph, deployed on Databricks.**
+
+<p align="center">
+  <img src="images/banners/terminal-banner.png" width="540" alt="dao-ai — Orchestrate intelligence. Empower builders. Ship the future.">
+</p>
 
 DAO is an **infrastructure-as-code framework** for building, deploying, and managing
 multi-agent AI systems. Instead of writing boilerplate Python to wire up agents, tools,
@@ -18,6 +31,13 @@ agents:
     prompt: |
       You are a product expert. Answer questions about inventory and pricing.
 ```
+
+<p align="center">
+  <img src="images/banners/yaml-first.png" height="76" alt="YAML First — configure everything with simple YAML">
+  <img src="images/banners/python-powered.png" height="76" alt="Python Powered — built for developers, by developers">
+  <img src="images/banners/modular-extensible.png" height="76" alt="Modular & Extensible — add your own agents, tools, and capabilities">
+  <img src="images/banners/observability.png" height="76" alt="Observability Built-in — logs, traces, and metrics out of the box">
+</p>
 
 ## Getting started
 
@@ -39,11 +59,17 @@ agents:
 - [**Background Agents**](background_agents.md) — kickoff / poll / cancel for multi-minute runs.
 - [**Auditable Tool Invocations**](audit.md) — tamper-evident approval receipts and audit-trail queries.
 
-## Visual configuration studio
+## Companion projects
 
-Prefer a visual interface?
-[**DAO AI Builder**](https://github.com/natefleming/dao-ai-builder) is a React web app that
-provides a graphical interface for creating and editing DAO configurations — explore
-capabilities, learn the configuration structure with guided forms, and build agents without
-writing YAML by hand. It generates valid configurations that work seamlessly with this
-framework.
+DAO has two companion repos that make it easier to learn and to author configs:
+
+- [**DAO AI Workshop**](https://github.com/natefleming/dao-ai-workshop) — a self-paced,
+  hands-on workshop that takes you from zero to a deployed, governed multi-agent system.
+  Organized as **L100 → L200 → L300** with lectures and lab notebooks covering tool use,
+  NL-to-SQL with Genie, vector search, memory, prompts + guardrails, and orchestration —
+  all defined in YAML and running as a Databricks App. Start here if you're new to DAO.
+- [**DAO AI Builder**](https://github.com/natefleming/dao-ai-builder) — a React web app
+  that provides a graphical interface for creating and editing DAO configurations. Explore
+  capabilities, learn the configuration structure with guided forms, and build agents
+  without writing YAML by hand. It generates valid configurations that work seamlessly
+  with this framework.

--- a/docs/key-capabilities.md
+++ b/docs/key-capabilities.md
@@ -1,5 +1,7 @@
 # Key Capabilities
 
+<img src="images/stickers/team-of-agents.png" align="right" width="130" alt="A team of DAO-ai agents">
+
 These are the powerful features that make DAO production-ready. Don't worry if some seem complex — you can start simple and add these capabilities as you need them.
 
 ## 1. Dual Deployment Targets

--- a/docs/why-dao.md
+++ b/docs/why-dao.md
@@ -1,5 +1,7 @@
 # Why DAO?
 
+<img src="images/mascots/wand-thumbs-up.png" align="right" width="130" alt="DAO-ai mascot casting a wand">
+
 ## For Newcomers to AI Agents
 
 **What is an AI Agent?**

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,15 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="../docs/images/brand/logo-lockup.png">
+    <img src="../docs/images/brand/logo-lockup-lightbg.png" width="420" alt="DAO-ai">
+  </picture>
+</p>
+
 # DAO AI Example Configurations
+
+<p align="center">
+  <img src="../docs/images/banners/terminal-banner.png" width="540" alt="dao-ai — Orchestrate intelligence. Empower builders. Ship the future.">
+</p>
 
 Welcome to the DAO AI examples! This directory contains ready-to-use configurations organized in a **numbered, progressive learning path**.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,8 @@ edit_uri: edit/main/docs/
 # Configuration
 theme:
   name: material
+  logo: images/brand/logo-symbol.png
+  favicon: images/brand/logo-symbol.png
   palette:
     # Palette toggle for light mode
     - scheme: default


### PR DESCRIPTION
## Summary

Documentation-only changes across the root README, the MkDocs site, and `examples/README.md`. Three threads:

### 1. Brand imagery
The repo recently gained a self-documented library of AI-generated brand assets under `docs/images/` (logos, hero panel, terminal banner, feature banners, mascots, stickers, icons). The technical diagrams were already embedded; the branding imagery was not. This weaves it in:
- **Front page + root README**: main hero panel, logo lockup (light/dark theme swap), terminal banner, and the four feature banners.
- **MkDocs theme**: `logo` + `favicon` wired to `logo-symbol.png`.
- **Concept + guide pages**: tasteful single mascot/sticker accents (why-dao, architecture, key-capabilities, faq, contributing).

Light/dark handling follows the asset README's guidance (white-text lockups only on dark, `-lightbg` twins on light) using Material's `#only-light`/`#only-dark` in docs and GitHub's `<picture>` swap in the READMEs.

### 2. CLI Reference — Deploy section rewrite
Restructured to follow the customer journey instead of leading with `sync`:
- Leads with `agent up` (one command: **build → sync → start**), with examples for all three modes.
- Explains the **`up`-only** `--direct` SDK fast-path — corrected the prior "apps/mcp only" claim (the code supports all three modes: `cli.py` Route 1).
- Shows the granular **build → sync → start** flow in order.

I also audited **every runnable CLI example** across the docs against the live command surface (`dao-ai --help` + each subcommand). All examples are valid; legacy verbs (`generate`/`--deploy`/`--run`) appear only in the migration comparison table, which is correct.

### 3. DAO AI Workshop
Added the [DAO AI Workshop](https://github.com/natefleming/dao-ai-workshop) alongside DAO AI Builder as a companion project on both home surfaces.

## Verification
- `mkdocs build --strict` passes with no warnings.
- All referenced image paths and example config paths resolve.
- Existing diagram embeds untouched; no `uv.lock` / `site/` churn.

This pull request and its description were written by Isaac.