### PR TITLE
fix(vector-search): gate index.sync() on pipeline-idle to avoid spurious 'Pipeline is in state RUNNING' 400

### DIFF
--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -13,6 +13,7 @@ import yaml
 from databricks import agents
 from databricks.agents import PermissionLevel, set_permissions
 from databricks.ai_search.client import VectorSearchClient
+from databricks.ai_search.exceptions import BadRequest as AISearchBadRequest
 from databricks.ai_search.index import VectorSearchIndex
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors.platform import (
@@ -453,6 +454,51 @@ def _wait_until_index_absent(
         "Index still present after delete wait — proceeding anyway",
         index_name=index_full_name,
     )
+
+
+def _sync_when_pipeline_idle(
+    index: VectorSearchIndex,
+    index_name: str,
+    timeout_seconds: int = _VS_INDEX_READY_TIMEOUT_SECONDS,
+) -> None:
+    """Trigger an incremental ``index.sync()``, tolerating a still-running sync.
+
+    ``index.sync()`` (Delta-Sync, ``pipeline_type=TRIGGERED``) only succeeds when
+    the underlying pipeline is idle; the platform rejects it with a 400 (message
+    contains ``Pipeline is in state RUNNING``) while a sync is in flight. That is
+    benign — a pipeline already RUNNING is a sync already in progress, which
+    reaches the same end state. Poll past that specific 400 until the pipeline is
+    idle and the sync is accepted (or the pipeline finishes on its own). Any other
+    ``BadRequest`` re-raises unchanged. Bounded so a genuinely stuck pipeline
+    can't hang provisioning — the caller's ``wait_until_ready(wait_for_updates=
+    True)`` asserts the index actually lands ``ONLINE_NO_PENDING_UPDATE``.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    attempt = 0
+    while True:
+        try:
+            index.sync()
+            return
+        except AISearchBadRequest as exc:
+            attempt += 1
+            if "pipeline is in state running" not in str(exc).lower():
+                raise
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    "Delta-Sync pipeline still RUNNING at sync timeout — relying "
+                    "on the in-flight sync; proceeding to readiness wait",
+                    index_name=index_name,
+                    timeout_seconds=timeout_seconds,
+                    attempts=attempt,
+                )
+                return
+            logger.info(
+                "Delta-Sync pipeline still RUNNING — a sync is already in flight; "
+                "waiting for it to settle before retrying",
+                index_name=index_name,
+                attempt=attempt,
+            )
+            time.sleep(30)
 
 
 def link_experiment_trace_location(config: AppConfig, experiment_id: str) -> None:
@@ -2852,10 +2898,20 @@ class DatabricksProvider(ServiceProvider):
                     index_name=index_name,
                     detailed_state=current_state,
                 )
-                # Wait for the index to be queryable before issuing sync, so we
-                # don't race against a still-provisioning index.
-                index.wait_until_ready(verbose=True, wait_for_updates=False)
-                index.sync()
+                # Wait for the pipeline to be idle (not merely queryable) before
+                # issuing sync. wait_for_updates=False returns while an update is
+                # still in flight (detailed_state merely *contains* ONLINE), and
+                # sync() 400s ("Pipeline is in state RUNNING") against a running
+                # pipeline. wait_for_updates=True blocks until
+                # ONLINE_NO_PENDING_UPDATE. Bounded like the final readiness wait.
+                index.wait_until_ready(
+                    verbose=True,
+                    wait_for_updates=True,
+                    timeout=timedelta(seconds=_VS_INDEX_READY_TIMEOUT_SECONDS),
+                )
+                # Defensive: tolerate the residual TOCTOU window if the pipeline
+                # re-enters RUNNING between the wait and the sync.
+                _sync_when_pipeline_idle(index, index_name)
 
         # create_delta_sync_index_and_wait and index.sync() return before the
         # underlying data sync completes. wait_for_updates=True blocks until the

--- a/tests/dao_ai/test_vector_store_self_heal.py
+++ b/tests/dao_ai/test_vector_store_self_heal.py
@@ -178,6 +178,71 @@ class TestSelfHeal:
 
 
 @pytest.mark.unit
+class TestSyncPipelineRunningRace:
+    """``index.sync()`` 400s ("Pipeline is in state RUNNING") when a Delta-Sync
+    pipeline is mid-update. That is benign — a sync is already in flight — so
+    provisioning must poll past it, not fail the task."""
+
+    def test_running_pipeline_400_is_retried_then_succeeds(self) -> None:
+        provider, vsc = _provider()
+        idx = MagicMock()
+        idx.describe.return_value = _delta_sync_details("ONLINE_NO_PENDING_UPDATE")
+        # First sync() races the pipeline; second succeeds once it's idle.
+        idx.sync.side_effect = [
+            dbx.AISearchBadRequest(
+                "Index is not ready to sync yet. Pipeline is in state RUNNING "
+                "and needs to be in one of the following states to sync: "
+                "COMPLETED, FAILED, CANCELED."
+            ),
+            None,
+        ]
+        vsc.get_index.return_value = idx
+        with (
+            patch.object(dbx, "endpoint_exists", return_value=True),
+            patch.object(dbx, "index_exists", return_value=True),
+            patch.object(dbx, "_source_table_delta_uuid", return_value="uuid-1"),
+            patch.object(dbx.time, "sleep"),
+        ):
+            provider.create_vector_store(_vector_store())
+        assert idx.sync.call_count == 2
+        vsc.delete_index.assert_not_called()
+
+    def test_other_bad_request_is_reraised(self) -> None:
+        provider, vsc = _provider()
+        idx = MagicMock()
+        idx.describe.return_value = _delta_sync_details("ONLINE_NO_PENDING_UPDATE")
+        idx.sync.side_effect = dbx.AISearchBadRequest("Some other 400")
+        vsc.get_index.return_value = idx
+        with (
+            patch.object(dbx, "endpoint_exists", return_value=True),
+            patch.object(dbx, "index_exists", return_value=True),
+            patch.object(dbx, "_source_table_delta_uuid", return_value="uuid-1"),
+        ):
+            with pytest.raises(dbx.AISearchBadRequest, match="Some other 400"):
+                provider.create_vector_store(_vector_store())
+
+    def test_presync_wait_uses_wait_for_updates(self) -> None:
+        """The pre-sync gate must wait for the pipeline to be idle
+        (wait_for_updates=True), not merely queryable, to avoid the race."""
+        provider, vsc = _provider()
+        idx = MagicMock()
+        idx.describe.return_value = _delta_sync_details("ONLINE_NO_PENDING_UPDATE")
+        vsc.get_index.return_value = idx
+        with (
+            patch.object(dbx, "endpoint_exists", return_value=True),
+            patch.object(dbx, "index_exists", return_value=True),
+            patch.object(dbx, "_source_table_delta_uuid", return_value="uuid-1"),
+        ):
+            provider.create_vector_store(_vector_store())
+        # Every wait_until_ready in the healthy path waits for updates to settle.
+        assert idx.wait_until_ready.call_count >= 2
+        assert all(
+            call.kwargs.get("wait_for_updates") is True
+            for call in idx.wait_until_ready.call_args_list
+        )
+
+
+@pytest.mark.unit
 class TestStaleHelpers:
     def test_index_is_delta_sync_true_false(self) -> None:
         assert dbx._index_is_delta_sync(_delta_sync_details()) is True


### PR DESCRIPTION
## Problem

`provision-vector-search` (and any `create_vector_store` on an existing index) could fail with a spurious 400:

```
BadRequest: Index is not ready to sync yet. Pipeline is in state RUNNING and
needs to be in one of the following states to sync: COMPLETED, FAILED, CANCELED.
```

The underlying Delta-Sync pipeline was healthy and completed ingestion — the sync request just raced it.

## Root cause

In `DatabricksProvider.create_vector_store()`, the existing-and-healthy index branch did:

```python
index.wait_until_ready(verbose=True, wait_for_updates=False)  # queryable only
index.sync()                                                   # 400s if pipeline RUNNING
```

`wait_until_ready(wait_for_updates=False)` returns as soon as `detailed_state` merely *contains* `ONLINE` — including in-progress update states. It does **not** wait for the Delta-Sync pipeline to be idle, so `index.sync()` (`pipeline_type=TRIGGERED`) could fire against a `RUNNING` pipeline, which the platform rejects. The SDK's real "no update in progress" gate is `wait_for_updates=True` (ready set `{ONLINE, ONLINE_NO_PENDING_UPDATE, ONLINE_DIRECT_ACCESS}`).

Only the existing-index path calls `sync()`; fresh-create (`create_delta_sync_index_and_wait`) never syncs and was unaffected. This is adjacent to, but distinct from, the #198 stale-checkpoint self-heal (that fixed a *hang*; this fixes a spurious *400*).

Note: `index.sync()` raises `databricks.ai_search.exceptions.BadRequest`, which is a **different class** from the `databricks.sdk.errors.platform.BadRequest` already imported in `databricks.py`.

## Fix

1. **Gate on pipeline-idle**: pre-sync wait changed to `wait_for_updates=True`, bounded by the existing `_VS_INDEX_READY_TIMEOUT_SECONDS` (1200s) — closes the common race.
2. **`_sync_when_pipeline_idle()`**: tolerates the residual TOCTOU window by polling past the specific `AISearchBadRequest("...Pipeline is in state RUNNING...")` (a running pipeline is a sync already in flight). Any other `BadRequest` re-raises unchanged; bounded by the same 1200s. The caller's final `wait_until_ready(wait_for_updates=True)` still asserts the index lands `ONLINE_NO_PENDING_UPDATE`.
3. Import the correct exception class (`databricks.ai_search.exceptions.BadRequest as AISearchBadRequest`).

## Testing

- **Unit**: 3 new tests in `tests/dao_ai/test_vector_store_self_heal.py::TestSyncPipelineRunningRace` (running-400 retried-then-succeeds; other `BadRequest` re-raised; pre-sync wait uses `wait_for_updates=True`). 13/13 in that file pass; +49 other VS tests pass; no new lint.
- **Live** (fevm-brickmeter, `hardware_store_lakebase`, clean repro):
  - Fresh-create path: `provision-vector-search` SUCCESS (38,291 rows, no 400).
  - Fixed existing-index gated-sync branch (`jobs repair-run` of just that task): **SUCCESS in 1.8 min** — the exact branch that previously 400'd.

This pull request and its description were written by Isaac.