### PR TITLE
fix(cli): workflow sync auto-builds when unstaged, matching agent sync

### DIFF
--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -3948,7 +3948,19 @@ def run_databricks_command(
 
         use_local_source: bool = resolve_use_local_source(development)
 
-        if stage:
+        # Auto-build when a `sync` (bundle deploy) lands on an unstaged dir —
+        # matching `agent sync`'s build-if-needed contract (CDK/SAM norm) so a
+        # deploy "just works" from a clean checkout. `start`/`down` still error
+        # on an unstaged dir (nothing to run/destroy), like agent start/down.
+        is_deploy: bool = command is not None and command[:2] == ["bundle", "deploy"]
+        unstaged: bool = not (staging_dir / "databricks.yaml").exists()
+        auto_build: bool = (not stage) and is_deploy and unstaged
+        if stage or auto_build:
+            if auto_build:
+                logger.info(
+                    f"No staged workflow bundle at {staging_dir}; "
+                    f"auto-generating before deploy."
+                )
             # Regenerate the owned default dir cleanly so stale dev artifacts
             # (e.g. dist/ wheels) don't linger across dev/published switches.
             _clean_default_staging_dir(
@@ -3968,8 +3980,8 @@ def run_databricks_command(
             _write_staging_manifest(
                 staging_dir, is_default=is_default_dir, registry=registry or {}
             )
-        elif not (staging_dir / "databricks.yaml").exists():
-            # Standalone sync/start/down on an unstaged dir: nothing to run.
+        elif unstaged:
+            # Standalone start/down on an unstaged dir: nothing to run/destroy.
             logger.error(
                 f"No staged workflow bundle at {staging_dir}. "
                 f"Run `dao-ai workflow build -c {config}"
@@ -4401,7 +4413,14 @@ def handle_workflow_command(options: Namespace) -> None:
 
 
 def _exec_workflow_verb(options: Namespace, command: list[str]) -> None:
-    """Run a bundle verb against an already-staged workflow bundle (no restage)."""
+    """Run a bundle verb against a staged workflow bundle (no forced restage).
+
+    ``stage=False`` so an already-staged bundle deploys in place. A `sync`
+    (``bundle deploy``) on an UNSTAGED dir auto-builds first (see
+    :func:`run_databricks_command`), matching `agent sync`; `start`/`down` still
+    error on an unstaged dir. ``development``/``overwrite`` (parsed only on
+    ``sync``) are forwarded so the auto-build honors them.
+    """
     run_databricks_command(
         command,
         profile=options.profile,
@@ -4410,8 +4429,10 @@ def _exec_workflow_verb(options: Namespace, command: list[str]) -> None:
         cloud=options.cloud,
         dry_run=options.dry_run,
         mode=getattr(options, "mode", None),
+        development=getattr(options, "development", None),
         config_vars=_parse_var_args(options.var),
         staging_dir=options.staging_dir,
+        overwrite=getattr(options, "overwrite", False),
         stage=False,
     )
 

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -613,28 +613,108 @@ class TestPipelineEmitsDevelopmentVar:
         exec_mock.assert_called_once()
         assert exec_mock.call_args.kwargs["cwd"] == out
 
-    def test_stage_false_errors_when_not_staged(
+    _CFG = (
+        "resources:\n  models:\n    m: &m\n      name: databricks-gpt-5-4-mini\n"
+        "agents:\n  g: &g\n    name: g\n    description: d\n    model: *m\n"
+        "    prompt: p\n"
+        "app:\n  name: stage_only_app\n  agents:\n    - *g\n"
+    )
+
+    def test_stage_false_deploy_auto_builds_when_not_staged(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """`workflow deploy` against an unstaged dir exits with guidance."""
+        """`workflow sync` (stage=False, `bundle deploy`) on an UNSTAGED dir now
+        auto-builds first, then deploys — matching `agent sync`."""
         cfg = tmp_path / "c.yaml"
-        cfg.write_text(
-            "resources:\n  models:\n    m: &m\n      name: databricks-gpt-5-4-mini\n"
-            "agents:\n  g: &g\n    name: g\n    description: d\n    model: *m\n"
-            "    prompt: p\n"
-            "app:\n  name: stage_only_app\n  agents:\n    - *g\n"
-        )
+        cfg.write_text(self._CFG)
+        out = tmp_path / "nonexistent"  # no databricks.yaml on disk
+
+        wrote: dict[str, object] = {}
         monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
         monkeypatch.setattr(cli, "detect_cloud_provider", lambda p: "aws")
+        monkeypatch.setattr(
+            "dao_ai.pipeline.bundle.write_pipeline_bundle",
+            lambda *a, **k: wrote.setdefault("wrote", True) or {},
+        )
+        monkeypatch.setattr(cli, "_write_staging_manifest", lambda *a, **k: None)
+        monkeypatch.setattr(cli, "_clean_default_staging_dir", lambda *a, **k: None)
+        exec_mock = patch.object(cli, "_exec_bundle_command").start()
+
+        run_databricks_command(
+            ["bundle", "deploy"],
+            config=str(cfg),
+            staging_dir=str(out),
+            development=False,
+            stage=False,
+        )
+        patch.stopall()
+
+        assert wrote.get("wrote") is True, "unstaged deploy must auto-build"
+        exec_mock.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            ["bundle", "run", "deploy_job"],  # start
+            ["bundle", "destroy", "--auto-approve"],  # down
+        ],
+    )
+    def test_stage_false_start_down_still_error_when_not_staged(
+        self, command: list[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`workflow start`/`down` on an unstaged dir still exit with guidance —
+        only `sync` (bundle deploy) auto-builds; there's nothing to run/destroy."""
+        cfg = tmp_path / "c.yaml"
+        cfg.write_text(self._CFG)
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(cli, "detect_cloud_provider", lambda p: "aws")
+        wrote: dict[str, object] = {}
+        monkeypatch.setattr(
+            "dao_ai.pipeline.bundle.write_pipeline_bundle",
+            lambda *a, **k: wrote.setdefault("wrote", True) or {},
+        )
         with pytest.raises(SystemExit) as exc:
             run_databricks_command(
-                ["bundle", "deploy"],
+                command,
                 config=str(cfg),
                 staging_dir=str(tmp_path / "nonexistent"),
                 development=False,
                 stage=False,
             )
         assert exc.value.code == 1
+        assert "wrote" not in wrote, "start/down must NOT auto-build"
+
+
+@pytest.mark.unit
+class TestWorkflowSyncForwardsSourceFlags:
+    """`workflow sync` parses --development/--overwrite; _exec_workflow_verb must
+    forward them so the auto-build (unstaged deploy) honors them."""
+
+    def test_sync_forwards_development_and_overwrite(self) -> None:
+        opts = parse_args(
+            ["workflow", "sync", "-c", "c.yaml", "--development", "--overwrite"]
+        )
+        captured: dict = {}
+        with patch.object(
+            cli, "run_databricks_command",
+            side_effect=lambda *a, **k: captured.update(k),
+        ):
+            cli._exec_workflow_verb(opts, ["bundle", "deploy"])
+        assert captured["development"] is True
+        assert captured["overwrite"] is True
+        assert captured["stage"] is False
+
+    def test_start_defaults_when_flags_absent(self) -> None:
+        # start doesn't parse the source flags; forwarding must fall back safely.
+        opts = parse_args(["workflow", "start", "-c", "c.yaml"])
+        captured: dict = {}
+        with patch.object(
+            cli, "run_databricks_command",
+            side_effect=lambda *a, **k: captured.update(k),
+        ):
+            cli._exec_workflow_verb(opts, ["bundle", "run", "deploy_job"])
+        assert captured["development"] is None
+        assert captured["overwrite"] is False
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem
`dao-ai workflow sync` on an unstaged dir **errored** ("No staged workflow bundle... Run `dao-ai workflow build` first" → `sys.exit(1)`), while `dao-ai agent sync` **auto-builds** then deploys. `workflow sync` was the lone outlier — `agent sync`, `agent up`, and `workflow up` all build-if-needed.

| entry point | unstaged → |
|---|---|
| `agent sync` | auto-build |
| `agent up` | auto-build |
| `workflow up` | auto-build |
| `workflow sync` | **error** ← outlier |

## Fix
Turn the unstaged-error branch in `run_databricks_command` into an auto-build, but **only for `bundle deploy`** (sync/up). `start` (`bundle run deploy_job`) and `down` (`bundle destroy`) still error on an unstaged dir — there's nothing to run/destroy — matching `agent start`/`down`.

- Already-staged dirs still deploy in place (no forced restage), mirroring `agent sync` exactly.
- Plumb `development`/`overwrite` through `_exec_workflow_verb` so the auto-build honors the flags `sync` already parses (it was discarding them).

## Verification
- **Live (fevm):** `rm -rf .dao-ai/bundle/workflow/<app>` then `workflow sync --dry-run` logs "auto-generating before deploy", stages, and would deploy — no error. `workflow start` on the same clean dir still exits with build-first guidance.
- **Unit:** `workflow sync` unstaged auto-builds; `workflow start`/`down` unstaged still `exit(1)` and do NOT build; `_exec_workflow_verb` forwards development/overwrite. Full CLI suite: 260 passed.

No `config.py` change, so no `make schema`.

This pull request and its description were written by Isaac.