### PR TITLE
feat(cli): auto-adopt existing workspace resources before bundle deploy

### DIFF
--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -3646,6 +3646,196 @@ def _declared_bundle_variables(bundle_dir: Path) -> set[str]:
     return set(variables) if isinstance(variables, dict) else set()
 
 
+def _bundle_subprocess_env(profile: Optional[str]) -> dict[str, str]:
+    """Env for a side ``databricks`` subprocess, mirroring _exec_bundle_command.
+
+    When a profile is passed, the ambient ``DATABRICKS_*`` auth vars are cleared
+    so the profile is authoritative (same rule the streaming executor applies).
+    """
+    env = os.environ.copy()
+    if profile:
+        for var in DATABRICKS_AUTH_ENV_VARS:
+            env.pop(var, None)
+    return env
+
+
+def _adopt_untracked_bundle_resources(
+    *,
+    staging_dir: Path,
+    profile: Optional[str],
+    target: Optional[str],
+    extra_vars: Optional[list[str]] = None,
+    dry_run: bool = False,
+) -> None:
+    """Adopt workspace resources that exist but aren't in this bundle's state.
+
+    Runs BEFORE ``bundle deploy`` for every sync scenario (agent apps/mcp,
+    ``agent --mode model_serving``, and ``workflow`` — they all funnel through
+    :func:`_exec_bundle_command`). The DABs ``direct`` engine plans a CREATE for
+    any resource missing from its deploy state; if that resource already exists
+    in the workspace (a prior ``--direct`` SDK deploy, a manual create, or a
+    reset state), the CREATE fails with 409 ALREADY_EXISTS. This makes deploy
+    idempotent: for each resource the plan would CREATE that ALSO already exists
+    in the workspace, ``bundle deployment bind`` adopts it into state so the
+    deploy UPDATEs instead.
+
+    Best-effort by design: any failure here (plan errors, unparseable JSON, a
+    failed/again-bound bind) is logged and swallowed so the real ``bundle
+    deploy`` still runs and surfaces its own errors. Enumeration is delegated to
+    ``bundle plan`` (the engine's authoritative per-resource action list); only
+    id-resolution + the bind call are per-resource.
+    """
+    import json as _json
+
+    plan_cmd: list[str] = ["databricks"]
+    if profile:
+        plan_cmd.extend(["--profile", profile])
+    plan_cmd.extend(["bundle", "plan", "--output", "json"])
+    if target:
+        plan_cmd.extend(["--target", target])
+    # summary/plan re-evaluate the bundle and hard-fail on unset required --vars
+    # (e.g. the Job bundle's config_path); forward the same overrides deploy uses.
+    plan_cmd.extend(extra_vars or [])
+
+    env = _bundle_subprocess_env(profile)
+    try:
+        out = subprocess.run(
+            plan_cmd,
+            cwd=str(staging_dir),
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+        )
+        if out.returncode != 0:
+            logger.debug(
+                f"bundle plan for resource adoption failed (rc={out.returncode}); "
+                f"skipping adopt. stderr: {out.stderr.strip()[:400]}"
+            )
+            return
+        plan = _json.loads(out.stdout).get("plan") or {}
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"Could not compute bundle plan for resource adoption: {e}")
+        return
+
+    # Collect (bundle-resource-key, workspace-resource-id) to bind: every plan
+    # entry the engine would CREATE whose resource ALREADY exists in the
+    # workspace. Key form is ``resources.<type>.<short-key>``.
+    to_bind: list[tuple[str, str]] = []
+    for node, entry in plan.items():
+        if not isinstance(entry, dict) or entry.get("action") != "create":
+            continue
+        parts = node.split(".")
+        if len(parts) != 3 or parts[0] != "resources":
+            continue
+        _, rtype, short_key = parts
+        rid: Optional[str] = _resolve_existing_resource_id(rtype, short_key, entry, profile)
+        if rid is not None:
+            to_bind.append((short_key, rid))
+
+    if not to_bind:
+        return
+
+    for short_key, rid in to_bind:
+        bind_cmd: list[str] = ["databricks"]
+        if profile:
+            bind_cmd.extend(["--profile", profile])
+        bind_cmd.extend(["bundle", "deployment", "bind", short_key, rid, "--auto-approve"])
+        if target:
+            bind_cmd.extend(["--target", target])
+        if dry_run:
+            logger.info(f"[DRY RUN] Would run: {' '.join(bind_cmd)}")
+            continue
+        try:
+            logger.info(
+                f"Adopting existing workspace resource into bundle state: "
+                f"bind {short_key} -> {rid}"
+            )
+            bound = subprocess.run(
+                bind_cmd,
+                cwd=str(staging_dir),
+                capture_output=True,
+                text=True,
+                timeout=120,
+                env=env,
+            )
+            if bound.returncode != 0:
+                # Non-fatal: already-bound / racing / transient — the subsequent
+                # deploy still runs and reports any real problem itself.
+                logger.debug(
+                    f"bundle deployment bind {short_key} -> {rid} returned "
+                    f"rc={bound.returncode}; continuing. stderr: "
+                    f"{bound.stderr.strip()[:400]}"
+                )
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"bind {short_key} -> {rid} failed: {e}; continuing.")
+
+
+def _resolve_existing_resource_id(
+    rtype: str,
+    short_key: str,
+    plan_entry: dict[str, Any],
+    profile: Optional[str],
+) -> Optional[str]:
+    """Workspace id to bind, if a would-CREATE resource already exists — else None.
+
+    Apps are self-contained: the plan's ``new_state`` carries the app name, and
+    an app's bind id IS its name. Other resource types (jobs, pipelines,
+    experiments) use a numeric workspace id not present in an unbound plan entry,
+    so they're resolved by name via the SDK. Returning None means "leave it" — a
+    genuine create, not a 409 risk. Never raises.
+    """
+    try:
+        from databricks.sdk import WorkspaceClient
+        from databricks.sdk.errors import NotFound
+    except Exception:  # noqa: BLE001
+        return None
+
+    new_state = (plan_entry.get("new_state") or {}).get("value") or {}
+
+    try:
+        w = WorkspaceClient(profile=profile) if profile else WorkspaceClient()
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"Could not init WorkspaceClient for adopt lookup: {e}")
+        return None
+
+    try:
+        if rtype == "apps":
+            # App id == app name; confirm it actually exists in the workspace.
+            name = new_state.get("name")
+            if not name:
+                return None
+            w.apps.get(name=name)
+            return str(name)
+
+        if rtype == "jobs":
+            name = new_state.get("name")
+            if not name:
+                return None
+            for job in w.jobs.list(name=name):
+                if job.settings and job.settings.name == name and job.job_id:
+                    return str(job.job_id)
+            return None
+
+        if rtype == "pipelines":
+            name = new_state.get("name")
+            if not name:
+                return None
+            for p in w.pipelines.list_pipelines(filter=f"name LIKE '{name}'"):
+                if p.name == name and p.pipeline_id:
+                    return str(p.pipeline_id)
+            return None
+
+        # Other types (experiments, etc.): conservative — the app/job/pipeline
+        # resources are the create-vs-update 409 cases. Skip rather than guess.
+        return None
+    except NotFound:
+        return None
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"adopt id-resolution for {rtype}.{short_key} failed: {e}")
+        return None
+
+
 def _exec_bundle_command(
     command: list[str],
     *,
@@ -3670,6 +3860,19 @@ def _exec_bundle_command(
         extra_vars: pre-formatted ``--var="k=v"`` args to append.
         dry_run: print the command instead of executing.
     """
+    # Before a deploy, adopt any workspace resource that already exists but is
+    # missing from this bundle's deploy state, so the deploy UPDATEs instead of
+    # issuing a CREATE that 409s (ALREADY_EXISTS). Best-effort; covers every sync
+    # path since they all deploy through here. run/destroy/other verbs skip this.
+    if command[:2] == ["bundle", "deploy"]:
+        _adopt_untracked_bundle_resources(
+            staging_dir=cwd,
+            profile=profile,
+            target=target,
+            extra_vars=extra_vars,
+            dry_run=dry_run,
+        )
+
     cmd: list[str] = ["databricks"]
     if profile:
         cmd.extend(["--profile", profile])

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -2283,3 +2283,202 @@ class TestParametersSubcommand:
     def test_config_still_required(self) -> None:
         with pytest.raises(SystemExit):
             parse_args(["parameters", "list"])
+
+
+# ---------------------------------------------------------------------------
+# Auto-adopt: bind an existing-but-untracked workspace resource before deploy
+# so `bundle deploy` UPDATEs instead of 409-ing on a blind CREATE.
+# ---------------------------------------------------------------------------
+
+
+import json as _json  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+
+def _plan_json(*resources: tuple[str, str, dict]) -> str:
+    """Build a `bundle plan --output json` payload.
+
+    Each resource is (node_type, short_key, extra_entry_fields). The node key is
+    ``resources.<type>.<short_key>``; extra fields (e.g. action, new_state) merge
+    into the entry.
+    """
+    plan: dict = {}
+    for rtype, key, fields in resources:
+        plan[f"resources.{rtype}.{key}"] = fields
+    return _json.dumps({"plan": plan})
+
+
+def _completed(returncode: int, stdout: str = "", stderr: str = "") -> SimpleNamespace:
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+@pytest.mark.unit
+class TestAdoptUntrackedBundleResources:
+    _APP_CREATE = (
+        "apps",
+        "my-app",
+        {"action": "create", "new_state": {"value": {"name": "my-app"}}},
+    )
+
+    def _run_adopt(
+        self, tmp_path: Path, *, plan: str, target: str = "dev",
+        extra_vars=None, dry_run: bool = False, app_exists: bool = True,
+    ):
+        """Drive the helper with subprocess + WorkspaceClient patched.
+
+        Returns the list of argv lists passed to subprocess.run so the test can
+        assert which commands (plan/bind) ran.
+        """
+        calls: list[list[str]] = []
+
+        def _fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[-3:] == ["bundle", "plan", "--output"] or "plan" in cmd:
+                return _completed(0, stdout=plan)
+            return _completed(0)  # bind
+
+        w = MagicMock()
+        if app_exists:
+            w.apps.get.return_value = SimpleNamespace(name="my-app")
+        else:
+            from databricks.sdk.errors import NotFound
+
+            w.apps.get.side_effect = NotFound("no such app")
+
+        with patch.object(cli.subprocess, "run", side_effect=_fake_run), patch(
+            "databricks.sdk.WorkspaceClient", return_value=w
+        ):
+            cli._adopt_untracked_bundle_resources(
+                staging_dir=tmp_path, profile="fevm", target=target,
+                extra_vars=extra_vars, dry_run=dry_run,
+            )
+        return calls
+
+    def test_app_would_create_and_exists_binds(self, tmp_path: Path) -> None:
+        calls = self._run_adopt(tmp_path, plan=_plan_json(self._APP_CREATE))
+        bind_calls = [c for c in calls if "bind" in c]
+        assert len(bind_calls) == 1
+        b = bind_calls[0]
+        assert b[-4:] == ["bind", "my-app", "my-app", "--auto-approve"] or (
+            "bind" in b and "my-app" in b and "--auto-approve" in b
+        )
+
+    def test_app_would_create_but_absent_no_bind(self, tmp_path: Path) -> None:
+        calls = self._run_adopt(
+            tmp_path, plan=_plan_json(self._APP_CREATE), app_exists=False
+        )
+        assert not [c for c in calls if "bind" in c]
+
+    def test_resource_skip_action_no_bind(self, tmp_path: Path) -> None:
+        entry = ("apps", "my-app", {"action": "skip"})
+        calls = self._run_adopt(tmp_path, plan=_plan_json(entry))
+        assert not [c for c in calls if "bind" in c]
+
+    def test_dry_run_prints_no_bind(self, tmp_path: Path) -> None:
+        calls = self._run_adopt(
+            tmp_path, plan=_plan_json(self._APP_CREATE), dry_run=True
+        )
+        # plan still runs (read-only); bind is NOT executed as a subprocess.
+        assert not [c for c in calls if "bind" in c]
+        assert any("plan" in c for c in calls)
+
+    def test_bind_failure_is_swallowed(self, tmp_path: Path) -> None:
+        def _fake_run(cmd, **kwargs):
+            if "plan" in cmd:
+                return _completed(0, stdout=_plan_json(self._APP_CREATE))
+            return _completed(1, stderr="bind boom")  # bind fails
+
+        w = MagicMock()
+        w.apps.get.return_value = SimpleNamespace(name="my-app")
+        with patch.object(cli.subprocess, "run", side_effect=_fake_run), patch(
+            "databricks.sdk.WorkspaceClient", return_value=w
+        ):
+            # Must not raise.
+            cli._adopt_untracked_bundle_resources(
+                staging_dir=tmp_path, profile="fevm", target="dev",
+            )
+
+    def test_plan_failure_is_noop(self, tmp_path: Path) -> None:
+        def _fake_run(cmd, **kwargs):
+            return _completed(1, stderr="plan boom")
+
+        with patch.object(cli.subprocess, "run", side_effect=_fake_run):
+            cli._adopt_untracked_bundle_resources(
+                staging_dir=tmp_path, profile="fevm", target="dev",
+            )  # no raise, no bind
+
+    def test_plan_non_json_is_noop(self, tmp_path: Path) -> None:
+        def _fake_run(cmd, **kwargs):
+            return _completed(0, stdout="not json")
+
+        with patch.object(cli.subprocess, "run", side_effect=_fake_run):
+            cli._adopt_untracked_bundle_resources(
+                staging_dir=tmp_path, profile="fevm", target="dev",
+            )
+
+    def test_job_target_and_vars_forwarded(self, tmp_path: Path) -> None:
+        calls = self._run_adopt(
+            tmp_path,
+            plan=_plan_json(),  # empty plan; we only assert the plan argv
+            target="myapp-aws",
+            extra_vars=['--var="config_path=../config/x.yaml"'],
+        )
+        plan_call = next(c for c in calls if "plan" in c)
+        assert "--target" in plan_call and "myapp-aws" in plan_call
+        assert '--var="config_path=../config/x.yaml"' in plan_call
+
+
+@pytest.mark.unit
+class TestDeployTriggersAdopt:
+    """The adopt step fires only for `bundle deploy`, across both exec paths."""
+
+    def _fake_popen(self):
+        """A Popen stand-in whose stdout.readline drains cleanly (empty output)."""
+        proc = MagicMock()
+        proc.stdout.readline.side_effect = [""]  # iter(readline, "") stops at once
+        proc.wait.return_value = None
+        proc.returncode = 0
+        return proc
+
+    def test_deploy_triggers_adopt(self, tmp_path: Path) -> None:
+        with patch.object(cli, "_adopt_untracked_bundle_resources") as adopt, patch.object(
+            cli.subprocess, "Popen", return_value=self._fake_popen()
+        ):
+            cli._exec_bundle_command(
+                ["bundle", "deploy"], profile="fevm", target="dev", cwd=tmp_path,
+            )
+        adopt.assert_called_once()
+        assert adopt.call_args.kwargs["target"] == "dev"
+        assert adopt.call_args.kwargs["staging_dir"] == tmp_path
+
+    def test_run_skips_adopt(self, tmp_path: Path) -> None:
+        with patch.object(cli, "_adopt_untracked_bundle_resources") as adopt, patch.object(
+            cli.subprocess, "Popen", return_value=self._fake_popen()
+        ):
+            cli._exec_bundle_command(
+                ["bundle", "run", "my-app"], profile="fevm", target="dev", cwd=tmp_path,
+            )
+        adopt.assert_not_called()
+
+    def test_destroy_skips_adopt(self, tmp_path: Path) -> None:
+        with patch.object(cli, "_adopt_untracked_bundle_resources") as adopt, patch.object(
+            cli.subprocess, "Popen", return_value=self._fake_popen()
+        ):
+            cli._exec_bundle_command(
+                ["bundle", "destroy", "--auto-approve"], profile="fevm",
+                target="dev", cwd=tmp_path,
+            )
+        adopt.assert_not_called()
+
+    def test_job_deploy_forwards_target_and_vars(self, tmp_path: Path) -> None:
+        with patch.object(cli, "_adopt_untracked_bundle_resources") as adopt, patch.object(
+            cli.subprocess, "Popen", return_value=self._fake_popen()
+        ):
+            cli._exec_bundle_command(
+                ["bundle", "deploy"], profile="fevm", target="myapp-aws",
+                cwd=tmp_path, extra_vars=['--var="mode=apps"'],
+            )
+        adopt.assert_called_once()
+        assert adopt.call_args.kwargs["target"] == "myapp-aws"
+        assert adopt.call_args.kwargs["extra_vars"] == ['--var="mode=apps"']


### PR DESCRIPTION
## Problem
`dao-ai agent sync`/`up` (and `workflow sync`) failed with **409 ALREADY_EXISTS** when the target App already existed in the workspace but was missing from the DABs `direct`-engine deploy state. `bundle deploy` planned a blind CREATE (`POST /api/2.0/apps`) against an existing resource; dao-ai had no 409 handling, so the deploy hard-failed.

This happens when the app was created outside the current bundle-state lineage — an earlier `--direct` SDK deploy (which does get-or-create but writes no bundle state), a manual/UI create, or a reset state file.

## Fix
Add `_adopt_untracked_bundle_resources`, invoked before every `bundle deploy` at the shared `_exec_bundle_command` chokepoint — so it covers **all sync scenarios** uniformly (agent apps/mcp, `agent --mode model_serving`, and `workflow`). `run`/`destroy` are skipped; the `--direct` SDK path never reaches here.

It runs `bundle plan --output json` (the engine's authoritative per-resource action list) and, for each resource the plan would **create** that **also already exists** in the workspace, runs `bundle deployment bind <key> <id> --auto-approve` so the deploy UPDATEs instead of CREATE-ing.

- App id resolves from the plan's `new_state.name`; jobs/pipelines resolve by name via the SDK; unknown/absent resources are left alone (a genuine create).
- **Best-effort**: plan/bind failures are logged and swallowed so a real deploy still runs and surfaces its own errors.
- `dry_run` prints the bind commands.

## Verification (live on fevm)
- Repro precondition: `bundle plan` showed the app as `create` while the app existed.
- After fix: `dao-ai agent sync` issued `POST /api/2.0/apps/<name>/update` (UPDATE, not CREATE) → **Deployment complete!**, no 409.
- Plan action flipped `create` → `update`; re-sync is idempotent (no bind, no 409).
- 12 new unit tests (7 adopt-behavior + 5 chokepoint wiring); full CLI suite 268 passed.

No `config.py` change, so no `make schema`.

This pull request and its description were written by Isaac.