### PR TITLE
feat(cli): opt-in `up --wait [SECONDS]` — block until the app/endpoint can serve inference

### DIFF
--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -327,15 +327,25 @@ def _add_bundle_source_args(parser: ArgumentParser) -> None:
 
 
 def _add_wait_argument(parser: ArgumentParser) -> None:
-    """Add the opt-in ``--wait [SECONDS]`` flag to a ``down`` verb.
+    """Add the opt-in ``--wait [SECONDS]`` flag to an ``up`` or ``down`` verb.
 
-    ``down`` deletes the deployed resource (App or serving endpoint) and returns
-    as soon as the delete is *issued* — the delete is async, so the resource can
-    still be ``DELETING`` afterward. A deploy that immediately follows a teardown
-    then races it and hits ``400 ... compute is in DELETING state``. ``--wait``
-    makes ``down`` block until the resource is fully gone, so a following deploy
-    can't race it. Bare ``--wait`` uses the default timeout; ``--wait N`` overrides
-    it; omitting the flag returns immediately (default fire-and-forget).
+    The flag blocks until the deployment reaches a stable state, so a follow-on
+    step can't race an async transition. Its meaning depends on the verb:
+
+    * ``down`` — the delete is issued async (the resource can still be
+      ``DELETING``), so a deploy that immediately follows races it and hits
+      ``400 ... compute is in DELETING state``. ``--wait`` blocks until the
+      resource is fully GONE.
+    * ``up`` — the deploy returns as soon as it is issued (or the provisioning
+      job finishes), while the app/endpoint may not yet be able to serve
+      inference. ``--wait`` blocks until the resource is READY: for an App,
+      compute is ``ACTIVE`` and ``GET <url>/health`` returns 200; for a serving
+      endpoint, the endpoint is ``READY`` and its served model is
+      ``DEPLOYMENT_READY``. A terminal failure (App ``CRASHED``, served model
+      ``DEPLOYMENT_FAILED``) or timeout exits non-zero.
+
+    Bare ``--wait`` uses the default timeout; ``--wait N`` overrides it; omitting
+    the flag returns immediately (default fire-and-forget).
     """
     parser.add_argument(
         "--wait",
@@ -344,18 +354,21 @@ def _add_wait_argument(parser: ArgumentParser) -> None:
         const=_DEFAULT_WAIT_SECONDS,
         default=None,
         metavar="SECONDS",
-        help="After deleting, wait up to SECONDS (default %(const)s) for the "
-        "app/endpoint to be fully gone before returning, so a following deploy "
-        "can't race the teardown. Omit to return as soon as the delete is issued.",
+        help="Wait up to SECONDS (default %(const)s) for the deployment to reach a "
+        "stable state before returning: on `up`, until the app/endpoint is READY "
+        "to serve (exits non-zero on failure/timeout); on `down`, until the "
+        "app/endpoint is fully deleted. Omit to return as soon as the operation is "
+        "issued.",
     )
 
 
 def _wait_timeout_of(options: Namespace) -> Optional[int]:
     """The ``--wait`` timeout (seconds) for a verb, or ``None`` when not waiting.
 
