### PR TITLE
feat(cli): down --purge also drops the app's per-experiment OTEL trace tables

### DIFF
--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -3966,6 +3966,9 @@ def _purge_experiment(config: AppConfig, profile: Optional[str]) -> None:
     externally-referenced experiment (``app.experiment.id``) is left alone —
     dao-ai didn't create it.
 
+    After deleting the nodes, :func:`_purge_otel_trace_tables` also drops the app's
+    UC OTEL trace tables when it can do so safely (per-experiment prefix only).
+
     Best-effort: a missing node or any error is logged and swallowed so ``down``
     still completes.
     """
@@ -4003,17 +4006,73 @@ def _purge_experiment(config: AppConfig, profile: Optional[str]) -> None:
         if not matches:
             logger.info(f"Purge: no experiment nodes matching '{leaf}' to delete.")
             return
+        purged_ids: list[str] = []
         for exp in matches:
             try:
                 w.workspace.delete(exp.name, recursive=True)
+                purged_ids.append(str(exp.experiment_id))
                 logger.info(
                     f"Purged (permanently deleted) experiment node '{exp.name}' "
                     f"(id={exp.experiment_id})."
                 )
             except Exception as e:  # noqa: BLE001
                 logger.debug(f"purge of experiment node '{exp.name}' skipped: {e}")
+        _purge_otel_trace_tables(config, purged_ids, profile)
     except Exception as e:  # noqa: BLE001
         logger.debug(f"purge of experiment skipped: {e}")
+
+
+def _purge_otel_trace_tables(
+    config: AppConfig, experiment_ids: list[str], profile: Optional[str]
+) -> None:
+    """Drop the app's OTEL trace tables when ``down --purge`` can do so SAFELY.
+
+    MLflow lazily materializes four Delta tables per trace-location prefix
+    (``<catalog>.<schema>.<prefix>_otel_{spans,logs,metrics,annotations}``).
+    Purging the experiment node leaves these orphaned, so ``--purge`` cleans them
+    up — but only when it can prove no OTHER agent shares the table set (the same
+    sibling-safety principle as the experiment-node purge):
+
+    * ``trace_location.table_prefix`` UNSET → MLflow uses the ``experiment_id`` as
+      the prefix, so tables are per-experiment. For each experiment id this purge
+      just deleted, drop its ``<id>_otel_*`` tables — cannot collide with another
+      agent.
+    * ``trace_location.table_prefix`` SET → the prefix is chosen precisely to
+      NAMESPACE/SHARE a table set across agents, so dao-ai can't know if another
+      agent still writes there. Do NOT drop; log the exact table names + a manual
+      ``DROP TABLE`` hint so the operator can clean a genuinely single-agent prefix.
+
+    No-op when ``trace_location`` is unset (no UC tables) or nothing was purged.
+    Best-effort: any failure is logged and swallowed so ``down`` still completes.
+    """
+    if config.app is None or config.app.trace_location is None:
+        return
+    if not experiment_ids:
+        return
+    try:
+        from dao_ai.providers.databricks import (
+            _drop_uc_otel_tables,
+            _otel_table_names,
+        )
+
+        loc = config.app.trace_location
+        catalog_name = loc.catalog_name
+        schema_name = loc.schema_name
+        prefix = loc.resolved_table_prefix
+        if prefix:
+            # Explicit prefix — potentially shared; don't drop. Surface the names.
+            tables = _otel_table_names(catalog_name, schema_name, prefix)
+            hint = "; ".join(f"DROP TABLE IF EXISTS `{t}`" for t in tables)
+            logger.warning(
+                "Purge left OTEL trace tables in place: trace_location.table_prefix "
+                f"'{prefix}' may be shared across agents. Drop manually if this "
+                f"prefix is single-agent: {hint}"
+            )
+            return
+        for experiment_id in experiment_ids:
+            _drop_uc_otel_tables(catalog_name, schema_name, experiment_id, profile)
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"purge of OTEL trace tables skipped: {e}")
 
 
 def _exec_bundle_command(

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -4061,8 +4061,17 @@ def _purge_otel_trace_tables(
         prefix = loc.resolved_table_prefix
         if prefix:
             # Explicit prefix — potentially shared; don't drop. Surface the names.
+            # Backtick EACH identifier segment (`cat`.`sch`.`tbl`), not the whole
+            # dotted name — a single backtick pair around a dotted name is parsed
+            # as one literal identifier, so the DROP silently no-ops (the same trap
+            # `_drop_uc_otel_tables` avoids by using the Tables SDK). An OTEL prefix
+            # is often the experiment_id, which starts with a digit and so genuinely
+            # requires quoting; per-segment backticks are both correct and runnable.
             tables = _otel_table_names(catalog_name, schema_name, prefix)
-            hint = "; ".join(f"DROP TABLE IF EXISTS `{t}`" for t in tables)
+            quoted = [
+                ".".join(f"`{seg}`" for seg in t.split(".")) for t in tables
+            ]
+            hint = "; ".join(f"DROP TABLE IF EXISTS {q}" for q in quoted)
             logger.warning(
                 "Purge left OTEL trace tables in place: trace_location.table_prefix "
                 f"'{prefix}' may be shared across agents. Drop manually if this "

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -865,6 +865,67 @@ def _grant_uc_trace_table_permissions_to_principal(
     )
 
 
+def _otel_table_names(
+    catalog_name: str, schema_name: str, table_prefix: str
+) -> list[str]:
+    """The four fully-qualified OTEL trace table names for a prefix.
+
+    Mirrors what MLflow materializes for a UC trace location:
+    ``<catalog>.<schema>.<prefix>_otel_{spans,logs,metrics,annotations}``.
+    """
+    return [
+        f"{catalog_name}.{schema_name}.{table_prefix}_otel_{suffix}"
+        for suffix in ("spans", "logs", "metrics", "annotations")
+    ]
+
+
+def _drop_uc_otel_tables(
+    catalog_name: str,
+    schema_name: str,
+    table_prefix: str,
+    profile: Optional[str] = None,
+) -> None:
+    """Permanently drop the four OTEL trace tables for ``table_prefix``.
+
+    The inverse of :func:`_grant_uc_trace_table_permissions_to_principal` — used by
+    ``down --purge`` to clean up the Delta tables MLflow lazily materialized at
+    ``<catalog>.<schema>.<prefix>_otel_{spans,logs,metrics,annotations}``. Deletes
+    each table via the UC Tables SDK (``w.tables.delete(full_name=...)``) rather
+    than a SQL ``DROP`` — no warehouse needed, and it sidesteps the identifier-
+    quoting trap where a fully-qualified dotted name inside a single backtick pair
+    is parsed as one literal identifier (so ``DROP TABLE IF EXISTS`` silently
+    no-ops instead of dropping). A table that was never materialized (traces never
+    exported) raises ``NotFound`` and is treated as a harmless no-op.
+
+    CALLER CONTRACT: only call this with a prefix that uniquely identifies ONE
+    experiment (i.e. the experiment_id, when ``trace_location.table_prefix`` is
+    unset). An explicitly-configured ``table_prefix`` may be SHARED across agents,
+    so purge must not drop those tables — see :func:`_purge_experiment`.
+
+    Best-effort: each delete is independent; any failure is logged and swallowed so
+    ``down`` still completes.
+    """
+    from databricks.sdk import WorkspaceClient
+    from databricks.sdk.errors import NotFound
+
+    w = WorkspaceClient(profile=profile) if profile else WorkspaceClient()
+    for full_name in _otel_table_names(catalog_name, schema_name, table_prefix):
+        try:
+            w.tables.delete(full_name=full_name)
+            logger.info(f"Purged (dropped) OTEL trace table '{full_name}'.")
+        except NotFound:
+            logger.debug(
+                f"OTEL trace table '{full_name}' not found (never materialized) "
+                "— nothing to drop."
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "Failed to drop OTEL trace table during purge",
+                full_name=full_name,
+                error=str(e),
+            )
+
+
 def _resolve_trace_table_prefix(config: AppConfig, experiment_id: Optional[str]) -> str:
     """Return the table prefix MLflow uses for OTEL trace tables.
 

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -3189,12 +3189,11 @@ class TestPurgeOtelTraceTables:
         return cfg
 
     @staticmethod
