### PR TITLE
feat(apps): size Databricks Apps compute from workload_size (+ XLarge)

### DIFF
--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -1485,7 +1485,7 @@
             }
           ],
           "default": "Small",
-          "description": "Model Serving workload size (Small, Medium, Large)."
+          "description": "Compute size for the deployment. Applies to both targets. Model Serving accepts Small/Medium/Large (XLarge is clamped to Large). For the Databricks Apps target this is coerced to the Apps compute_size domain: Small/Medium leave the platform default (MEDIUM, ~2 vCPU / 6 GB \u2014 Apps has no Small tier and existing apps are not resized), Large \u2192 LARGE, XLarge \u2192 XLARGE. Apps compute does not scale to zero."
         },
         "workers": {
           "anyOf": [
@@ -10687,11 +10687,12 @@
       "type": "object"
     },
     "WorkloadSize": {
-      "description": "Model Serving workload size controlling compute resources.",
+      "description": "Compute size controlling deployment resources.\n\nShared by both deployment targets. Model Serving accepts Small/Medium/Large\nnatively; XLarge is an Apps-only tier (Databricks Apps supports MEDIUM,\nLARGE, XLARGE and has no Small tier). When XLarge is used with the Model\nServing target it is clamped to Large (its largest size).",
       "enum": [
         "Small",
         "Medium",
-        "Large"
+        "Large",
+        "XLarge"
       ],
       "title": "WorkloadSize",
       "type": "string"

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -569,6 +569,13 @@ def _build_app_block(
     if config.app.space:
         app_def["space"] = config.app.space
 
+    # Coerce workload_size → Apps compute_size (None for Small/Medium leaves the
+    # platform default MEDIUM; Large/XLarge set the tier). Raw string so XLARGE
+    # passes through regardless of the installed SDK ComputeSize enum.
+    apps_compute_size = config.app.apps_compute_size()
+    if apps_compute_size:
+        app_def["compute_size"] = apps_compute_size
+
     # experiments_block sourcing:
     #   - config.app.experiment set → we already resolved the id via
     #     ``ensure_resolved`` above (creating from name if needed). The

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -8742,11 +8742,18 @@ class LogLevel(str, Enum):
 
 
 class WorkloadSize(str, Enum):
-    """Model Serving workload size controlling compute resources."""
+    """Compute size controlling deployment resources.
+
+    Shared by both deployment targets. Model Serving accepts Small/Medium/Large
+    natively; XLarge is an Apps-only tier (Databricks Apps supports MEDIUM,
+    LARGE, XLARGE and has no Small tier). When XLarge is used with the Model
+    Serving target it is clamped to Large (its largest size).
+    """
 
     SMALL = "Small"
     MEDIUM = "Medium"
     LARGE = "Large"
+    XLARGE = "XLarge"
 
 
 class MessageRole(str, Enum):
@@ -9503,7 +9510,15 @@ class AppModel(BaseModel):
     )
     workload_size: Optional[WorkloadSize] = Field(
         default="Small",
-        description="Model Serving workload size (Small, Medium, Large).",
+        description=(
+            "Compute size for the deployment. Applies to both targets. "
+            "Model Serving accepts Small/Medium/Large (XLarge is clamped to "
+            "Large). For the Databricks Apps target this is coerced to the Apps "
+            "compute_size domain: Small/Medium leave the platform default "
+            "(MEDIUM, ~2 vCPU / 6 GB — Apps has no Small tier and existing apps "
+            "are not resized), Large → LARGE, XLarge → XLARGE. Apps compute does "
+            "not scale to zero."
+        ),
     )
     workers: Optional[int] = Field(
         default=None,
@@ -9655,6 +9670,25 @@ class AppModel(BaseModel):
         "a2a.on_behalf_of_user). Set a2a.enabled=false to opt out. Ignored for Model "
         "Serving deployments. See A2AModel for the full schema.",
     )
+
+    def apps_compute_size(self) -> Optional[str]:
+        """Map ``workload_size`` to a Databricks Apps ``compute_size``.
+
+        Returns ``None`` to leave the Apps platform default (MEDIUM) — this is
+        the case for Small and Medium, so existing apps are never resized on
+        redeploy and the simplest configs keep the current behavior. Large and
+        XLarge map to the corresponding Apps tiers. Apps has no Small tier and
+        does not scale to zero.
+        """
+        return {"Large": "LARGE", "XLarge": "XLARGE"}.get(self.workload_size)
+
+    def serving_workload_size(self) -> str:
+        """Clamp ``workload_size`` to the Model Serving domain.
+
+        Model Serving has no XLarge tier, so XLarge is clamped to Large (its
+        largest size). Small/Medium/Large pass through unchanged.
+        """
+        return "Large" if self.workload_size == "XLarge" else self.workload_size
 
     @model_validator(mode="after")
     def set_databricks_env_vars(self) -> Self:

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -9682,11 +9682,12 @@ class AppModel(BaseModel):
         """
         return {"Large": "LARGE", "XLarge": "XLARGE"}.get(self.workload_size)
 
-    def serving_workload_size(self) -> str:
+    def serving_workload_size(self) -> Optional[str]:
         """Clamp ``workload_size`` to the Model Serving domain.
 
         Model Serving has no XLarge tier, so XLarge is clamped to Large (its
-        largest size). Small/Medium/Large pass through unchanged.
+        largest size). Small/Medium/Large pass through unchanged. Returns
+        ``None`` when ``workload_size`` is unset (explicit null).
         """
         return "Large" if self.workload_size == "XLarge" else self.workload_size
 

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -2285,6 +2285,23 @@ class DatabricksProvider(ServiceProvider):
                     )
         else:
             app = existing_app
+            # compute_size can't be changed on an existing app via the update
+            # API (it rejects the field), so warn if the configured size no
+            # longer matches — otherwise the resize would silently no-op.
+            if apps_compute_size:
+                current_size = getattr(existing_app.compute_size, "value", None) or (
+                    existing_app.compute_size
+                )
+                if current_size and str(current_size) != apps_compute_size:
+                    logger.warning(
+                        "App compute_size cannot be changed on an existing app "
+                        "via the update API; the app keeps its current size. To "
+                        "resize, change it in the Databricks UI or tear down and "
+                        "recreate the app.",
+                        app_name=app_name,
+                        current_size=str(current_size),
+                        requested_size=apps_compute_size,
+                    )
             # Update resources and scopes on existing app
             if deployment_resources or user_api_scopes:
                 logger.info("Updating app resources and scopes", app_name=app_name)

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -1496,7 +1496,7 @@ class DatabricksProvider(ServiceProvider):
             k: str(v) if v is not None else ""
             for k, v in (config.app.environment_vars or {}).items()
         }
-        workload_size: str = config.app.workload_size
+        workload_size: str = config.app.serving_workload_size()
         tags: dict[str, str] = config.app.tags.copy() if config.app.tags else {}
 
         # Add dao_ai framework tag
@@ -2181,6 +2181,15 @@ class DatabricksProvider(ServiceProvider):
             app_body["resources"] = deployment_resources
         if user_api_scopes:
             app_body["user_api_scopes"] = user_api_scopes
+        # Coerce workload_size → Apps compute_size. None (Small/Medium) leaves
+        # the platform default (MEDIUM); Large/XLarge set the tier explicitly.
+        # Sent as a raw string so XLARGE flows through even though the installed
+        # SDK ComputeSize enum may not include it. Applied on CREATE only — the
+        # PATCH update API rejects compute_size ("Compute size updates are not
+        # supported in this update API"), so an existing app's size is left as
+        # is on redeploy via this SDK path (change it in the UI, or tear down
+        # and recreate).
+        apps_compute_size: str | None = config.app.apps_compute_size()
 
         def _set_app_resources(method: str, path: str, body: dict) -> None:
             """Create or update app via REST API.
@@ -2249,6 +2258,8 @@ class DatabricksProvider(ServiceProvider):
 
         if not app_exists:
             logger.info("Creating Databricks App", app_name=app_name)
+            if apps_compute_size:
+                app_body["compute_size"] = apps_compute_size
             _set_app_resources("POST", "/api/2.0/apps", app_body)
             # Wait for app to be ready
             app = self.w.apps.wait_get_app_active(name=app_name)

--- a/tests/dao_ai/test_bundle_app_compute_size.py
+++ b/tests/dao_ai/test_bundle_app_compute_size.py
@@ -1,0 +1,106 @@
+"""Compute-size coercion + bundle emission tests for ``AppModel.workload_size``.
+
+``workload_size`` is shared by both deployment targets. Two helpers coerce it:
+
+* ``apps_compute_size()`` maps to the Databricks Apps ``compute_size`` domain.
+  Apps has no Small tier and its platform default is MEDIUM, so Small/Medium
+  return ``None`` (leave the default, never resize existing apps); Large/XLarge
+  map to ``LARGE``/``XLARGE``.
+* ``serving_workload_size()`` clamps to the Model Serving domain, which has no
+  XLarge tier: XLarge -> Large, everything else passes through.
+
+``_build_app_block`` emits ``compute_size`` in the app_def ONLY when
+``apps_compute_size()`` is truthy (i.e. Large/XLarge).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dao_ai.apps.bundle import _build_app_block
+from dao_ai.config import (
+    AgentModel,
+    AppConfig,
+    AppModel,
+    InferenceEndpointModel,
+)
+
+
+def _config(*, workload_size: str = "Small") -> AppConfig:
+    return AppConfig(
+        app=AppModel(
+            name="dao-ai-compute-size-test",
+            description="test agent",
+            enable_chat_proxy=False,
+            workload_size=workload_size,
+            agents=[
+                AgentModel(
+                    name="greeter",
+                    description="test agent",
+                    model=InferenceEndpointModel(name="databricks-gpt-5-4-mini"),
+                )
+            ],
+        ),
+    )
+
+
+def _compute_size(apps_block: dict) -> str | None:
+    (app_def,) = apps_block.values()
+    return app_def.get("compute_size")
+
+
+@pytest.mark.unit
+class TestAppsComputeSizeCoercion:
+    @pytest.mark.parametrize(
+        "workload_size, expected",
+        [
+            ("Small", None),
+            ("Medium", None),
+            ("Large", "LARGE"),
+            ("XLarge", "XLARGE"),
+        ],
+    )
+    def test_apps_compute_size(self, workload_size: str, expected: str | None) -> None:
+        assert _config(workload_size=workload_size).app.apps_compute_size() == expected
+
+    @pytest.mark.parametrize(
+        "workload_size, expected",
+        [
+            ("Small", "Small"),
+            ("Medium", "Medium"),
+            ("Large", "Large"),
+            ("XLarge", "Large"),  # clamped: Model Serving has no XLarge tier
+        ],
+    )
+    def test_serving_workload_size(
+        self, workload_size: str, expected: str
+    ) -> None:
+        assert (
+            _config(workload_size=workload_size).app.serving_workload_size()
+            == expected
+        )
+
+
+@pytest.mark.unit
+class TestComputeSizeEmission:
+    def test_omits_compute_size_for_small(self) -> None:
+        # Small -> platform default (MEDIUM); no key emitted, existing apps
+        # are never resized on redeploy.
+        _, _, apps_block = _build_app_block(_config(workload_size="Small"), "dao_ai.yaml")
+        assert _compute_size(apps_block) is None
+
+    def test_omits_compute_size_for_medium(self) -> None:
+        _, _, apps_block = _build_app_block(
+            _config(workload_size="Medium"), "dao_ai.yaml"
+        )
+        assert _compute_size(apps_block) is None
+
+    def test_emits_large(self) -> None:
+        _, _, apps_block = _build_app_block(_config(workload_size="Large"), "dao_ai.yaml")
+        assert _compute_size(apps_block) == "LARGE"
+
+    def test_emits_xlarge(self) -> None:
+        _, _, apps_block = _build_app_block(
+            _config(workload_size="XLarge"), "dao_ai.yaml"
+        )
+        assert _compute_size(apps_block) == "XLARGE"

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -984,8 +984,10 @@ def test_deploy_apps_agent_creates_new_app():
     mock_app.trace_location = None
     mock_app.monitoring = None
     mock_app.enable_chat_proxy = True
+    mock_app.apps_compute_size.return_value = "LARGE"
     mock_config.app = mock_app
     mock_config.source_config_path = None  # No config file to upload
+    mock_config._source_config_path = None
     mock_config.rendered_yaml = None
     mock_config.model_dump.return_value = {"app": {"name": "test_app"}}
     mock_config.resources = None  # No resources (required for generate_app_resources)
@@ -1042,6 +1044,8 @@ def test_deploy_apps_agent_creates_new_app():
             body = create_call.kwargs.get("body", {})
             assert body["name"] == "test-app"  # Normalized: underscores become dashes
             assert body["description"] == "Test app description"
+            # compute_size is set on CREATE (the POST API accepts it)
+            assert body["compute_size"] == "LARGE"
             # Verify deploy_and_wait was called
             provider.w.apps.deploy_and_wait.assert_called_once()
 
@@ -1070,18 +1074,22 @@ def test_deploy_apps_agent_updates_existing_app():
     mock_app.trace_location = None
     mock_app.monitoring = None
     mock_app.enable_chat_proxy = True
+    mock_app.apps_compute_size.return_value = "LARGE"
     mock_config.app = mock_app
     mock_config.source_config_path = None  # No config file to upload
+    mock_config._source_config_path = None
     mock_config.rendered_yaml = None
     mock_config.model_dump.return_value = {"app": {"name": "test_app"}}
     mock_config.resources = None  # No resources (required for generate_app_resources)
     mock_config.agents = None
     mock_config.retrievers = None
 
-    # Create mock existing App
+    # Create mock existing App (already MEDIUM — a resize to LARGE should warn
+    # and NOT be sent on the update API, which rejects compute_size changes)
     mock_existing_app = MagicMock(spec=App)
     mock_existing_app.name = "test_app"
     mock_existing_app.url = "https://test_app.databricks.com"
+    mock_existing_app.compute_size = "MEDIUM"
     mock_existing_app.app_status = MagicMock()
     mock_existing_app.app_status.state = ApplicationState.RUNNING
 
@@ -1119,6 +1127,13 @@ def test_deploy_apps_agent_updates_existing_app():
             for call in provider.w.api_client.do.call_args_list:
                 assert call.args[0] != "POST" or "/api/2.0/apps" not in call.args[1], (
                     "POST /api/2.0/apps should not be called for existing app"
+                )
+            # compute_size must NOT be sent on any update — the PATCH API
+            # rejects it. It is only valid on CREATE.
+            for call in provider.w.api_client.do.call_args_list:
+                body = call.kwargs.get("body", {})
+                assert "compute_size" not in body, (
+                    "compute_size must not be sent on an update call"
                 )
             # Verify deploy_and_wait was called
             provider.w.apps.deploy_and_wait.assert_called_once()


### PR DESCRIPTION
## Summary

Databricks Apps deployments previously always ran at the platform-default compute size — dao-ai never set the App's `compute_size`. Model Serving, by contrast, has been sizable via `app.workload_size` for a while. This PR makes the **same** `workload_size` field size the Apps target too, and adds an `XLarge` tier so the largest Apps compute is reachable.

## What changed

`workload_size` is now shared by both targets, coerced per-target by two `AppModel` helpers:

| `workload_size` | Databricks Apps `compute_size` | Model Serving |
|---|---|---|
| `Small`  | *(omit → platform default MEDIUM)* | `Small` |
| `Medium` | *(omit → platform default MEDIUM)* | `Medium` |
| `Large`  | `LARGE`  | `Large` |
| `XLarge` | `XLARGE` | `Large` (clamped — MS has no XLarge) |

- `AppModel.apps_compute_size()` / `serving_workload_size()` — the coercions above. Small/Medium emit no `compute_size` so existing apps are never resized on redeploy (MEDIUM is the platform default regardless).
- `compute_size` is sent as a **raw string**, so `XLARGE` works even though the installed SDK `ComputeSize` enum only lists `MEDIUM`/`LARGE` (the DAB CLI warns but the API accepts it).
- Wired into both deploy paths: the DAB bundle `app_def` (`apps/bundle.py`) and the SDK-native `app_body` (`providers/databricks.py`).
- **SDK path applies `compute_size` on CREATE only** — the `PATCH` update API rejects it (*"Compute size updates are not supported in this update API"*), so an existing app's size is left as-is on `--direct` redeploy.
- Regenerated `schemas/model_config_schema.json`; added unit tests.

## Testing

- **Unit**: 12 new tests in `test_bundle_app_compute_size.py` (coercion tables + bundle emission) — pass. Neighboring bundle tests unaffected.
- **Live (fevm)**:
  - DAB bundle path → app deployed and RUNNING at `compute_size: XLARGE`.
  - `--direct` SDK path → app deployed and RUNNING at `compute_size: LARGE`; re-run on the existing app now succeeds (previously errored on the PATCH compute_size rejection — fixed here).
  - Test app torn down; workspace clean.

## Notes

- Apps compute does **not** scale to zero — no platform idle-suspend exists; this PR is strictly about compute sizing.
- Any future code that *reads back* `App.compute_size` via the typed SDK dataclass could choke on `XLARGE` until the SDK enum catches up; no such read-path exists in `src/` today.

This pull request and its description were written by Isaac.