-    ``--wait`` is defined only on the ``down`` verb parser, so ``options.wait`` is
-    absent for other verbs; treat that (and an omitted flag) as ``None`` = don't
-    wait. Centralizes the one conditional-attribute read so call sites stay typed.
+    ``--wait`` is defined only on the ``up`` and ``down`` verb parsers, so
+    ``options.wait`` is absent for other verbs; treat that (and an omitted flag)
+    as ``None`` = don't wait. Centralizes the one conditional-attribute read so
+    call sites stay typed.
     """
     return getattr(options, "wait", None)
 
@@ -519,6 +532,11 @@ def _add_noun_verb_parsers(
     if is_workflow:
         _add_workflow_target_args(up_parser)
     _add_mode_argument(up_parser, choices=["model_serving", "apps", "mcp"])
+    # `up --wait [SECONDS]` blocks until the App/endpoint is READY to serve
+    # inference (App: compute ACTIVE + GET /health 200; endpoint: READY +
+    # served-model DEPLOYMENT_READY), exiting non-zero on failure/timeout. The
+    # `down` verb (in the verb loop below) offers the deletion-oriented `--wait`.
+    _add_wait_argument(up_parser)
     # --direct (SDK, no DAB on disk) is agent-only: the workflow noun's whole
     # purpose is running the provisioning JOB, which requires the DAB — there is
     # no meaningful bundle-less path, so --direct would be a silent no-op.
@@ -630,8 +648,9 @@ def _add_noun_verb_parsers(
         # `down` returns as soon as the (async) delete is issued; `--wait` blocks
         # until the deployed App/endpoint is fully gone so a following deploy
         # can't race the teardown. `--purge` also PERMANENTLY deletes the MLflow
-        # experiment (not just soft-delete). Both nouns deploy an App (apps/mcp)
-        # or a serving endpoint (model_serving), so both offer them.
+        # experiment (not just soft-delete). (`up` offers its own readiness
+        # `--wait`, registered on the dedicated `up` parser above.) This loop
+        # never processes `up`, so it is not handled here.
         if verb == "down":
             _add_wait_argument(verb_parser)
             _add_purge_argument(verb_parser)
@@ -4508,6 +4527,30 @@ def run_databricks_command(
                 purge=purge,
             )
 
+    # `workflow up --wait`: the provisioning job's `06_deploy_agent` step deploys
+    # the agent IMPERATIVELY (App for apps/mcp, serving endpoint for
+    # model_serving), and `bundle run deploy_job` returns when the job finishes —
+    # but the App/endpoint may still be starting. Block until it is READY to serve
+    # (mirrors the mode-branch of the destroy cleanup above). Exits non-zero on a
+    # failed deploy or timeout.
+    if (
+        command is not None
+        and command[:2] == ["bundle", "run"]
+        and wait_timeout is not None
+        and not dry_run
+        and app_config
+    ):
+        deployed_mode_up: str = mode or "apps"
+        if deployed_mode_up == "model_serving":
+            if app_config.app.endpoint_name:
+                _wait_for_resource_ready(
+                    "endpoint", app_config.app.endpoint_name, profile, wait_timeout
+                )
+        else:
+            _wait_for_resource_ready(
+                "app", app_config.app.app_resource_name, profile, wait_timeout
+            )
+
 
 def _print_job_link(
     cwd: Path,
@@ -4656,6 +4699,168 @@ def _wait_for_resource_deleted(
     )
 
 
+def _wait_for_resource_ready(
+    kind: str,
+    name: str,
+    profile: Optional[str],
+    timeout_seconds: int = _DEFAULT_WAIT_SECONDS,
+) -> None:
+    """Block until a just-deployed resource is READY to serve inference, or fail.
+
+    ``up`` returns as soon as the deploy is issued (or the provisioning job
+    finishes) — the App/endpoint may still be starting and unable to serve. This
+    blocks until it is actually servable. The readiness signal DIFFERS by resource:
+
+    * ``kind == "app"`` (Databricks Apps, agent + mcp) — two phases against a
+      single deadline: (a) poll ``w.apps.get`` until ``compute_status.state`` is
+      ``ACTIVE`` (so the URL/proxy exists), then (b) poll ``GET <app.url>/health``
+      (behind the Apps auth proxy → auth headers from ``w.config.authenticate()``)
+      until it returns 200 — a 200 means the app PROCESS is up and answering HTTP.
+      ``app_status.state == CRASHED`` or ``compute_status.state == ERROR`` is a
+      terminal failure.
+    * ``kind == "endpoint"`` (Model Serving; no HTTP health route exists) — poll
+      ``w.serving_endpoints.get`` until ``state.ready == READY``,
+      ``state.config_update == NOT_UPDATING``, and every served entity's
+      ``state.deployment == DEPLOYMENT_READY``. ``UPDATE_FAILED`` or a served
+      entity in ``DEPLOYMENT_FAILED``/``DEPLOYMENT_ABORTED`` is terminal.
+
+    Unlike :func:`_wait_for_resource_deleted` (which warns and returns on timeout),
+    readiness is an ASSERTION: a terminal-failure state OR timeout logs an error
+    and ``sys.exit(1)`` so CI/scripts catch a broken deploy.
+    """
+    import random
+    import time
+
+    from databricks.sdk import WorkspaceClient
+    from databricks.sdk.service.apps import ApplicationState, ComputeState
+    from databricks.sdk.service.serving import (
+        EndpointStateConfigUpdate,
+        EndpointStateReady,
+        ServedModelStateDeployment,
+    )
+
+    _apply_profile_context(profile)
+    w = WorkspaceClient(profile=profile) if profile else WorkspaceClient()
+
+    logger.info(
+        f"Waiting up to {timeout_seconds}s for {kind} '{name}' to be ready to "
+        "serve inference..."
+    )
+    deadline = time.monotonic() + timeout_seconds
+    attempt = 1
+
+    def _sleep() -> None:
+        nonlocal attempt
+        time.sleep(min(attempt, 10) + random.random())
+        attempt += 1
+
+    def _fail(msg: str) -> None:
+        logger.error(msg)
+        sys.exit(1)
+
+    if kind == "app":
+        # Phase (a): compute ACTIVE (URL/proxy exists) — surfaces CRASHED early.
+        app_url: Optional[str] = None
+        while time.monotonic() < deadline:
+            app = w.apps.get(name=name)
+            compute_state = getattr(getattr(app, "compute_status", None), "state", None)
+            app_state = getattr(getattr(app, "app_status", None), "state", None)
+            if app_state == ApplicationState.CRASHED:
+                _fail(f"App '{name}' CRASHED during startup — deploy is not servable.")
+            if compute_state == ComputeState.ERROR:
+                msg = getattr(getattr(app, "compute_status", None), "message", "")
+                _fail(f"App '{name}' compute is in ERROR state: {msg}")
+            if compute_state == ComputeState.ACTIVE:
+                app_url = app.url
+                break
+            logger.debug(f"App '{name}' compute state={compute_state}; waiting...")
+            _sleep()
+        if app_url is None:
+            _fail(
+                f"App '{name}' compute did not reach ACTIVE within {timeout_seconds}s."
+            )
+        # Phase (b): the app process answers HTTP 200 on /health (behind the proxy).
+        import httpx
+
+        health_url = f"{app_url.rstrip('/')}/health"
+        headers = w.config.authenticate() or {}
+        while time.monotonic() < deadline:
+            # A live CRASHED signal can still surface here (compute ACTIVE but the
+            # process died); check it before the HTTP poll so we fail fast.
+            app_state = getattr(
+                getattr(w.apps.get(name=name), "app_status", None), "state", None
+            )
+            if app_state == ApplicationState.CRASHED:
+                _fail(f"App '{name}' CRASHED during startup — deploy is not servable.")
+            try:
+                resp = httpx.get(
+                    health_url, headers=headers, timeout=10.0, follow_redirects=True
+                )
+                if resp.status_code == 200:
+                    logger.info(f"App '{name}' is ready (GET /health → 200).")
+                    return
+                logger.debug(f"App '{name}' /health → {resp.status_code}; waiting...")
+            except Exception as e:  # noqa: BLE001 — pre-ready connection errors are expected
+                logger.debug(f"App '{name}' /health not reachable yet: {e}")
+            _sleep()
+        _fail(
+            f"App '{name}' compute is ACTIVE but /health did not return 200 within "
+            f"{timeout_seconds}s — the app process is not serving."
+        )
+
+    elif kind == "endpoint":
+        while time.monotonic() < deadline:
+            ep = w.serving_endpoints.get(name=name)
+            state = getattr(ep, "state", None)
+            ready = getattr(state, "ready", None)
+            config_update = getattr(state, "config_update", None)
+            if config_update == EndpointStateConfigUpdate.UPDATE_FAILED:
+                _fail(
+                    f"Endpoint '{name}' config update FAILED — deploy is not servable."
+                )
+            entities = (
+                getattr(getattr(ep, "config", None), "served_entities", None) or []
+            )
+            deployments = [
+                getattr(getattr(se, "state", None), "deployment", None)
+                for se in entities
+            ]
+            for dep in deployments:
+                if dep in (
+                    ServedModelStateDeployment.DEPLOYMENT_FAILED,
+                    ServedModelStateDeployment.DEPLOYMENT_ABORTED,
+                ):
+                    _fail(
+                        f"Endpoint '{name}' served model deployment {dep} — "
+                        "deploy is not servable."
+                    )
+            all_models_ready = bool(deployments) and all(
+                dep == ServedModelStateDeployment.DEPLOYMENT_READY
+                for dep in deployments
+            )
+            if (
+                ready == EndpointStateReady.READY
+                and config_update == EndpointStateConfigUpdate.NOT_UPDATING
+                and all_models_ready
+            ):
+                logger.info(
+                    f"Endpoint '{name}' is ready (READY + served model "
+                    "DEPLOYMENT_READY)."
+                )
+                return
+            logger.debug(
+                f"Endpoint '{name}' ready={ready} config_update={config_update} "
+                f"deployments={deployments}; waiting..."
+            )
+            _sleep()
+        _fail(
+            f"Endpoint '{name}' did not become READY within {timeout_seconds}s — "
+            "the endpoint is not serving."
+        )
+    else:
+        raise ValueError(f"unknown resource kind: {kind!r} (expected 'app'/'endpoint')")
+
+
 def deploy_app_bundle(
     config: AppConfig,
     *,
@@ -4732,6 +4937,11 @@ def deploy_app_bundle(
             cwd=staging_dir,
             dry_run=dry_run,
         )
+        # `--wait`: block until the App is actually serving (compute ACTIVE +
+        # GET /health 200) so a caller can send inference immediately. Exits
+        # non-zero on a CRASHED app or timeout.
+        if wait_timeout is not None and not dry_run:
+            _wait_for_resource_ready("app", app_name, profile, wait_timeout)
 
     if (deploy or run) and not dry_run:
         _print_app_link(app_name)
@@ -4873,6 +5083,14 @@ def _run_ms_job_bundle(
             dry_run=dry_run,
             stage_only_msg="",
         )
+        # `--wait`: the deploy-agent job returns once `agents.deploy()` is issued,
+        # but the endpoint may still be spinning up its served model. Block until
+        # the endpoint is READY + served model DEPLOYMENT_READY so inference can
+        # follow immediately. Exits non-zero on a failed deployment or timeout.
+        if wait_timeout is not None and not dry_run and config.app.endpoint_name:
+            _wait_for_resource_ready(
+                "endpoint", config.app.endpoint_name, profile, wait_timeout
+            )
 
     if (deploy or run) and not dry_run and config.app.endpoint_name:
         _print_endpoint_link(config.app.endpoint_name)
@@ -5147,6 +5365,9 @@ def _handle_up_workflow_command(options: Namespace) -> None:
         # Build already happened on the deploy call above; the run must NOT
         # re-stage (that rebuilt the bundle every `up`). `up` builds exactly once.
         stage=False,
+        # `--wait`: block until the imperatively-deployed App/endpoint is READY
+        # to serve (resolved by mode inside run_databricks_command).
+        wait_timeout=_wait_timeout_of(options),
     )
 
 
@@ -5336,6 +5557,18 @@ def _deploy_run_destroy_app_bundle(
             config.deploy_agent(
                 target=ServingMode.MODEL_SERVING, development=development
             )
+            # `--wait`: `deploy_agent` (agents.deploy) returns once the update is
+            # issued; block until the endpoint is READY + served model
+            # DEPLOYMENT_READY. (The apps/mcp direct path already waits internally
+            # via the provider's apps.deploy_and_wait, so only MS needs this here.)
+            wait_timeout = _wait_timeout_of(options)
+            if wait_timeout is not None and config.app.endpoint_name:
+                _wait_for_resource_ready(
+                    "endpoint",
+                    config.app.endpoint_name,
+                    options.profile,
+                    wait_timeout,
+                )
         else:
             # Apps/MCP deploy directly from config + wheel (no MLflow model).
             config.deploy_agent(target=ServingMode(mode), development=development)

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -4785,13 +4785,6 @@ def _wait_for_resource_ready(
         health_url = f"{app_url.rstrip('/')}/health"
         headers = w.config.authenticate() or {}
         while time.monotonic() < deadline:
-            # A live CRASHED signal can still surface here (compute ACTIVE but the
-            # process died); check it before the HTTP poll so we fail fast.
-            app_state = getattr(
-                getattr(w.apps.get(name=name), "app_status", None), "state", None
-            )
-            if app_state == ApplicationState.CRASHED:
-                _fail(f"App '{name}' CRASHED during startup — deploy is not servable.")
             try:
                 resp = httpx.get(
                     health_url, headers=headers, timeout=10.0, follow_redirects=True
@@ -4802,6 +4795,14 @@ def _wait_for_resource_ready(
                 logger.debug(f"App '{name}' /health → {resp.status_code}; waiting...")
             except Exception as e:  # noqa: BLE001 — pre-ready connection errors are expected
                 logger.debug(f"App '{name}' /health not reachable yet: {e}")
+            # /health isn't passing yet — spend one SDK call to see WHY: a live
+            # CRASHED signal (compute ACTIVE but the process died) is terminal, so
+            # fail fast instead of polling to the deadline.
+            app_state = getattr(
+                getattr(w.apps.get(name=name), "app_status", None), "state", None
+            )
+            if app_state == ApplicationState.CRASHED:
+                _fail(f"App '{name}' CRASHED during startup — deploy is not servable.")
             _sleep()
         _fail(
             f"App '{name}' compute is ACTIVE but /health did not return 200 within "

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -1451,6 +1451,44 @@ class TestDeployAppBundle:
         )
         link.assert_not_called()
 
+    def test_up_wait_calls_ready_poller_for_app(self, tmp_path: Path) -> None:
+        # `up --wait` (wait_timeout set) blocks on the App readiness poller with
+        # kind="app" and the app_resource_name (my_app -> my-app).
+        cfg = _app_config(trace=False)
+        with (
+            patch.object(cli, "_exec_bundle_command"),
+            patch.object(cli, "_link_and_grant_trace"),
+            patch.object(cli, "_wait_for_resource_ready") as ready,
+        ):
+            deploy_app_bundle(
+                cfg,
+                staging_dir=tmp_path,
+                deploy=True,
+                run=True,
+                destroy=False,
+                profile="fevm",
+                wait_timeout=120,
+            )
+        ready.assert_called_once_with("app", "my-app", "fevm", 120)
+
+    def test_up_without_wait_does_not_poll(self, tmp_path: Path) -> None:
+        cfg = _app_config(trace=False)
+        with (
+            patch.object(cli, "_exec_bundle_command"),
+            patch.object(cli, "_link_and_grant_trace"),
+            patch.object(cli, "_wait_for_resource_ready") as ready,
+        ):
+            deploy_app_bundle(
+                cfg,
+                staging_dir=tmp_path,
+                deploy=True,
+                run=True,
+                destroy=False,
+                profile="fevm",
+                wait_timeout=None,
+            )
+        ready.assert_not_called()
+
 
 @pytest.mark.unit
 class TestDeleteServingEndpoint:
@@ -1548,6 +1586,32 @@ class TestDeleteServingEndpoint:
             config_vars={},
         )
         assert order == ["bundle_destroy", "endpoint_delete"], order
+
+    def test_ms_up_wait_calls_ready_poller_for_endpoint(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_run_ms_job_bundle(run=True, wait_timeout=N) blocks on the endpoint
+        readiness poller with kind="endpoint" and the endpoint name."""
+        monkeypatch.setattr(cli, "_exec_job_bundle", lambda **k: None)
+        monkeypatch.setattr(cli, "_resolve_job_dao_ai_dep", lambda *a, **k: "dao-ai")
+        monkeypatch.setattr(cli, "detect_cloud_provider", lambda p: "aws")
+        monkeypatch.setattr(cli, "_print_endpoint_link", lambda _n: None)
+        with patch.object(cli, "_wait_for_resource_ready") as ready:
+            cli._run_ms_job_bundle(
+                self._ms_config("my_ep"),
+                staging_dir=tmp_path,
+                deploy=True,
+                run=True,
+                destroy=False,
+                dry_run=False,
+                profile="fevm",
+                development=None,
+                target=None,
+                cloud=None,
+                config_vars={},
+                wait_timeout=200,
+            )
+        ready.assert_called_once_with("endpoint", "my_ep", "fevm", 200)
 
 
 @pytest.mark.unit
