### PR TITLE
fix(cli): workflow down removes the deployed App/endpoint, not just the Job

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -257,10 +257,12 @@ dao-ai workflow up|build|sync|start|down  -c <cfg> [-p <profile>]
   deploy_job) **and** deletes the serving endpoint — the endpoint is created by
   the deploy-agent job, not the DAB, so `bundle destroy` alone would leave it
   running and billing; the registered UC model + versions are **kept** (a
-  reusable artifact). For `workflow`, `down` removes the provisioning job only —
-  it does **not** delete the infrastructure that job provisioned (Vector Search
-  indexes, Lakebase, Genie spaces, UC schemas/functions); tear those down
-  yourself if you no longer need them.
+  reusable artifact). For `workflow`, `down` removes the provisioning job **and**
+  the agent it deployed — the App (apps/mcp) or serving endpoint (model_serving)
+  the `deploy_agent` step created imperatively, which `bundle destroy` alone
+  would orphan. It does **not** delete the *data* infrastructure that job
+  provisioned (Vector Search indexes, Lakebase, Genie spaces, UC
+  schemas/functions); tear those down yourself if you no longer need them.
 
 This is the payoff: a sync that failed on a transient error can be retried with
 just `dao-ai agent sync -c <cfg> -p fevm` — no rebuild. To build, sync, *and*

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -4261,6 +4261,22 @@ def run_databricks_command(
         stage_only_msg=f"Workflow bundle staged in {staging_dir}",
     )
 
+    # `bundle destroy` only removes the provisioning Job. The workflow's
+    # `06_deploy_agent` step deployed the agent IMPERATIVELY (App for apps/mcp,
+    # serving endpoint for model_serving) — not a DAB resource of the Job — so
+    # destroy orphans it. Remove it too, so `workflow down` fully tears the
+    # deployment down (mirrors `agent --mode model_serving` down). Provisioned
+    # DATA infra (Vector Search, Lakebase, Genie, UC) is intentionally kept.
+    if command is not None and command[:2] == ["bundle", "destroy"] and app_config:
+        # The notebook defaults an unset mode to apps (06_deploy_agent.py), so
+        # resolve the deployed mode as `apps` when unspecified — NOT the
+        # model_serving fallback the Job's runtime var uses above.
+        deployed_mode: str = mode or "apps"
+        if deployed_mode == "model_serving":
+            _delete_serving_endpoint(app_config, profile=profile, dry_run=dry_run)
+        else:
+            _delete_app(app_config, profile=profile, dry_run=dry_run)
+
 
 def _print_job_link(
     cwd: Path,
@@ -4590,6 +4606,44 @@ def _delete_serving_endpoint(
             f"Could not delete Model Serving endpoint '{endpoint_name}' "
             f"({type(e).__name__}: {e}). Delete it manually with "
             f"`databricks serving-endpoints delete {endpoint_name}`."
+        )
+
+
+def _delete_app(config: AppConfig, *, profile: Optional[str], dry_run: bool) -> None:
+    """Delete the Databricks App a workflow `down` leaves behind.
+
+    The workflow DAB only manages the provisioning Job; its ``06_deploy_agent``
+    step creates the App imperatively (``config.deploy_agent``), so ``bundle
+    destroy`` on the Job orphans it. This removes it so ``workflow down`` fully
+    tears the deployment down — the App analogue of :func:`_delete_serving_endpoint`
+    (the ``agent --mode model_serving`` endpoint cleanup). Provisioned data
+    infrastructure (Vector Search, Lakebase, Genie, UC) is intentionally kept.
+    Best-effort: a missing App (already gone) is not an error.
+    """
+    app_name: Optional[str] = config.app.app_resource_name if config.app else None
+    if not app_name:
+        return
+    if dry_run:
+        logger.info(f"[DRY RUN] Would delete App '{app_name}'.")
+        return
+    try:
+        from databricks.sdk import WorkspaceClient
+        from databricks.sdk.errors import NotFound
+
+        w: WorkspaceClient = (
+            WorkspaceClient(profile=profile) if profile else WorkspaceClient()
+        )
+        try:
+            w.apps.delete(name=app_name)
+            logger.info(f"Deleted App '{app_name}'.")
+        except NotFound:
+            logger.info(
+                f"App '{app_name}' not found (already deleted) — nothing to do."
+            )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            f"Could not delete App '{app_name}' ({type(e).__name__}: {e}). "
+            f"Delete it manually with `databricks apps delete {app_name}`."
         )
 
 

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -1544,6 +1544,155 @@ class TestDeleteServingEndpoint:
 
 
 @pytest.mark.unit
