### PR TITLE
refactor(cli): strict lifecycle primitives, `up` is the sole orchestrator

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -130,11 +130,13 @@ dao-ai agent sync -c config/my_config.yaml --profile fevm
 dao-ai agent start -c config/my_config.yaml --profile fevm
 ```
 
-- **`build`** stages the bundle and does nothing else. `sync` will auto-build first
-  if nothing is staged, so step 1 is optional unless you want to hand-edit.
+- **`build`** stages the bundle and does nothing else. `sync`/`start`/`down`
+  require it first (they never build) — or use `up`, the one command that builds
+  for you.
 - **`sync`** pushes to the workspace but **does not start** the app (it runs
-  `databricks bundle deploy`). A `sync` that failed on a transient error is safe to
-  retry on its own — no rebuild.
+  `databricks bundle deploy`) and **does not build** — it errors if nothing is
+  staged. A `sync` that failed on a transient error is safe to retry on its own —
+  no rebuild.
 - **`start`** makes the synced bundle live (`databricks bundle run <app>`), and
   **does not re-sync or rebuild** — it errors if nothing is synced. Re-run it any
   time to restart an app or re-execute a model_serving/workflow job.
@@ -145,7 +147,7 @@ dao-ai agent start -c config/my_config.yaml --profile fevm
 > The one-command `up` path does this linking for you.
 
 To ship the **local dao-ai wheel** instead of the published PyPI package, add
-`--development` on `build` (or on `sync`, which can auto-build):
+`--development` on `build` (or on `up`, which builds):
 
 ```bash
 dao-ai agent build -c config/my_config.yaml --development --profile fevm
@@ -231,15 +233,16 @@ dao-ai workflow up|build|sync|start|down  -c <cfg> [-p <profile>]
 - **`build`** stages a bundle to disk (`<base>/<noun>/<app>`, where `<base>` is
   `$DAO_AI_BUNDLE_DIR` or `./.dao-ai/bundle`, or `-s <dir>`) and does nothing
   else — inspect or hand-edit the staged files before shipping.
-- **`sync`** pushes the bundle to the workspace but **does not start it**. For
+- **`sync`** pushes the **already-built** bundle to the workspace but **does not
+  start it**, and **does not build** — run `build` (or `up`) first; it errors
+  with the exact next command if nothing is staged. This is uniform across every
+  noun and mode (`agent`/`workflow` × `apps`/`mcp`/`model_serving`) — a primitive
+  acts on prepared state, it never provisions its own prerequisites. For
   `agent`/`mcp`, `sync` runs `databricks bundle deploy` — it creates/updates the
-  App resource and uploads its source; when a staged bundle exists it syncs it in
-  place (preserving hand-edits), and when **nothing is staged it auto-builds
-  first**, so `dao-ai agent sync -c <cfg> -p fevm` works from a clean tree. For
-  `workflow`, `sync` acts on the **already-built** bundle and does **not**
-  auto-build — run `dao-ai workflow build` (or `workflow up`) first; it errors if
-  nothing is staged. Use `--mode model_serving` on `agent sync` to go SDK-direct
-  to an endpoint.
+  App resource and uploads its source; a staged bundle is synced in place
+  (preserving hand-edits), and on config drift it warns and deploys as-is rather
+  than rebuilding. Use `--mode model_serving` on `agent sync` to sync the
+  deploy-agent Job bundle.
 - **`start`** makes the synced bundle live and **does not re-sync, build, or
   push** — it errors if nothing is synced. For `agent`/`mcp`, `start` runs
   `databricks bundle run <app>` (starts/restarts the app — a DABs App is not
@@ -269,9 +272,9 @@ per-file SHA-256 registry — content-based, so mtime-preserving copies can't
 defeat it), unless you pass `--overwrite`. The error points you at
 `<noun> sync` to ship the edits instead. A `-s <dir>` is never auto-wiped.
 The source-selection flags `--overwrite`, `--development`, and `--no-development`
-are on `up`, `build`, and `sync` (for `agent`/`mcp`, `sync` can auto-build; for
-`workflow` it acts on the already-built bundle); `start` and `down` act on
-already-built artifacts and don't carry them.
+take effect on the verbs that build — `up` and `build`. `sync`/`start`/`down`
+act on already-built artifacts and never build, so these flags don't apply
+there.
 
 > **Migration:** the flat commands `generate-agent`, `generate-mcp`, and
 > `generate-workflow` have been removed. Use `dao-ai agent build`,
