### PR TITLE
feat(cli): opt-in `down --wait [SECONDS]` to block until the App/endpoint is deleted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,12 +217,14 @@ pyrightconfig.json
 ### venv ###
 # Virtualenv
 # http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
-[Bb]in
-[Ii]nclude
-[Ll]ib
-[Ll]ib64
-[Ll]ocal
-[Ss]cripts
+# Anchored to the repo root so these venv dir names don't also ignore
+# same-named project dirs deeper in the tree (e.g. tests/scripts, tests/lib).
+/[Bb]in
+/[Ii]nclude
+/[Ll]ib
+/[Ll]ib64
+/[Ll]ocal
+/[Ss]cripts
 pyvenv.cfg
 pip-selfcheck.json
 

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -255,6 +255,11 @@ def _global_parent_parser() -> ArgumentParser:
     return p
 
 
+# Default timeout (seconds) for the App-deploy ``--wait`` gate: how long to wait
+# for the app's compute to leave a transient state before ``bundle deploy``.
+_DEFAULT_WAIT_SECONDS = 600
+
+
 def _add_bundle_common_args(parser: ArgumentParser, *, kind: str) -> None:
     """Add the flags every bundle verb shares: -c/-s/-p/--dry-run/--param.
 
@@ -317,6 +322,28 @@ def _add_bundle_source_args(parser: ArgumentParser) -> None:
         action="store_false",
         help="Force the published PyPI dao-ai package even from a local/editable "
         "install.",
+    )
+
+
+def _add_no_wait_argument(parser: ArgumentParser) -> None:
+    """Add the ``--no-wait`` flag to a ``down`` verb.
+
+    By default ``down`` blocks until the deployed resource (App or serving
+    endpoint) is fully deleted — the underlying deletes are async (they return
+    while the resource is still ``DELETING``), so a deploy that immediately
+    follows a teardown otherwise races it and hits ``400 ... compute is in
+    DELETING state``. Waiting makes "down" mean "the resource is actually gone".
+    ``--no-wait`` restores fire-and-forget: return as soon as the delete is
+    issued (faster, but a following deploy may race the teardown).
+    """
+    parser.add_argument(
+        "--no-wait",
+        dest="no_wait",
+        action="store_true",
+        default=False,
+        help="Return as soon as the delete is issued instead of waiting for the "
+        "app/endpoint to be fully deleted. By default `down` waits so a following "
+        "deploy can't race the teardown.",
     )
 
 
@@ -563,6 +590,12 @@ def _add_noun_verb_parsers(
             # development for create_agent/deploy_agent). start/down act on
             # already-built artifacts so source flags are omitted there.
             _add_bundle_source_args(verb_parser)
+        # `down` waits for the deployed App/endpoint to be fully deleted by
+        # default so a following deploy can't race the (async) teardown;
+        # --no-wait opts out. Both nouns deploy an App (apps/mcp) or a serving
+        # endpoint (model_serving), so both need it.
+        if verb == "down":
+            _add_no_wait_argument(verb_parser)
 
 
 # Env var that overrides the base directory for generated bundles. The
@@ -4004,6 +4037,7 @@ def run_databricks_command(
     staging_dir: Optional[str] = None,
     overwrite: bool = False,
     stage: bool = True,
+    wait: bool = True,
 ) -> None:
     """Execute a databricks CLI command with optional profile, target, and cloud.
 