-    def _trace_location(*, prefix, catalog="cat", schema="sch", warehouse_id="wh1"):
+    def _trace_location(*, prefix, catalog="cat", schema="sch"):
         loc = MagicMock()
         loc.resolved_table_prefix = prefix
         loc.catalog_name = catalog
         loc.schema_name = schema
-        loc.warehouse_id = warehouse_id
         return loc
 
     def test_unset_prefix_drops_per_experiment_tables(self) -> None:
@@ -3217,10 +3216,15 @@ class TestPurgeOtelTraceTables:
         ) as drop, patch.object(cli.logger, "warning") as warn:
             cli._purge_otel_trace_tables(cfg, ["111"], profile="fevm")
         drop.assert_not_called()
-        # The four shared table names are surfaced for manual cleanup.
+        # The four shared table names are surfaced for manual cleanup, with EACH
+        # identifier segment backticked (`cat`.`sch`.`tbl`) — NOT the whole dotted
+        # name in one pair, which SQL parses as a single literal identifier and
+        # silently no-ops. This is the runnable form.
         logged = " ".join(str(c.args[0]) for c in warn.call_args_list)
         for suffix in ("spans", "logs", "metrics", "annotations"):
-            assert f"cat.sch.shared_x_otel_{suffix}" in logged
+            assert f"`cat`.`sch`.`shared_x_otel_{suffix}`" in logged
+        # Guard against a regression to the broken single-backtick-pair form.
+        assert "`cat.sch." not in logged
 
     def test_no_trace_location_is_noop(self) -> None:
         cfg = self._config(trace_location=None)

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -3042,6 +3042,9 @@ class TestPurgeExperiment:
     def _config(self, *, external_id: str | None = None):
         app = MagicMock()
         app.experiment = SimpleNamespace(id=external_id) if external_id else None
