### PR TITLE
fix(cli): raise --wait default 600s to 1200s for cold MS agent builds

### DIFF
--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -258,7 +258,7 @@ def _global_parent_parser() -> ArgumentParser:
 
 # Default timeout (seconds) for `down --wait`: how long to block waiting for the
 # deleted App/endpoint to be fully gone before returning.
-_DEFAULT_WAIT_SECONDS = 600
+_DEFAULT_WAIT_SECONDS = 1200
 
 
 def _add_bundle_common_args(parser: ArgumentParser, *, kind: str) -> None:


### PR DESCRIPTION
## What

Raise `_DEFAULT_WAIT_SECONDS` in `src/dao_ai/cli.py` from **600 to 1200**.

## Why

A cold `dao-ai ... agent up --mode ms --wait` deploy failed with:

> `Endpoint 'ai_gateway_example' did not become READY within 600s — the endpoint is not serving.`

Investigation showed this was **bad timing, not a bug**:

| Time (EDT) | Event |
|---|---|
| 12:39:51 | deploy-agent job TERMINATED SUCCESS, --wait poll begins |
| **12:50:15** | **600s gate fires, _fail** |
| 12:52:38 | Container first boots gunicorn |
| 12:52:54 | endpoint flips READY |

The cold Model Serving container build took **~13 min** (conda env creation ~54s + image build/push + deploy + boot). The poll conditions in `_wait_for_resource_ready` are correct — the endpoint came up clean (single config_version; ready=READY / NOT_UPDATING / DEPLOYMENT_READY). The gate simply gave up ~2.5 min too early.

`_wait_for_resource_ready` is a **short-circuiting upper bound**, not a fixed sleep — it returns the instant all readiness conditions are met. Raising the default costs nothing on fast deploys; it only buys headroom for cold agent MS builds. Override per-invocation with `--wait N`.

## Notes

- Same constant backs both `up --wait` (readiness) and `down --wait` (deletion) — harmless, both are upper bounds.
- Help text uses `%(const)s`, so it auto-updates to "default 1200".

## Verification

- `dao-ai agent up --help` shows `default 1200`.
- `pytest tests/dao_ai/test_development_flag_cli.py -k wait` — 40 passed (incl. `test_bare_wait_uses_default`, which asserts against the symbol not the literal).

This pull request and its description were written by Isaac.