### PR TITLE
fix(pipeline): install feature extras in step notebooks (deploy-agents memory ImportError)

### DIFF
--- a/src/dao_ai/pipeline/notebooks/01_ingest_and_transform.py
+++ b/src/dao_ai/pipeline/notebooks/01_ingest_and_transform.py
@@ -4,13 +4,20 @@
 # PyPI package. In a deployed job the serverless environment has already
 # installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
 # installed package importable in the cells below.
+# This notebook ingests datasets, which may be EXCEL-format (pd.read_excel needs
+# openpyxl). The dataset format is not known until the config loads below, so it
+# installs the ``[excel]`` extra unconditionally. Notebooks that build the agent
+# graph (06_deploy_agent, 08_run_evaluation) install ``[all]``. The install spec
+# is single-quoted in the magic so a dev wheel's ``+local`` version tag and the
+# ``[excel]`` bracket survive shell glob/bracket expansion.
 import glob
 
-_dao_ai_dep = next(
-    iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai"
+_dao_ai_dep = (
+    next(iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai")
+    + "[excel]"
 )
 
-# MAGIC %uv pip install --quiet {_dao_ai_dep}
+# MAGIC %uv pip install --quiet '{_dao_ai_dep}'
 # MAGIC %restart_python
 
 # COMMAND ----------

--- a/src/dao_ai/pipeline/notebooks/02_provision_vector_search.py
+++ b/src/dao_ai/pipeline/notebooks/02_provision_vector_search.py
@@ -4,13 +4,18 @@
 # PyPI package. In a deployed job the serverless environment has already
 # installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
 # installed package importable in the cells below.
+# No extras suffix: this provisioning notebook only calls core APIs. Notebooks
+# that build the agent graph (06_deploy_agent, 08_run_evaluation) install
+# ``[all]``; 01_ingest_and_transform installs ``[excel]``. The install spec is
+# single-quoted in the magic so a dev wheel's ``+local`` version tag and any
+# ``[extras]`` survive shell glob/bracket expansion.
 import glob
 
 _dao_ai_dep = next(
     iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai"
 )
 
-# MAGIC %uv pip install --quiet {_dao_ai_dep}
+# MAGIC %uv pip install --quiet '{_dao_ai_dep}'
 # MAGIC %restart_python
 
 # COMMAND ----------

--- a/src/dao_ai/pipeline/notebooks/03_provision_lakebase.py
+++ b/src/dao_ai/pipeline/notebooks/03_provision_lakebase.py
@@ -4,13 +4,18 @@
 # PyPI package. In a deployed job the serverless environment has already
 # installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
 # installed package importable in the cells below.
+# No extras suffix: this provisioning notebook only calls core APIs. Notebooks
+# that build the agent graph (06_deploy_agent, 08_run_evaluation) install
+# ``[all]``; 01_ingest_and_transform installs ``[excel]``. The install spec is
+# single-quoted in the magic so a dev wheel's ``+local`` version tag and any
+# ``[extras]`` survive shell glob/bracket expansion.
 import glob
 
 _dao_ai_dep = next(
     iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai"
 )
 
-# MAGIC %uv pip install --quiet {_dao_ai_dep}
+# MAGIC %uv pip install --quiet '{_dao_ai_dep}'
 # MAGIC %restart_python
 
 # COMMAND ----------

--- a/src/dao_ai/pipeline/notebooks/04_unity_catalog_tools.py
+++ b/src/dao_ai/pipeline/notebooks/04_unity_catalog_tools.py
@@ -4,13 +4,18 @@
 # PyPI package. In a deployed job the serverless environment has already
 # installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
 # installed package importable in the cells below.
+# No extras suffix: this provisioning notebook only calls core APIs. Notebooks
+# that build the agent graph (06_deploy_agent, 08_run_evaluation) install
+# ``[all]``; 01_ingest_and_transform installs ``[excel]``. The install spec is
+# single-quoted in the magic so a dev wheel's ``+local`` version tag and any
+# ``[extras]`` survive shell glob/bracket expansion.
 import glob
 
 _dao_ai_dep = next(
     iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai"
 )
 
-# MAGIC %uv pip install --quiet {_dao_ai_dep}
+# MAGIC %uv pip install --quiet '{_dao_ai_dep}'
 # MAGIC %restart_python
 
 # COMMAND ----------

--- a/src/dao_ai/pipeline/notebooks/05_provision_genie.py
+++ b/src/dao_ai/pipeline/notebooks/05_provision_genie.py
@@ -4,13 +4,18 @@
 # PyPI package. In a deployed job the serverless environment has already
 # installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
 # installed package importable in the cells below.
+# No extras suffix: this provisioning notebook only calls core APIs. Notebooks
+# that build the agent graph (06_deploy_agent, 08_run_evaluation) install
+# ``[all]``; 01_ingest_and_transform installs ``[excel]``. The install spec is
+# single-quoted in the magic so a dev wheel's ``+local`` version tag and any
+# ``[extras]`` survive shell glob/bracket expansion.
 import glob
 
 _dao_ai_dep = next(
     iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai"
 )
 
-# MAGIC %uv pip install --quiet {_dao_ai_dep}
+# MAGIC %uv pip install --quiet '{_dao_ai_dep}'
 # MAGIC %restart_python
 
 # COMMAND ----------

--- a/src/dao_ai/pipeline/notebooks/06_deploy_agent.py
+++ b/src/dao_ai/pipeline/notebooks/06_deploy_agent.py
@@ -4,13 +4,20 @@
 # PyPI package. In a deployed job the serverless environment has already
 # installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
 # installed package importable in the cells below.
+# This notebook builds the agent graph (display_graph / create_agent below), so
+# it must install every optional feature extra — the graph is built before the
+# config is known, and any agent may use memory (langmem), a2a, deepagents,
+# rerank, or search. Hence ``[all]``. The install spec is single-quoted in the
+# magic so a dev wheel's ``+local`` version tag and the ``[all]`` bracket survive
+# shell glob/bracket expansion.
 import glob
 
-_dao_ai_dep = next(
-    iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai"
+_dao_ai_dep = (
+    next(iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai")
+    + "[all]"
 )
 
-# MAGIC %uv pip install --quiet {_dao_ai_dep}
+# MAGIC %uv pip install --quiet '{_dao_ai_dep}'
 # MAGIC %restart_python
 
 # COMMAND ----------

--- a/src/dao_ai/pipeline/notebooks/07_generate_evaluation_data.py
+++ b/src/dao_ai/pipeline/notebooks/07_generate_evaluation_data.py
@@ -4,13 +4,18 @@
 # PyPI package. In a deployed job the serverless environment has already
 # installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
 # installed package importable in the cells below.
+# No extras suffix: this notebook only calls core APIs (databricks.agents eval
+# generation). Notebooks that build the agent graph (06_deploy_agent,
+# 08_run_evaluation) install ``[all]``; 01_ingest_and_transform installs
+# ``[excel]``. The install spec is single-quoted in the magic so a dev wheel's
+# ``+local`` version tag and any ``[extras]`` survive shell glob/bracket expansion.
 import glob
 
 _dao_ai_dep = next(
     iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai"
 )
 
-# MAGIC %uv pip install --quiet {_dao_ai_dep}
+# MAGIC %uv pip install --quiet '{_dao_ai_dep}'
 # MAGIC %restart_python
 
 # COMMAND ----------

--- a/src/dao_ai/pipeline/notebooks/08_run_evaluation.py
+++ b/src/dao_ai/pipeline/notebooks/08_run_evaluation.py
@@ -4,13 +4,20 @@
 # PyPI package. In a deployed job the serverless environment has already
 # installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
 # installed package importable in the cells below.
+# This notebook builds the agent graph (as_responses_agent below), so it must
+# install every optional feature extra — the graph is built before the config is
+# known, and any agent may use memory (langmem), a2a, deepagents, rerank, or
+# search. Hence ``[all]``. The install spec is single-quoted in the magic so a
+# dev wheel's ``+local`` version tag and the ``[all]`` bracket survive shell
+# glob/bracket expansion.
 import glob
 
-_dao_ai_dep = next(
-    iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai"
+_dao_ai_dep = (
+    next(iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai")
+    + "[all]"
 )
 
-# MAGIC %uv pip install --quiet {_dao_ai_dep}
+# MAGIC %uv pip install --quiet '{_dao_ai_dep}'
 # MAGIC %restart_python
 
 # COMMAND ----------

--- a/tests/dao_ai/test_pipeline_bundle.py
+++ b/tests/dao_ai/test_pipeline_bundle.py
@@ -120,8 +120,10 @@ class TestPackagedAssets:
 
             suffix = expected_suffix[prefix]
             if suffix:
-                assert f'+ "{suffix}"' in text, (
-                    f"{p.name} must append the {suffix} extras suffix"
+                # Bind the suffix to the concatenation onto the glob fallback
+                # expression (not merely present somewhere, e.g. a comment).
+                assert f'), "dao-ai")\n    + "{suffix}"' in text, (
+                    f"{p.name} must append {suffix} onto the _dao_ai_dep spec"
                 )
             else:
                 # Core provisioning notebooks must not append any extras suffix.

--- a/tests/dao_ai/test_pipeline_bundle.py
+++ b/tests/dao_ai/test_pipeline_bundle.py
@@ -81,6 +81,57 @@ class TestPackagedAssets:
                 f"{p.name} still has the ../src fallback"
             )
 
+    def test_notebooks_bootstrap_extras_suffix(self) -> None:
+        """Each step notebook's ``%uv pip install`` bootstrap must install the
+        feature extras its own body can exercise.
+
+        Graph-building notebooks (06_deploy_agent, 08_run_evaluation) build the
+        agent before the config is known, so they install ``[all]``;
+        01_ingest_and_transform may read EXCEL datasets so it installs
+        ``[excel]``; the pure provisioning notebooks install bare dao-ai. Every
+        notebook single-quotes the interpolated spec so a dev wheel's ``+local``
+        version tag and any ``[extras]`` bracket survive shell expansion.
+        """
+        # notebook filename prefix -> the extras suffix its bootstrap must append
+        # ("" means no suffix — bare core install).
+        expected_suffix: dict[str, str] = {
+            "01_": "[excel]",
+            "02_": "",
+            "03_": "",
+            "04_": "",
+            "05_": "",
+            "06_": "[all]",
+            "07_": "",
+            "08_": "[all]",
+        }
+        seen: set[str] = set()
+        for p in files("dao_ai.pipeline.notebooks").iterdir():
+            if not p.name.endswith(".py") or p.name == "__init__.py":
+                continue
+            prefix = p.name[:3]
+            assert prefix in expected_suffix, f"unmapped notebook {p.name}"
+            seen.add(prefix)
+            text = p.read_text(encoding="utf-8")
+
+            # The magic must single-quote the interpolated spec (glob-safe).
+            assert "# MAGIC %uv pip install --quiet '{_dao_ai_dep}'" in text, (
+                f"{p.name} must single-quote the %uv install spec"
+            )
+
+            suffix = expected_suffix[prefix]
+            if suffix:
+                assert f'+ "{suffix}"' in text, (
+                    f"{p.name} must append the {suffix} extras suffix"
+                )
+            else:
+                # Core provisioning notebooks must not append any extras suffix.
+                assert '+ "[' not in text, (
+                    f"{p.name} must not append an extras suffix"
+                )
+        assert seen == set(expected_suffix), (
+            f"notebook set changed: {sorted(seen)}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # generate_pipeline_databricks_yaml — programmatic DAB (dict -> YAML)


### PR DESCRIPTION
## Problem

The `deploy-agents` pipeline task crashed at notebook-interpreter time:

```
ImportError: Long-term memory tools requires the 'memory' extra, which is not
installed. Install it with: pip install 'dao-ai[memory]' (or 'dao-ai[all]' ...)
```

(from `src/dao_ai/_extras.py::require_extra`). Seen on `quick_serve_restaurant`, reproduced on `hardware_store_lakebase`. Same failure mode for any optional extra (a2a, rerank, deepagents, memory, search, excel).

## Root cause

All 8 step notebooks (`src/dao_ai/pipeline/notebooks/NN_*.py`) shared an identical bootstrap that installed dao-ai **without any extras suffix**:

```python
_dao_ai_dep = next(iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai")
# MAGIC %uv pip install --quiet {_dao_ai_dep}
```

`_dao_ai_dep` is a bare local wheel path (`--development`) or bare `"dao-ai"` (PyPI). Neither carries `[all]`/`[memory]`, so the extra's backing package (e.g. langmem) was never installed in the task interpreter. `06_deploy_agent.py` then builds the agent graph (`config.display_graph()` — runs in **all** serving modes incl. Apps; `config.create_agent()` — non-Apps/MCP) → memory-tool factory (`src/dao_ai/tools/memory.py`) → `require_extra("memory")` → ImportError.

Notebooks are static package data copied verbatim by `_materialize_notebooks` (`pipeline/bundle.py:322`) — not templated — so the fix is a text edit in each.

## Fix

Scope the install per notebook to exactly what its body can exercise (the bootstrap runs **before** config load, so graph-builders can't know which agent extras a config uses → install `[all]`):

| Notebook | Body | Suffix |
|---|---|---|
| 01_ingest_and_transform | `dataset.create()` → `pd.read_excel` for EXCEL | `[excel]` (unconditional) |
| 02/03/04/05 provision, 07 gen-eval | core APIs only | bare `dao-ai` |
| 06_deploy_agent | `display_graph` + `create_agent` + `deploy_agent` | `[all]` |
| 08_run_evaluation | `as_responses_agent` | `[all]` |

Also single-quote the interpolated spec in every `%uv` magic (`'{_dao_ai_dep}'`) so a dev wheel's `+local` version tag and the `[extras]` bracket survive shell glob/bracket expansion — a latent correctness fix for all 8.

**Works in both modes** (verified with `uv pip install --dry-run`, uv 0.12.1): dev = `'<wheel-path>[all]'`, PyPI = `'dao-ai[all]'` — both resolve langmem etc.

**Deliberately untouched:**
- The serverless env-spec dependency `["${var.dao_ai_dep}"]` stays extras-free / glob-safe (guarded by `test_dev_env_deps_are_glob_safe_no_extras_on_wheel`). The `%uv pip install` is a separate second install in the task interpreter; extras belong there.
- `get_installed_packages` (`utils.py`) needs no change: once `06`'s interpreter has `[all]`, `version("langmem")` succeeds and the Model-Serving container pin is emitted (fixed transitively).

## Testing

- **Unit**: new `test_notebooks_bootstrap_extras_suffix` asserts the per-notebook suffix + quoted magic across all 8; the glob-safe env-spec guard still passes (41/41 in `tests/dao_ai/test_pipeline_bundle.py`). No new lint.
- **Live** (brickmeter, `hardware_store_lakebase`, dev wheel, workflow run 716237711143591): both `deploy-agents` attempts show **NO memory-extra ImportError** — execution reached secret-resolution, well past the graph build / memory-tool factory that previously crashed. `ingest-and-transform` (`[excel]`), lakebase, VS, UC-tools, genie, gen-eval all SUCCEEDED. (The run's remaining failure is an unrelated environmental gap — the config hardcodes a `retail_consumer_goods` secret scope absent on the brickmeter workspace.)

This pull request and its description were written by Isaac.