@@ -914,10 +917,9 @@ dao-ai workflow down  -c config/my_config.yaml [OPTIONS]
 ```
 
 `up` builds (if needed) → syncs → starts in one command. `build` stages the
-bundle only; `sync` pushes the already-built bundle (unlike `agent sync`,
-`workflow sync` does **not** auto-build — run `build` or `up` first);
-`start`/`down` act on already-built artifacts. For `workflow`, `start` is
-`databricks bundle run deploy_job` (the provisioning job).
+bundle only; `sync`/`start`/`down` act on the already-built bundle and never
+build — run `build` (or `up`) first, else they error with the next command. For
+`workflow`, `start` is `databricks bundle run deploy_job` (the provisioning job).
 
 | Option | Description | Verbs |
 |--------|-------------|-------|
@@ -929,8 +931,8 @@ bundle only; `sync` pushes the already-built bundle (unlike `agent sync`,
 | `-t, --target NAME` | Bundle target name (auto-generated if not specified) | all |
 | `--mode {apps,mcp,model_serving}` | Serving mode selector (default: `apps`; `ms`/`model-serving` accepted as aliases). Forwarded to the deploy-agent job step as a runtime var. | all |
 | `--dry-run` | Preview commands without executing | all |
-| `--overwrite` | Overwrite copied-in files in the staging dir | `up`, `build`, `sync` |
-| `--development` / `--no-development` | Ship the local dao-ai wheel vs pin PyPI (default: auto-detect) | `up`, `build`, `sync` |
+| `--overwrite` | Overwrite copied-in files in the staging dir | `up`, `build` |
+| `--development` / `--no-development` | Ship the local dao-ai wheel vs pin PyPI (default: auto-detect) | `up`, `build` |
 | `--direct` | Go via SDK directly, no bundle on disk (apps/mcp) | `up` |
 
 The flat `generate-workflow` command and the one-shot `generate --deploy/--run`
@@ -948,9 +950,9 @@ dao-ai agent down  -c config/my_config.yaml [OPTIONS]
 ```
 
 `up` builds (if needed) → syncs → starts in one command. `build` stages the
-bundle only; `sync` pushes it (auto-building if nothing is staged);
-`start`/`down` act on already-built artifacts. For `agent`, `start` is
-`databricks bundle run <app>`.
+bundle only; `sync`/`start`/`down` act on the already-built bundle and never
+build — run `build` (or `up`) first, else they error with the next command. For
+`agent`, `start` is `databricks bundle run <app>`.
 
 | Option | Description | Verbs |
 |--------|-------------|-------|
@@ -961,8 +963,8 @@ bundle only; `sync` pushes it (auto-building if nothing is staged);
 | `--mode {apps,mcp,model_serving}` | Serving target (default: `apps`; `ms`/`model-serving` accepted as aliases) | all |
 | `--dry-run` | Preview commands without executing | all |
 | `--direct` | Go via SDK directly, no bundle on disk (all modes) | `up` |
-| `--overwrite` | Overwrite existing files in the output directory | `up`, `build`, `sync` |
-| `--development` / `--no-development` | Bundle a local dao-ai wheel vs pin PyPI (default: auto-detect) | `up`, `build`, `sync` |
+| `--overwrite` | Overwrite existing files in the output directory | `up`, `build` |
+| `--development` / `--no-development` | Bundle a local dao-ai wheel vs pin PyPI (default: auto-detect) | `up`, `build` |
 
 The flat `generate-agent` / `generate-mcp` commands and the one-shot
 `generate --deploy/--run` flags have been removed — use `dao-ai agent up` (or

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -3970,10 +3970,12 @@ def run_databricks_command(
             )
         elif not (staging_dir / "databricks.yaml").exists():
             # Standalone sync/start/down on an unstaged dir: nothing to run.
+            # Primitives never build — `up` is the sole orchestrator/builder.
+            _s: str = f" -s {staging_dir_arg}" if staging_dir_arg else ""
             logger.error(
                 f"No staged workflow bundle at {staging_dir}. "
-                f"Run `dao-ai workflow build -c {config}"
-                f"{f' -s {staging_dir_arg}' if staging_dir_arg else ''}` first."
+                f"Run `dao-ai workflow build -c {config}{_s}` first "
+                f"(or `dao-ai workflow up -c {config}{_s}` to build, sync, and run)."
             )
             sys.exit(1)
 
@@ -4490,6 +4492,9 @@ def _handle_up_workflow_command(options: Namespace) -> None:
         config_vars=config_vars,
         staging_dir=staging_dir,
         overwrite=overwrite,
+        # Build already happened on the deploy call above; the run must NOT
+        # re-stage (that rebuilt the bundle every `up`). `up` builds exactly once.
+        stage=False,
     )
 
 