@@ -2883,35 +2947,275 @@ class TestWaitForResourceDeleted:
         self._patch_ws(monkeypatch, "app", lambda name: object())
         with pytest.raises(ValueError, match="unknown resource kind"):
             cli._wait_for_resource_deleted("App", "res", profile=None, timeout_seconds=1)
+
+
+@pytest.mark.unit
+class TestWaitForResourceReady:
+    """`_wait_for_resource_ready` blocks until servable; exits non-zero on
+    terminal failure/timeout. Apps: SDK compute-ACTIVE then GET /health 200.
+    Model Serving: endpoint READY + served-model DEPLOYMENT_READY (no HTTP)."""
+
+    @staticmethod
+    def _app(compute=None, app_state=None, deployment=None, url="https://app.example"):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            url=url,
+            compute_status=SimpleNamespace(state=compute, message=""),
+            app_status=SimpleNamespace(state=app_state, message=""),
+            active_deployment=SimpleNamespace(status=SimpleNamespace(state=deployment)),
+        )
+
+    @staticmethod
+    def _endpoint(ready=None, config_update=None, deployments=()):
+        from types import SimpleNamespace
+
+        served = [
+            SimpleNamespace(state=SimpleNamespace(deployment=d))
+            for d in deployments
+        ]
+        return SimpleNamespace(
+            state=SimpleNamespace(ready=ready, config_update=config_update),
+            config=SimpleNamespace(served_entities=served),
+        )
+
+    def _patch(self, monkeypatch, *, app_get=None, ep_get=None, http_get=None):
+        from unittest.mock import MagicMock
+
+        fake = MagicMock()
+        fake.config.authenticate.return_value = {"Authorization": "Bearer x"}
+        if app_get is not None:
+            fake.apps.get.side_effect = app_get
+        if ep_get is not None:
+            fake.serving_endpoints.get.side_effect = ep_get
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        import time as _time
+
+        import databricks.sdk as _sdk
+
+        monkeypatch.setattr(_sdk, "WorkspaceClient", lambda *a, **k: fake)
+        monkeypatch.setattr(_time, "sleep", lambda *_a, **_k: None)
+        if http_get is not None:
+            import httpx
+
+            monkeypatch.setattr(httpx, "get", http_get)
+        return fake
+
+    # --- Apps ---------------------------------------------------------------
+    def test_app_ready_when_compute_active_and_health_200(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from databricks.sdk.service.apps import ApplicationState, ComputeState
+
+        # compute becomes ACTIVE on 2nd poll, then /health 200 on 2nd HTTP poll.
+        app_calls = {"n": 0}
+
+        def _app_get(name: str):
+            app_calls["n"] += 1
+            compute = (
+                ComputeState.ACTIVE if app_calls["n"] >= 2 else ComputeState.STARTING
+            )
+            return self._app(compute=compute, app_state=ApplicationState.RUNNING)
+
+        http_calls = {"n": 0}
+
+        def _http(url, **kw):
+            http_calls["n"] += 1
+            from types import SimpleNamespace
+
+            return SimpleNamespace(status_code=200 if http_calls["n"] >= 2 else 503)
+
+        fake = self._patch(monkeypatch, app_get=_app_get, http_get=_http)
+        cli._wait_for_resource_ready("app", "my-app", profile=None, timeout_seconds=60)
+        # Health was polled at the resolved app URL with auth headers.
+        assert http_calls["n"] >= 2
+        assert fake.config.authenticate.called
+
+    def test_app_crashed_exits_nonzero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from databricks.sdk.service.apps import ApplicationState, ComputeState
+
+        def _app_get(name: str):
+            return self._app(
+                compute=ComputeState.ACTIVE, app_state=ApplicationState.CRASHED
+            )
+
+        # No http_get: must fail before/without needing a 200.
+        self._patch(monkeypatch, app_get=_app_get, http_get=lambda *a, **k: None)
+        with pytest.raises(SystemExit):
+            cli._wait_for_resource_ready(
+                "app", "my-app", profile=None, timeout_seconds=60
+            )
+
+    def test_app_compute_never_active_times_out(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from databricks.sdk.service.apps import ApplicationState, ComputeState
+
+        def _app_get(name: str):
+            return self._app(
+                compute=ComputeState.STARTING, app_state=ApplicationState.DEPLOYING
+            )
+
+        self._patch(monkeypatch, app_get=_app_get)
+        import time as _time
+
+        ticks = iter([0.0, 0.5, 1.0, 5.0, 999.0])
+        monkeypatch.setattr(_time, "monotonic", lambda: next(ticks))
+        with pytest.raises(SystemExit):
+            cli._wait_for_resource_ready(
+                "app", "my-app", profile=None, timeout_seconds=2
+            )
+
+    def test_app_health_never_200_times_out(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from databricks.sdk.service.apps import ApplicationState, ComputeState
+
+        def _app_get(name: str):
+            return self._app(
+                compute=ComputeState.ACTIVE, app_state=ApplicationState.RUNNING
+            )
+
+        def _http(url, **kw):
+            from types import SimpleNamespace
+
+            return SimpleNamespace(status_code=503)
+
+        self._patch(monkeypatch, app_get=_app_get, http_get=_http)
+        import time as _time
+
+        ticks = iter([0.0, 0.1, 0.2, 0.3, 1.0, 5.0, 999.0])
+        monkeypatch.setattr(_time, "monotonic", lambda: next(ticks))
+        with pytest.raises(SystemExit):
+            cli._wait_for_resource_ready(
+                "app", "my-app", profile=None, timeout_seconds=2
+            )
+
+    # --- Model Serving ------------------------------------------------------
+    def test_endpoint_ready_when_all_served_models_ready(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from databricks.sdk.service.serving import (
+            EndpointStateConfigUpdate,
+            EndpointStateReady,
+            ServedModelStateDeployment,
+        )
+
+        calls = {"n": 0}
+
+        def _ep_get(name: str):
+            calls["n"] += 1
+            if calls["n"] < 2:
+                return self._endpoint(
+                    ready=EndpointStateReady.NOT_READY,
+                    config_update=EndpointStateConfigUpdate.IN_PROGRESS,
+                    deployments=[ServedModelStateDeployment.DEPLOYMENT_CREATING],
+                )
+            return self._endpoint(
+                ready=EndpointStateReady.READY,
+                config_update=EndpointStateConfigUpdate.NOT_UPDATING,
+                deployments=[ServedModelStateDeployment.DEPLOYMENT_READY],
+            )
+
+        self._patch(monkeypatch, ep_get=_ep_get)
+        cli._wait_for_resource_ready("endpoint", "ep", profile=None, timeout_seconds=60)
+        assert calls["n"] >= 2
+
+    def test_endpoint_served_model_failed_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from databricks.sdk.service.serving import (
+            EndpointStateConfigUpdate,
+            EndpointStateReady,
+            ServedModelStateDeployment,
+        )
+
+        def _ep_get(name: str):
+            return self._endpoint(
+                ready=EndpointStateReady.NOT_READY,
+                config_update=EndpointStateConfigUpdate.NOT_UPDATING,
+                deployments=[ServedModelStateDeployment.DEPLOYMENT_FAILED],
+            )
+
+        self._patch(monkeypatch, ep_get=_ep_get)
+        with pytest.raises(SystemExit):
+            cli._wait_for_resource_ready(
+                "endpoint", "ep", profile=None, timeout_seconds=60
+            )
+
+    def test_endpoint_ready_but_model_still_creating_keeps_polling(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Endpoint READY but served model still CREATING → NOT ready yet; must
+        # keep polling (and here, time out rather than falsely returning).
+        from databricks.sdk.service.serving import (
+            EndpointStateConfigUpdate,
+            EndpointStateReady,
+            ServedModelStateDeployment,
+        )
+
+        calls = {"n": 0}
+
+        def _ep_get(name: str):
+            calls["n"] += 1
+            return self._endpoint(
+                ready=EndpointStateReady.READY,
+                config_update=EndpointStateConfigUpdate.NOT_UPDATING,
+                deployments=[ServedModelStateDeployment.DEPLOYMENT_CREATING],
+            )
+
+        self._patch(monkeypatch, ep_get=_ep_get)
+        import time as _time
+
+        ticks = iter([0.0, 0.5, 1.0, 5.0, 999.0])
+        monkeypatch.setattr(_time, "monotonic", lambda: next(ticks))
+        with pytest.raises(SystemExit):
+            cli._wait_for_resource_ready(
+                "endpoint", "ep", profile=None, timeout_seconds=2
+            )
+        assert calls["n"] >= 1
+
+    def test_unknown_kind_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch(monkeypatch)
+        with pytest.raises(ValueError, match="unknown resource kind"):
+            cli._wait_for_resource_ready(
+                "App", "res", profile=None, timeout_seconds=1
+            )
+
+
+@pytest.mark.unit
 class TestWaitFlagParsing:
-    """`--wait [SECONDS]` is opt-in on the `down` verb of BOTH nouns."""
+    """`--wait [SECONDS]` is opt-in on the `up` AND `down` verbs of BOTH nouns."""
 
     @pytest.mark.parametrize("noun", ["agent", "workflow"])
-    def test_down_bare_wait_uses_default(self, noun: str) -> None:
-        opts = parse_args([noun, "down", "-c", "c.yaml", "--wait"])
+    @pytest.mark.parametrize("verb", ["up", "down"])
+    def test_bare_wait_uses_default(self, noun: str, verb: str) -> None:
+        opts = parse_args([noun, verb, "-c", "c.yaml", "--wait"])
         assert opts.wait == cli._DEFAULT_WAIT_SECONDS
 
     @pytest.mark.parametrize("noun", ["agent", "workflow"])
-    def test_down_wait_explicit_count(self, noun: str) -> None:
-        opts = parse_args([noun, "down", "-c", "c.yaml", "--wait", "90"])
+    @pytest.mark.parametrize("verb", ["up", "down"])
+    def test_wait_explicit_count(self, noun: str, verb: str) -> None:
+        opts = parse_args([noun, verb, "-c", "c.yaml", "--wait", "90"])
         assert opts.wait == 90
 
     @pytest.mark.parametrize("noun", ["agent", "workflow"])
-    def test_down_without_wait_is_none(self, noun: str) -> None:
-        opts = parse_args([noun, "down", "-c", "c.yaml"])
+    @pytest.mark.parametrize("verb", ["up", "down"])
+    def test_without_wait_is_none(self, noun: str, verb: str) -> None:
+        opts = parse_args([noun, verb, "-c", "c.yaml"])
         assert opts.wait is None
         # And the typed accessor reflects "don't wait".
         assert cli._wait_timeout_of(opts) is None
 
     @pytest.mark.parametrize("noun", ["agent", "workflow"])
-    @pytest.mark.parametrize("verb", ["up", "sync", "build", "start"])
-    def test_non_down_verbs_reject_wait(self, noun: str, verb: str) -> None:
+    @pytest.mark.parametrize("verb", ["sync", "build", "start"])
+    def test_non_up_down_verbs_reject_wait(self, noun: str, verb: str) -> None:
         with pytest.raises(SystemExit):
             parse_args([noun, verb, "-c", "c.yaml", "--wait"])
 
-    @pytest.mark.parametrize("verb", ["up", "sync", "build", "start"])
+    @pytest.mark.parametrize("verb", ["sync", "build", "start"])
     def test_wait_timeout_of_none_for_verbs_without_flag(self, verb: str) -> None:
-        # Non-down verbs never define --wait; the accessor must return None, not raise.
+        # Non-up/down verbs never define --wait; the accessor returns None, not raise.
         opts = parse_args(["agent", verb, "-c", "c.yaml"])
         assert cli._wait_timeout_of(opts) is None
 

--- a/tests/scripts/validate-cli.sh
+++ b/tests/scripts/validate-cli.sh
@@ -42,6 +42,63 @@ dai() {
   uv run dao-ai -p "$PROFILE" "$@"
 }
 
+# Send ONE real inference request to the just-deployed resource and require a
+# valid response. Run this immediately after `up --wait` so it doubly proves the
+# readiness gate: `up --wait` only returns once the App/endpoint is servable, so
+# this request must succeed straight away (no retry/sleep). `kind` is "app"
+# (apps/mcp) or "endpoint" (model_serving) — the check path differs per the
+# platform surface.
+#   Apps: POST <app.url>/invocations behind the Apps auth proxy.
+#   Model Serving: query the serving endpoint via the SDK OpenAI client.
+infer() {
+  local kind="$1"
+  printf '\n\033[1;35m# immediate inference check (%s) against %s\033[0m\n' \
+    "$kind" "$CONFIG"
+  DAO_AI_INFER_KIND="$kind" DAO_AI_INFER_CONFIG="$CONFIG" \
+    DATABRICKS_CONFIG_PROFILE="$PROFILE" uv run python - <<'PY'
+import os
+import sys
+
+from databricks.sdk import WorkspaceClient
+
+from dao_ai.config import AppConfig
+
+kind = os.environ["DAO_AI_INFER_KIND"]
+config = AppConfig.from_file(os.environ["DAO_AI_INFER_CONFIG"])
+w = WorkspaceClient()
+prompt = "Reply with a short greeting."
+
+if kind == "app":
+    import httpx
+
+    app_name = config.app.app_resource_name
+    url = w.apps.get(name=app_name).url.rstrip("/") + "/invocations"
+    headers = w.config.authenticate() or {}
+    headers["Content-Type"] = "application/json"
+    resp = httpx.post(
+        url,
+        headers=headers,
+        json={"input": [{"role": "user", "content": prompt}]},
+        timeout=120.0,
+    )
+    resp.raise_for_status()
+    body = resp.text
+else:  # endpoint (model_serving)
+    endpoint = config.app.endpoint_name
+    oai = w.serving_endpoints.get_open_ai_client()
+    completion = oai.chat.completions.create(
+        model=endpoint,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    body = completion.choices[0].message.content or ""
+
+if not body.strip():
+    print("Inference check FAILED: empty response", file=sys.stderr)
+    sys.exit(1)
+print(f"  inference OK — response: {body[:200]}")
+PY
+}
+
 # ---------------------------------------------------------------------------
 # Sanity: version, resolved env, config validity, declared params, MCP tools.
 # ---------------------------------------------------------------------------
@@ -61,7 +118,10 @@ dai workflow start -c "$CONFIG"
 # --wait: block until the deployed App/endpoint is fully deleted so the next
 # deploy (the `up` below, and the agent section) can't race the async teardown.
 dai workflow down -c "$CONFIG" --wait
-dai workflow up    -c "$CONFIG"
+# `up --wait`: block until the workflow-deployed App is READY to serve, then send
+# a real inference request immediately to prove it.
+dai workflow up   -c "$CONFIG" --wait
+infer app
 # Last workflow down before the agent section redeploys the same app — wait it out.
 dai workflow down  -c "$CONFIG" --wait
 
@@ -75,20 +135,27 @@ dai agent start -c "$CONFIG"
 # --wait: block until the app is fully deleted so the following `up` can't race
 # the async teardown (400 "compute is in DELETING state"). Omit for fire-and-forget.
 dai agent down  -c "$CONFIG" --wait
-dai agent up    -c "$CONFIG"
+# `up --wait`: block until the App is READY (compute ACTIVE + GET /health 200),
+# then send a real inference request immediately to prove it is servable.
+dai agent up    -c "$CONFIG" --wait
+infer app
 dai monitor logs -c "$CONFIG"
 dai agent down  -c "$CONFIG"
 
 # ---------------------------------------------------------------------------
-# Agent on Model Serving (-m ms).
+# Agent on Model Serving (-m ms). `up --wait` blocks until the endpoint is READY
+# + its served model is DEPLOYMENT_READY; then query it immediately.
 # ---------------------------------------------------------------------------
-dai agent up   -c "$CONFIG" -m ms
+dai agent up   -c "$CONFIG" -m ms --wait
+infer endpoint
 dai agent down -c "$CONFIG" -m ms
 
 # ---------------------------------------------------------------------------
-# Agent via the --direct SDK fast-path (no bundle on disk).
+# Agent via the --direct SDK fast-path (no bundle on disk). `up --wait` here too,
+# then an immediate inference request against the directly-deployed App.
 # ---------------------------------------------------------------------------
-dai agent up   -c "$CONFIG" --direct
+dai agent up   -c "$CONFIG" --direct --wait
+infer app
 dai agent down -c "$CONFIG"
 
 # Reaching here means every command above exited 0 (set -euo pipefail aborts on

--- a/tests/scripts/validate-cli.sh
+++ b/tests/scripts/validate-cli.sh
@@ -46,10 +46,13 @@ dai() {
 # valid response. Run this immediately after `up --wait` so it doubly proves the
 # readiness gate: `up --wait` only returns once the App/endpoint is servable, so
 # this request must succeed straight away (no retry/sleep). `kind` is "app"
-# (apps/mcp) or "endpoint" (model_serving) — the check path differs per the
-# platform surface.
-#   Apps: POST <app.url>/invocations behind the Apps auth proxy.
-#   Model Serving: query the serving endpoint via the SDK OpenAI client.
+# (apps/mcp) or "endpoint" (model_serving).
+#
+# dao-ai agents ALWAYS speak the MLflow Responses contract (`{"input": [...]}`)
+# on `/invocations` — identical request/response body for Apps and Model Serving
+# (see docs/background_agents.md); only the URL differs:
+#   Apps:          POST <app.url>/invocations              (behind the Apps proxy)
+#   Model Serving: POST <host>/serving-endpoints/<ep>/invocations
 infer() {
   local kind="$1"
   printf '\n\033[1;35m# immediate inference check (%s) against %s\033[0m\n' \
@@ -59,6 +62,7 @@ infer() {
 import os
 import sys
 
+import httpx
 from databricks.sdk import WorkspaceClient
 
 from dao_ai.config import AppConfig
@@ -66,31 +70,24 @@ from dao_ai.config import AppConfig
 kind = os.environ["DAO_AI_INFER_KIND"]
 config = AppConfig.from_file(os.environ["DAO_AI_INFER_CONFIG"])
 w = WorkspaceClient()
-prompt = "Reply with a short greeting."
+host = (w.config.host or "").rstrip("/")
 
 if kind == "app":
-    import httpx
-
-    app_name = config.app.app_resource_name
-    url = w.apps.get(name=app_name).url.rstrip("/") + "/invocations"
-    headers = w.config.authenticate() or {}
-    headers["Content-Type"] = "application/json"
-    resp = httpx.post(
-        url,
-        headers=headers,
-        json={"input": [{"role": "user", "content": prompt}]},
-        timeout=120.0,
-    )
-    resp.raise_for_status()
-    body = resp.text
+    url = w.apps.get(name=config.app.app_resource_name).url.rstrip("/") + "/invocations"
 else:  # endpoint (model_serving)
-    endpoint = config.app.endpoint_name
-    oai = w.serving_endpoints.get_open_ai_client()
-    completion = oai.chat.completions.create(
-        model=endpoint,
-        messages=[{"role": "user", "content": prompt}],
-    )
-    body = completion.choices[0].message.content or ""
+    url = f"{host}/serving-endpoints/{config.app.endpoint_name}/invocations"
+
+# Same Responses-contract body for both surfaces.
+headers = w.config.authenticate() or {}
+headers["Content-Type"] = "application/json"
+resp = httpx.post(
+    url,
+    headers=headers,
+    json={"input": [{"role": "user", "content": "Reply with a short greeting."}]},
+    timeout=120.0,
+)
+resp.raise_for_status()
+body = resp.text
 
 if not body.strip():
     print("Inference check FAILED: empty response", file=sys.stderr)
@@ -144,9 +141,11 @@ dai agent down  -c "$CONFIG"
 
 # ---------------------------------------------------------------------------
 # Agent on Model Serving (-m ms). `up --wait` blocks until the endpoint is READY
-# + its served model is DEPLOYMENT_READY; then query it immediately.
+# + its served model is DEPLOYMENT_READY; then query it immediately. Model
+# Serving cold-start (container build + model load) routinely exceeds the 600s
+# default, so give it a generous 1800s — live-observed ~12min+ on fevm.
 # ---------------------------------------------------------------------------
-dai agent up   -c "$CONFIG" -m ms --wait
+dai agent up   -c "$CONFIG" -m ms --wait 1800
 infer endpoint
 dai agent down -c "$CONFIG" -m ms
 


### PR DESCRIPTION
## Problem
`agent up` / `workflow up` return as soon as the deploy is issued (or the provisioning job finishes) — the app/endpoint may still be starting, so a follow-on inference call fails. This adds an opt-in readiness `--wait`, distinct from the existing deletion-oriented `down --wait`.

## Behavior
Opt-in, mirroring `down --wait`: bare `--wait` = 600s, `--wait N` = N seconds, omitted = fire-and-forget (unchanged default). Registered on `up` for both nouns.

Readiness is **resource-specific** (verified live on fevm):

- **Apps (agent + mcp):** two phases against one deadline — SDK `apps.get` until `compute_status.state == ACTIVE` (URL/proxy exists; a `CRASHED` app fails fast), then `GET <app.url>/health` (behind the Apps auth proxy, headers via `w.config.authenticate()`) until **200**, proving the app PROCESS answers HTTP. `/health` is served by MLflow's AgentServer for both agent and mcp apps.
- **Model Serving:** SDK only (no HTTP health route exists) — endpoint `state.ready == READY` + `config_update == NOT_UPDATING` AND every served entity `state.deployment == DEPLOYMENT_READY`.

Unlike `down --wait` (warn-and-return on timeout), readiness is an **assertion**: a terminal-failure state (App `CRASHED`, served model `DEPLOYMENT_FAILED`, endpoint `UPDATE_FAILED`) or timeout logs an error and `sys.exit(1)` so CI catches a broken deploy.

## Implementation
`_wait_for_resource_ready` is a sibling of `_wait_for_resource_deleted`. Wired into all six combos: `deploy_app_bundle` (apps/mcp), `_run_ms_job_bundle` (ms), the `--direct` model_serving branch (apps `--direct` already waits internally via `apps.deploy_and_wait`), and a new bundle-run block in `run_databricks_command` for `workflow up` (mode-branched App vs endpoint, mirroring the destroy cleanup).

## Tests
`TestWaitForResourceReady` (apps `/health` phase + endpoint served-model phases + hard-fail/timeout cases), `TestWaitFlagParsing` extended for `up`, and driver-wiring tests (right `kind`+name per mode; no poll without `--wait`). Full module: 359 passed; ruff at pre-existing baseline.

## Live verification (fevm)
`agent up --wait` (apps) returned readiness-gated at **19:41:07**; an immediate `/invocations` call succeeded (**HTTP 200**, real agent response `"Hello to you!"`) at **19:43:09** — `up --wait` completion preceded servable inference (the timestamp cross-check). The app poller ran end to end (compute-ACTIVE → `/health` 200, ~3s). The endpoint poller is unit-tested (no custom serving endpoint was live on fevm to exercise it directly).

This pull request and its description were written by Isaac.