### PR TITLE
feat(sp): grant volumes/connections + Lakebase-aware, identity-safe granting

### DIFF
--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -1680,14 +1680,20 @@ Manage the service principal a dao-ai agent runs as.
 
 Sub-commands:
   provision  One shot: create the SP, store its secret to the config's scope,
-             and grant it every resource in the config. The secret is never
-             printed. This is the easiest way to make a config runnable.
+             and grant it the config's resources. The secret is never printed.
+             This is the easiest way to make a config runnable. NOTE: provision
+             mints a NEW SP, so it will not create Lakebase Postgres roles for a
+             DatabaseModel that pins a different client_id — use `grant --app-sp`
+             for that (see grant).
   create     Create (or reuse) a workspace service principal and mint an OAuth
              secret. Prints the client id + one-time secret.
   store      Write the client id / secret into a Databricks secret scope.
   grant      Grant the service principal the read/execute privileges an agent
-             needs on every resource declared in the config (catalog, schema,
-             table, function, vector index, warehouse, genie room, ...).
+             needs on the config's resources: catalog, schema, table, function,
+             vector index, volume, connection, warehouse, genie room, experiment,
+             serving endpoint. For Lakebase, a Postgres SUPERUSER role is created
+             only when the granted SP matches the DatabaseModel's client_id;
+             a mismatch is reported and skipped (grant --app-sp <that-id>).
 
 All read the config (-c) for defaults; explicit flags override.
         """,
@@ -2831,7 +2837,12 @@ def _print_grants(plan, *, applied: bool) -> None:
         status = ""
         if applied and g.applied is False:
             status = "  ✗ FAILED"
+        elif getattr(g, "note", None):
+            # A planned-but-skipped grant (e.g. Lakebase identity mismatch).
+            status = "  ⚠ SKIP"
         print(f"    [{g.kind}] {target} -> {', '.join(g.privileges)}{status}")
+        if getattr(g, "note", None):
+            print(f"        {g.note}")
 
 
 def _handle_sp_create(options, config, sp, WorkspaceClient) -> None:

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -2837,11 +2837,11 @@ def _print_grants(plan, *, applied: bool) -> None:
         status = ""
         if applied and g.applied is False:
             status = "  ✗ FAILED"
-        elif getattr(g, "note", None):
+        elif g.note:
             # A planned-but-skipped grant (e.g. Lakebase identity mismatch).
             status = "  ⚠ SKIP"
         print(f"    [{g.kind}] {target} -> {', '.join(g.privileges)}{status}")
-        if getattr(g, "note", None):
+        if g.note:
             print(f"        {g.note}")
 
 

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -3604,8 +3604,12 @@ class DatabricksProvider(ServiceProvider):
             workspace_client, database.project
         )
 
-        # role_id must match ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$ so sanitize the client_id
-        # Must start with a lowercase letter, so prefix with 'sp-' for service principal
+        # ``role_id`` is a client-supplied hint that must match
+        # ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$ — sanitize the client_id and prefix
+        # with 'sp-'. NOTE: the server does NOT persist roles under this id; it
+        # assigns its own (e.g. ``rol-<random>``) and dedupes on ``postgres_role``
+        # (the client_id). So this hint is only used on the create call — the
+        # existence check below must match on ``status.postgres_role`` instead.
         import re
 
         sanitized = re.sub(r"[^a-z0-9-]", "-", client_id.lower()).strip("-")
@@ -3620,21 +3624,28 @@ class DatabricksProvider(ServiceProvider):
         )
 
         try:
-            # Check if role already exists
-            try:
-                role_resource_name = f"{branch_name}/roles/{sanitized_role_id}"
-                _ = workspace_client.postgres.get_role(name=role_resource_name)
+            # Check if a role for this service principal already exists. Roles
+            # are keyed server-side by ``status.postgres_role`` (the client_id),
+            # NOT by the ``role_id`` we pass to create_role, so we must scan the
+            # branch's roles rather than get_role(name=".../sp-<client-id>")
+            # (which always 404s and used to force a create → RESOURCE_ALREADY_
+            # EXISTS round-trip on every call).
+            existing_role = next(
+                (
+                    r
+                    for r in workspace_client.postgres.list_roles(branch_name)
+                    if r.status and r.status.postgres_role == client_id
+                ),
+                None,
+            )
+            if existing_role is not None:
                 logger.info(
                     "Autoscaling Lakebase role already exists",
                     role_name=client_id,
+                    role_id=existing_role.role_id,
                     project=database.project,
                 )
                 return
-            except NotFound:
-                logger.debug(
-                    "Autoscaling role not found, creating",
-                    role_name=client_id,
-                )
 
             role = Role(
                 spec=RoleRoleSpec(

--- a/src/dao_ai/service_principal.py
+++ b/src/dao_ai/service_principal.py
@@ -7,17 +7,25 @@ Three operations, all workspace-level (no AccountClient needed):
 * :func:`store` — write client id / secret into a Databricks secret scope.
 * :func:`grant` — walk an :class:`~dao_ai.config.AppConfig` and grant the service
   principal the read/execute privileges an agent runtime needs on every declared
-  resource (catalog, schema, table, function, vector index, warehouse, genie room,
-  experiment, serving endpoint).
+  resource (catalog, schema, table, function, vector index, volume, connection,
+  warehouse, genie room, experiment, serving endpoint).
 
 The grant path reuses the same idempotent, warn-and-continue Unity Catalog
 permissions REST call dao-ai already uses at deploy time
 (``PATCH /api/2.1/unity-catalog/permissions/{securable_type}/{full_name}``).
+
+Lakebase autoscaling projects are a separate plane: SP access there is a Postgres
+role (created via the Postgres API), not a UC grant. :func:`grant` delegates to
+:meth:`~dao_ai.providers.databricks.DatabricksProvider.create_lakebase_autoscaling_role`,
+but only when the SP being granted matches the ``DatabaseModel``'s ``client_id`` —
+otherwise the role would belong to a different identity than the one the agent
+connects as, so the step is reported and skipped.
 """
 
 from __future__ import annotations
 
 import re