@@ -4685,12 +4690,26 @@ def _deploy_run_destroy_app_bundle(
     )
     is_staged: bool = (bundle_dir / "databricks.yaml").exists()
 
-    if not is_staged and not deploy:
-        # start/down on an unstaged dir: nothing to act on.
+    # Only `up` (deploy AND run) orchestrates build→sync→start; the granular
+    # primitives (sync=deploy, start=run, down=destroy) act on prepared state and
+    # NEVER build. So `up` is the sole builder, and any primitive on an unstaged
+    # dir errors with the exact next command — a single, consistent contract
+    # across agent|workflow × apps|mcp|ms (this guard precedes the mode split).
+    orchestrating: bool = deploy and run
+
+    if not is_staged and not orchestrating:
+        _s: str = f" -s {options.staging_dir}" if options.staging_dir else ""
+        nxt: str = (
+            f"Run `dao-ai {kind} build -c {options.config}{_s}` first"
+            if deploy  # sync: only build is missing
+            else (
+                f"Run `dao-ai {kind} build -c {options.config}{_s}` + "
+                f"`dao-ai {kind} sync -c {options.config}{_s}` first"
+            )  # start/down: build AND sync are missing
+        )
         logger.error(
-            f"No staged {kind} bundle at {bundle_dir}. "
-            f"Run `dao-ai {kind} build -c {options.config}"
-            f"{f' -s {options.staging_dir}' if options.staging_dir else ''}` first."
+            f"No staged {kind} bundle at {bundle_dir}. {nxt} "
+            f"(or `dao-ai {kind} up -c {options.config}{_s}` to do it all)."
         )
         sys.exit(1)
 
@@ -4700,14 +4719,14 @@ def _deploy_run_destroy_app_bundle(
         # Fingerprint the UNRESOLVED config (matches the generate-time stamp).
         fingerprint: str = _config_fingerprint(config, development=development)
 
-        # Decide whether to (re)stage. Fresh dir → stage (CDK/SAM auto-generate
-        # norm). Already staged → stage only when the source config drifted from
-        # the staged fingerprint, and only if the dir carries no hand-edits (or
-        # --overwrite). A stale bundle with hand-edits deploys in place with a
-        # warning so the user's edits win but they're told source changes aren't
-        # reflected. run/destroy never reach here unstaged (guarded above).
-        should_stage: bool = not is_staged
-        if is_staged and _staged_config_is_stale(bundle_dir, fingerprint):
+        # Only `up` builds. A pure `sync` never (re)stages — it deploys what's on
+        # disk (erroring above if nothing is staged), and on config drift it warns
+        # + deploys in place rather than silently rebuilding. `up` builds when
+        # unstaged and rebuilds a clean dir on drift (hand-edits preserved).
+        should_stage: bool = orchestrating and not is_staged
+        if orchestrating and is_staged and _staged_config_is_stale(
+            bundle_dir, fingerprint
+        ):
             # Only a dao-ai-owned default dir is safe to rebuild; a user `-s`
             # dir is never touched. --overwrite forces rebuild even over
             # hand-edits; otherwise a clean default dir rebuilds and an edited
@@ -4728,6 +4747,14 @@ def _deploy_run_destroy_app_bundle(
                     f"--overwrite (or re-run `dao-ai {kind} build --overwrite`) "
                     f"to discard the edits and rebuild from the current config."
                 )
+        elif is_staged and _staged_config_is_stale(bundle_dir, fingerprint):
+            # Pure `sync` on a drifted bundle: never rebuild — deploy in place and
+            # tell the user how to pick up the config change.
+            logger.warning(
+                f"Source config changed since {bundle_dir} was built; syncing "
+                f"the staged bundle as-is. Run `dao-ai {kind} build` (or `up`) "
+                f"to rebuild from the current config."
+            )
 
         if should_stage:
             if not is_staged:

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -1007,11 +1007,12 @@ class TestAgentModeWriterSelection:
             f"Expected mcp staging dir path to contain /mcp, got {resolved['mcp']}"
         )
 