+class TestDeleteApp:
+    """_delete_app removes the imperatively-deployed App on workflow down."""
+
+    @staticmethod
+    def _app_config(name: str = "My_App") -> AppConfig:
+        class _App:
+            def __init__(self, n: str) -> None:
+                self.name = n
+
+            @property
+            def app_resource_name(self) -> str:
+                return self.name.lower().replace("_", "-")
+
+        return AppConfig.model_construct(app=_App(name))
+
+    def test_deletes_app_by_normalized_name(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        deleted: list[str] = []
+
+        class _WC:
+            class apps:
+                @staticmethod
+                def delete(name: str) -> None:
+                    deleted.append(name)
+
+        import databricks.sdk as sdk
+
+        monkeypatch.setattr(sdk, "WorkspaceClient", lambda *a, **k: _WC())
+        cli._delete_app(self._app_config("My_App"), profile=None, dry_run=False)
+        # App name is the lower/hyphen form the App was deployed under.
+        assert deleted == ["my-app"]
+
+    def test_dry_run_does_not_delete(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        called: list[str] = []
+
+        class _WC:
+            class apps:
+                @staticmethod
+                def delete(name: str) -> None:
+                    called.append(name)
+
+        import databricks.sdk as sdk
+
+        monkeypatch.setattr(sdk, "WorkspaceClient", lambda *a, **k: _WC())
+        cli._delete_app(self._app_config(), profile=None, dry_run=True)
+        assert called == [], "dry-run must not delete the app"
+
+    def test_missing_app_is_not_an_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from databricks.sdk.errors import NotFound
+
+        class _WC:
+            class apps:
+                @staticmethod
+                def delete(name: str) -> None:
+                    raise NotFound("gone")
+
+        import databricks.sdk as sdk
+
+        monkeypatch.setattr(sdk, "WorkspaceClient", lambda *a, **k: _WC())
+        # Must not raise — an already-deleted app is fine.
+        cli._delete_app(self._app_config(), profile=None, dry_run=False)
+
+    def test_delete_failure_is_non_fatal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class _WC:
+            class apps:
+                @staticmethod
+                def delete(name: str) -> None:
+                    raise RuntimeError("boom")
+
+        import databricks.sdk as sdk
+
+        monkeypatch.setattr(sdk, "WorkspaceClient", lambda *a, **k: _WC())
+        # Best-effort: any failure is logged, not raised.
+        cli._delete_app(self._app_config(), profile=None, dry_run=False)
+
+
+@pytest.mark.unit
+class TestWorkflowDownRemovesDeployedAgent:
+    """workflow down destroys the Job THEN removes the imperatively-deployed
+    App (apps/mcp) or serving endpoint (model_serving)."""
+
+    _CFG = (
+        "resources:\n  models:\n    m: &m\n      name: databricks-gpt-5-4-mini\n"
+        "agents:\n  g: &g\n    name: g\n    description: d\n    model: *m\n"
+        "    prompt: p\n"
+        "app:\n  name: my_app\n  agents:\n    - *g\n"
+    )
+
+    def _cfg(self, tmp_path: Path) -> Path:
+        cfg = tmp_path / "c.yaml"
+        cfg.write_text(self._CFG)
+        (tmp_path / "databricks.yaml").write_text("bundle: {}\n")  # pretend staged
+        return cfg
+
+    def _run_down(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, mode_argv: list[str]
+    ) -> list[str]:
+        order: list[str] = []
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(cli, "detect_cloud_provider", lambda p: "aws")
+        monkeypatch.setattr(cli, "_resolve_job_dao_ai_dep", lambda *a, **k: "dao-ai")
+        monkeypatch.setattr(
+            cli, "_exec_job_bundle", lambda **k: order.append("bundle_destroy")
+        )
+        monkeypatch.setattr(
+            cli,
+            "_delete_app",
+            lambda config, *, profile, dry_run: order.append("app_delete"),
+        )
+        monkeypatch.setattr(
+            cli,
+            "_delete_serving_endpoint",
+            lambda config, *, profile, dry_run: order.append("endpoint_delete"),
+        )
+        cfg = self._cfg(tmp_path)
+        argv = ["workflow", "down", "-c", str(cfg), "-s", str(tmp_path)] + mode_argv
+        opts = parse_args(argv)
+        cli.handle_workflow_command(opts)
+        return order
+
+    def test_apps_mode_deletes_app_after_destroy(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        order = self._run_down(tmp_path, monkeypatch, mode_argv=["--mode", "apps"])
+        assert order == ["bundle_destroy", "app_delete"], order
+
+    def test_no_mode_defaults_to_app_delete(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Unspecified mode → the workflow deployed apps (notebook default), so
+        # cleanup must target the App, NOT a serving endpoint.
+        order = self._run_down(tmp_path, monkeypatch, mode_argv=[])
+        assert order == ["bundle_destroy", "app_delete"], order
+
+    def test_model_serving_deletes_endpoint_after_destroy(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        order = self._run_down(
+            tmp_path, monkeypatch, mode_argv=["--mode", "model_serving"]
+        )
+        assert order == ["bundle_destroy", "endpoint_delete"], order
+
+
+@pytest.mark.unit
 class TestLinkAndGrantTrace:
     """_link_and_grant_trace no-ops without trace_location, links with it."""
 


### PR DESCRIPTION
## Problem
`dao-ai workflow down` ran `bundle destroy` on the provisioning **Job** bundle and reported "Destroy complete!" — but left the **App** the workflow deployed running. The workflow's `06_deploy_agent` step creates the App (apps/mcp) or serving endpoint (model_serving) **imperatively** via the SDK, so it's not a DAB resource of the Job bundle and `bundle destroy` orphans it.

This diverged from `agent down`, which removes the App, and from `agent --mode model_serving` down, which already deletes its endpoint via `_delete_serving_endpoint`. Same config, two teardown paths, different residue.

## Fix
- New `_delete_app` helper, mirroring `_delete_serving_endpoint` exactly: best-effort, `NotFound` = no-op, `dry_run` logs only, any other failure warns with the manual command and does **not** fail teardown.
- After the workflow's `bundle destroy`, dispatch cleanup by the mode the workflow actually deployed: `apps`/`mcp` → `_delete_app`, `model_serving` → `_delete_serving_endpoint`.
- **Mode subtlety:** an unspecified mode resolves to `apps` (the deploy notebook's default) for cleanup — *not* the `model_serving` fallback the Job's runtime var uses — so a no-`--mode` teardown removes the App.
- Provisioned **data** infrastructure (Vector Search, Lakebase, Genie, UC schemas) is still intentionally kept — that carve-out is unchanged.
- Docs updated: `workflow down` now removes the job **and** the deployed agent.

## Verification
- **Live (fevm):** `workflow down` on the ai_gateway config destroyed the Job and the App `ai-gateway-example` transitioned `DELETING` → `NotFound`; dry-run showed `bundle destroy` then `[DRY RUN] Would delete App 'ai-gateway-example'`.
- **Unit:** `_delete_app` matrix (deletes by normalized name, dry-run no-op, NotFound swallowed, other failure non-fatal); workflow-down dispatch (apps + no-mode → app delete; model_serving → endpoint delete; both after `bundle destroy`). Full CLI suite: **292 passed**.

No `config.py` change, so no `make schema`.

This pull request and its description were written by Isaac.