+import sys
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Optional, Sequence
 
@@ -31,11 +39,14 @@ if TYPE_CHECKING:
     from dao_ai.config import (
         AiSearchVectorStoreModel,
         AppConfig,
+        ConnectionModel,
+        DatabaseModel,
         FunctionModel,
         GenieRoomModel,
         SchemaModel,
         ServicePrincipalModel,
         TableModel,
+        VolumeModel,
         WarehouseModel,
     )
 
@@ -288,9 +299,15 @@ class Grant:
     """A single intended permission grant (used for dry-run reporting)."""
 
     kind: str  # "uc" | "warehouse" | "genie" | "experiment" | "serving_endpoint"
+    #          | "lakebase_role"
     target: str  # full name / id
     privileges: Sequence[str]
     securable_type: Optional[str] = None  # for kind == "uc"
+    # Human-readable context surfaced in the plan (dry-run and apply). Used by
+    # the ``lakebase_role`` kind to explain an intentional skip (e.g. the granted
+    # SP does not match the DatabaseModel's ``client_id``). When set on a
+    # ``lakebase_role`` grant, the Postgres role is NOT created.
+    note: Optional[str] = None
     # Set during apply (not dry-run): True if applied, False if it errored,
     # None if not attempted (dry-run).
     applied: Optional[bool] = None
@@ -361,6 +378,28 @@ def build_grant_plan(config: "AppConfig", principal: str) -> GrantPlan:
             if index_name and str(index_name).count(".") == 2:
                 plan.grants.append(Grant("uc", str(index_name), ["SELECT"], "table"))
 
+        # Volumes → READ_VOLUME (+ ensure their schema is granted)
+        volume: "VolumeModel"
+        for volume in resources.volumes.values():
+            if volume.schema_model is not None:
+                _add_schema(
+                    volume.schema_model.catalog_name, volume.schema_model.schema_name
+                )
+            if volume.full_name and volume.full_name.count(".") == 2:
+                plan.grants.append(
+                    Grant("uc", volume.full_name, ["READ_VOLUME"], "volume")
+                )
+
+        # Connections → USE_CONNECTION (connection names are top-level, unqualified)
+        connection: "ConnectionModel"
+        for connection in resources.connections.values():
+            if connection.full_name:
+                plan.grants.append(
+                    Grant(
+                        "uc", connection.full_name, ["USE_CONNECTION"], "connection"
+                    )
+                )
+
         # Warehouses → CAN_USE (workspace permission, not UC)
         warehouse: "WarehouseModel"
         for warehouse in resources.warehouses.values():