-    def test_agent_deploy_model_serving_uses_ms_writer_and_job_driver(
+    def test_agent_up_model_serving_uses_ms_writer_and_job_driver(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """agent deploy --mode model_serving stages via the MS writer and runs
-        the Job driver (_run_ms_job_bundle), NOT the App driver."""
+        """agent up --mode model_serving stages via the MS writer and runs
+        the Job driver (_run_ms_job_bundle), NOT the App driver. (Only `up`
+        builds; unstaged `sync` errors.)"""
         called: dict[str, bool] = {}
         monkeypatch.setattr(
             "dao_ai.pipeline.bundle.write_model_serving_agent_bundle",
@@ -1030,7 +1031,7 @@ class TestAgentModeWriterSelection:
                 opts = parse_args(
                     [
                         "agent",
-                        "sync",
+                        "up",
                         "-c",
                         str(cfg),
                         "-s",
@@ -1048,7 +1049,8 @@ class TestAgentModeWriterSelection:
 
 @pytest.mark.unit
 class TestDeployRestagesOnConfigDrift:
-    """agent deploy re-stages an already-staged bundle when the source config drifts."""
+    """agent `up` re-stages an already-staged bundle when the source config drifts.
+    (Re-staging on drift is an `up`-only concern — `sync` never rebuilds.)"""
 
     def _write_config(self, tmp_path: Path) -> Path:
         cfg = tmp_path / "c.yaml"
@@ -1099,7 +1101,7 @@ class TestDeployRestagesOnConfigDrift:
             lambda *a, **k: restaged.setdefault("staged", True),
         )
 
-        argv = ["agent", "sync", "-c", str(cfg)]
+        argv = ["agent", "up", "-c", str(cfg)]
         if overwrite:
             argv.append("--overwrite")
         opts = parse_args(argv)
@@ -1164,6 +1166,141 @@ class TestDeployRestagesOnConfigDrift:
             )
             is True
         )
+
+
+_STRICT_CFG = (
+    "resources:\n  models:\n    m: &m\n      name: databricks-gpt-5-4-mini\n"
+    "agents:\n  g: &g\n    name: g\n    description: d\n    model: *m\n"
+    "    prompt: p\n"
+    "app:\n  name: my_app\n  agents:\n    - *g\n"
+)
+
+
+@pytest.mark.unit
+class TestStrictPrimitivesErrorWhenUnstaged:
+    """Model B: only `up` builds. sync/start/down on an unstaged dir error with
+    the exact next command — consistent across agent (apps/mcp/ms) and workflow.
+    `up` on the same unstaged dir succeeds (auto-builds)."""
+
+    def _cfg(self, tmp_path: Path) -> Path:
+        cfg = tmp_path / "c.yaml"
+        cfg.write_text(_STRICT_CFG)
+        return cfg
+
+    @pytest.mark.parametrize("verb", ["sync", "start", "down"])
+    @pytest.mark.parametrize("mode", ["apps", "mcp", "model_serving"])
+    def test_agent_primitive_errors_when_unstaged(
+        self, verb: str, mode: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = self._cfg(tmp_path)
+        out = tmp_path / "out"  # no databricks.yaml
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        # Guard must fire BEFORE any writer/driver — patch them to blow up if hit.
+        monkeypatch.setattr(
+            "dao_ai.apps.bundle.write_bundle",
+            lambda *a, **k: pytest.fail("must not build a primitive"),
+        )
+        with patch.object(cli, "deploy_app_bundle") as dep, patch.object(
+            cli, "_run_ms_job_bundle"
+        ) as job:
+            opts = parse_args(
+                ["agent", verb, "-c", str(cfg), "-s", str(out), "--mode", mode]
+            )
+            with pytest.raises(SystemExit) as exc:
+                cli.handle_agent_command(opts)
+        assert exc.value.code == 1
+        dep.assert_not_called()
+        job.assert_not_called()
+
+    @pytest.mark.parametrize("mode", ["apps", "mcp", "model_serving"])
+    def test_agent_up_autobuilds_when_unstaged(
+        self, mode: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = self._cfg(tmp_path)
+        out = tmp_path / "out"
+        built: dict[str, bool] = {}
+
+        def fake_writer(config: object, bundle_dir: object, **kw: object) -> dict:
+            built["yes"] = True
+            import pathlib
+
+            p = pathlib.Path(str(bundle_dir))
+            p.mkdir(parents=True, exist_ok=True)
+            (p / "databricks.yaml").write_text("bundle: {}\n")
+            return {}
+
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(cli, "detect_cloud_provider", lambda p: "aws")
+        monkeypatch.setattr(AppConfig, "_resolve_all_resources", lambda self: None)
+        monkeypatch.setattr(
+            AppConfig, "assert_provided_params_satisfied", lambda self: None
+        )
+        monkeypatch.setattr(cli, "_resolve_job_dao_ai_dep", lambda *a, **k: "dao-ai")
+        # _mode_writer imports the writer per mode at call time — patch each source.
+        monkeypatch.setattr("dao_ai.apps.bundle.write_bundle", fake_writer)
+        monkeypatch.setattr("dao_ai.mcp.generate.write_mcp_bundle", fake_writer)
+        monkeypatch.setattr(
+            "dao_ai.pipeline.bundle.write_model_serving_agent_bundle", fake_writer
+        )
+        with patch.object(cli, "deploy_app_bundle"), patch.object(
+            cli, "_run_ms_job_bundle"
+        ):
+            opts = parse_args(
+                ["agent", "up", "-c", str(cfg), "-s", str(out), "--mode", mode]
+            )
+            cli.handle_agent_command(opts)
+        assert built.get("yes"), f"up --mode {mode} must auto-build when unstaged"
+
+    @pytest.mark.parametrize("verb", ["sync", "start", "down"])
+    def test_workflow_primitive_errors_when_unstaged(
+        self, verb: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = self._cfg(tmp_path)
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(cli, "detect_cloud_provider", lambda p: "aws")
+        monkeypatch.setattr(
+            "dao_ai.pipeline.bundle.write_pipeline_bundle",
+            lambda *a, **k: pytest.fail("must not build a primitive"),
+        )
+        with patch.object(cli, "_exec_bundle_command"):
+            opts = parse_args(
+                ["workflow", verb, "-c", str(cfg), "-s", str(tmp_path / "out")]
+            )
+            with pytest.raises(SystemExit) as exc:
+                cli.handle_workflow_command(opts)
+        assert exc.value.code == 1
+
+    def test_workflow_up_builds_exactly_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """workflow up = build → sync → start. It must stage ONCE (the deploy
+        call builds; the run call passes stage=False), not twice."""
+        cfg = self._cfg(tmp_path)
+        out = tmp_path / "out"
+        builds: list[int] = []
+
+        def fake_writer(config: object, bundle_dir: object, **kw: object) -> dict:
+            builds.append(1)
+            import pathlib
+
+            p = pathlib.Path(str(bundle_dir))
+            p.mkdir(parents=True, exist_ok=True)
+            (p / "databricks.yaml").write_text("bundle: {}\n")
+            return {}
+
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(cli, "detect_cloud_provider", lambda p: "aws")
+        monkeypatch.setattr(AppConfig, "_resolve_all_resources", lambda self: None)
+        monkeypatch.setattr(cli, "_resolve_job_dao_ai_dep", lambda *a, **k: "dao-ai")
+        monkeypatch.setattr(cli, "_clean_default_staging_dir", lambda *a, **k: None)
+        monkeypatch.setattr(cli, "_write_staging_manifest", lambda *a, **k: None)
+        monkeypatch.setattr(
+            "dao_ai.pipeline.bundle.write_pipeline_bundle", fake_writer
+        )
+        with patch.object(cli, "_exec_bundle_command"):
+            opts = parse_args(["workflow", "up", "-c", str(cfg), "-s", str(out)])
+            cli.handle_workflow_command(opts)
+        assert len(builds) == 1, f"workflow up must build once, built {len(builds)}x"
 
 
 @pytest.mark.unit
@@ -1565,10 +1702,12 @@ class TestDeployAutoGenerate:
         cfg.write_text(_MINIMAL_CONFIG_NO_TARGET)
         return cfg
 
-    def test_deploy_autogenerates_when_unstaged(
+    def test_up_autogenerates_when_unstaged(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """`agent deploy` on an empty dir stages first, then deploys the bundle."""
+        """`agent up` on an empty dir stages first, then deploys the bundle.
+        (Only `up` builds; `sync` on an unstaged dir errors — see
+        TestStrictPrimitivesErrorWhenUnstaged.)"""
         cfg = self._write_cfg(tmp_path)
         out = tmp_path / "out"  # does NOT pre-exist with databricks.yaml
 
@@ -1590,7 +1729,7 @@ class TestDeployAutoGenerate:
             fake_writer,
         )
         with patch.object(cli, "deploy_app_bundle") as dep:
-            opts = parse_args(["agent", "sync", "-c", str(cfg), "-s", str(out)])
+            opts = parse_args(["agent", "up", "-c", str(cfg), "-s", str(out)])
             cli.handle_agent_command(opts)
 
         assert wrote.get("called"), "writer must be called to auto-generate the bundle"
@@ -1746,7 +1885,7 @@ class TestDeployAutoGenerate:
             opts = parse_args(
                 [
                     "agent",
-                    "sync",
+                    "up",
                     "-c",
                     str(cfg),
                     "-s",
@@ -1879,7 +2018,7 @@ class TestDeployAutoGenerate:
             track_resolve,
         )
         with patch.object(cli, "deploy_app_bundle"):
-            opts = parse_args(["agent", "sync", "-c", str(cfg), "-s", str(out)])
+            opts = parse_args(["agent", "up", "-c", str(cfg), "-s", str(out)])
             cli.handle_agent_command(opts)
 
         assert resolve_calls == ["called"], (


### PR DESCRIPTION
## Problem
The `build`/`sync`/`start`/`up`/`down` verbs had an inconsistent prerequisite contract: `sync` auto-built when unstaged, but `start`/`down` hard-failed. A primitive that auto-satisfied one prerequisite while its siblings refused — confusing and inconsistent across `agent`/`workflow` and `--mode apps`/`mcp`/`ms`.

## Decision
Commit fully to the model the docs already described: **primitives act on prepared state; `up` orchestrates.** Since this is pre-release, we optimized purely for the most consistent/intuitive experience (not to preserve prior behavior).

| verb | does | unstaged / prereq missing |
|---|---|---|
| build | stage to disk | n/a |
| sync | `bundle deploy` what's staged | **error**: run `build` first (or `up`) |
| start | `bundle run` what's synced | **error**: run `build` + `sync` first (or `up`) |
| down | `bundle destroy` | **error**: nothing staged |
| up | build-if-needed → sync → start | auto-provisions all (the **only** builder) |

Errors name the exact next command.

## Changes
- **Agent** (`_deploy_run_destroy_app_bundle`): `orchestrating = deploy and run` (only `up`). The unstaged guard now also errors for pure `sync`; `should_stage` and the stale-config rebuild are gated on `orchestrating`, so `sync` never (re)builds — on config drift it warns and deploys in place. The guard runs **before** the mode split, so **apps/mcp/ms are covered by one change**.
- **Workflow**: `sync`/`start`/`down` already errored on unstaged (kept); improved the message to name the next command. Fixed a latent **double-build in `workflow up`** — the `bundle run deploy_job` call now passes `stage=False` so `up` builds exactly once.
- **Docs** (`cli-reference.md`): rewrote the lifecycle model + option tables — `sync` acts on the already-built bundle for both nouns and errors if unstaged; only `up`/`build` carry `--overwrite`/`--development`.

Supersedes #255 (workflow sync auto-build), now closed.

## Verification
- **Unit**: strict-primitive error matrix — `sync`/`start`/`down` × `apps`/`mcp`/`ms` + workflow all error when unstaged; `up` auto-builds per mode; `up` idempotent (no rebuild when staged + fingerprint matches); `workflow up` builds exactly once. Full CLI suite: **272 passed**.
- **Live (fevm)**: `agent sync` (apps) and `agent sync --mode ms` unstaged → error with next command; `agent up` unstaged → builds; staged `up` → no rebuild (idempotent); `workflow sync` unstaged → error.

No `config.py` change, so no `make schema`.

This pull request and its description were written by Isaac.