### PR TITLE
fix(cli): gate `up --direct --wait` (apps/mcp) on /health, not just deploy_and_wait

### DIFF
--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -5560,8 +5560,7 @@ def _deploy_run_destroy_app_bundle(
             )
             # `--wait`: `deploy_agent` (agents.deploy) returns once the update is
             # issued; block until the endpoint is READY + served model
-            # DEPLOYMENT_READY. (The apps/mcp direct path already waits internally
-            # via the provider's apps.deploy_and_wait, so only MS needs this here.)
+            # DEPLOYMENT_READY.
             wait_timeout = _wait_timeout_of(options)
             if wait_timeout is not None and config.app.endpoint_name:
                 _wait_for_resource_ready(
@@ -5573,6 +5572,18 @@ def _deploy_run_destroy_app_bundle(
         else:
             # Apps/MCP deploy directly from config + wheel (no MLflow model).
             config.deploy_agent(target=ServingMode(mode), development=development)
+            # `--wait`: the provider's `apps.deploy_and_wait` only blocks until the
+            # DEPLOYMENT is SUCCEEDED — the app PROCESS can still be booting and
+            # 502 on the first request. Gate on compute ACTIVE + GET /health 200
+            # (same poller the bundle path uses) so inference can follow at once.
+            wait_timeout = _wait_timeout_of(options)
+            if wait_timeout is not None:
+                _wait_for_resource_ready(
+                    "app",
+                    config.app.app_resource_name,
+                    options.profile,
+                    wait_timeout,
+                )
         return
 
     # --- Route 2: bundle path (default; apps/mcp App bundle, MS Job bundle) ---

--- a/tests/dao_ai/test_development_flag_cli.py
+++ b/tests/dao_ai/test_development_flag_cli.py
@@ -2039,6 +2039,48 @@ class TestDeployAutoGenerate:
         dep.assert_not_called()
         exec_cmd.assert_not_called()
 
+    def test_direct_apps_up_wait_gates_on_health(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`agent up --direct --wait` (apps) must block on the App readiness poller
+        AFTER deploy_agent — deploy_and_wait only reaches deployment SUCCEEDED, but
+        the app process can still 502, so we gate on compute ACTIVE + /health 200.
+        """
+        cfg = self._write_cfg(tmp_path)
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(
+            "dao_ai.config.AppConfig.deploy_agent",
+            lambda self_config, target=None, development=None: None,
+        )
+        with (
+            patch.object(cli, "deploy_app_bundle"),
+            patch.object(cli, "_exec_bundle_command"),
+            patch.object(cli, "_wait_for_resource_ready") as ready,
+        ):
+            opts = parse_args(
+                ["agent", "up", "-c", str(cfg), "--direct", "--wait", "120"]
+            )
+            cli.handle_agent_command(opts)
+        ready.assert_called_once_with("app", "my-app", None, 120)
+
+    def test_direct_apps_up_without_wait_does_not_poll(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = self._write_cfg(tmp_path)
+        monkeypatch.setattr(cli, "_apply_profile_context", lambda p: None)
+        monkeypatch.setattr(
+            "dao_ai.config.AppConfig.deploy_agent",
+            lambda self_config, target=None, development=None: None,
+        )
+        with (
+            patch.object(cli, "deploy_app_bundle"),
+            patch.object(cli, "_exec_bundle_command"),
+            patch.object(cli, "_wait_for_resource_ready") as ready,
+        ):
+            opts = parse_args(["agent", "up", "-c", str(cfg), "--direct"])
+            cli.handle_agent_command(opts)
+        ready.assert_not_called()
+
     def test_model_serving_direct_registers_then_deploys_no_bundle(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
Follow-up to #264, **caught by a full `validate-cli.sh` run**.

## Problem
The apps/mcp `--direct` SDK path (`agent up --direct`) called `deploy_agent` and returned with **no readiness wait** — so `--wait` was a silent no-op there. The provider's `apps.deploy_and_wait` only blocks until the *deployment* reaches `SUCCEEDED`, but the app *process* can still be booting, so an inference request fired immediately after `up --wait` **502s**.

Live-reproduced on fevm during `validate-cli.sh`: `agent up --direct --wait` → `POST /invocations` → **502 Bad Gateway**. Moments later the same app was `/health` 200 + `/invocations` 200 — i.e. it was still starting when the (no-op) wait returned.

## Fix
The apps/mcp `--direct` branch now calls `_wait_for_resource_ready("app", ...)` (compute `ACTIVE` + `GET /health` 200) after `deploy_agent` — the same gate the bundle path already uses. The MS `--direct` branch already had the endpoint wait; only apps/mcp was missing it.

**Re-verified live:** `agent up --direct --wait` + immediate `/invocations` now returns **HTTP 200**.

## Tests
`test_direct_apps_up_wait_gates_on_health` (poller called with the app resource name + timeout) and `test_direct_apps_up_without_wait_does_not_poll`. 361 unit tests pass; ruff at baseline.

This pull request and its description were written by Isaac.