+        # No trace_location by default, so the existing purge tests exercise only
+        # the experiment-node path (OTEL cleanup is covered in its own class).
+        app.trace_location = None
         cfg = MagicMock()
         cfg.app = app
         return cfg
@@ -3168,3 +3171,92 @@ class TestPurgeExperiment:
         ):
             # Must not raise.
             cli._purge_experiment(self._config(), profile="fevm")
+
+
+@pytest.mark.unit
+class TestPurgeOtelTraceTables:
+    """`down --purge` also drops the app's OTEL trace tables — but ONLY when the
+    prefix is per-experiment (unset ``table_prefix``). An explicit prefix may be
+    shared across agents, so it's left in place with a manual-drop hint."""
+
+    @staticmethod
+    def _config(*, trace_location, external_id: str | None = None):
+        app = MagicMock()
+        app.experiment = SimpleNamespace(id=external_id) if external_id else None
+        app.trace_location = trace_location
+        cfg = MagicMock()
+        cfg.app = app
+        return cfg
+
+    @staticmethod
+    def _trace_location(*, prefix, catalog="cat", schema="sch", warehouse_id="wh1"):
+        loc = MagicMock()
+        loc.resolved_table_prefix = prefix
+        loc.catalog_name = catalog
+        loc.schema_name = schema
+        loc.warehouse_id = warehouse_id
+        return loc
+
+    def test_unset_prefix_drops_per_experiment_tables(self) -> None:
+        cfg = self._config(trace_location=self._trace_location(prefix=None))
+        with patch(
+            "dao_ai.providers.databricks._drop_uc_otel_tables"
+        ) as drop:
+            cli._purge_otel_trace_tables(cfg, ["111", "222"], profile="fevm")
+        # One drop call per purged experiment id, keyed on that id as the prefix.
+        assert drop.call_count == 2
+        called_prefixes = {c.args[2] for c in drop.call_args_list}
+        assert called_prefixes == {"111", "222"}
+        for c in drop.call_args_list:
+            assert c.args[0] == "cat" and c.args[1] == "sch"  # catalog, schema
+
+    def test_explicit_prefix_does_not_drop_but_logs(self) -> None:
+        cfg = self._config(trace_location=self._trace_location(prefix="shared_x"))
+        with patch(
+            "dao_ai.providers.databricks._drop_uc_otel_tables"
+        ) as drop, patch.object(cli.logger, "warning") as warn:
+            cli._purge_otel_trace_tables(cfg, ["111"], profile="fevm")
+        drop.assert_not_called()
+        # The four shared table names are surfaced for manual cleanup.
+        logged = " ".join(str(c.args[0]) for c in warn.call_args_list)
+        for suffix in ("spans", "logs", "metrics", "annotations"):
+            assert f"cat.sch.shared_x_otel_{suffix}" in logged
+
+    def test_no_trace_location_is_noop(self) -> None:
+        cfg = self._config(trace_location=None)
+        with patch("dao_ai.providers.databricks._drop_uc_otel_tables") as drop:
+            cli._purge_otel_trace_tables(cfg, ["111"], profile="fevm")
+        drop.assert_not_called()
+
+    def test_no_purged_ids_is_noop(self) -> None:
+        cfg = self._config(trace_location=self._trace_location(prefix=None))
+        with patch("dao_ai.providers.databricks._drop_uc_otel_tables") as drop:
+            cli._purge_otel_trace_tables(cfg, [], profile="fevm")
+        drop.assert_not_called()
+
+    def test_drop_failure_is_swallowed(self) -> None:
+        cfg = self._config(trace_location=self._trace_location(prefix=None))
+        with patch(
+            "dao_ai.providers.databricks._drop_uc_otel_tables",
+            side_effect=RuntimeError("boom"),
+        ):
+            # Must not raise — best-effort so `down` still completes.
+            cli._purge_otel_trace_tables(cfg, ["111"], profile="fevm")
+
+    def test_purge_experiment_passes_purged_ids_to_otel_cleanup(self) -> None:
+        # Integration: _purge_experiment forwards the ids it actually deleted.
+        w = MagicMock()
+        client = MagicMock()
+        node = SimpleNamespace(experiment_id="777", name="/Users/u@d.com/my_app")
+        client.search_experiments.return_value = [node]
+        provider = MagicMock()
+        provider.experiment_name.return_value = "/Users/u@d.com/my_app"
+        cfg = self._config(trace_location=self._trace_location(prefix=None))
+        with patch("databricks.sdk.WorkspaceClient", return_value=w), patch(
+            "mlflow.MlflowClient", return_value=client
+        ), patch(
+            "dao_ai.providers.databricks.DatabricksProvider", return_value=provider
+        ), patch.object(cli, "_purge_otel_trace_tables") as otel:
+            cli._purge_experiment(cfg, profile="fevm")
+        otel.assert_called_once()
+        assert otel.call_args.args[1] == ["777"]