@@ -4206,9 +4240,11 @@ def run_databricks_command(
         # model_serving fallback the Job's runtime var uses above.
         deployed_mode: str = mode or "apps"
         if deployed_mode == "model_serving":
-            _delete_serving_endpoint(app_config, profile=profile, dry_run=dry_run)
+            _delete_serving_endpoint(
+                app_config, profile=profile, dry_run=dry_run, wait=wait
+            )
         else:
-            _delete_app(app_config, profile=profile, dry_run=dry_run)
+            _delete_app(app_config, profile=profile, dry_run=dry_run, wait=wait)
 
 
 def _print_job_link(
@@ -4302,6 +4338,57 @@ def _link_and_grant_trace(
     _grant_trace_writes_to_app_sp(config, experiment_id, sp_override=None)
 
 
+def _wait_for_resource_deleted(
+    kind: str,
+    name: str,
+    profile: Optional[str],
+    timeout_seconds: int = _DEFAULT_WAIT_SECONDS,
+) -> None:
+    """Block until a just-deleted deployment resource is fully gone, or timeout.
+
+    dao-ai's teardowns are async: ``bundle destroy`` / ``apps.delete`` /
+    ``serving_endpoints.delete`` return while the resource is still ``DELETING``,
+    so a deploy that immediately follows a ``down`` races it and hits e.g.
+    ``400 ... compute is in DELETING state``. Calling this after the delete makes
+    ``down`` block until the resource is actually gone, so nothing is left to race.
+
+    ``kind`` selects the resource — ``"app"`` (``w.apps.get``) or ``"endpoint"``
+    (``w.serving_endpoints.get``); both raise ``NotFound`` once deleted. Bounded by
+    ``timeout_seconds``; on expiry it warns and returns rather than hanging.
+    Mirrors :func:`dao_ai.providers.databricks._wait_until_index_absent`.
+    """
+    import random
+    import time
+
+    from databricks.sdk import WorkspaceClient
+    from databricks.sdk.errors import NotFound
+
+    _apply_profile_context(profile)
+    w = WorkspaceClient(profile=profile) if profile else WorkspaceClient()
+    getter = w.apps.get if kind == "app" else w.serving_endpoints.get
+
+    logger.info(
+        f"Waiting up to {timeout_seconds}s for {kind} '{name}' to be fully "
+        f"deleted..."
+    )
+    deadline = time.monotonic() + timeout_seconds
+    attempt = 1
+    while time.monotonic() < deadline:
+        try:
+            getter(name=name)
+        except NotFound:
+            logger.info(f"{kind.capitalize()} '{name}' is fully deleted.")
+            return
+        sleep_s = min(attempt, 10)
+        logger.debug(f"{kind} '{name}' still present; retrying in ~{sleep_s}s")
+        time.sleep(sleep_s + random.random())
+        attempt += 1
+    logger.warning(
+        f"{kind.capitalize()} '{name}' still present after {timeout_seconds}s; "
+        "returning anyway."
+    )
+
+
 def deploy_app_bundle(
     config: AppConfig,
     *,
@@ -4311,6 +4398,7 @@ def deploy_app_bundle(
     destroy: bool,
     profile: Optional[str],
     dry_run: bool = False,
+    wait: bool = True,
 ) -> None:
     """Sync/start/down an already-staged App bundle (agent or MCP).
 
@@ -4328,6 +4416,8 @@ def deploy_app_bundle(
         deploy / run / destroy: which action(s) to perform.
         profile: Databricks CLI profile.
         dry_run: print instead of executing.
+        wait: on destroy, block after ``bundle destroy`` until the app is fully
+            deleted (default). ``down --no-wait`` sets this False.
     """
     if config.app is None:
         raise ValueError("Config must have an 'app' section to deploy a bundle.")
@@ -4342,6 +4432,11 @@ def deploy_app_bundle(
             cwd=staging_dir,
             dry_run=dry_run,
         )
+        # `bundle destroy` returns once the delete is issued; by default block
+        # until the app is actually gone so a following deploy can't race it
+        # (--no-wait sets wait=False).
+        if wait and not dry_run:
+            _wait_for_resource_deleted("app", app_name, profile)
         return
 
     if deploy:
@@ -4382,6 +4477,7 @@ def _run_ms_job_bundle(
     target: Optional[str],
     cloud: Optional[str],
     config_vars: dict[str, str],
+    wait: bool = True,
 ) -> None:
     """Deploy/run/destroy a staged model_serving *Job* bundle (``agent/<app>/ms``).
 
@@ -4459,7 +4555,9 @@ def _run_ms_job_bundle(
         # otherwise. Delete it explicitly so `down` fully tears the deployment
         # down. The registered UC model + versions are intentionally KEPT — a
         # reusable artifact a later `up`/`start` can redeploy.
-        _delete_serving_endpoint(config, profile=profile, dry_run=dry_run)
+        _delete_serving_endpoint(
+            config, profile=profile, dry_run=dry_run, wait=wait
+        )
         return
 
     if deploy:
@@ -4503,7 +4601,7 @@ def _run_ms_job_bundle(
 
 
 def _delete_serving_endpoint(
-    config: AppConfig, *, profile: Optional[str], dry_run: bool
+    config: AppConfig, *, profile: Optional[str], dry_run: bool, wait: bool = True
 ) -> None:
     """Delete the Model Serving endpoint a model_serving `down` leaves behind.
 
@@ -4534,15 +4632,23 @@ def _delete_serving_endpoint(
                 f"Model Serving endpoint '{endpoint_name}' not found "
                 "(already deleted) — nothing to do."
             )
+            return
     except Exception as e:  # noqa: BLE001
         logger.warning(
             f"Could not delete Model Serving endpoint '{endpoint_name}' "
             f"({type(e).__name__}: {e}). Delete it manually with "
             f"`databricks serving-endpoints delete {endpoint_name}`."
         )
+        return
+    # serving_endpoints.delete is async; by default block until the endpoint is
+    # gone so a following deploy can't race the teardown (--no-wait sets False).
+    if wait:
+        _wait_for_resource_deleted("endpoint", endpoint_name, profile)
 
 
-def _delete_app(config: AppConfig, *, profile: Optional[str], dry_run: bool) -> None:
+def _delete_app(
+    config: AppConfig, *, profile: Optional[str], dry_run: bool, wait: bool = True
+) -> None:
     """Delete the Databricks App a workflow `down` leaves behind.
 
     The workflow DAB only manages the provisioning Job; its ``06_deploy_agent``
@@ -4573,11 +4679,17 @@ def _delete_app(config: AppConfig, *, profile: Optional[str], dry_run: bool) -> 
             logger.info(
                 f"App '{app_name}' not found (already deleted) — nothing to do."
             )
+            return
     except Exception as e:  # noqa: BLE001
         logger.warning(
             f"Could not delete App '{app_name}' ({type(e).__name__}: {e}). "
             f"Delete it manually with `databricks apps delete {app_name}`."
         )
+        return
+    # apps.delete is async; by default block until the App is gone so a following
+    # deploy can't race the teardown (workflow down --no-wait sets wait=False).
+    if wait:
+        _wait_for_resource_deleted("app", app_name, profile)
 
 
 def _print_app_link(app_name: str) -> None:
@@ -4647,6 +4759,10 @@ def _exec_workflow_verb(options: Namespace, command: list[str]) -> None:
         config_vars=_parse_var_args(options.var),
         staging_dir=options.staging_dir,
         stage=False,
+        # `down` deletes the deployed App/endpoint and waits for it to be gone by
+        # default; --no-wait opts out. Only `down` adds the flag; other verbs
+        # never reach the destroy branch that consults `wait`.
+        wait=not getattr(options, "no_wait", False),
     )
 
 
@@ -5043,6 +5159,7 @@ def _deploy_run_destroy_app_bundle(
             target=None,
             cloud=None,
             config_vars=_parse_var_args(options.var),
+            wait=not getattr(options, "no_wait", False),
         )
         return
 
@@ -5057,6 +5174,10 @@ def _deploy_run_destroy_app_bundle(
         destroy=destroy,
         profile=options.profile,
         dry_run=dry_run,
+        # `down` waits for full deletion by default; --no-wait opts out. getattr
+        # keeps non-down verbs (which never add the flag) at the wait=True default
+        # (only the destroy branch consults it).
+        wait=not getattr(options, "no_wait", False),
     )
 
 

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -359,29 +359,6 @@ def _wait_timeout_of(options: Namespace) -> Optional[int]:
     return getattr(options, "wait", None)
 
 
-def _add_purge_argument(parser: ArgumentParser) -> None:
-    """Add the opt-in ``--purge`` flag to a ``down`` verb.
-
-    A normal ``down`` SOFT-deletes the MLflow experiment (leaves it in the
-    workspace trash), which lingers and can collide with a later redeploy.
-    ``--purge`` permanently removes the experiment too, for a true clean slate.
-    Destructive: it deletes the experiment's run/trace history irrecoverably.
-    """
-    parser.add_argument(
-        "--purge",
-        action="store_true",
-        default=False,
-        help="Also PERMANENTLY delete the MLflow experiment (not just "
-        "soft-delete/trash it) — a clean slate. Destroys the experiment's run and "
-        "trace history irrecoverably.",
-    )
-
-
-def _purge_of(options: Namespace) -> bool:
-    """Whether ``--purge`` was set. Absent on non-``down`` verbs → ``False``."""
-    return getattr(options, "purge", False)
-
-
 def _add_workflow_target_args(parser: ArgumentParser) -> None:
     """Add workflow-only target/cloud flags used to resolve the bundle target.
 
@@ -627,12 +604,10 @@ def _add_noun_verb_parsers(
             _add_bundle_source_args(verb_parser)
         # `down` returns as soon as the (async) delete is issued; `--wait` blocks
         # until the deployed App/endpoint is fully gone so a following deploy
-        # can't race the teardown. `--purge` also permanently deletes the MLflow
-        # experiment (not just soft-delete). Both nouns deploy an App (apps/mcp)
-        # or a serving endpoint (model_serving), so both offer them.
+        # can't race the teardown. Both nouns deploy an App (apps/mcp) or a
+        # serving endpoint (model_serving), so both offer it.
         if verb == "down":
             _add_wait_argument(verb_parser)
-            _add_purge_argument(verb_parser)
 
 
 # Env var that overrides the base directory for generated bundles. The
@@ -3763,16 +3738,6 @@ def _adopt_untracked_bundle_resources(
         if len(parts) != 3 or parts[0] != "resources":
             continue
         _, rtype, short_key = parts
-        # Experiments aren't adopted by binding: a prior `down` SOFT-deletes
-        # (trashes) the tracked experiment, and a bind wouldn't un-trash it — the
-        # deploy would still try to move the trashed node back to its name and hit
-        # `Cannot move node ... in trash folder (400)`. Restore it instead so the
-        # deploy's update targets a live experiment. (Side effect, not a bind.)
-        if rtype == "experiments":
-            exp_name = ((entry.get("new_state") or {}).get("value") or {}).get("name")
-            if exp_name:
-                _restore_trashed_experiment(str(exp_name), profile)
-            continue
         rid: Optional[str] = _resolve_existing_resource_id(rtype, short_key, entry, profile)
         if rid is not None:
             to_bind.append((short_key, rid))
@@ -3870,77 +3835,14 @@ def _resolve_existing_resource_id(
                     return str(p.pipeline_id)
             return None
 
-        # Other types: conservative — apps/jobs/pipelines are the create-vs-update
-        # 409 cases handled by binding. Experiments are handled separately by
-        # _restore_trashed_experiment (a restore, not a bind), so skip here.
+        # Other types (experiments, etc.): conservative — the app/job/pipeline
+        # resources are the create-vs-update 409 cases. Skip rather than guess.
         return None
     except NotFound:
         return None
     except Exception as e:  # noqa: BLE001
         logger.debug(f"adopt id-resolution for {rtype}.{short_key} failed: {e}")
         return None
-
-
-def _restore_trashed_experiment(name: str, profile: Optional[str]) -> None:
-    """Un-trash a soft-deleted MLflow experiment so a redeploy's update succeeds.
-
-    ``down``/``bundle destroy`` SOFT-deletes the experiment the bundle declares
-    (leaves it in ``lifecycle_stage == "deleted"``). On the next deploy DABs tries
-    to move/rename that trashed node back to ``name`` and MLflow rejects it
-    (``Cannot move node ... in trash folder``). Restoring it first makes the node
-    live again so the deploy's update lands. If the experiment is absent or
-    already live, this is a no-op. Reuses the restore idiom in
-    :meth:`dao_ai.providers.databricks.DatabricksProvider.get_or_create_experiment`.
-
-    Best-effort (matches :func:`_adopt_untracked_bundle_resources`): any failure is
-    logged and swallowed so the subsequent ``bundle deploy`` still runs.
-    """
-    try:
-        import mlflow
-        from mlflow import MlflowClient
-
-        _apply_profile_context(profile)
-        experiment = mlflow.get_experiment_by_name(name)
-        if experiment is not None and experiment.lifecycle_stage == "deleted":
-            MlflowClient().restore_experiment(experiment.experiment_id)
-            logger.info(
-                f"Restored soft-deleted experiment '{name}' "
-                f"(id={experiment.experiment_id}) before deploy."
-            )
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"restore of trashed experiment '{name}' skipped: {e}")
-
-
-def _purge_experiment(config: AppConfig, profile: Optional[str]) -> None:
-    """Permanently delete the app's MLflow experiment (``down --purge``).
-
-    A normal ``down`` only soft-deletes the experiment (trash); MLflow exposes no
-    permanent-delete API, so purge removes the experiment's workspace node
-    directly via ``workspace.delete(path, recursive=True)``. The path is resolved
-    the same way it was generated — :meth:`DatabricksProvider.experiment_name`
-    (explicit ``app.experiment.name``, else ``/Users/<deployer>/<app.name>``). An
-    externally-referenced experiment (``app.experiment.id``) is left alone — dao-ai
-    didn't create it.
-
-    Best-effort: a missing node or any error is logged and swallowed so ``down``
-    still completes.
-    """
-    if config.app is None or (
-        config.app.experiment is not None and config.app.experiment.id
-    ):
-        return
-    try:
-        from databricks.sdk import WorkspaceClient
-
-        from dao_ai.providers.databricks import DatabricksProvider
-
-        _apply_profile_context(profile)
-        w = WorkspaceClient(profile=profile) if profile else WorkspaceClient()
-        path: str = DatabricksProvider(w=w).experiment_name(config)
-        w.workspace.delete(path, recursive=True)
-        logger.info(f"Purged (permanently deleted) experiment node '{path}'.")
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"purge of experiment skipped: {e}")
 
 
 def _exec_bundle_command(
@@ -4148,7 +4050,6 @@ def run_databricks_command(
     overwrite: bool = False,
     stage: bool = True,
     wait_timeout: Optional[int] = None,
-    purge: bool = False,
 ) -> None:
     """Execute a databricks CLI command with optional profile, target, and cloud.
 
@@ -4356,7 +4257,6 @@ def run_databricks_command(
                 profile=profile,
                 dry_run=dry_run,
                 wait_timeout=wait_timeout,
-                purge=purge,
             )
         else:
             _delete_app(
@@ -4364,7 +4264,6 @@ def run_databricks_command(
                 profile=profile,
                 dry_run=dry_run,
                 wait_timeout=wait_timeout,
-                purge=purge,
             )
 
 
@@ -4525,7 +4424,6 @@ def deploy_app_bundle(
     profile: Optional[str],
     dry_run: bool = False,
     wait_timeout: Optional[int] = None,
-    purge: bool = False,
 ) -> None:
     """Sync/start/down an already-staged App bundle (agent or MCP).
 
@@ -4564,9 +4462,6 @@ def deploy_app_bundle(
         # until the app is actually gone so a following deploy can't race it.
         if wait_timeout is not None and not dry_run:
             _wait_for_resource_deleted("app", app_name, profile, wait_timeout)
-        # --purge: also permanently delete the experiment (destroy only trashes it).
-        if purge and not dry_run:
-            _purge_experiment(config, profile)
         return
 
     if deploy:
@@ -4608,7 +4503,6 @@ def _run_ms_job_bundle(
     cloud: Optional[str],
     config_vars: dict[str, str],
     wait_timeout: Optional[int] = None,
-    purge: bool = False,
 ) -> None:
     """Deploy/run/destroy a staged model_serving *Job* bundle (``agent/<app>/ms``).
 
@@ -4691,7 +4585,6 @@ def _run_ms_job_bundle(
             profile=profile,
             dry_run=dry_run,
             wait_timeout=wait_timeout,
-            purge=purge,
         )
         return
 
@@ -4741,7 +4634,6 @@ def _delete_serving_endpoint(
     profile: Optional[str],
     dry_run: bool,
     wait_timeout: Optional[int] = None,
-    purge: bool = False,
 ) -> None:
     """Delete the Model Serving endpoint a model_serving `down` leaves behind.
 
@@ -4786,9 +4678,6 @@ def _delete_serving_endpoint(
         _wait_for_resource_deleted(
             "endpoint", endpoint_name, profile, wait_timeout
         )
-    # --purge: also permanently delete the experiment (destroy only trashes it).
-    if purge:
-        _purge_experiment(config, profile)
 
 
 def _delete_app(
@@ -4797,7 +4686,6 @@ def _delete_app(
     profile: Optional[str],
     dry_run: bool,
     wait_timeout: Optional[int] = None,
-    purge: bool = False,
 ) -> None:
     """Delete the Databricks App a workflow `down` leaves behind.
 
@@ -4840,9 +4728,6 @@ def _delete_app(
     # following deploy can't race the teardown.
     if wait_timeout is not None:
         _wait_for_resource_deleted("app", app_name, profile, wait_timeout)
-    # --purge: also permanently delete the experiment (destroy only trashes it).
-    if purge:
-        _purge_experiment(config, profile)
 
 
 def _print_app_link(app_name: str) -> None:
@@ -4915,7 +4800,6 @@ def _exec_workflow_verb(options: Namespace, command: list[str]) -> None:
         # `--wait` (down only) blocks until the deleted App/endpoint is gone;
         # other verbs never reach the destroy branch that consults it.
         wait_timeout=_wait_timeout_of(options),
-        purge=_purge_of(options),
     )
 
 
@@ -5313,8 +5197,7 @@ def _deploy_run_destroy_app_bundle(
             cloud=None,
             config_vars=_parse_var_args(options.var),
             wait_timeout=_wait_timeout_of(options),
-            purge=_purge_of(options),
-        )
+            )
         return
 
     if run and not deploy and not destroy and not dry_run:
@@ -5331,7 +5214,6 @@ def _deploy_run_destroy_app_bundle(
         # `--wait` (down only) blocks until the deleted App is gone; non-down
         # verbs never reach the destroy branch that consults it.
         wait_timeout=_wait_timeout_of(options),
-        purge=_purge_of(options),
     )
 
 

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -255,8 +255,8 @@ def _global_parent_parser() -> ArgumentParser:
     return p
 
 
-# Default timeout (seconds) for the App-deploy ``--wait`` gate: how long to wait
-# for the app's compute to leave a transient state before ``bundle deploy``.
+# Default timeout (seconds) for `down --wait`: how long to block waiting for the
+# deleted App/endpoint to be fully gone before returning.
 _DEFAULT_WAIT_SECONDS = 600
 
 
@@ -325,26 +325,61 @@ def _add_bundle_source_args(parser: ArgumentParser) -> None:
     )
 
 
-def _add_no_wait_argument(parser: ArgumentParser) -> None:
-    """Add the ``--no-wait`` flag to a ``down`` verb.
+def _add_wait_argument(parser: ArgumentParser) -> None:
+    """Add the opt-in ``--wait [SECONDS]`` flag to a ``down`` verb.
 
-    By default ``down`` blocks until the deployed resource (App or serving
-    endpoint) is fully deleted — the underlying deletes are async (they return
-    while the resource is still ``DELETING``), so a deploy that immediately
-    follows a teardown otherwise races it and hits ``400 ... compute is in
-    DELETING state``. Waiting makes "down" mean "the resource is actually gone".
-    ``--no-wait`` restores fire-and-forget: return as soon as the delete is
-    issued (faster, but a following deploy may race the teardown).
+    ``down`` deletes the deployed resource (App or serving endpoint) and returns
+    as soon as the delete is *issued* — the delete is async, so the resource can
+    still be ``DELETING`` afterward. A deploy that immediately follows a teardown
+    then races it and hits ``400 ... compute is in DELETING state``. ``--wait``
+    makes ``down`` block until the resource is fully gone, so a following deploy
+    can't race it. Bare ``--wait`` uses the default timeout; ``--wait N`` overrides
+    it; omitting the flag returns immediately (default fire-and-forget).
     """
     parser.add_argument(
-        "--no-wait",
-        dest="no_wait",
+        "--wait",
+        nargs="?",
+        type=int,
+        const=_DEFAULT_WAIT_SECONDS,
+        default=None,
+        metavar="SECONDS",
+        help="After deleting, wait up to SECONDS (default %(const)s) for the "
+        "app/endpoint to be fully gone before returning, so a following deploy "
+        "can't race the teardown. Omit to return as soon as the delete is issued.",
+    )
+
+
+def _wait_timeout_of(options: Namespace) -> Optional[int]:
+    """The ``--wait`` timeout (seconds) for a verb, or ``None`` when not waiting.
+
+    ``--wait`` is defined only on the ``down`` verb parser, so ``options.wait`` is
+    absent for other verbs; treat that (and an omitted flag) as ``None`` = don't
+    wait. Centralizes the one conditional-attribute read so call sites stay typed.
+    """
+    return getattr(options, "wait", None)
+
+
+def _add_purge_argument(parser: ArgumentParser) -> None:
+    """Add the opt-in ``--purge`` flag to a ``down`` verb.
+
+    A normal ``down`` SOFT-deletes the MLflow experiment (leaves it in the
+    workspace trash), which lingers and can collide with a later redeploy.
+    ``--purge`` permanently removes the experiment too, for a true clean slate.
+    Destructive: it deletes the experiment's run/trace history irrecoverably.
+    """
+    parser.add_argument(
+        "--purge",
         action="store_true",
         default=False,
-        help="Return as soon as the delete is issued instead of waiting for the "
-        "app/endpoint to be fully deleted. By default `down` waits so a following "
-        "deploy can't race the teardown.",
+        help="Also PERMANENTLY delete the MLflow experiment (not just "
+        "soft-delete/trash it) — a clean slate. Destroys the experiment's run and "
+        "trace history irrecoverably.",
     )
+
+
+def _purge_of(options: Namespace) -> bool:
+    """Whether ``--purge`` was set. Absent on non-``down`` verbs → ``False``."""
+    return getattr(options, "purge", False)
 
 
 def _add_workflow_target_args(parser: ArgumentParser) -> None:
@@ -590,12 +625,14 @@ def _add_noun_verb_parsers(
             # development for create_agent/deploy_agent). start/down act on
             # already-built artifacts so source flags are omitted there.
             _add_bundle_source_args(verb_parser)
-        # `down` waits for the deployed App/endpoint to be fully deleted by
-        # default so a following deploy can't race the (async) teardown;
-        # --no-wait opts out. Both nouns deploy an App (apps/mcp) or a serving
-        # endpoint (model_serving), so both need it.
+        # `down` returns as soon as the (async) delete is issued; `--wait` blocks
+        # until the deployed App/endpoint is fully gone so a following deploy
+        # can't race the teardown. `--purge` also permanently deletes the MLflow
+        # experiment (not just soft-delete). Both nouns deploy an App (apps/mcp)
+        # or a serving endpoint (model_serving), so both offer them.
         if verb == "down":
-            _add_no_wait_argument(verb_parser)
+            _add_wait_argument(verb_parser)
+            _add_purge_argument(verb_parser)
 
 
 # Env var that overrides the base directory for generated bundles. The
@@ -3726,6 +3763,16 @@ def _adopt_untracked_bundle_resources(
         if len(parts) != 3 or parts[0] != "resources":
             continue
         _, rtype, short_key = parts
+        # Experiments aren't adopted by binding: a prior `down` SOFT-deletes
+        # (trashes) the tracked experiment, and a bind wouldn't un-trash it — the
+        # deploy would still try to move the trashed node back to its name and hit
+        # `Cannot move node ... in trash folder (400)`. Restore it instead so the
+        # deploy's update targets a live experiment. (Side effect, not a bind.)
+        if rtype == "experiments":
+            exp_name = ((entry.get("new_state") or {}).get("value") or {}).get("name")
+            if exp_name:
+                _restore_trashed_experiment(str(exp_name), profile)
+            continue
         rid: Optional[str] = _resolve_existing_resource_id(rtype, short_key, entry, profile)
         if rid is not None:
             to_bind.append((short_key, rid))
@@ -3823,14 +3870,77 @@ def _resolve_existing_resource_id(
                     return str(p.pipeline_id)
             return None
 
-        # Other types (experiments, etc.): conservative — the app/job/pipeline
-        # resources are the create-vs-update 409 cases. Skip rather than guess.
+        # Other types: conservative — apps/jobs/pipelines are the create-vs-update
+        # 409 cases handled by binding. Experiments are handled separately by
+        # _restore_trashed_experiment (a restore, not a bind), so skip here.
         return None
     except NotFound:
         return None
     except Exception as e:  # noqa: BLE001
         logger.debug(f"adopt id-resolution for {rtype}.{short_key} failed: {e}")
         return None
+
+
+def _restore_trashed_experiment(name: str, profile: Optional[str]) -> None:
+    """Un-trash a soft-deleted MLflow experiment so a redeploy's update succeeds.
+
+    ``down``/``bundle destroy`` SOFT-deletes the experiment the bundle declares
+    (leaves it in ``lifecycle_stage == "deleted"``). On the next deploy DABs tries
+    to move/rename that trashed node back to ``name`` and MLflow rejects it
+    (``Cannot move node ... in trash folder``). Restoring it first makes the node
+    live again so the deploy's update lands. If the experiment is absent or
+    already live, this is a no-op. Reuses the restore idiom in
+    :meth:`dao_ai.providers.databricks.DatabricksProvider.get_or_create_experiment`.
+
+    Best-effort (matches :func:`_adopt_untracked_bundle_resources`): any failure is
+    logged and swallowed so the subsequent ``bundle deploy`` still runs.
+    """
+    try:
+        import mlflow
+        from mlflow import MlflowClient
+
+        _apply_profile_context(profile)
+        experiment = mlflow.get_experiment_by_name(name)
+        if experiment is not None and experiment.lifecycle_stage == "deleted":
+            MlflowClient().restore_experiment(experiment.experiment_id)
+            logger.info(
+                f"Restored soft-deleted experiment '{name}' "
+                f"(id={experiment.experiment_id}) before deploy."
+            )
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"restore of trashed experiment '{name}' skipped: {e}")
+
+
+def _purge_experiment(config: AppConfig, profile: Optional[str]) -> None:
+    """Permanently delete the app's MLflow experiment (``down --purge``).
+
+    A normal ``down`` only soft-deletes the experiment (trash); MLflow exposes no
+    permanent-delete API, so purge removes the experiment's workspace node
+    directly via ``workspace.delete(path, recursive=True)``. The path is resolved
+    the same way it was generated — :meth:`DatabricksProvider.experiment_name`
+    (explicit ``app.experiment.name``, else ``/Users/<deployer>/<app.name>``). An
+    externally-referenced experiment (``app.experiment.id``) is left alone — dao-ai
+    didn't create it.
+
+    Best-effort: a missing node or any error is logged and swallowed so ``down``
+    still completes.
+    """
+    if config.app is None or (
+        config.app.experiment is not None and config.app.experiment.id
+    ):
+        return
+    try:
+        from databricks.sdk import WorkspaceClient
+
+        from dao_ai.providers.databricks import DatabricksProvider
+
+        _apply_profile_context(profile)
+        w = WorkspaceClient(profile=profile) if profile else WorkspaceClient()
+        path: str = DatabricksProvider(w=w).experiment_name(config)
+        w.workspace.delete(path, recursive=True)
+        logger.info(f"Purged (permanently deleted) experiment node '{path}'.")
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"purge of experiment skipped: {e}")
 
 
 def _exec_bundle_command(
@@ -4037,7 +4147,8 @@ def run_databricks_command(
     staging_dir: Optional[str] = None,
     overwrite: bool = False,
     stage: bool = True,
-    wait: bool = True,
+    wait_timeout: Optional[int] = None,
+    purge: bool = False,
 ) -> None:
     """Execute a databricks CLI command with optional profile, target, and cloud.
 
@@ -4241,10 +4352,20 @@ def run_databricks_command(
         deployed_mode: str = mode or "apps"
         if deployed_mode == "model_serving":
             _delete_serving_endpoint(
-                app_config, profile=profile, dry_run=dry_run, wait=wait
+                app_config,
+                profile=profile,
+                dry_run=dry_run,
+                wait_timeout=wait_timeout,
+                purge=purge,
             )
         else:
-            _delete_app(app_config, profile=profile, dry_run=dry_run, wait=wait)
+            _delete_app(
+                app_config,
+                profile=profile,
+                dry_run=dry_run,
+                wait_timeout=wait_timeout,
+                purge=purge,
+            )
 
 
 def _print_job_link(
@@ -4365,7 +4486,12 @@ def _wait_for_resource_deleted(
 
     _apply_profile_context(profile)
     w = WorkspaceClient(profile=profile) if profile else WorkspaceClient()
-    getter = w.apps.get if kind == "app" else w.serving_endpoints.get
+    if kind == "app":
+        getter = w.apps.get
+    elif kind == "endpoint":
+        getter = w.serving_endpoints.get
+    else:
+        raise ValueError(f"unknown resource kind: {kind!r} (expected 'app'/'endpoint')")
 
     logger.info(
         f"Waiting up to {timeout_seconds}s for {kind} '{name}' to be fully "
@@ -4398,7 +4524,8 @@ def deploy_app_bundle(
     destroy: bool,
     profile: Optional[str],
     dry_run: bool = False,
-    wait: bool = True,
+    wait_timeout: Optional[int] = None,
+    purge: bool = False,
 ) -> None:
     """Sync/start/down an already-staged App bundle (agent or MCP).
 
@@ -4416,8 +4543,9 @@ def deploy_app_bundle(
         deploy / run / destroy: which action(s) to perform.
         profile: Databricks CLI profile.
         dry_run: print instead of executing.
-        wait: on destroy, block after ``bundle destroy`` until the app is fully
-            deleted (default). ``down --no-wait`` sets this False.
+        wait_timeout: on destroy, block after ``bundle destroy`` until the app is
+            fully deleted, up to this many seconds. None (default) = don't wait;
+            set from ``down --wait [SECONDS]``.
     """
     if config.app is None:
         raise ValueError("Config must have an 'app' section to deploy a bundle.")
@@ -4432,11 +4560,13 @@ def deploy_app_bundle(
             cwd=staging_dir,
             dry_run=dry_run,
         )
-        # `bundle destroy` returns once the delete is issued; by default block
-        # until the app is actually gone so a following deploy can't race it
-        # (--no-wait sets wait=False).
-        if wait and not dry_run:
-            _wait_for_resource_deleted("app", app_name, profile)
+        # `bundle destroy` returns once the delete is issued; with --wait, block
+        # until the app is actually gone so a following deploy can't race it.
+        if wait_timeout is not None and not dry_run:
+            _wait_for_resource_deleted("app", app_name, profile, wait_timeout)
+        # --purge: also permanently delete the experiment (destroy only trashes it).
+        if purge and not dry_run:
+            _purge_experiment(config, profile)
         return
 
     if deploy:
@@ -4477,7 +4607,8 @@ def _run_ms_job_bundle(
     target: Optional[str],
     cloud: Optional[str],
     config_vars: dict[str, str],
-    wait: bool = True,
+    wait_timeout: Optional[int] = None,
+    purge: bool = False,
 ) -> None:
     """Deploy/run/destroy a staged model_serving *Job* bundle (``agent/<app>/ms``).
 
@@ -4556,7 +4687,11 @@ def _run_ms_job_bundle(
         # down. The registered UC model + versions are intentionally KEPT — a
         # reusable artifact a later `up`/`start` can redeploy.
         _delete_serving_endpoint(
-            config, profile=profile, dry_run=dry_run, wait=wait
+            config,
+            profile=profile,
+            dry_run=dry_run,
+            wait_timeout=wait_timeout,
+            purge=purge,
         )
         return
 
@@ -4601,7 +4736,12 @@ def _run_ms_job_bundle(
 
 
 def _delete_serving_endpoint(
-    config: AppConfig, *, profile: Optional[str], dry_run: bool, wait: bool = True
+    config: AppConfig,
+    *,
+    profile: Optional[str],
+    dry_run: bool,
+    wait_timeout: Optional[int] = None,
+    purge: bool = False,
 ) -> None:
     """Delete the Model Serving endpoint a model_serving `down` leaves behind.
 
@@ -4640,14 +4780,24 @@ def _delete_serving_endpoint(
             f"`databricks serving-endpoints delete {endpoint_name}`."
         )
         return
-    # serving_endpoints.delete is async; by default block until the endpoint is
-    # gone so a following deploy can't race the teardown (--no-wait sets False).
-    if wait:
-        _wait_for_resource_deleted("endpoint", endpoint_name, profile)
+    # serving_endpoints.delete is async; with --wait, block until the endpoint is
+    # gone so a following deploy can't race the teardown.
+    if wait_timeout is not None:
+        _wait_for_resource_deleted(
+            "endpoint", endpoint_name, profile, wait_timeout
+        )
+    # --purge: also permanently delete the experiment (destroy only trashes it).
+    if purge:
+        _purge_experiment(config, profile)
 
 
 def _delete_app(
-    config: AppConfig, *, profile: Optional[str], dry_run: bool, wait: bool = True
+    config: AppConfig,
+    *,
+    profile: Optional[str],
+    dry_run: bool,
+    wait_timeout: Optional[int] = None,
+    purge: bool = False,
 ) -> None:
     """Delete the Databricks App a workflow `down` leaves behind.
 
@@ -4686,10 +4836,13 @@ def _delete_app(
             f"Delete it manually with `databricks apps delete {app_name}`."
         )
         return
-    # apps.delete is async; by default block until the App is gone so a following
-    # deploy can't race the teardown (workflow down --no-wait sets wait=False).
-    if wait:
-        _wait_for_resource_deleted("app", app_name, profile)
+    # apps.delete is async; with --wait, block until the App is gone so a
+    # following deploy can't race the teardown.
+    if wait_timeout is not None:
+        _wait_for_resource_deleted("app", app_name, profile, wait_timeout)
+    # --purge: also permanently delete the experiment (destroy only trashes it).
+    if purge:
+        _purge_experiment(config, profile)
 
 
 def _print_app_link(app_name: str) -> None:
@@ -4759,10 +4912,10 @@ def _exec_workflow_verb(options: Namespace, command: list[str]) -> None:
         config_vars=_parse_var_args(options.var),
         staging_dir=options.staging_dir,
         stage=False,
-        # `down` deletes the deployed App/endpoint and waits for it to be gone by
-        # default; --no-wait opts out. Only `down` adds the flag; other verbs
-        # never reach the destroy branch that consults `wait`.
-        wait=not getattr(options, "no_wait", False),
+        # `--wait` (down only) blocks until the deleted App/endpoint is gone;
+        # other verbs never reach the destroy branch that consults it.
+        wait_timeout=_wait_timeout_of(options),
+        purge=_purge_of(options),
     )
 
 
@@ -5159,7 +5312,8 @@ def _deploy_run_destroy_app_bundle(
             target=None,
             cloud=None,
             config_vars=_parse_var_args(options.var),
-            wait=not getattr(options, "no_wait", False),
+            wait_timeout=_wait_timeout_of(options),
+            purge=_purge_of(options),
         )
         return
 
@@ -5174,10 +5328,10 @@ def _deploy_run_destroy_app_bundle(
         destroy=destroy,
         profile=options.profile,
         dry_run=dry_run,
-        # `down` waits for full deletion by default; --no-wait opts out. getattr
-        # keeps non-down verbs (which never add the flag) at the wait=True default
-        # (only the destroy branch consults it).
-        wait=not getattr(options, "no_wait", False),
+        # `--wait` (down only) blocks until the deleted App is gone; non-down
+        # verbs never reach the destroy branch that consults it.
+        wait_timeout=_wait_timeout_of(options),
+        purge=_purge_of(options),
     )
 
 

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -1479,7 +1479,7 @@ class TestDeleteServingEndpoint:
 
         monkeypatch.setattr(sdk, "WorkspaceClient", lambda *a, **k: _WC())
         cli._delete_serving_endpoint(
-            self._ms_config("my_ep"), profile=None, dry_run=False, wait=False
+            self._ms_config("my_ep"), profile=None, dry_run=False, wait_timeout=None
         )
         assert deleted == ["my_ep"]
 
@@ -1530,7 +1530,7 @@ class TestDeleteServingEndpoint:
         monkeypatch.setattr(
             cli,
             "_delete_serving_endpoint",
-            lambda config, *, profile, dry_run, wait=True: order.append(
+            lambda config, *, profile, dry_run, wait_timeout=None, purge=False: order.append(
                 "endpoint_delete"
             ),
         )
@@ -1583,7 +1583,7 @@ class TestDeleteApp:
 
         monkeypatch.setattr(sdk, "WorkspaceClient", lambda *a, **k: _WC())
         cli._delete_app(
-            self._app_config("My_App"), profile=None, dry_run=False, wait=False
+            self._app_config("My_App"), profile=None, dry_run=False, wait_timeout=None
         )
         # App name is the lower/hyphen form the App was deployed under.
         assert deleted == ["my-app"]
@@ -1667,12 +1667,14 @@ class TestWorkflowDownRemovesDeployedAgent:
         monkeypatch.setattr(
             cli,
             "_delete_app",
-            lambda config, *, profile, dry_run, wait=True: order.append("app_delete"),
+            lambda config, *, profile, dry_run, wait_timeout=None, purge=False: order.append(
+                "app_delete"
+            ),
         )
         monkeypatch.setattr(
             cli,
             "_delete_serving_endpoint",
-            lambda config, *, profile, dry_run, wait=True: order.append(
+            lambda config, *, profile, dry_run, wait_timeout=None, purge=False: order.append(
                 "endpoint_delete"
             ),
         )
@@ -2864,28 +2866,203 @@ class TestWaitForResourceDeleted:
     def test_timeout_warns_and_returns_when_never_deleted(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # get() always succeeds (never disappears) -> must not hang/raise; returns
-        # after the (zero) timeout with a warning.
+        # A resource that never disappears must be POLLED (>=1 get) and then time
+        # out gracefully (warn + return, no hang/raise). Drive a fake monotonic
+        # clock so the deadline is reached after a couple of real poll iterations
+        # without waiting wall-clock time.
+        calls = {"n": 0}
+
+        def _get(name: str):  # never raises NotFound -> "still present"
+            calls["n"] += 1
+            return object()
+
+        self._patch_ws(monkeypatch, "app", _get)
+        import time as _time
+
+        ticks = iter([0.0, 0.5, 1.0, 5.0, 999.0])  # advances past a 2s timeout
+        monkeypatch.setattr(_time, "monotonic", lambda: next(ticks))
+        cli._wait_for_resource_deleted("app", "res", profile=None, timeout_seconds=2)
+        assert calls["n"] >= 1, "must poll at least once before timing out"
+
+    def test_unknown_kind_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A bad kind must fail loud, not silently poll the endpoint getter.
         self._patch_ws(monkeypatch, "app", lambda name: object())
-        cli._wait_for_resource_deleted("app", "res", profile=None, timeout_seconds=0)
+        with pytest.raises(ValueError, match="unknown resource kind"):
+            cli._wait_for_resource_deleted("App", "res", profile=None, timeout_seconds=1)
 
 
 @pytest.mark.unit
-class TestNoWaitFlagParsing:
-    """`--no-wait` is on the `down` verb of BOTH nouns; default-on wait otherwise."""
+class TestRestoreTrashedExperiment:
+    """`_restore_trashed_experiment` un-trashes a soft-deleted experiment; else no-op."""
+
+    def _patch_mlflow(
+        self, monkeypatch: pytest.MonkeyPatch, experiment, restored: list[str]
+    ) -> None:
+        import mlflow
+
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(
+            mlflow, "get_experiment_by_name", lambda name: experiment
+        )
+
+        class _Client:
+            def restore_experiment(self, experiment_id: str) -> None:
+                restored.append(experiment_id)
+
+        monkeypatch.setattr(mlflow, "MlflowClient", lambda *a, **k: _Client())
+
+    def test_restores_when_deleted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from types import SimpleNamespace
+
+        restored: list[str] = []
+        exp = SimpleNamespace(experiment_id="123", lifecycle_stage="deleted")
+        self._patch_mlflow(monkeypatch, exp, restored)
+        cli._restore_trashed_experiment("/Users/u/app", profile=None)
+        assert restored == ["123"]
+
+    def test_noop_when_active(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from types import SimpleNamespace
+
+        restored: list[str] = []
+        exp = SimpleNamespace(experiment_id="123", lifecycle_stage="active")
+        self._patch_mlflow(monkeypatch, exp, restored)
+        cli._restore_trashed_experiment("/Users/u/app", profile=None)
+        assert restored == []
+
+    def test_noop_when_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        restored: list[str] = []
+        self._patch_mlflow(monkeypatch, None, restored)
+        cli._restore_trashed_experiment("/Users/u/app", profile=None)
+        assert restored == []
+
+    def test_errors_are_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import mlflow
+
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+
+        def _boom(name: str):
+            raise RuntimeError("mlflow down")
+
+        monkeypatch.setattr(mlflow, "get_experiment_by_name", _boom)
+        # Best-effort: must not raise.
+        cli._restore_trashed_experiment("/Users/u/app", profile=None)
+
+
+@pytest.mark.unit
+class TestWaitFlagParsing:
+    """`--wait [SECONDS]` is opt-in on the `down` verb of BOTH nouns."""
 
     @pytest.mark.parametrize("noun", ["agent", "workflow"])
-    def test_down_no_wait_sets_true(self, noun: str) -> None:
-        opts = parse_args([noun, "down", "-c", "c.yaml", "--no-wait"])
-        assert opts.no_wait is True
+    def test_down_bare_wait_uses_default(self, noun: str) -> None:
+        opts = parse_args([noun, "down", "-c", "c.yaml", "--wait"])
+        assert opts.wait == cli._DEFAULT_WAIT_SECONDS
 
     @pytest.mark.parametrize("noun", ["agent", "workflow"])
-    def test_down_defaults_to_wait(self, noun: str) -> None:
+    def test_down_wait_explicit_count(self, noun: str) -> None:
+        opts = parse_args([noun, "down", "-c", "c.yaml", "--wait", "90"])
+        assert opts.wait == 90
+
+    @pytest.mark.parametrize("noun", ["agent", "workflow"])
+    def test_down_without_wait_is_none(self, noun: str) -> None:
         opts = parse_args([noun, "down", "-c", "c.yaml"])
-        assert opts.no_wait is False
+        assert opts.wait is None
+        # And the typed accessor reflects "don't wait".
+        assert cli._wait_timeout_of(opts) is None
 
     @pytest.mark.parametrize("noun", ["agent", "workflow"])
     @pytest.mark.parametrize("verb", ["up", "sync", "build", "start"])
-    def test_non_down_verbs_reject_no_wait(self, noun: str, verb: str) -> None:
+    def test_non_down_verbs_reject_wait(self, noun: str, verb: str) -> None:
         with pytest.raises(SystemExit):
-            parse_args([noun, verb, "-c", "c.yaml", "--no-wait"])
+            parse_args([noun, verb, "-c", "c.yaml", "--wait"])
+
+    @pytest.mark.parametrize("verb", ["up", "sync", "build", "start"])
+    def test_wait_timeout_of_none_for_verbs_without_flag(self, verb: str) -> None:
+        # Non-down verbs never define --wait; the accessor must return None, not raise.
+        opts = parse_args(["agent", verb, "-c", "c.yaml"])
+        assert cli._wait_timeout_of(opts) is None
+
+
+@pytest.mark.unit
+class TestPurgeFlagParsing:
+    """`--purge` is opt-in on the `down` verb of BOTH nouns; default False."""
+
+    @pytest.mark.parametrize("noun", ["agent", "workflow"])
+    def test_down_purge_sets_true(self, noun: str) -> None:
+        opts = parse_args([noun, "down", "-c", "c.yaml", "--purge"])
+        assert opts.purge is True
+        assert cli._purge_of(opts) is True
+
+    @pytest.mark.parametrize("noun", ["agent", "workflow"])
+    def test_down_default_no_purge(self, noun: str) -> None:
+        opts = parse_args([noun, "down", "-c", "c.yaml"])
+        assert opts.purge is False
+
+    @pytest.mark.parametrize("verb", ["up", "sync", "build", "start"])
+    def test_non_down_verbs_reject_purge(self, verb: str) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(["agent", verb, "-c", "c.yaml", "--purge"])
+        # And the accessor returns False (flag absent) rather than raising.
+        assert cli._purge_of(parse_args(["agent", verb, "-c", "c.yaml"])) is False
+
+
+@pytest.mark.unit
+class TestPurgeExperiment:
+    """`_purge_experiment` deletes the experiment's workspace node; best-effort."""
+
+    def _config(self, *, experiment_id: str | None = None):
+        from dao_ai.config import AppConfig
+
+        class _Exp:
+            def __init__(self, eid):
+                self.id = eid
+
+        class _App:
+            name = "my_app"
+            experiment = _Exp(experiment_id) if experiment_id else None
+
+        return AppConfig.model_construct(app=_App())
+
+    def _patch(self, monkeypatch, deleted: list[str], exp_path: str = "/Users/u/my_app"):
+        import databricks.sdk as _sdk
+
+        from dao_ai.providers import databricks as _prov
+
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+
+        class _WS:
+            def delete(self, path: str, recursive: bool = False) -> None:
+                deleted.append((path, recursive))
+
+        class _WC:
+            workspace = _WS()
+
+        monkeypatch.setattr(_sdk, "WorkspaceClient", lambda *a, **k: _WC())
+        monkeypatch.setattr(
+            _prov.DatabricksProvider, "experiment_name", lambda self, config: exp_path
+        )
+
+    def test_purges_default_experiment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        deleted: list[str] = []
+        self._patch(monkeypatch, deleted)
+        cli._purge_experiment(self._config(), profile=None)
+        assert deleted == [("/Users/u/my_app", True)]
+
+    def test_skips_external_experiment_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An externally-referenced experiment (app.experiment.id) is not ours.
+        deleted: list[str] = []
+        self._patch(monkeypatch, deleted)
+        cli._purge_experiment(self._config(experiment_id="999"), profile=None)
+        assert deleted == []
+
+    def test_errors_are_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import databricks.sdk as _sdk
+
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+
+        def _boom(*a, **k):
+            raise RuntimeError("workspace down")
+
+        monkeypatch.setattr(_sdk, "WorkspaceClient", _boom)
+        cli._purge_experiment(self._config(), profile=None)  # must not raise

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -1479,7 +1479,7 @@ class TestDeleteServingEndpoint:
 
         monkeypatch.setattr(sdk, "WorkspaceClient", lambda *a, **k: _WC())
         cli._delete_serving_endpoint(
-            self._ms_config("my_ep"), profile=None, dry_run=False
+            self._ms_config("my_ep"), profile=None, dry_run=False, wait=False
         )
         assert deleted == ["my_ep"]
 
@@ -1530,7 +1530,9 @@ class TestDeleteServingEndpoint:
         monkeypatch.setattr(
             cli,
             "_delete_serving_endpoint",
-            lambda config, *, profile, dry_run: order.append("endpoint_delete"),
+            lambda config, *, profile, dry_run, wait=True: order.append(
+                "endpoint_delete"
+            ),
         )
         monkeypatch.setattr(cli, "_resolve_job_dao_ai_dep", lambda *a, **k: "dao-ai")
         monkeypatch.setattr(cli, "detect_cloud_provider", lambda p: "aws")
@@ -1580,7 +1582,9 @@ class TestDeleteApp:
         import databricks.sdk as sdk
 
         monkeypatch.setattr(sdk, "WorkspaceClient", lambda *a, **k: _WC())
-        cli._delete_app(self._app_config("My_App"), profile=None, dry_run=False)
+        cli._delete_app(
+            self._app_config("My_App"), profile=None, dry_run=False, wait=False
+        )
         # App name is the lower/hyphen form the App was deployed under.
         assert deleted == ["my-app"]
 
@@ -1663,12 +1667,14 @@ class TestWorkflowDownRemovesDeployedAgent:
         monkeypatch.setattr(
             cli,
             "_delete_app",
-            lambda config, *, profile, dry_run: order.append("app_delete"),
+            lambda config, *, profile, dry_run, wait=True: order.append("app_delete"),
         )
         monkeypatch.setattr(
             cli,
             "_delete_serving_endpoint",
-            lambda config, *, profile, dry_run: order.append("endpoint_delete"),
+            lambda config, *, profile, dry_run, wait=True: order.append(
+                "endpoint_delete"
+            ),
         )
         cfg = self._cfg(tmp_path)
         argv = ["workflow", "down", "-c", str(cfg), "-s", str(tmp_path)] + mode_argv
@@ -2803,3 +2809,83 @@ class TestDeployTriggersAdopt:
         adopt.assert_called_once()
         assert adopt.call_args.kwargs["target"] == "myapp-aws"
         assert adopt.call_args.kwargs["extra_vars"] == ['--var="mode=apps"']
+
+
+@pytest.mark.unit
+class TestWaitForResourceDeleted:
+    """`_wait_for_resource_deleted` polls get() until NotFound, else times out."""
+
+    def _patch_ws(
+        self, monkeypatch: pytest.MonkeyPatch, kind: str, get_side_effect
+    ) -> None:
+        """Install a fake WorkspaceClient whose <kind>.get uses get_side_effect."""
+        from unittest.mock import MagicMock
+
+        fake = MagicMock()
+        getter = fake.apps.get if kind == "app" else fake.serving_endpoints.get
+        getter.side_effect = get_side_effect
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        # Patch the symbols the helper imports lazily (databricks.sdk.WorkspaceClient
+        # + the stdlib time.sleep) at their source modules.
+        import time as _time
+
+        import databricks.sdk as _sdk
+
+        monkeypatch.setattr(_sdk, "WorkspaceClient", lambda *a, **k: fake)
+        monkeypatch.setattr(_time, "sleep", lambda *_a, **_k: None)
+
+    @pytest.mark.parametrize("kind", ["app", "endpoint"])
+    def test_returns_when_absent_after_polls(
+        self, kind: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from databricks.sdk.errors import NotFound
+
+        calls = {"n": 0}
+
+        def _get(name: str):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                return object()  # still present
+            raise NotFound("gone")
+
+        self._patch_ws(monkeypatch, kind, _get)
+        cli._wait_for_resource_deleted(kind, "res", profile=None, timeout_seconds=60)
+        assert calls["n"] == 3
+
+    @pytest.mark.parametrize("kind", ["app", "endpoint"])
+    def test_returns_immediately_when_already_absent(
+        self, kind: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from databricks.sdk.errors import NotFound
+
+        self._patch_ws(monkeypatch, kind, NotFound("gone"))
+        cli._wait_for_resource_deleted(kind, "res", profile=None, timeout_seconds=60)
+
+    def test_timeout_warns_and_returns_when_never_deleted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # get() always succeeds (never disappears) -> must not hang/raise; returns
+        # after the (zero) timeout with a warning.
+        self._patch_ws(monkeypatch, "app", lambda name: object())
+        cli._wait_for_resource_deleted("app", "res", profile=None, timeout_seconds=0)
+
+
+@pytest.mark.unit
+class TestNoWaitFlagParsing:
+    """`--no-wait` is on the `down` verb of BOTH nouns; default-on wait otherwise."""
+
+    @pytest.mark.parametrize("noun", ["agent", "workflow"])
+    def test_down_no_wait_sets_true(self, noun: str) -> None:
+        opts = parse_args([noun, "down", "-c", "c.yaml", "--no-wait"])
+        assert opts.no_wait is True
+
+    @pytest.mark.parametrize("noun", ["agent", "workflow"])
+    def test_down_defaults_to_wait(self, noun: str) -> None:
+        opts = parse_args([noun, "down", "-c", "c.yaml"])
+        assert opts.no_wait is False
+
+    @pytest.mark.parametrize("noun", ["agent", "workflow"])
+    @pytest.mark.parametrize("verb", ["up", "sync", "build", "start"])
+    def test_non_down_verbs_reject_no_wait(self, noun: str, verb: str) -> None:
+        with pytest.raises(SystemExit):
+            parse_args([noun, verb, "-c", "c.yaml", "--no-wait"])

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -1530,7 +1530,7 @@ class TestDeleteServingEndpoint:
         monkeypatch.setattr(
             cli,
             "_delete_serving_endpoint",
-            lambda config, *, profile, dry_run, wait_timeout=None, purge=False: order.append(
+            lambda config, *, profile, dry_run, wait_timeout=None: order.append(
                 "endpoint_delete"
             ),
         )
@@ -1667,14 +1667,14 @@ class TestWorkflowDownRemovesDeployedAgent:
         monkeypatch.setattr(
             cli,
             "_delete_app",
-            lambda config, *, profile, dry_run, wait_timeout=None, purge=False: order.append(
+            lambda config, *, profile, dry_run, wait_timeout=None: order.append(
                 "app_delete"
             ),
         )
         monkeypatch.setattr(
             cli,
             "_delete_serving_endpoint",
-            lambda config, *, profile, dry_run, wait_timeout=None, purge=False: order.append(
+            lambda config, *, profile, dry_run, wait_timeout=None: order.append(
                 "endpoint_delete"
             ),
         )
@@ -2889,66 +2889,6 @@ class TestWaitForResourceDeleted:
         self._patch_ws(monkeypatch, "app", lambda name: object())
         with pytest.raises(ValueError, match="unknown resource kind"):
             cli._wait_for_resource_deleted("App", "res", profile=None, timeout_seconds=1)
-
-
-@pytest.mark.unit
-class TestRestoreTrashedExperiment:
-    """`_restore_trashed_experiment` un-trashes a soft-deleted experiment; else no-op."""
-
-    def _patch_mlflow(
-        self, monkeypatch: pytest.MonkeyPatch, experiment, restored: list[str]
-    ) -> None:
-        import mlflow
-
-        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
-        monkeypatch.setattr(
-            mlflow, "get_experiment_by_name", lambda name: experiment
-        )
-
-        class _Client:
-            def restore_experiment(self, experiment_id: str) -> None:
-                restored.append(experiment_id)
-
-        monkeypatch.setattr(mlflow, "MlflowClient", lambda *a, **k: _Client())
-
-    def test_restores_when_deleted(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from types import SimpleNamespace
-
-        restored: list[str] = []
-        exp = SimpleNamespace(experiment_id="123", lifecycle_stage="deleted")
-        self._patch_mlflow(monkeypatch, exp, restored)
-        cli._restore_trashed_experiment("/Users/u/app", profile=None)
-        assert restored == ["123"]
-
-    def test_noop_when_active(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from types import SimpleNamespace
-
-        restored: list[str] = []
-        exp = SimpleNamespace(experiment_id="123", lifecycle_stage="active")
-        self._patch_mlflow(monkeypatch, exp, restored)
-        cli._restore_trashed_experiment("/Users/u/app", profile=None)
-        assert restored == []
-
-    def test_noop_when_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        restored: list[str] = []
-        self._patch_mlflow(monkeypatch, None, restored)
-        cli._restore_trashed_experiment("/Users/u/app", profile=None)
-        assert restored == []
-
-    def test_errors_are_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import mlflow
-
-        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
-
-        def _boom(name: str):
-            raise RuntimeError("mlflow down")
-
-        monkeypatch.setattr(mlflow, "get_experiment_by_name", _boom)
-        # Best-effort: must not raise.
-        cli._restore_trashed_experiment("/Users/u/app", profile=None)
-
-
-@pytest.mark.unit
 class TestWaitFlagParsing:
     """`--wait [SECONDS]` is opt-in on the `down` verb of BOTH nouns."""
 
@@ -2980,89 +2920,3 @@ class TestWaitFlagParsing:
         # Non-down verbs never define --wait; the accessor must return None, not raise.
         opts = parse_args(["agent", verb, "-c", "c.yaml"])
         assert cli._wait_timeout_of(opts) is None
-
-
-@pytest.mark.unit
-class TestPurgeFlagParsing:
-    """`--purge` is opt-in on the `down` verb of BOTH nouns; default False."""
-
-    @pytest.mark.parametrize("noun", ["agent", "workflow"])
-    def test_down_purge_sets_true(self, noun: str) -> None:
-        opts = parse_args([noun, "down", "-c", "c.yaml", "--purge"])
-        assert opts.purge is True
-        assert cli._purge_of(opts) is True
-
-    @pytest.mark.parametrize("noun", ["agent", "workflow"])
-    def test_down_default_no_purge(self, noun: str) -> None:
-        opts = parse_args([noun, "down", "-c", "c.yaml"])
-        assert opts.purge is False
-
-    @pytest.mark.parametrize("verb", ["up", "sync", "build", "start"])
-    def test_non_down_verbs_reject_purge(self, verb: str) -> None:
-        with pytest.raises(SystemExit):
-            parse_args(["agent", verb, "-c", "c.yaml", "--purge"])
-        # And the accessor returns False (flag absent) rather than raising.
-        assert cli._purge_of(parse_args(["agent", verb, "-c", "c.yaml"])) is False
-
-
-@pytest.mark.unit
-class TestPurgeExperiment:
-    """`_purge_experiment` deletes the experiment's workspace node; best-effort."""
-
-    def _config(self, *, experiment_id: str | None = None):
-        from dao_ai.config import AppConfig
-
-        class _Exp:
-            def __init__(self, eid):
-                self.id = eid
-
-        class _App:
-            name = "my_app"
-            experiment = _Exp(experiment_id) if experiment_id else None
-
-        return AppConfig.model_construct(app=_App())
-
-    def _patch(self, monkeypatch, deleted: list[str], exp_path: str = "/Users/u/my_app"):
-        import databricks.sdk as _sdk
-
-        from dao_ai.providers import databricks as _prov
-
-        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
-
-        class _WS:
-            def delete(self, path: str, recursive: bool = False) -> None:
-                deleted.append((path, recursive))
-
-        class _WC:
-            workspace = _WS()
-
-        monkeypatch.setattr(_sdk, "WorkspaceClient", lambda *a, **k: _WC())
-        monkeypatch.setattr(
-            _prov.DatabricksProvider, "experiment_name", lambda self, config: exp_path
-        )
-
-    def test_purges_default_experiment(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        deleted: list[str] = []
-        self._patch(monkeypatch, deleted)
-        cli._purge_experiment(self._config(), profile=None)
-        assert deleted == [("/Users/u/my_app", True)]
-
-    def test_skips_external_experiment_id(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        # An externally-referenced experiment (app.experiment.id) is not ours.
-        deleted: list[str] = []
-        self._patch(monkeypatch, deleted)
-        cli._purge_experiment(self._config(experiment_id="999"), profile=None)
-        assert deleted == []
-
-    def test_errors_are_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import databricks.sdk as _sdk
-
-        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
-
-        def _boom(*a, **k):
-            raise RuntimeError("workspace down")
-
-        monkeypatch.setattr(_sdk, "WorkspaceClient", _boom)
-        cli._purge_experiment(self._config(), profile=None)  # must not raise

--- a/tests/scripts/validate-cli.sh
+++ b/tests/scripts/validate-cli.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# validate-cli.sh — run a dao-ai config through the common CLI lifecycle a
+# user hits during a manual validation session.
+#
+# Drives the real `dao-ai` CLI against a live Databricks workspace, so it needs
+# a profile with the workspace already provisioned (VS / Lakebase / Genie, etc).
+# The command sequence is hard-coded; the only inputs are the profile and an
+# optional config path.
+#
+# Usage:
+#   tests/scripts/validate-cli.sh -p fevm
+#   tests/scripts/validate-cli.sh -p fevm ./examples/04_genie/genie.yaml
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# ---------------------------------------------------------------------------
+# Inputs: -p/--profile (required), optional config path (positional).
+# ---------------------------------------------------------------------------
+PROFILE=""
+CONFIG="./examples/01_getting_started/ai_gateway.yaml"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p|--profile) PROFILE="$2"; shift 2 ;;
+    -h|--help)    grep '^#' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *)            CONFIG="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$PROFILE" ]]; then
+  echo "ERROR: -p/--profile is required (e.g. -p fevm)." >&2
+  exit 1
+fi
+
+# Echo each command before running it.
+dai() {
+  printf '\n\033[1;34m$ dao-ai -p %s %s\033[0m\n' "$PROFILE" "$*"
+  uv run dao-ai -p "$PROFILE" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Sanity: version, resolved env, config validity, declared params, MCP tools.
+# ---------------------------------------------------------------------------
+dai version
+dai doctor
+dai validate -c "$CONFIG"
+dai parameters -c "$CONFIG"
+dai mcp tools -c "$CONFIG"
+
+# ---------------------------------------------------------------------------
+# Provisioning workflow lifecycle (granular build → sync → start, then the
+# idempotent one-shot up), then tear it down.
+# ---------------------------------------------------------------------------
+dai workflow build -c "$CONFIG"
+dai workflow sync  -c "$CONFIG"
+dai workflow start -c "$CONFIG"
+dai workflow down -c "$CONFIG"
+dai workflow up    -c "$CONFIG"
+dai workflow down  -c "$CONFIG"
+
+# ---------------------------------------------------------------------------
+# Agent lifecycle on Apps (default mode): granular build → sync → start → down,
+# then the idempotent one-shot up, then tear it down.
+# ---------------------------------------------------------------------------
+dai agent build -c "$CONFIG"
+dai agent sync  -c "$CONFIG"
+dai agent start -c "$CONFIG"
+# `down` waits for the app to be fully deleted by default, so the following `up`
+# never races the teardown (no `--wait` needed; pass `--no-wait` to skip).
+dai agent down  -c "$CONFIG"
+dai agent up    -c "$CONFIG"
+dai monitor logs -c "$CONFIG"
+dai agent down  -c "$CONFIG"
+
+# ---------------------------------------------------------------------------
+# Agent on Model Serving (-m ms).
+# ---------------------------------------------------------------------------
+dai agent up   -c "$CONFIG" -m ms
+dai agent down -c "$CONFIG" -m ms
+
+# ---------------------------------------------------------------------------
+# Agent via the --direct SDK fast-path (no bundle on disk).
+# ---------------------------------------------------------------------------
+dai agent up   -c "$CONFIG" --direct
+dai agent down -c "$CONFIG"
+
+# Reaching here means every command above exited 0 (set -euo pipefail aborts on
+# the first failure), so this banner is an unambiguous end-to-end success signal.
+echo -e "\n\033[1;32m✅ validate-cli.sh: all commands completed successfully.\033[0m"

--- a/tests/scripts/validate-cli.sh
+++ b/tests/scripts/validate-cli.sh
@@ -58,9 +58,12 @@ dai mcp tools -c "$CONFIG"
 dai workflow build -c "$CONFIG"
 dai workflow sync  -c "$CONFIG"
 dai workflow start -c "$CONFIG"
-dai workflow down -c "$CONFIG"
+# --wait: block until the deployed App/endpoint is fully deleted so the next
+# deploy (the `up` below, and the agent section) can't race the async teardown.
+dai workflow down -c "$CONFIG" --wait
 dai workflow up    -c "$CONFIG"
-dai workflow down  -c "$CONFIG"
+# Last workflow down before the agent section redeploys the same app — wait it out.
+dai workflow down  -c "$CONFIG" --wait
 
 # ---------------------------------------------------------------------------
 # Agent lifecycle on Apps (default mode): granular build → sync → start → down,
@@ -69,9 +72,9 @@ dai workflow down  -c "$CONFIG"
 dai agent build -c "$CONFIG"
 dai agent sync  -c "$CONFIG"
 dai agent start -c "$CONFIG"
-# `down` waits for the app to be fully deleted by default, so the following `up`
-# never races the teardown (no `--wait` needed; pass `--no-wait` to skip).
-dai agent down  -c "$CONFIG"
+# --wait: block until the app is fully deleted so the following `up` can't race
+# the async teardown (400 "compute is in DELETING state"). Omit for fire-and-forget.
+dai agent down  -c "$CONFIG" --wait
 dai agent up    -c "$CONFIG"
 dai monitor logs -c "$CONFIG"
 dai agent down  -c "$CONFIG"
@@ -86,7 +89,10 @@ dai agent down -c "$CONFIG" -m ms
 # Agent via the --direct SDK fast-path (no bundle on disk).
 # ---------------------------------------------------------------------------
 dai agent up   -c "$CONFIG" --direct
-dai agent down -c "$CONFIG"
+# Final teardown uses --purge for a clean slate: permanently delete the MLflow
+# experiment too (not just soft-delete/trash it), so no trashed node lingers to
+# collide with a future redeploy. Also exercises the --purge path live.
+dai agent down -c "$CONFIG" --purge
 
 # Reaching here means every command above exited 0 (set -euo pipefail aborts on
 # the first failure), so this banner is an unambiguous end-to-end success signal.

--- a/tests/scripts/validate-cli.sh
+++ b/tests/scripts/validate-cli.sh
@@ -89,10 +89,7 @@ dai agent down -c "$CONFIG" -m ms
 # Agent via the --direct SDK fast-path (no bundle on disk).
 # ---------------------------------------------------------------------------
 dai agent up   -c "$CONFIG" --direct
-# Final teardown uses --purge for a clean slate: permanently delete the MLflow
-# experiment too (not just soft-delete/trash it), so no trashed node lingers to
-# collide with a future redeploy. Also exercises the --purge path live.
-dai agent down -c "$CONFIG" --purge
+dai agent down -c "$CONFIG"
 
 # Reaching here means every command above exited 0 (set -euo pipefail aborts on
 # the first failure), so this banner is an unambiguous end-to-end success signal.


### PR DESCRIPTION
## Summary

`dao-ai <noun> down` runs an **async** teardown, so a deploy that immediately follows a teardown races it and fails:

```
Error: cannot update resources.apps.<app>: ... Cannot update app <app> as its compute is in
DELETING state. App compute needs to be ACTIVE or STOPPED to update. (400 BAD_REQUEST)
```

The error surfaces in `sync`/`up`, but the **root cause is `down`**: `bundle destroy` / `apps.delete` / `serving_endpoints.delete` all return while the resource is still `DELETING`. This fixes it at the source — **`down` now blocks until the deployed resource is actually gone**, so a completed `down` means "deleted" and nothing is left to race.

## What changed

- **Default-on wait on `down`** (both `agent` and `workflow`); **`--no-wait`** restores fire-and-forget.
- Both nouns deploy either an **App** (apps/mcp) or a **serving endpoint** (model_serving), so the wait covers all three teardown chokepoints:
  - `deploy_app_bundle` destroy branch (agent apps/mcp — `bundle destroy`)
  - `_delete_app` (workflow apps/mcp — `apps.delete`)
  - `_delete_serving_endpoint` (either noun, model_serving — `serving_endpoints.delete`)
- New `_wait_for_resource_deleted(kind, name, …)` polls `apps.get`/`serving_endpoints.get` until `NotFound` (mirrors the existing `_wait_until_index_absent`); bounded, warns + returns on timeout (never hangs).
- **`.gitignore`**: anchor the venv patterns (`/[Bb]in`, `/[Ss]cripts`, …) so they only match a repo-root venv — `tests/scripts/` was being ignored by the un-anchored `[Ss]cripts` rule.
- **Add `tests/scripts/validate-cli.sh`** — the live CLI-lifecycle harness that surfaced this race — with a clear success banner.

## Verification

- **Unit**: 305 pass in `test_development_flag_cli.py` (new `TestWaitForResourceDeleted` covers app+endpoint, poll-until-gone, and timeout-warns-not-hangs; `TestNoWaitFlagParsing` covers the flag on both nouns' `down` and its rejection elsewhere). ruff clean.
- **Live on fevm**: `workflow down` now blocks ~52s until the App is `NotFound` and returns only once gone. A full `validate-cli.sh -p fevm` run completes end-to-end with **zero** `DELETING` races (previously failed at `workflow down` → `agent sync`).

This pull request and its description were written by Isaac.