@@ -374,6 +413,44 @@ def build_grant_plan(config: "AppConfig", principal: str) -> GrantPlan:
             space_id = value_of(room.space_id) if room.space_id else None
             if space_id:
                 plan.grants.append(Grant("genie", str(space_id), ["CAN_RUN"]))
+
+        # Lakebase autoscaling projects → Postgres SUPERUSER role (created via the
+        # Postgres API, NOT a UC PATCH — see DatabricksProvider.create_lakebase_
+        # autoscaling_role). The Postgres role is keyed on the DatabaseModel's own
+        # ``client_id``, so we only create it when the SP being granted matches;
+        # otherwise the deployed agent would connect to Postgres as one identity
+        # while the role belongs to another (silent runtime auth failure). Mismatch
+        # / unresolved cases are planned with a ``note`` and skipped at apply time.
+        database: "DatabaseModel"
+        for database in resources.databases.values():
+            if not database.is_lakebase or database.on_behalf_of_user:
+                continue
+            configured = value_of(database.client_id) if database.client_id else None
+            project = str(database.project) if database.project else "<lakebase>"
+            note: Optional[str] = None
+            if not configured:
+                note = (
+                    "SKIP: DatabaseModel.client_id is unset or resolved to None "
+                    "(secret scope populated?). A Postgres role can only be created "
+                    "for a concrete service-principal client id — provision the SP "
+                    "and populate the scope, then re-run."
+                )
+            elif configured != principal:
+                note = (
+                    f"SKIP: granting SP '{principal}' but this Lakebase project is "
+                    f"configured for client_id '{configured}'. The Postgres role is "
+                    f"created for the configured id, so '{principal}' would fail at "
+                    f"connect time. Grant the configured SP (--app-sp) or align "
+                    f"DatabaseModel.client_id."
+                )
+            plan.grants.append(
+                Grant(
+                    "lakebase_role",
+                    project,
+                    ["DATABRICKS_SUPERUSER"],
+                    note=note,
+                )
+            )
 
     # Experiment + serving endpoint (only if declared on the app)
     app = config.app