### PR DESCRIPTION
Follow-on to #262.

## Problem
`down --purge` now permanently deletes the MLflow **experiment node**, but the UC **OTEL trace tables** MLflow lazily materializes when `trace_location` is set (`<catalog>.<schema>.<prefix>_otel_{spans,logs,metrics,annotations}`) were left orphaned.

## Behavior
Purge cleans these up too — but only when it can prove no other agent shares the table set, mirroring the sibling-safety principle from #262:

- **`table_prefix` UNSET** → MLflow uses the `experiment_id` as the prefix, so the tables are per-experiment. For each experiment id this purge just deleted, drop its `<id>_otel_*` tables. Cannot collide with another agent.
- **`table_prefix` SET** → the prefix exists precisely to namespace/**share** a table set across agents, so dao-ai can't know whether another agent still writes there. Do **NOT** drop; log the four table names + a manual `DROP TABLE` hint.
- **No `trace_location`** (most apps) → no-op; nothing to clean up.

## Why the UC Tables SDK, not SQL DROP
`_drop_uc_otel_tables` deletes via `w.tables.delete(full_name=...)`, not a SQL `DROP`. A fully-qualified dotted name inside a single backtick pair is parsed as one *literal* identifier, so `` DROP TABLE IF EXISTS `cat.sch.tbl` `` silently **no-ops** (SUCCEEDED, deletes nothing) — a trap caught during live testing. The SDK path avoids the quoting issue entirely and needs no warehouse. A never-materialized table raises `NotFound` and is a harmless no-op. Best-effort: failures are logged and swallowed so `down` still completes.

`_purge_experiment` collects the ids it actually deleted and forwards them to `_purge_otel_trace_tables`.

## Tests
New `TestPurgeOtelTraceTables`: unset-prefix drops per-experiment tables (keyed on each purged id), explicit-prefix logs-but-skips (asserts the four FQNs surfaced), no `trace_location` no-op, drop-failure swallowed, and `_purge_experiment` forwards the purged ids.

## Verification (live on fevm)
Two-process method (materialize → exit so the async tracer is dead, then purge in a fresh process; authoritative existence via `w.tables.get`, since `information_schema` is eventually-consistent):
- Purging an app dropped its four per-experiment OTEL tables (`[False,False,False,False]`).
- A prefix-sharing **sibling** app's tables stayed fully intact (`[True,True,True,True]`).
- Explicit-prefix and no-`trace_location` paths drop nothing.
- Unit: `test_development_flag_cli.py` 345 passed; ruff at pre-existing baseline.

This pull request and its description were written by Isaac.