@@ -423,6 +500,19 @@ def grant(
                 _grant_experiment(w, principal, g.target)
             elif g.kind == "serving_endpoint":
                 _grant_serving_endpoint(w, principal, g.target)
+            elif g.kind == "lakebase_role":
+                if g.note:
+                    # Intentional skip (identity mismatch or unresolved
+                    # client_id) — surface the reason and leave ``applied`` None
+                    # (not attempted) so it never reads as a success.
+                    logger.warning(
+                        "Lakebase Postgres role not created",
+                        project=g.target,
+                        reason=g.note,
+                    )
+                    print(f"  ⚠ Lakebase '{g.target}': {g.note}", file=sys.stderr)
+                    continue
+                _grant_lakebase_role(w, config, g.target)
             g.applied = True
         except Exception as e:  # noqa: BLE001 — warn-and-continue per resource
             g.applied = False
@@ -435,6 +525,31 @@ def grant(
             )
 
     return plan
+
+
+def _grant_lakebase_role(
+    w: "WorkspaceClient", config: "AppConfig", project: str
+) -> None:
+    """Create the Postgres SUPERUSER role for a Lakebase project's service principal.
+
+    Delegates to the existing, idempotent
+    :meth:`DatabricksProvider.create_lakebase_autoscaling_role` rather than
+    reinventing the Postgres-API role logic. The provider method reads the
+    ``DatabaseModel``'s own ``client_id`` and connects with its configured
+    credentials, so the caller has already verified (in :func:`build_grant_plan`)
+    that the SP being granted matches that ``client_id``.
+    """
+    from dao_ai.providers.databricks import DatabricksProvider
+
+    databases = config.resources.databases if config.resources else {}
+    database = next(
+        (db for db in databases.values() if str(db.project) == project), None
+    )
+    if database is None:
+        raise ValueError(
+            f"No Lakebase DatabaseModel with project '{project}' found in config"
+        )
+    DatabricksProvider(w=w).create_lakebase_autoscaling_role(database)
 
 
 def _grant_uc(

--- a/src/dao_ai/service_principal.py
+++ b/src/dao_ai/service_principal.py
@@ -25,7 +25,6 @@ connects as, so the step is reported and skipped.
 from __future__ import annotations
 
 import re
-import sys
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Optional, Sequence
 
@@ -303,6 +302,12 @@ class Grant:
     target: str  # full name / id
     privileges: Sequence[str]
     securable_type: Optional[str] = None  # for kind == "uc"
+    # The config dict key of the resource this grant came from. Set for the
+    # ``lakebase_role`` kind so the apply step re-resolves the exact
+    # ``DatabaseModel`` that passed the identity check in ``build_grant_plan``
+    # (matching on ``project`` alone could pick a different model when two
+    # DatabaseModels share a project but pin different ``client_id``s).
+    resource_key: Optional[str] = None
     # Human-readable context surfaced in the plan (dry-run and apply). Used by
     # the ``lakebase_role`` kind to explain an intentional skip (e.g. the granted
     # SP does not match the DatabaseModel's ``client_id``). When set on a
@@ -421,12 +426,15 @@ def build_grant_plan(config: "AppConfig", principal: str) -> GrantPlan:
         # otherwise the deployed agent would connect to Postgres as one identity
         # while the role belongs to another (silent runtime auth failure). Mismatch
         # / unresolved cases are planned with a ``note`` and skipped at apply time.
+        db_key: str
         database: "DatabaseModel"
-        for database in resources.databases.values():
+        for db_key, database in resources.databases.items():
             if not database.is_lakebase or database.on_behalf_of_user:
                 continue
+            # ``is_lakebase`` is defined as ``project is not None``, so project
+            # is always set here.
+            project = str(database.project)
             configured = value_of(database.client_id) if database.client_id else None
-            project = str(database.project) if database.project else "<lakebase>"
             note: Optional[str] = None
             if not configured:
                 note = (
@@ -448,6 +456,7 @@ def build_grant_plan(config: "AppConfig", principal: str) -> GrantPlan:
                     "lakebase_role",
                     project,
                     ["DATABRICKS_SUPERUSER"],
+                    resource_key=db_key,
                     note=note,
                 )
             )
@@ -504,15 +513,15 @@ def grant(
                 if g.note:
                     # Intentional skip (identity mismatch or unresolved
                     # client_id) — surface the reason and leave ``applied`` None
-                    # (not attempted) so it never reads as a success.
+                    # (not attempted) so it never reads as a success. The CLI
+                    # layer (``_print_grants``) renders the note for the user.
                     logger.warning(
                         "Lakebase Postgres role not created",
                         project=g.target,
                         reason=g.note,
                     )
-                    print(f"  ⚠ Lakebase '{g.target}': {g.note}", file=sys.stderr)
                     continue
-                _grant_lakebase_role(w, config, g.target)
+                _grant_lakebase_role(w, config, g.resource_key)
             g.applied = True
         except Exception as e:  # noqa: BLE001 — warn-and-continue per resource
             g.applied = False
@@ -528,7 +537,7 @@ def grant(
 
 
 def _grant_lakebase_role(
-    w: "WorkspaceClient", config: "AppConfig", project: str
+    w: "WorkspaceClient", config: "AppConfig", resource_key: Optional[str]
 ) -> None:
     """Create the Postgres SUPERUSER role for a Lakebase project's service principal.
 
@@ -538,16 +547,18 @@ def _grant_lakebase_role(
     ``DatabaseModel``'s own ``client_id`` and connects with its configured
     credentials, so the caller has already verified (in :func:`build_grant_plan`)
     that the SP being granted matches that ``client_id``.
+
+    Re-resolves the model by its config dict key (not by ``project``) so we act
+    on the exact ``DatabaseModel`` that passed the identity check — two models
+    can share a ``project`` while pinning different ``client_id``s.
     """
     from dao_ai.providers.databricks import DatabricksProvider
 
     databases = config.resources.databases if config.resources else {}
-    database = next(
-        (db for db in databases.values() if str(db.project) == project), None
-    )
+    database = databases.get(resource_key) if resource_key is not None else None
     if database is None:
         raise ValueError(
-            f"No Lakebase DatabaseModel with project '{project}' found in config"
+            f"No Lakebase DatabaseModel with key '{resource_key}' found in config"
         )
     DatabricksProvider(w=w).create_lakebase_autoscaling_role(database)
 

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -3170,3 +3170,70 @@ def test_deploy_apps_agent_dev_path_ships_uv_lock(tmp_path):
     assert pyproject_uploads
     pyproject_text = pyproject_uploads[0].kwargs["content"].getvalue().decode("utf-8")
     assert "[tool.uv.sources]" in pyproject_text and stub_wheel.name in pyproject_text
+
+
+# =============================================================================
+# create_lakebase_autoscaling_role — idempotency via postgres_role match
+# =============================================================================
+
+_LB_CLIENT_ID = "ad1118d0-d49d-47a6-8aa5-7f67ef14da3c"
+
+
+def _mock_lakebase_ws(existing_postgres_roles: list[str]) -> Mock:
+    """A mock WorkspaceClient whose postgres branch has the given SP roles.
+
+    ``list_branches`` yields one default branch; ``list_roles`` yields a Role
+    per entry in ``existing_postgres_roles`` (matched on ``status.postgres_role``,
+    which is how the server keys SP roles — NOT the client-supplied role_id).
+    """
+    w = Mock()
+    branch = Mock()
+    branch.name = "projects/proj/branches/main"
+    branch.status = Mock(default=True)
+    w.postgres.list_branches.return_value = iter([branch])
+    roles = []
+    for pr in existing_postgres_roles:
+        role = Mock()
+        role.role_id = "rol-server-assigned"
+        role.status = Mock(postgres_role=pr)
+        roles.append(role)
+    w.postgres.list_roles.return_value = iter(roles)
+    return w
+
+
+@pytest.mark.unit
+def test_create_lakebase_role_skips_create_when_role_exists(monkeypatch):
+    """Role keyed by status.postgres_role already present → no create_role call."""
+    w = _mock_lakebase_ws(existing_postgres_roles=[_LB_CLIENT_ID])
+    monkeypatch.setattr(
+        "dao_ai.config.WorkspaceClient", lambda **kwargs: w
+    )
+    db = DatabaseModel(
+        name="lb", project="proj", client_id=_LB_CLIENT_ID, client_secret="s"
+    )
+    DatabricksProvider(w=w).create_lakebase_autoscaling_role(db)
+
+    w.postgres.list_roles.assert_called_once()
+    w.postgres.create_role.assert_not_called()
+
+
+@pytest.mark.unit
+def test_create_lakebase_role_creates_when_absent(monkeypatch):
+    """No role matching the SP's client_id → create_role is issued once."""
+    w = _mock_lakebase_ws(
+        existing_postgres_roles=["22222222-2222-2222-2222-222222222222"]
+    )
+    monkeypatch.setattr(
+        "dao_ai.config.WorkspaceClient", lambda **kwargs: w
+    )
+    db = DatabaseModel(
+        name="lb", project="proj", client_id=_LB_CLIENT_ID, client_secret="s"
+    )
+    DatabricksProvider(w=w).create_lakebase_autoscaling_role(db)
+
+    w.postgres.create_role.assert_called_once()
+    _, kwargs = w.postgres.create_role.call_args
+    assert kwargs["parent"] == "projects/proj/branches/main"
+    # The role hint is sanitized from the client_id and 'sp-' prefixed.
+    assert kwargs["role_id"] == f"sp-{_LB_CLIENT_ID}"
+    assert kwargs["role"].spec.postgres_role == _LB_CLIENT_ID

--- a/tests/dao_ai/test_service_principal.py
+++ b/tests/dao_ai/test_service_principal.py
@@ -122,6 +122,94 @@ def test_grant_plan_warehouse_and_serving_endpoint() -> None:
     assert kinds["serving_endpoint"].privileges == ["CAN_QUERY"]
 
 
+def test_grant_plan_volume_and_connection_privileges() -> None:
+    from dao_ai.config import ConnectionModel, ResourcesModel, VolumeModel
+
+    schema = _schema()
+    config = AppConfig(
+        schemas={"s": schema},
+        resources=ResourcesModel(
+            volumes={"v": VolumeModel(schema=schema, name="landing")},
+            connections={"c": ConnectionModel(name="my_conn")},
+        ),
+    )
+    plan = build_grant_plan(config, PRINCIPAL)
+    mapping = {(g.securable_type, g.target): list(g.privileges) for g in plan.grants}
+
+    assert mapping[("volume", "cat.sch.landing")] == ["READ_VOLUME"]
+    assert mapping[("connection", "my_conn")] == ["USE_CONNECTION"]
+
+
+def test_grant_plan_volume_reuses_schema_grant() -> None:
+    from dao_ai.config import ResourcesModel, VolumeModel
+
+    schema = _schema()
+    config = AppConfig(
+        schemas={"s": schema},
+        resources=ResourcesModel(
+            volumes={"v": VolumeModel(schema=schema, name="landing")},
+        ),
+    )
+    plan = build_grant_plan(config, PRINCIPAL)
+    # The volume's schema is deduped against the top-level schema grant.
+    schemas = [g for g in plan.grants if g.securable_type == "schema"]
+    assert len(schemas) == 1
+
+
+def _lakebase_db(client_id: str):
+    from dao_ai.config import DatabaseModel
+
+    return DatabaseModel(
+        name="lb",
+        project="my-proj",
+        client_id=client_id,
+        client_secret="secret",
+    )
+
+
+def test_grant_plan_lakebase_role_matching_sp_has_no_skip_note() -> None:
+    from dao_ai.config import ResourcesModel
+
+    config = AppConfig(
+        resources=ResourcesModel(databases={"d": _lakebase_db(PRINCIPAL)}),
+    )
+    plan = build_grant_plan(config, PRINCIPAL)
+    lb = [g for g in plan.grants if g.kind == "lakebase_role"]
+    assert len(lb) == 1
+    assert lb[0].target == "my-proj"
+    assert lb[0].privileges == ["DATABRICKS_SUPERUSER"]
+    assert lb[0].note is None  # matching SP → will be created at apply time
+
+
+def test_grant_plan_lakebase_role_mismatched_sp_is_skipped() -> None:
+    from dao_ai.config import ResourcesModel
+
+    config = AppConfig(
+        resources=ResourcesModel(
+            databases={"d": _lakebase_db("22222222-2222-2222-2222-222222222222")}
+        ),
+    )
+    plan = build_grant_plan(config, PRINCIPAL)
+    lb = next(g for g in plan.grants if g.kind == "lakebase_role")
+    assert lb.note is not None
+    assert "SKIP" in lb.note
+    assert "22222222-2222-2222-2222-222222222222" in lb.note
+
+
+def test_grant_plan_lakebase_role_unset_client_id_is_skipped() -> None:
+    from dao_ai.config import DatabaseModel, ResourcesModel
+
+    config = AppConfig(
+        resources=ResourcesModel(
+            databases={"d": DatabaseModel(name="lb", project="my-proj")}
+        ),
+    )
+    plan = build_grant_plan(config, PRINCIPAL)
+    lb = next(g for g in plan.grants if g.kind == "lakebase_role")
+    assert lb.note is not None
+    assert "client_id is unset" in lb.note
+
+
 def test_grant_plan_empty_config_yields_nothing() -> None:
     plan = build_grant_plan(AppConfig(), PRINCIPAL)
     assert plan.grants == []
@@ -169,6 +257,88 @@ def test_grant_continues_after_a_failure_and_tracks_status() -> None:
     assert plan.grants[0].applied is False
     assert plan.grants[0].error
     assert any(g.applied is True for g in plan.grants[1:])
+
+
+def test_grant_applies_uc_patch_for_volume_and_connection() -> None:
+    from dao_ai.config import ConnectionModel, ResourcesModel, VolumeModel
+
+    w = MagicMock()
+    schema = _schema()
+    config = AppConfig(
+        schemas={"s": schema},
+        resources=ResourcesModel(
+            volumes={"v": VolumeModel(schema=schema, name="landing")},
+            connections={"c": ConnectionModel(name="my_conn")},
+        ),
+    )
+    grant(w, principal=PRINCIPAL, config=config, dry_run=False)
+
+    calls = w.api_client.do.call_args_list
+    patched = {
+        c.args[1]: c.kwargs["body"]["changes"][0] for c in calls if c.args[0] == "PATCH"
+    }
+    assert (
+        patched["/api/2.1/unity-catalog/permissions/volume/cat.sch.landing"]["add"]
+        == ["READ_VOLUME"]
+    )
+    assert (
+        patched["/api/2.1/unity-catalog/permissions/connection/my_conn"]["add"]
+        == ["USE_CONNECTION"]
+    )
+
+
+def test_grant_lakebase_role_created_when_sp_matches(monkeypatch) -> None:
+    from dao_ai.config import ResourcesModel
+    import dao_ai.providers.databricks as dbx
+
+    provider = MagicMock()
+    monkeypatch.setattr(dbx, "DatabricksProvider", lambda w: provider)
+
+    w = MagicMock()
+    config = AppConfig(
+        resources=ResourcesModel(databases={"d": _lakebase_db(PRINCIPAL)}),
+    )
+    plan = grant(w, principal=PRINCIPAL, config=config, dry_run=False)
+
+    provider.create_lakebase_autoscaling_role.assert_called_once()
+    lb = next(g for g in plan.grants if g.kind == "lakebase_role")
+    assert lb.applied is True
+
+
+def test_grant_lakebase_role_skipped_when_sp_mismatched(monkeypatch) -> None:
+    from dao_ai.config import ResourcesModel
+    import dao_ai.providers.databricks as dbx
+
+    provider = MagicMock()
+    monkeypatch.setattr(dbx, "DatabricksProvider", lambda w: provider)
+
+    w = MagicMock()
+    config = AppConfig(
+        resources=ResourcesModel(
+            databases={"d": _lakebase_db("22222222-2222-2222-2222-222222222222")}
+        ),
+    )
+    plan = grant(w, principal=PRINCIPAL, config=config, dry_run=False)
+
+    provider.create_lakebase_autoscaling_role.assert_not_called()
+    lb = next(g for g in plan.grants if g.kind == "lakebase_role")
+    # skipped (not attempted) → applied stays None, never reads as success
+    assert lb.applied is None
+
+
+def test_grant_lakebase_role_not_created_on_dry_run(monkeypatch) -> None:
+    from dao_ai.config import ResourcesModel
+    import dao_ai.providers.databricks as dbx
+
+    provider = MagicMock()
+    monkeypatch.setattr(dbx, "DatabricksProvider", lambda w: provider)
+
+    w = MagicMock()
+    config = AppConfig(
+        resources=ResourcesModel(databases={"d": _lakebase_db(PRINCIPAL)}),
+    )
+    grant(w, principal=PRINCIPAL, config=config, dry_run=True)
+    provider.create_lakebase_autoscaling_role.assert_not_called()
 
 
 def test_grant_warehouse_uses_additive_update_not_set() -> None:

--- a/tests/dao_ai/test_service_principal.py
+++ b/tests/dao_ai/test_service_principal.py
@@ -156,12 +156,12 @@ def test_grant_plan_volume_reuses_schema_grant() -> None:
     assert len(schemas) == 1
 
 
-def _lakebase_db(client_id: str):
+def _lakebase_db(client_id: str, project: str = "my-proj", name: str = "lb"):
     from dao_ai.config import DatabaseModel
 
     return DatabaseModel(
-        name="lb",
-        project="my-proj",
+        name=name,
+        project=project,
         client_id=client_id,
         client_secret="secret",
     )
@@ -324,6 +324,34 @@ def test_grant_lakebase_role_skipped_when_sp_mismatched(monkeypatch) -> None:
     lb = next(g for g in plan.grants if g.kind == "lakebase_role")
     # skipped (not attempted) → applied stays None, never reads as success
     assert lb.applied is None
+
+
+def test_grant_lakebase_role_resolves_by_key_not_project(monkeypatch) -> None:
+    """Two DBs share a project but pin different client_ids; only the matching
+    one must be acted on — apply must re-resolve by config key, not project, so
+    it can't pick the mismatched model and create a role for the wrong SP."""
+    from dao_ai.config import ResourcesModel
+    import dao_ai.providers.databricks as dbx
+
+    provider = MagicMock()
+    monkeypatch.setattr(dbx, "DatabricksProvider", lambda w: provider)
+
+    other = "22222222-2222-2222-2222-222222222222"
+    match_db = _lakebase_db(PRINCIPAL, project="shared-proj", name="match")
+    mismatch_db = _lakebase_db(other, project="shared-proj", name="mismatch")
+    w = MagicMock()
+    config = AppConfig(
+        resources=ResourcesModel(
+            databases={"match": match_db, "mismatch": mismatch_db}
+        ),
+    )
+    plan = grant(w, principal=PRINCIPAL, config=config, dry_run=False)
+
+    # Exactly one role created, and it's the model whose client_id == principal.
+    provider.create_lakebase_autoscaling_role.assert_called_once_with(match_db)
+    lb = {g.resource_key: g for g in plan.grants if g.kind == "lakebase_role"}
+    assert lb["match"].applied is True and lb["match"].note is None
+    assert lb["mismatch"].applied is None and lb["mismatch"].note
 
 
 def test_grant_lakebase_role_not_created_on_dry_run(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

`dao-ai sp grant` / `sp provision` is meant to be the turnkey "make this config's service principal able to run the app" command, but it was incomplete and, for Lakebase, silently misleading. This PR makes it complete for UC-securable resources and Lakebase-aware without reinventing Postgres logic or creating identity splits.

## Changes

- **Volumes + connections** — `build_grant_plan` now walks `resources.volumes` (`READ_VOLUME`) and `resources.connections` (`USE_CONNECTION`), both real UC grants the Apps platform already auto-grants but `sp grant` omitted.
- **Lakebase, identity-safe** — Lakebase SP access is a Postgres role (via `create_lakebase_autoscaling_role`), keyed on `DatabaseModel.client_id`, not a UC grant. `grant` now delegates to that existing provider method **only when the granted SP == `database.client_id`**. A mismatch (or unset `client_id`) is planned but **skipped** with a loud warning, since creating the role for a different identity than the agent connects as causes a silent runtime `password authentication failed`. Skips render as `[lakebase_role] <proj> -> DATABRICKS_SUPERUSER  ⚠ SKIP` with the reason.
  - Note: `sp provision` mints a *new* SP, so its Lakebase step will (correctly) skip for a config that pins a specific `client_id` — use `sp grant --app-sp <configured-id>`.
- **Fixed dead existence check** in `create_lakebase_autoscaling_role` — the Lakebase server assigns its own `role_id` (e.g. `rol-<random>`) and dedupes on `status.postgres_role` (the client_id), so the old `get_role(".../sp-<client-id>")` always 404'd and forced a `create_role` → `RESOURCE_ALREADY_EXISTS` round-trip on every call. Now scans `list_roles(branch)` matching `postgres_role`.
- **Corrected** the overstated `sp provision`/`grant` help text.

## Coverage after this PR

catalog, schema, table, function, vector index, **volume**, **connection**, warehouse, genie room, experiment, serving endpoint, **Lakebase Postgres role** (conditional on identity match).

## Verification

- **Live on fevm** (`hardware_store_lakebase.yaml`): 11/11 grants applied; UC schema grant confirmed via `databricks grants get`; Lakebase role confirmed created and then correctly detected as existing on re-run (no create attempt); mismatched principal shows the `⚠ SKIP` identity warning with the real configured client_id resolved.
- **Unit tests**: new coverage for volumes/connections and the Lakebase match/mismatch/unset/dry-run branches (`test_service_principal.py`, +9), plus the role existence-check fix (`test_databricks.py`, +2). All pass. No `make schema` diff (no model changes).
- The 8 pre-existing `test_databricks.py` `deploy_apps_agent`/`create_agent` Mock-harness failures are unrelated (confirmed failing identically without this change).

This pull request and its description were written by Isaac.