### PR TITLE
feat(sp): multi-service-principal provisioning, dry-run, and two Lakebase identity fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,15 @@ UV := uv
 # index and, behind the internal mirror, rewrites uv.lock with unreachable proxy
 # URLs. `--frozen` installs the pinned artifacts (public CDN) without touching
 # the lock, and works offline-of-the-index (only the artifact CDN is needed).
-SYNC := $(UV) sync --frozen
+#
+# `--extra all` pulls in every runtime feature extra (a2a, rerank, deepagents,
+# memory, search, excel). A local dev environment is expected to be able to run
+# and validate any example config, and without this an extras-dependent config
+# fails with "requires the 'memory' extra, which is not installed" — a packaging
+# gap rather than a real problem with the config. Deployment artifacts are
+# unaffected: dao_ai._extras still selects the minimal set per config, so the
+# published wheel and generated requirements stay lean.
+SYNC := $(UV) sync --frozen --extra all
 # Deliberate re-lock after a real dependency change. Forced to public PyPI so
 # the lock never picks up the internal mirror host. NOTE: run this where
 # pypi.org is reachable (Databricks sandbox / CI) — the corp mirror blocks the

--- a/examples/99_complete_applications/hardware_store/hardware_store_lakebase.yaml
+++ b/examples/99_complete_applications/hardware_store/hardware_store_lakebase.yaml
@@ -58,6 +58,30 @@ variables:
       secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
     - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET    # Service principal secret
 
+# =============================================================================
+# SERVICE PRINCIPALS
+# =============================================================================
+# `dao-ai sp provision` creates every service principal declared here, stores its
+# credentials to the secret scope, and grants it the config's resources.
+#
+# One entry is the common case. Declaring several is supported: each resource is
+# then granted only to the service principal that owns it — the one whose secret
+# keys its credentials point at, or that it names via `service_principal:` —
+# while resources matching no service principal are shared and granted to all.
+service_principals:
+  retail_consumer_goods_sp: &retail_consumer_goods_sp
+    # `name` binds this entry to a service principal that already exists, so its
+    # stored credentials are reused as-is. Without it the display name is derived
+    # (`<app.name>-retail_consumer_goods_sp`), which would not match the SP whose
+    # credentials are already in the scope below — provisioning then stops rather
+    # than rotating a credential a deployed agent is using.
+    name: dao-ai-sp
+    description: >-
+      Runs the agent. Owns the Lakebase project backing agent memory and
+      LangGraph checkpoints, so the Postgres SUPERUSER role is created for it.
+    client_id: *client_id
+    client_secret: *client_secret
+
 schemas:
   retail_schema: &retail_schema
     catalog_name: ${var.catalog}                    # Unity Catalog name
@@ -194,8 +218,8 @@ resources:
       name: "Retail and Consumer Goods Database"
       project: ${var.lakebase_project}  # Autoscaling Lakebase project name
       description: "Database for agent memory and checkpoints"
-      client_id: *client_id
-      client_secret: *client_secret
+      service_principal: *retail_consumer_goods_sp
+                                        # Expands to client_id + client_secret
       on_behalf_of_user: false
 
 # =============================================================================
@@ -836,8 +860,8 @@ app:
     name: hardware_store_lakebase_dao
   endpoint_name: hardware_store_lakebase_dao           # Model serving endpoint name
   environment_vars:
-    RETAIL_AI_DATABRICKS_CLIENT_ID: "{{secrets/retail_consumer_goods/RETAIL_AI_DATABRICKS_CLIENT_ID}}"
-    RETAIL_AI_DATABRICKS_CLIENT_SECRET: "{{secrets/retail_consumer_goods/RETAIL_AI_DATABRICKS_CLIENT_SECRET}}"
+    RETAIL_AI_DATABRICKS_CLIENT_ID: *client_id
+    RETAIL_AI_DATABRICKS_CLIENT_SECRET: *client_secret
   tags:                                             # Tags for resource organization
     business: rcg                                   # Business unit identifier
     streaming: true                                 # Indicates streaming capabilities

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -8828,6 +8828,32 @@
     "ServicePrincipalModel": {
       "description": "Databricks service principal credentials for OAuth M2M authentication.",
       "properties": {
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Workspace display name of the service principal. Used by `dao-ai service-principal provision` to create or reuse the SP; defaults to '<app.name>-<key>' where <key> is this entry's name under `service_principals`. Set it explicitly to bind a config to an SP that already exists.",
+          "title": "Name"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "What this service principal is for \u2014 which resources it owns and why it is separate from the others. Documentation only: the Databricks service-principal API has no description field, so this is never sent to the workspace.",
+          "title": "Description"
+        },
         "client_id": {
           "anyOf": [
             {

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -2819,30 +2819,89 @@ def _handle_sp_provision(options, config, sp, WorkspaceClient) -> None:
 def _print_grants(plan, *, applied: bool) -> None:
     """Print a readable list of the grants in a plan (secret-free).
 
-    When ``applied`` (real run), reports each grant's success and a failure count;
-    otherwise labels the list as a dry-run plan.
+    When ``applied`` (real run), reports each grant's outcome plus per-bucket
+    counts; otherwise labels the list as a dry-run plan.
+
+    Failures print their actual error and are split into ``ABSENT`` (the target
+    isn't in this workspace) and ``DENIED`` (it is, but the caller lacks GRANT).
+    Those need opposite fixes, and a bare "FAILED" hid the difference — a run
+    against the wrong ``--var catalog=`` reported ten permission-looking
+    failures whose real cause was "that catalog does not exist here".
     """
+    from dao_ai.service_principal import (
+        GRANT_FAILURE_ABSENT,
+        GRANT_FAILURE_DENIED,
+    )
+
     if not applied:
         print(f"  grants (dry-run — nothing applied) ({len(plan.grants)}):")
     else:
-        failed = sum(1 for g in plan.grants if g.applied is False)
         ok = sum(1 for g in plan.grants if g.applied is True)
-        suffix = f"{ok} applied" + (f", {failed} failed" if failed else "")
-        print(f"  grants ({suffix}):")
+        absent = sum(1 for g in plan.grants if g.failure_kind == GRANT_FAILURE_ABSENT)
+        denied = sum(1 for g in plan.grants if g.failure_kind == GRANT_FAILURE_DENIED)
+        # An absent target is not a permissions failure, and _grant_serving_endpoint
+        # already no-ops silently on one, so count it in its own bucket.
+        failed = sum(
+            1
+            for g in plan.grants
+            if g.applied is False
+            and g.failure_kind not in (GRANT_FAILURE_ABSENT, GRANT_FAILURE_DENIED)
+        )
+        parts = [f"{ok} applied"]
+        for count, label in (
+            (absent, "absent"),
+            (denied, "denied"),
+            (failed, "failed"),
+        ):
+            if count:
+                parts.append(f"{count} {label}")
+        print(f"  grants ({', '.join(parts)}):")
     if not plan.grants:
         print("    (no grantable resources found in config)")
         return
+
+    missing_catalogs: list[str] = []
     for g in plan.grants:
         target = f"{g.securable_type} {g.target}" if g.securable_type else g.target
         status = ""
         if applied and g.applied is False:
-            status = "  ✗ FAILED"
+            if g.failure_kind == GRANT_FAILURE_ABSENT:
+                status = "  ⚠ ABSENT"
+                if g.securable_type == "catalog":
+                    missing_catalogs.append(g.target)
+            elif g.failure_kind == GRANT_FAILURE_DENIED:
+                status = "  ✗ DENIED"
+            else:
+                status = "  ✗ FAILED"
         elif g.note:
             # A planned-but-skipped grant (e.g. Lakebase identity mismatch).
             status = "  ⚠ SKIP"
         print(f"    [{g.kind}] {target} -> {', '.join(g.privileges)}{status}")
         if g.note:
             print(f"        {g.note}")
+        if applied and g.applied is False and g.error:
+            print(f"        {g.error}")
+            if g.failure_kind == GRANT_FAILURE_ABSENT:
+                print(
+                    "        hint: not found in this workspace — check the config's "
+                    "--var overrides and the -p profile"
+                )
+            elif g.failure_kind == GRANT_FAILURE_DENIED:
+                print(
+                    "        hint: the calling identity needs GRANT/MANAGE on this "
+                    "securable"
+                )
+
+    if missing_catalogs:
+        names = ", ".join(dict.fromkeys(missing_catalogs))
+        print(
+            f"\n  {len(missing_catalogs)} grant(s) targeted a catalog that does not "
+            f"exist here: {names}"
+        )
+        print(
+            "  If the config parameterizes the catalog, point it at a real one, "
+            "e.g. --var catalog=<existing_catalog>."
+        )
 
 
 def _handle_sp_create(options, config, sp, WorkspaceClient) -> None:

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -2881,6 +2881,13 @@ def _print_provision_results(outcome, *, dry_run: bool) -> None:
     )
 
     for result in outcome.results:
+        print(f"\nservice principal '{result.name}' — {result.display_name}")
+
+        if result.blocked_reason:
+            # Nothing happened, so don't claim it was created or reused.
+            print(f"  ✗ BLOCKED: {result.blocked_reason}")
+            continue
+
         if dry_run:
             verb = "would REUSE existing" if result.reused else "would CREATE new"
             suffix = (
@@ -2891,12 +2898,7 @@ def _print_provision_results(outcome, *, dry_run: bool) -> None:
         else:
             verb = "Reused" if result.reused else "Created"
             suffix = f" (client_id {result.client_id})" if result.client_id else ""
-        print(f"\nservice principal '{result.name}' — {result.display_name}")
         print(f"  {verb} service principal{suffix}")
-
-        if result.blocked_reason:
-            print(f"  ✗ BLOCKED: {result.blocked_reason}")
-            continue
 
         if result.stored_scope:
             hidden = "(values hidden)"
@@ -2905,7 +2907,7 @@ def _print_provision_results(outcome, *, dry_run: bool) -> None:
                 for key in result.existing_keys:
                     print(
                         f"    {key}  already contains a value — "
-                        f"{'would NOT' if dry_run else 'NOT'} overwritten "
+                        f"{'would not be' if dry_run else 'not'} overwritten "
                         "(--overwrite to replace)"
                     )
             else:

--- a/src/dao_ai/cli.py
+++ b/src/dao_ai/cli.py
@@ -1678,32 +1678,39 @@ Examples:
         description="""
 Manage the service principal a dao-ai agent runs as.
 
+Every service principal the config declares under `service_principals` is
+provisioned. Resources are matched to the SP that owns them — a resource whose
+credentials point at an SP's secret keys belongs to that SP; anything matching no
+SP is shared and granted to all of them. For Lakebase, the Postgres SUPERUSER
+role is created for the project's owning SP.
+
 Sub-commands:
-  provision  One shot: create the SP, store its secret to the config's scope,
-             and grant it the config's resources. The secret is never printed.
-             This is the easiest way to make a config runnable. NOTE: provision
-             mints a NEW SP, so it will not create Lakebase Postgres roles for a
-             DatabaseModel that pins a different client_id — use `grant --app-sp`
-             for that (see grant).
+  provision  One shot: create each SP, store its secret to the config's scope,
+             and grant it the resources it owns. The secret is never printed.
+             This is the easiest way to make a config runnable. Idempotent: an
+             existing SP is reused and secret keys that already hold a value are
+             left alone unless you pass --overwrite.
   create     Create (or reuse) a workspace service principal and mint an OAuth
              secret. Prints the client id + one-time secret.
   store      Write the client id / secret into a Databricks secret scope.
-  grant      Grant the service principal the read/execute privileges an agent
-             needs on the config's resources: catalog, schema, table, function,
+  grant      Grant each service principal the read/execute privileges an agent
+             needs on the resources it owns: catalog, schema, table, function,
              vector index, volume, connection, warehouse, genie room, experiment,
-             serving endpoint. For Lakebase, a Postgres SUPERUSER role is created
-             only when the granted SP matches the DatabaseModel's client_id;
-             a mismatch is reported and skipped (grant --app-sp <that-id>).
+             serving endpoint, plus a Lakebase Postgres role.
 
 All read the config (-c) for defaults; explicit flags override.
         """,
         epilog="""
-Examples:
-  dao-ai sp provision -c config/model_config.yaml                   # create + store + grant, one step
-  dao-ai sp provision -c config/model_config.yaml --no-grant        # just create + store the secret
-  dao-ai sp create -c config/model_config.yaml --name my-agent-sp   # granular: create only
-  dao-ai sp store  -c config/model_config.yaml --client-id ID --client-secret SECRET
-  dao-ai sp grant  -c config/model_config.yaml --dry-run            # print grants, apply nothing
+Examples (CONFIG=config/model_config.yaml):
+  dao-ai sp provision -c $CONFIG              # create + store + grant, one step
+  dao-ai sp provision -c $CONFIG --dry-run    # show what would happen; change nothing
+  dao-ai sp provision -c $CONFIG --overwrite  # rotate secrets that already exist
+  dao-ai sp provision -c $CONFIG --sp memory_sp   # just one declared SP
+  dao-ai sp provision -c $CONFIG --no-grant   # just create + store the secret
+  dao-ai sp create -c $CONFIG --name my-sp    # granular: create only
+  dao-ai sp store  -c $CONFIG --client-id ID --client-secret SECRET
+  dao-ai sp grant  -c $CONFIG --dry-run       # print grants, apply nothing
+  dao-ai sp grant  -c $CONFIG --principal <uuid>  # grant one specific client id
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         parents=[_GLOBAL],
@@ -1782,6 +1789,14 @@ Examples:
         default=None,
         help="Secret key for the client secret (default: from config)",
     )
+    sp_store_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help=(
+            "Replace keys that already hold a value. Without this, an existing "
+            "key is reported and left untouched"
+        ),
+    )
     _add_var_argument(sp_store_parser)
 
     # grant
@@ -1810,6 +1825,16 @@ Examples:
         "--dry-run",
         action="store_true",
         help="Print the grants that would be applied without applying them",
+    )
+    sp_grant_parser.add_argument(
+        "--sp",
+        dest="sp_names",
+        action="append",
+        metavar="NAME",
+        help=(
+            "Grant only this service principal from the config's "
+            "service_principals block. Repeatable; default is all of them"
+        ),
     )
     _add_var_argument(sp_grant_parser)
 
@@ -1872,6 +1897,30 @@ The client secret is written straight to the secret scope and is never printed.
     )
     sp_provision_parser.add_argument(
         "--no-grant", action="store_true", help="Skip granting the config's resources"
+    )
+    sp_provision_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be provisioned without changing anything",
+    )
+    sp_provision_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help=(
+            "Replace secret keys that already hold a value. Without this, an "
+            "existing key is reported and left untouched (and no new secret is "
+            "minted, so a live credential is never rotated by accident)"
+        ),
+    )
+    sp_provision_parser.add_argument(
+        "--sp",
+        dest="sp_names",
+        action="append",
+        metavar="NAME",
+        help=(
+            "Provision only this service principal from the config's "
+            "service_principals block. Repeatable; default is all of them"
+        ),
     )
     _add_var_argument(sp_provision_parser)
 
@@ -2786,34 +2835,103 @@ def _handle_sp_provision(options, config, sp, WorkspaceClient) -> None:
         logger.error("provision requires -c/--config.")
         sys.exit(1)
 
-    display_name = _sp_display_name(options, config)
+    dry_run: bool = bool(getattr(options, "dry_run", False))
     w = WorkspaceClient()
     try:
-        result = sp.provision(
+        targets = sp.resolve_sp_targets(
+            config,
+            app_display_name=getattr(options, "name", None),
+            scope_override=options.scope,
+            client_id_key_override=options.client_id_key,
+            client_secret_key_override=options.client_secret_key,
+            only=getattr(options, "sp_names", None),
+        )
+        if not targets or not any(t.display_name for t in targets):
+            logger.error(
+                "No service-principal name. Pass --name, set `name:` on the "
+                "config's service_principals entry, or -c a config with an app.name."
+            )
+            sys.exit(1)
+        outcome = sp.provision_all(
             w,
             config=config,
-            display_name=display_name,
-            scope=options.scope,
-            client_id_key=options.client_id_key,
-            client_secret_key=options.client_secret_key,
+            targets=targets,
             lifetime=options.lifetime,
             do_store=not options.no_store,
             do_grant=not options.no_grant,
+            dry_run=dry_run,
+            overwrite=bool(getattr(options, "overwrite", False)),
         )
     except ValueError as e:
         logger.error(str(e))
         sys.exit(1)
 
-    verb = "Reused" if result.reused else "Created"
-    print(f"{verb} service principal: {result.display_name}")
-    print(f"  client_id: {result.client_id}")
-    if result.stored:
-        print(f"  secret stored in scope '{result.stored_scope}' (value hidden):")
-        print(f"    {result.stored_client_id_key}     = <client id>")
-        print(f"    {result.stored_client_secret_key} = <client secret>")
-    if result.grant_plan is not None:
-        _print_grants(result.grant_plan, applied=True)
-    print("\n✓ Service principal is ready for this config.")
+    _print_provision_results(outcome, dry_run=dry_run)
+
+    if outcome.blocked:
+        # The requested write did not happen, so this is not a success.
+        sys.exit(1)
+
+
+def _print_provision_results(outcome, *, dry_run: bool) -> None:
+    """Render a :class:`MultiProvisionResult` (secret values never printed)."""
+    from dao_ai.service_principal import (
+        SECRET_KEEP,
+        SECRET_ROTATE,
+    )
+
+    for result in outcome.results:
+        if dry_run:
+            verb = "would REUSE existing" if result.reused else "would CREATE new"
+            suffix = (
+                f" (client_id {result.client_id})"
+                if result.client_id
+                else " (client_id assigned at creation)"
+            )
+        else:
+            verb = "Reused" if result.reused else "Created"
+            suffix = f" (client_id {result.client_id})" if result.client_id else ""
+        print(f"\nservice principal '{result.name}' — {result.display_name}")
+        print(f"  {verb} service principal{suffix}")
+
+        if result.blocked_reason:
+            print(f"  ✗ BLOCKED: {result.blocked_reason}")
+            continue
+
+        if result.stored_scope:
+            hidden = "(values hidden)"
+            if result.secret_action == SECRET_KEEP:
+                print(f"  secrets → scope '{result.stored_scope}'")
+                for key in result.existing_keys:
+                    print(
+                        f"    {key}  already contains a value — "
+                        f"{'would NOT' if dry_run else 'NOT'} overwritten "
+                        "(--overwrite to replace)"
+                    )
+            else:
+                action = "would write" if dry_run else "wrote"
+                if result.secret_action == SECRET_ROTATE:
+                    action = "would rotate" if dry_run else "rotated"
+                print(f"  secrets → scope '{result.stored_scope}' {hidden}")
+                for key in (
+                    result.stored_client_id_key,
+                    result.stored_client_secret_key,
+                ):
+                    if key:
+                        print(f"    {key}  {action}")
+        elif result.secret_action is None:
+            print("  secrets: skipped (--no-store)")
+
+        if result.grant_plan is not None:
+            _print_grants(result.grant_plan, applied=not dry_run)
+
+    if dry_run:
+        print("\n✓ Dry run — nothing was created, written, or granted.")
+    elif outcome.blocked:
+        names = ", ".join(name for name, _ in outcome.blocked)
+        print(f"\n✗ Not provisioned: {names} (see BLOCKED above).")
+    else:
+        print("\n✓ Service principal(s) are ready for this config.")
 
 
 def _print_grants(plan, *, applied: bool) -> None:
@@ -2966,17 +3084,23 @@ def _handle_sp_store(options, config, sp, WorkspaceClient) -> None:
         sys.exit(1)
 
     w = WorkspaceClient()
-    sp.store(
+    result = sp.store(
         w,
         scope=scope,
         client_id_key=cid_key,
         client_secret_key=csec_key,
         client_id=options.client_id,
         client_secret=options.client_secret,
+        overwrite=bool(getattr(options, "overwrite", False)),
     )
-    print(f"Stored credentials in scope '{scope}':")
-    print(f"  {cid_key}   = <client id>")
-    print(f"  {csec_key} = <client secret>")
+    if result.written:
+        print(f"Stored credentials in scope '{scope}':")
+        for key in result.written:
+            print(f"  {key} = <hidden>")
+    for key in result.skipped:
+        print(f"  {key} already contains a value — not overwritten (--overwrite)")
+    if not result.written:
+        sys.exit(1)
 
 
 def _handle_sp_grant(options, config, sp, WorkspaceClient) -> None:
@@ -2984,19 +3108,42 @@ def _handle_sp_grant(options, config, sp, WorkspaceClient) -> None:
         logger.error("grant requires -c/--config.")
         sys.exit(1)
 
-    principal = sp.resolve_principal_from_config(config, override=options.principal)
-    if not principal:
-        logger.error(
-            "No grantee. Pass --principal <client-id>, or -c a config whose "
-            "service_principals define a client_id."
-        )
+    w = WorkspaceClient()
+    dry_run: bool = bool(getattr(options, "dry_run", False))
+
+    # An explicit --principal names one grantee, which bypasses ownership: the
+    # caller is telling us exactly who to grant, so grant them the whole config.
+    if options.principal:
+        plan = sp.grant(w, principal=options.principal, config=config, dry_run=dry_run)
+        print(f"principal {plan.principal}")
+        _print_grants(plan, applied=not dry_run)
+        return
+
+    try:
+        targets = sp.resolve_sp_targets(config, only=getattr(options, "sp_names", None))
+    except ValueError as e:
+        logger.error(str(e))
         sys.exit(1)
 
-    w = WorkspaceClient()
-    plan = sp.grant(w, principal=principal, config=config, dry_run=options.dry_run)
+    # No declared service principals and nothing to resolve: fall back to the
+    # config's own client_id (the documented single-SP behaviour).
+    if not config.service_principals:
+        principal = sp.resolve_principal_from_config(config)
+        if not principal:
+            logger.error(
+                "No grantee. Pass --principal <client-id>, or -c a config whose "
+                "service_principals define a client_id."
+            )
+            sys.exit(1)
+        plan = sp.grant(w, principal=principal, config=config, dry_run=dry_run)
+        print(f"principal {plan.principal}")
+        _print_grants(plan, applied=not dry_run)
+        return
 
-    print(f"principal {plan.principal}")
-    _print_grants(plan, applied=not options.dry_run)
+    plans = sp.grant_all(w, config=config, targets=targets, dry_run=dry_run)
+    for target, plan in zip(targets, plans):
+        print(f"\nservice principal '{target.name}' — principal {plan.principal}")
+        _print_grants(plan, applied=not dry_run)
 
 
 def _empty_config() -> "AppConfig":
@@ -5623,9 +5770,7 @@ def _deploy_run_destroy_app_bundle(
             # current config first, then deploy the endpoint. Without create_agent
             # the deploy would target a stale-or-nonexistent model version.
             config.create_agent(development=development)
-            config.deploy_agent(
-                mode=ServingMode.MODEL_SERVING, development=development
-            )
+            config.deploy_agent(mode=ServingMode.MODEL_SERVING, development=development)
             # `--wait`: `deploy_agent` (agents.deploy) returns once the update is
             # issued; block until the endpoint is READY + served model
             # DEPLOYMENT_READY.

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -10765,6 +10765,55 @@ class ResourcesModel(BaseModel):
         return self
 
 
+def _reject_relative_assets_for_remote_config(
+    config: "AppConfig", *, source: str
+) -> None:
+    """Raise if a URL-loaded config declares assets only a local tree could supply.
+
+    A remote config has no directory to resolve relative paths against, so
+    ``ddl: functions/x.sql`` cannot be found. Failing here — naming the field —
+    beats resolving against the process CWD and surfacing a FileNotFoundError
+    several provisioning steps later.
+
+    ``code_paths`` and ``skills`` matter for a second reason: resolving them would
+    put directories named by a remote document onto ``sys.path``.
+    """
+
+    def _is_relative(value: object) -> bool:
+        if not isinstance(value, str) or not value:
+            return False
+        if value.startswith(("/", "dbfs:", "s3:", "abfss:", "gs:")):
+            return False
+        # Inline SQL rather than a path — ``data:`` accepts either.
+        if "\n" in value or value.rstrip().endswith(";"):
+            return False
+        return True
+
+    offenders: list[str] = []
+    for dataset in config.datasets or []:
+        for field_name in ("ddl", "data"):
+            value = getattr(dataset, field_name, None)
+            if _is_relative(value):
+                offenders.append(f"datasets[].{field_name}: {value}")
+    for fn in config.unity_catalog_functions or []:
+        value = getattr(fn, "ddl", None)
+        if _is_relative(value):
+            offenders.append(f"unity_catalog_functions[].ddl: {value}")
+    if config.app is not None:
+        for code_path in config.app.code_paths or []:
+            if _is_relative(code_path):
+                offenders.append(f"app.code_paths: {code_path}")
+
+    if offenders:
+        raise ValueError(
+            f"Config loaded from {source} declares relative paths that cannot be "
+            "resolved — a remote config has no local directory to anchor them to:"
+            + "".join(f"\n  - {o}" for o in offenders)
+            + "\nUse absolute paths, a Unity Catalog Volume reference, or "
+            "download the config and pass its local path."
+        )
+
+
 class AppConfig(BaseModel):
     """Top-level configuration for a DAO AI application.
 
@@ -10983,6 +11032,42 @@ class AppConfig(BaseModel):
         return self
 
     @classmethod
+    def from_url(cls, url: str, **kwargs: Any) -> "AppConfig":
+        """Load an AppConfig from an ``http(s)`` URL.
+
+        A convenience alias for :meth:`from_file`, which accepts URLs directly —
+        useful when the caller wants the intent to be explicit, or wants a URL
+        validated as such rather than falling through to a filesystem read.
+
+        GitHub file-viewer links are rewritten to their raw equivalent, so both
+        of these work::
+
+            https://github.com/<owner>/<repo>/blob/main/config.yaml
+            https://raw.githubusercontent.com/<owner>/<repo>/main/config.yaml
+
+        Only YAML is parsed; remote content is never executed. Because a remote
+        config has no local directory, it cannot resolve relative ``ddl`` /
+        ``data`` / ``code_paths`` entries — declaring one raises ``ValueError``.
+
+        Args:
+            url: The config URL.
+            **kwargs: Forwarded to :meth:`from_file` (``params``,
+                ``task_values``, ``task_key``, ``initialize``).
+
+        Raises:
+            ValueError: if ``url`` is not an http(s) URL, if it cannot be
+                fetched, or if the config declares unresolvable relative paths.
+        """
+        from dao_ai.config_source import is_remote_config
+
+        if not is_remote_config(url):
+            raise ValueError(
+                f"Not an http(s) URL: {url!r}. Use AppConfig.from_file for "
+                "filesystem paths."
+            )
+        return cls.from_file(url, **kwargs)
+
+    @classmethod
     def from_file(
         cls,
         path: PathLike,
@@ -11022,10 +11107,26 @@ class AppConfig(BaseModel):
                 or any reference is undeclared (when a ``parameters:`` block
                 is present).
         """
-        path = Path(path).as_posix()
-        logger.debug(f"Loading config from {path}")
+        from dao_ai.config_source import (
+            fetch_config_text,
+            is_remote_config,
+            normalize_config_url,
+        )
 
-        raw_text: str = Path(path).read_text()
+        # A URL and a filesystem path diverge only here: how the text is read,
+        # and whether there is a local directory to anchor relative assets and
+        # code_paths against. Everything downstream is identical.
+        remote: bool = is_remote_config(path)
+        if remote:
+            path = normalize_config_url(str(path))
+            logger.debug(f"Loading config from {path}")
+            raw_text: str = fetch_config_text(path)
+            base_path: Optional[str] = None
+        else:
+            path = Path(path).as_posix()
+            logger.debug(f"Loading config from {path}")
+            raw_text = Path(path).read_text()
+            base_path = str(Path(path).parent)
 
         # Resolve ${workspace.*} refs first so they can appear inside
         # parameter defaults (e.g. default: /Users/${workspace.current_user.userName}/...).
@@ -11088,30 +11189,39 @@ class AppConfig(BaseModel):
         # relative ``ddl``/``data`` paths resolve against the config location
         # (assets colocated with the config), not the process CWD. Absolute
         # paths and Volume references are unaffected.
-        base_path: str = str(Path(path).parent)
-        for dataset in config.datasets or []:
-            dataset._base_path = base_path
-        for fn in config.unity_catalog_functions or []:
-            fn._base_path = base_path
+        if base_path is not None:
+            for dataset in config.datasets or []:
+                dataset._base_path = base_path
+            for fn in config.unity_catalog_functions or []:
+                fn._base_path = base_path
 
-        # Put custom code (``app.code_paths``) on ``sys.path`` now that the
-        # config directory is known, resolving each entry against it. The
-        # ``add_code_paths_to_sys_path`` validator ran at construction (before
-        # ``_source_config_path`` was set) and could only anchor at the process
-        # CWD; this makes config-relative custom modules importable for every
-        # consumer that loads a config from a file — the deploy notebook's
-        # ``display_graph``/``create_agent``, the Apps runtime, and any tool
-        # resolution via ``load_function`` — regardless of the process CWD.
-        from dao_ai.code_paths import (
-            prepend_code_paths_to_sys_path,
-            prepend_src_to_sys_path,
-        )
+            # Put custom code (``app.code_paths``) on ``sys.path`` now that the
+            # config directory is known, resolving each entry against it. The
+            # ``add_code_paths_to_sys_path`` validator ran at construction (before
+            # ``_source_config_path`` was set) and could only anchor at the process
+            # CWD; this makes config-relative custom modules importable for every
+            # consumer that loads a config from a file — the deploy notebook's
+            # ``display_graph``/``create_agent``, the Apps runtime, and any tool
+            # resolution via ``load_function`` — regardless of the process CWD.
+            from dao_ai.code_paths import (
+                prepend_code_paths_to_sys_path,
+                prepend_src_to_sys_path,
+            )
 
-        prepend_code_paths_to_sys_path(config)
-        # Convention: a colocated ``src/`` dir auto-ships its packages; put it on
-        # sys.path so ``src/foo/bar.py`` imports as ``foo.bar`` for every consumer
-        # (deploy notebook display_graph/create_agent, Apps runtime, load_function).
-        prepend_src_to_sys_path(config)
+            prepend_code_paths_to_sys_path(config)
+            # Convention: a colocated ``src/`` dir auto-ships its packages; put it
+            # on sys.path so ``src/foo/bar.py`` imports as ``foo.bar`` for every
+            # consumer (deploy notebook display_graph/create_agent, Apps runtime,
+            # load_function).
+            prepend_src_to_sys_path(config)
+        else:
+            # A remote config has no local directory, so anything it declares by
+            # relative path is unresolvable. Say so loudly rather than silently
+            # anchoring at the process CWD and failing much later with a
+            # FileNotFoundError. This is also a security boundary: code_paths and
+            # skills from a remote config would otherwise put remote-authored
+            # directories on sys.path.
+            _reject_relative_assets_for_remote_config(config, source=str(path))
         # Stash the pre-substitution dict so tooling can recover which
         # YAML fields were backed by ``${var.X}`` references.
         config._raw_yaml_dict = raw_dict

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -4000,10 +4000,21 @@ class DatabaseModel(IsDatabricksResource):
         return " ".join(parts)
 
     def create(self, w: WorkspaceClient | None = None) -> None:
+        """Provision this database (Lakebase project + service-principal role).
+
+        Args:
+            w: Workspace client to provision *with*. Defaults to ambient
+                authentication (the notebook/CLI caller), NOT
+                ``self.workspace_client`` — creating a Lakebase project and
+                granting a Postgres role require ``Can Manage`` on the project,
+                which the database's own service principal does not have. The
+                SP remains the role *subject*; see
+                :meth:`DatabricksProvider.create_lakebase_autoscaling_role`.
+        """
         from dao_ai.providers.databricks import DatabricksProvider
 
         if w is None:
-            w = self.workspace_client
+            w = WorkspaceClient()
         provider: DatabricksProvider = DatabricksProvider(w=w)
         if self.is_lakebase:
             provider.create_lakebase_autoscaling(self)

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -326,6 +326,25 @@ class ServicePrincipalModel(BaseModel):
         frozen=True,
         use_enum_values=True,
     )
+    name: Optional[str] = Field(
+        default=None,
+        description=(
+            "Workspace display name of the service principal. Used by "
+            "`dao-ai service-principal provision` to create or reuse the SP; "
+            "defaults to '<app.name>-<key>' where <key> is this entry's name "
+            "under `service_principals`. Set it explicitly to bind a config to "
+            "an SP that already exists."
+        ),
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description=(
+            "What this service principal is for — which resources it owns and "
+            "why it is separate from the others. Documentation only: the "
+            "Databricks service-principal API has no description field, so this "
+            "is never sent to the workspace."
+        ),
+    )
     client_id: AnyVariable = Field(
         description="OAuth application (client) ID for the service principal.",
     )

--- a/src/dao_ai/config_source.py
+++ b/src/dao_ai/config_source.py
@@ -1,0 +1,105 @@
+"""Loading dao-ai configs from somewhere other than the local filesystem.
+
+Small, pure helpers so ``AppConfig.from_file`` can accept an ``http(s)`` URL —
+a config shared from a GitHub repo, for instance — without the rest of the
+loader caring where the YAML came from.
+
+Only YAML is parsed. Nothing fetched here is executed, and no credentials are
+sent to third-party hosts.
+"""
+
+from __future__ import annotations
+
+from os import PathLike
+from urllib.parse import urlparse, urlunparse
+
+from loguru import logger
+
+#: Hosts whose "view this file" URLs point at an HTML page rather than raw bytes.
+_GITHUB_HOST = "github.com"
+_GITHUB_RAW_HOST = "raw.githubusercontent.com"
+
+#: Default timeout for fetching a remote config, in seconds.
+DEFAULT_FETCH_TIMEOUT: float = 30.0
+
+
+def is_remote_config(path: str | PathLike[str]) -> bool:
+    """True when ``path`` is an ``http``/``https`` URL rather than a file path.
+
+    Deliberately narrow: only http(s) counts. A ``file://`` URL would bypass the
+    filesystem branch's path handling for no benefit, and other schemes
+    (``ftp://``, ``s3://``) are not supported, so they are better reported as an
+    unreadable path than half-handled here.
+    """
+    text = str(path)
+    # A bare Windows drive letter ("C:\...") parses as a scheme, so require the
+    # scheme to be one we actually handle.
+    return urlparse(text).scheme in ("http", "https")
+
+
+def normalize_config_url(url: str) -> str:
+    """Rewrite a GitHub file-viewer URL to the raw content URL; pass others through.
+
+    ``https://github.com/<owner>/<repo>/blob/<ref>/<path>`` serves an HTML page,
+    so fetching it yields markup rather than YAML. The raw equivalent is
+    ``https://raw.githubusercontent.com/<owner>/<repo>/<ref>/<path>``.
+
+    Idempotent: a URL that is already raw, or that points at another host, is
+    returned unchanged.
+    """
+    parsed = urlparse(url)
+    if parsed.netloc not in (_GITHUB_HOST, f"www.{_GITHUB_HOST}"):
+        return url
+
+    # /<owner>/<repo>/(blob|raw)/<rest...>
+    parts = parsed.path.lstrip("/").split("/")
+    if len(parts) < 5 or parts[2] not in ("blob", "raw"):
+        return url
+
+    owner, repo, _, *rest = parts
+    raw_path = "/".join([owner, repo, *rest])
+    rewritten = urlunparse(
+        ("https", _GITHUB_RAW_HOST, f"/{raw_path}", "", parsed.query, "")
+    )
+    logger.debug(f"Rewrote GitHub URL to raw content: {url} -> {rewritten}")
+    return rewritten
+
+
+def fetch_config_text(url: str, *, timeout: float = DEFAULT_FETCH_TIMEOUT) -> str:
+    """Fetch a remote YAML config and return its text.
+
+    Args:
+        url: An ``http(s)`` URL. Pass it through :func:`normalize_config_url`
+            first if it may be a GitHub file-viewer link.
+        timeout: Seconds to wait for the request.
+
+    Returns:
+        The response body as text — parsed as YAML by the caller, never executed.
+
+    Raises:
+        ValueError: on any non-2xx response or transport failure, with a message
+            naming the URL. A private GitHub repo answers 404 rather than 401, so
+            a missing file and an unauthorized one are indistinguishable; the
+            error says so instead of guessing.
+    """
+    import httpx
+
+    try:
+        response = httpx.get(url, timeout=timeout, follow_redirects=True)
+    except httpx.HTTPError as e:
+        raise ValueError(f"Could not fetch config from {url}: {e}") from e
+
+    if response.status_code in (401, 403, 404):
+        raise ValueError(
+            f"Config not found at {url} (HTTP {response.status_code}). If it "
+            "lives in a private repository, download it locally and pass the "
+            "path — dao-ai does not send credentials to third-party hosts."
+        )
+    if response.status_code >= 400:
+        detail = response.text.strip()[:200]
+        raise ValueError(
+            f"Could not fetch config from {url} (HTTP {response.status_code})"
+            + (f": {detail}" if detail else "")
+        )
+
+    return response.text

--- a/src/dao_ai/pipeline/bundle.py
+++ b/src/dao_ai/pipeline/bundle.py
@@ -59,6 +59,11 @@ _CLOUDS = ("azure", "aws", "gcp")
 # (only the bundle name does), so it is expressed once here as data. Each entry
 # is (task_key, notebook, depends_on, extra_base_parameters).
 _PIPELINE_TASKS: tuple[tuple[str, str, tuple[str, ...], dict[str, str]], ...] = (
+    # Runs first and gates the two tasks that need the service principal to
+    # exist: provision-lakebase creates a Postgres role whose subject is the SP's
+    # client_id, and unity-catalog-tools creates the functions the SP needs
+    # EXECUTE on. Idempotent, so it is safe on every pipeline run.
+    ("provision-service-principal", "00_provision_service_principal.py", (), {}),
     ("ingest-and-transform", "01_ingest_and_transform.py", (), {}),
     (
         "provision-vector-search",
@@ -66,11 +71,20 @@ _PIPELINE_TASKS: tuple[tuple[str, str, tuple[str, ...], dict[str, str]], ...] = 
         ("ingest-and-transform",),
         {},
     ),
-    ("provision-lakebase", "03_provision_lakebase.py", (), {}),
+    (
+        "provision-lakebase",
+        "03_provision_lakebase.py",
+        ("provision-service-principal",),
+        {},
+    ),
     (
         "unity-catalog-tools",
         "04_unity_catalog_tools.py",
-        ("provision-vector-search", "provision-lakebase"),
+        (
+            "provision-vector-search",
+            "provision-lakebase",
+            "provision-service-principal",
+        ),
         {},
     ),
     ("provision-genie", "05_provision_genie.py", ("unity-catalog-tools",), {}),

--- a/src/dao_ai/pipeline/notebooks/00_provision_service_principal.py
+++ b/src/dao_ai/pipeline/notebooks/00_provision_service_principal.py
@@ -1,0 +1,153 @@
+# Databricks notebook source
+# Dependency bootstrap. Install dao-ai (which pulls its own transitive deps) via
+# uv — the newest bundled ../dist wheel in development mode, else the published
+# PyPI package. In a deployed job the serverless environment has already
+# installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
+# installed package importable in the cells below.
+# No extras suffix: this provisioning notebook only calls core APIs. Notebooks
+# that build the agent graph (06_deploy_agent, 08_run_evaluation) install
+# ``[all]``; 01_ingest_and_transform installs ``[excel]``. The install spec is
+# single-quoted in the magic so a dev wheel's ``+local`` version tag and any
+# ``[extras]`` survive shell glob/bracket expansion.
+import glob
+
+_dao_ai_dep = next(
+    iter(sorted(glob.glob("../dist/dao_ai-*.whl"), reverse=True)), "dao-ai"
+)
+
+# MAGIC %uv pip install --quiet '{_dao_ai_dep}'
+# MAGIC %restart_python
+
+# COMMAND ----------
+
+# Record the installed dao-ai version plus the key libraries resolved under
+# it, so each run's logs capture exactly what was installed. Alphabetical; the
+# list is short and hand-curated.
+from importlib.metadata import version
+
+print(f"dao-ai=={version('dao-ai')}")
+print(f"databricks-sdk=={version('databricks-sdk')}")
+print(f"mlflow=={version('mlflow')}")
+
+# COMMAND ----------
+
+import os
+from typing import Sequence
+
+
+def find_yaml_files_os_walk(base_path: str) -> Sequence[str]:
+    # Tolerate a missing/non-dir base path: when the pipeline runs from a
+    # wheel-only bundle an explicit `config-path` is always supplied, so the
+    # `../config` discovery dropdown is optional. Return [] instead of raising.
+    if not os.path.isdir(base_path):
+        return []
+
+    yaml_files = []
+
+    for root, dirs, files in os.walk(base_path):
+        for file in files:
+            if file.lower().endswith((".yaml", ".yml")):
+                yaml_files.append(os.path.join(root, file))
+
+    return sorted(yaml_files)
+
+
+# COMMAND ----------
+
+dbutils.widgets.text(name="config-path", defaultValue="")
+
+config_files: Sequence[str] = find_yaml_files_os_walk("../config")
+dbutils.widgets.dropdown(
+    name="config-paths", choices=config_files, defaultValue=next(iter(config_files), "")
+)
+
+# ``overwrite`` is deliberately a widget rather than always-on. This task runs on
+# every pipeline execution, so rotating credentials by default would replace the
+# secret a deployed agent is currently authenticating with, on every deploy.
+dbutils.widgets.dropdown(
+    name="overwrite", choices=["false", "true"], defaultValue="false"
+)
+
+config_path: str | None = dbutils.widgets.get("config-path") or None
+project_path: str = dbutils.widgets.get("config-paths") or None
+
+config_path: str = config_path or project_path
+overwrite: bool = dbutils.widgets.get("overwrite") == "true"
+
+print(config_path)
+
+# COMMAND ----------
+
+# MAGIC %load_ext autoreload
+# MAGIC %autoreload 2
+
+# COMMAND ----------
+
+from dotenv import find_dotenv, load_dotenv
+
+_ = load_dotenv(find_dotenv())
+
+# COMMAND ----------
+
+from dao_ai.config import AppConfig
+
+config: AppConfig = AppConfig.from_file(path=config_path)
+
+# COMMAND ----------
+
+# Provision every service principal the config declares, granting each one the
+# resources it owns. Same library entry point the ``dao-ai sp provision`` CLI
+# calls — the CLI is one provisioning surface, this is another.
+#
+# The WorkspaceClient is ambient: the job's identity. Creating service principals
+# and writing secret scopes need more privilege than reading a table, so if this
+# task fails with a permissions error, that identity is what to grant.
+from databricks.sdk import WorkspaceClient
+
+from dao_ai.service_principal import provision_all, resolve_sp_targets
+
+w: WorkspaceClient = WorkspaceClient()
+
+targets = resolve_sp_targets(config)
+result = provision_all(
+    w,
+    config=config,
+    targets=targets,
+    overwrite=overwrite,
+)
+
+for provisioned in result.results:
+    verb = "reused" if provisioned.reused else "created"
+    print(f"\nservice principal '{provisioned.name}' — {provisioned.display_name}")
+    print(f"  {verb}: client_id={provisioned.client_id or '(none)'}")
+    if provisioned.blocked_reason:
+        print(f"  BLOCKED: {provisioned.blocked_reason}")
+        continue
+    if provisioned.secret_action:
+        print(
+            f"  secrets: {provisioned.secret_action} "
+            f"(scope {provisioned.stored_scope})"
+        )
+    if provisioned.existing_keys:
+        print(f"  already populated: {', '.join(provisioned.existing_keys)}")
+    plan = provisioned.grant_plan
+    if plan is not None:
+        applied = sum(1 for g in plan.grants if g.applied is True)
+        print(f"  grants: {applied}/{len(plan.grants)} applied")
+        for g in plan.grants:
+            if g.applied is False:
+                print(f"    FAILED [{g.kind}] {g.target}: {g.error}")
+            elif g.note:
+                print(f"    SKIP [{g.kind}] {g.target}: {g.note}")
+
+# COMMAND ----------
+
+# Fail the task when a service principal could not be provisioned, so the
+# downstream tasks that depend on it (provision-lakebase needs the client_id as
+# its Postgres role subject; unity-catalog-tools creates functions the SP needs
+# EXECUTE on) do not run against a half-provisioned identity.
+if result.blocked:
+    raise RuntimeError(
+        "Service-principal provisioning was blocked for: "
+        + "; ".join(f"{name}: {reason}" for name, reason in result.blocked)
+    )

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -3564,11 +3564,35 @@ class DatabricksProvider(ServiceProvider):
         )
         return default_branch.name
 
-    def create_lakebase_autoscaling_role(self, database: DatabaseModel) -> None:
+    def create_lakebase_autoscaling_role(
+        self,
+        database: DatabaseModel,
+        *,
+        client_id: str | None = None,
+    ) -> None:
         """
         Create a role for a service principal on an autoscaling Lakebase project.
 
         Roles are created at the branch level in the autoscaling Postgres API.
+
+        Two distinct identities are in play here, and conflating them is a bug:
+
+        * The **caller** — every Postgres control-plane call below
+          (``list_branches`` / ``list_roles`` / ``create_role``) requires
+          ``Can Manage`` on the Database project. A service principal cannot
+          create its own role, so these run as ``self.w``: the identity the
+          caller supplied (e.g. the admin profile behind ``dao-ai -p <profile>``).
+        * The **role subject** — ``postgres_role`` is the service principal the
+          role is created *for*, i.e. the identity the agent later connects to
+          Postgres as. That remains ``client_id``.
+
+        Args:
+            database: The Lakebase ``DatabaseModel`` to create the role on.
+            client_id: Service-principal client id to create the role for. When
+                given it is authoritative — used by ``dao-ai sp provision`` to
+                pass a freshly minted SP's id, so provisioning completes in one
+                pass instead of requiring the secret scope to be populated
+                first. When omitted, falls back to ``database.client_id``.
         """
         from databricks.sdk.service.postgres import (
             Role,
@@ -3579,25 +3603,28 @@ class DatabricksProvider(ServiceProvider):
 
         from dao_ai.config import value_of
 
-        if not database.client_id:
-            logger.warning(
-                "client_id required to create autoscaling role",
-                project=database.project,
-            )
-            return
+        if client_id is None:
+            if not database.client_id:
+                logger.warning(
+                    "client_id required to create autoscaling role",
+                    project=database.project,
+                )
+                return
 
-        client_id: str | None = value_of(database.client_id)
-        if not client_id:
-            logger.warning(
-                "client_id resolved to None; skipping autoscaling role creation. "
-                "Check that the configured source (secret scope, env var, etc.) "
-                "is populated.",
-                project=database.project,
-                client_id_spec=database.client_id,
-            )
-            return
+            client_id = value_of(database.client_id)
+            if not client_id:
+                logger.warning(
+                    "client_id resolved to None; skipping autoscaling role creation. "
+                    "Check that the configured source (secret scope, env var, etc.) "
+                    "is populated.",
+                    project=database.project,
+                    client_id_spec=database.client_id,
+                )
+                return
 
-        workspace_client: WorkspaceClient = database.workspace_client
+        # The caller's client — NOT ``database.workspace_client`` (the SP's own
+        # oauth-m2m client), which cannot grant itself DATABRICKS_SUPERUSER.
+        workspace_client: WorkspaceClient = self.w
 
         # Roles are created on a branch, not on the project
         branch_name = self._resolve_autoscaling_default_branch(

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -3348,6 +3348,13 @@ class DatabricksProvider(ServiceProvider):
 
         Handles idempotent project creation, gracefully handling cases where
         the project already exists.
+
+        Runs as ``self.w`` — the caller's identity — for the same reason as
+        :meth:`create_lakebase_autoscaling_role`: creating a Database project is
+        a control-plane operation, and the database's own service principal has
+        no standing to create the project it is about to be granted a role on.
+        Runtime connections continue to authenticate as the configured SP via
+        ``database.workspace_client``.
         """
         import time
 
@@ -3357,7 +3364,7 @@ class DatabricksProvider(ServiceProvider):
             ProjectSpec,
         )
 
-        workspace_client: WorkspaceClient = database.workspace_client
+        workspace_client: WorkspaceClient = self.w
         project_name = f"projects/{database.project}"
 
         try:

--- a/src/dao_ai/service_principal.py
+++ b/src/dao_ai/service_principal.py
@@ -416,6 +416,22 @@ _OWNABLE_COLLECTIONS: Final[tuple[str, ...]] = (
 )
 
 
+def placeholder_principal(sp_name: str) -> str:
+    """A stand-in client id for an SP that does not exist yet (dry run only).
+
+    A dry run reports what *would* happen, so it must not create the service
+    principal — which means its client id is unknown. Ownership is resolved from
+    the config's secret refs rather than from ids (see :func:`resource_owner`),
+    so the plan is still correct; only the displayed principal is a stand-in.
+    """
+    return f"<new-sp:{sp_name}>"
+
+
+def _is_placeholder_principal(principal: str) -> bool:
+    """True if ``principal`` is a :func:`placeholder_principal` sentinel."""
+    return principal.startswith("<new-sp:")
+
+
 def resource_owner(
     resource: object, targets: Sequence[ServicePrincipalTarget]
 ) -> Optional[str]:
@@ -548,6 +564,11 @@ class Grant:
     # isn't in the workspace" from "you lack GRANT on it", which need different
     # fixes. See :func:`classify_grant_error`.
     failure_kind: Optional[str] = None
+    # For ``lakebase_role``: the client id to create the Postgres role for, when
+    # it is known here but not yet readable from the config's secret scope (a
+    # just-minted SP). Overrides ``value_of(DatabaseModel.client_id)``, which is
+    # what makes single-pass provisioning possible.
+    principal_override: Optional[str] = None
 
 
 @dataclass
@@ -558,15 +579,39 @@ class GrantPlan:
     grants: list[Grant] = field(default_factory=list)
 
 
-def build_grant_plan(config: "AppConfig", principal: str) -> GrantPlan:
+def build_grant_plan(
+    config: "AppConfig",
+    principal: str,
+    *,
+    ownership: Optional[OwnershipMap] = None,
+    sp_name: Optional[str] = None,
+    targets: Optional[Sequence[ServicePrincipalTarget]] = None,
+) -> GrantPlan:
     """Walk an AppConfig and compute the read/execute grants for ``principal``.
 
     Pure (no side effects) so it can back both ``--dry-run`` and the real apply.
     De-dupes catalogs and schemas across every resource that references them.
+
+    Args:
+        config: The config whose declared resources are walked.
+        principal: Client id being granted. May be a ``<new-sp:NAME>`` sentinel
+            during a dry run of a service principal that does not exist yet.
+        ownership: When given, restrict the walk to the resources ``sp_name``
+            owns plus every shared (unowned) resource. Omit it — the default —
+            to grant the whole config to ``principal``, which is exactly the
+            single-SP behaviour and keeps existing callers unchanged.
+        sp_name: Which named service principal this plan is for. Only meaningful
+            alongside ``ownership``.
+        targets: All declared targets, used to resolve the Lakebase role's
+            subject to the owning SP's client id.
     """
     plan = GrantPlan(principal=principal)
     catalogs: set[str] = set()
     schemas: set[str] = set()
+
+    def _owns(collection: str, key: str) -> bool:
+        """True when this plan should include ``collection[key]``."""
+        return ownership is None or ownership.owns(collection, key, sp_name)
 
     def _add_schema(catalog_name: str, schema_name: str) -> None:
         if catalog_name and catalog_name not in catalogs:
@@ -588,7 +633,9 @@ def build_grant_plan(config: "AppConfig", principal: str) -> GrantPlan:
     if resources is not None:
         # Tables → SELECT (+ ensure their schema is granted)
         table: "TableModel"
-        for table in resources.tables.values():
+        for table_key, table in resources.tables.items():
+            if not _owns("tables", table_key):
+                continue
             if table.schema_model is not None:
                 _add_schema(
                     table.schema_model.catalog_name, table.schema_model.schema_name
@@ -598,7 +645,9 @@ def build_grant_plan(config: "AppConfig", principal: str) -> GrantPlan:
 
         # UC functions → EXECUTE
         func: "FunctionModel"
-        for func in resources.functions.values():
+        for func_key, func in resources.functions.items():
+            if not _owns("functions", func_key):
+                continue
             if func.schema_model is not None:
                 _add_schema(
                     func.schema_model.catalog_name, func.schema_model.schema_name
@@ -608,7 +657,9 @@ def build_grant_plan(config: "AppConfig", principal: str) -> GrantPlan:
 
         # Vector-search indexes → SELECT on the backing UC index (a table securable)
         store_model: "AiSearchVectorStoreModel"
-        for store_model in resources.vector_stores.values():
+        for store_key, store_model in resources.vector_stores.items():
+            if not _owns("vector_stores", store_key):
+                continue
             index = store_model.index
             index_name = value_of(index.full_name) if index is not None else None
             if index_name and str(index_name).count(".") == 2:
@@ -616,7 +667,9 @@ def build_grant_plan(config: "AppConfig", principal: str) -> GrantPlan:
 
         # Volumes → READ_VOLUME (+ ensure their schema is granted)
         volume: "VolumeModel"
-        for volume in resources.volumes.values():
+        for volume_key, volume in resources.volumes.items():
+            if not _owns("volumes", volume_key):
+                continue
             if volume.schema_model is not None:
                 _add_schema(
                     volume.schema_model.catalog_name, volume.schema_model.schema_name
@@ -628,7 +681,9 @@ def build_grant_plan(config: "AppConfig", principal: str) -> GrantPlan:
 
         # Connections → USE_CONNECTION (connection names are top-level, unqualified)
         connection: "ConnectionModel"
-        for connection in resources.connections.values():
+        for conn_key, connection in resources.connections.items():
+            if not _owns("connections", conn_key):
+                continue
             if connection.full_name:
                 plan.grants.append(
                     Grant("uc", connection.full_name, ["USE_CONNECTION"], "connection")
@@ -636,14 +691,18 @@ def build_grant_plan(config: "AppConfig", principal: str) -> GrantPlan:
 
         # Warehouses → CAN_USE (workspace permission, not UC)
         warehouse: "WarehouseModel"
-        for warehouse in resources.warehouses.values():
+        for wh_key, warehouse in resources.warehouses.items():
+            if not _owns("warehouses", wh_key):
+                continue
             wid = value_of(warehouse.warehouse_id) if warehouse.warehouse_id else None
             if wid:
                 plan.grants.append(Grant("warehouse", str(wid), ["CAN_USE"]))
 
         # Genie rooms → CAN_RUN (workspace permission)
         room: "GenieRoomModel"
-        for room in resources.genie_rooms.values():
+        for room_key, room in resources.genie_rooms.items():
+            if not _owns("genie_rooms", room_key):
+                continue
             space_id = value_of(room.space_id) if room.space_id else None
             if space_id:
                 plan.grants.append(Grant("genie", str(space_id), ["CAN_RUN"]))
@@ -663,23 +722,66 @@ def build_grant_plan(config: "AppConfig", principal: str) -> GrantPlan:
             # ``is_lakebase`` is defined as ``project is not None``, so project
             # is always set here.
             project = str(database.project)
-            configured = value_of(database.client_id) if database.client_id else None
             note: Optional[str] = None
-            if not configured:
-                note = (
-                    "SKIP: DatabaseModel.client_id is unset or resolved to None "
-                    "(secret scope populated?). A Postgres role can only be created "
-                    "for a concrete service-principal client id — provision the SP "
-                    "and populate the scope, then re-run."
+            principal_override: Optional[str] = None
+
+            if ownership is not None:
+                owner = ownership.owner_of("databases", db_key)
+                if owner is not None and owner != sp_name:
+                    # Another declared SP owns this project. Emit nothing: with N
+                    # service principals a per-SP mismatch note would print N-1
+                    # alarming SKIPs per project per run, and the owner's own
+                    # grant already tells the whole story.
+                    continue
+                # Owned by us, or shared. Either way the role subject is this
+                # SP's real client id — which, for a freshly minted SP, is only
+                # known here and NOT yet readable from the secret scope. Passing
+                # it explicitly is what lets provisioning finish in one pass.
+                if targets is not None:
+                    principal_override = next(
+                        (
+                            t.resolved_client_id
+                            for t in targets
+                            if t.name == sp_name and t.resolved_client_id
+                        ),
+                        None,
+                    )
+                if principal_override is None and not _is_placeholder_principal(
+                    principal
+                ):
+                    principal_override = principal
+                if principal_override is None:
+                    note = (
+                        f"SKIP: no client id resolved yet for service principal "
+                        f"'{sp_name}', so the Postgres role has no subject. This is "
+                        f"expected in a dry run of an SP that does not exist yet."
+                    )
+            else:
+                # Single-SP path (no ownership map): the role is keyed on the
+                # DatabaseModel's own client_id, so only create it when the SP
+                # being granted matches. Otherwise the agent would connect to
+                # Postgres as one identity while the role belongs to another.
+                configured = (
+                    value_of(database.client_id) if database.client_id else None
                 )
-            elif configured != principal:
-                note = (
-                    f"SKIP: granting SP '{principal}' but this Lakebase project is "
-                    f"configured for client_id '{configured}'. The Postgres role is "
-                    f"created for the configured id, so '{principal}' would fail at "
-                    f"connect time. Grant the configured SP (--app-sp) or align "
-                    f"DatabaseModel.client_id."
-                )
+                if not configured:
+                    note = (
+                        "SKIP: DatabaseModel.client_id is unset or resolved to "
+                        "None (secret scope populated?). A Postgres role can "
+                        "only be created for a concrete service-principal "
+                        "client id — provision the SP and populate the scope, "
+                        "then re-run."
+                    )
+                elif configured != principal:
+                    note = (
+                        f"SKIP: granting SP '{principal}' but this Lakebase "
+                        f"project is configured for client_id '{configured}'. "
+                        f"The Postgres role is created for the configured id, "
+                        f"so '{principal}' would fail at connect time. Grant "
+                        f"the configured SP (sp grant --principal <client-id>) "
+                        f"or align DatabaseModel.client_id."
+                    )
+
             plan.grants.append(
                 Grant(
                     "lakebase_role",
@@ -687,6 +789,7 @@ def build_grant_plan(config: "AppConfig", principal: str) -> GrantPlan:
                     ["DATABRICKS_SUPERUSER"],
                     resource_key=db_key,
                     note=note,
+                    principal_override=principal_override,
                 )
             )
 
@@ -715,13 +818,22 @@ def grant(
     principal: str,
     config: "AppConfig",
     dry_run: bool = False,
+    ownership: Optional[OwnershipMap] = None,
+    sp_name: Optional[str] = None,
+    targets: Optional[Sequence[ServicePrincipalTarget]] = None,
 ) -> GrantPlan:
     """Grant ``principal`` read/execute access to every resource in ``config``.
 
     Returns the :class:`GrantPlan`. When ``dry_run`` is True nothing is applied.
     Individual failures warn-and-continue (consistent with deploy-time granting).
+
+    ``ownership`` / ``sp_name`` / ``targets`` restrict the grant to the resources
+    one named service principal owns; see :func:`build_grant_plan`. Omitting them
+    grants the whole config, which is the single-SP behaviour.
     """
-    plan = build_grant_plan(config, principal)
+    plan = build_grant_plan(
+        config, principal, ownership=ownership, sp_name=sp_name, targets=targets
+    )
 
     if dry_run:
         return plan
@@ -750,7 +862,9 @@ def grant(
                         reason=g.note,
                     )
                     continue
-                _grant_lakebase_role(w, config, g.resource_key)
+                _grant_lakebase_role(
+                    w, config, g.resource_key, client_id=g.principal_override
+                )
             g.applied = True
         except Exception as e:  # noqa: BLE001 — warn-and-continue per resource
             g.applied = False
@@ -776,20 +890,28 @@ def grant(
 
 
 def _grant_lakebase_role(
-    w: "WorkspaceClient", config: "AppConfig", resource_key: Optional[str]
+    w: "WorkspaceClient",
+    config: "AppConfig",
+    resource_key: Optional[str],
+    *,
+    client_id: Optional[str] = None,
 ) -> None:
     """Create the Postgres SUPERUSER role for a Lakebase project's service principal.
 
     Delegates to the existing, idempotent
     :meth:`DatabricksProvider.create_lakebase_autoscaling_role` rather than
-    reinventing the Postgres-API role logic. The provider method reads the
-    ``DatabaseModel``'s own ``client_id`` and connects with its configured
-    credentials, so the caller has already verified (in :func:`build_grant_plan`)
-    that the SP being granted matches that ``client_id``.
+    reinventing the Postgres-API role logic. The Postgres control-plane calls run
+    as ``w`` — the caller's identity — since a service principal cannot create
+    its own role.
 
     Re-resolves the model by its config dict key (not by ``project``) so we act
-    on the exact ``DatabaseModel`` that passed the identity check — two models
-    can share a ``project`` while pinning different ``client_id``s.
+    on the exact ``DatabaseModel`` the plan selected — two models can share a
+    ``project`` while pinning different ``client_id``s.
+
+    Args:
+        client_id: Role subject. Passed when the plan already knows the owning
+            SP's client id (e.g. just minted, so not yet readable from the
+            config's secret scope). Falls back to ``DatabaseModel.client_id``.
     """
     from dao_ai.providers.databricks import DatabricksProvider
 
@@ -799,7 +921,9 @@ def _grant_lakebase_role(
         raise ValueError(
             f"No Lakebase DatabaseModel with key '{resource_key}' found in config"
         )
-    DatabricksProvider(w=w).create_lakebase_autoscaling_role(database)
+    DatabricksProvider(w=w).create_lakebase_autoscaling_role(
+        database, client_id=client_id
+    )
 
 
 def _grant_uc(

--- a/src/dao_ai/service_principal.py
+++ b/src/dao_ai/service_principal.py
@@ -325,9 +325,15 @@ def _ensure_scope(w: "WorkspaceClient", scope: str) -> None:
 # =============================================================================
 
 
+#: What :func:`provision_all` did (or would do) with a target's secret keys.
+SECRET_WRITE: Final[str] = "write"  # keys absent → write them
+SECRET_ROTATE: Final[str] = "rotate"  # keys present + overwrite → replace them
+SECRET_KEEP: Final[str] = "keep"  # keys present, no overwrite → leave them alone
+
+
 @dataclass
 class ProvisionResult:
-    """Outcome of :func:`provision`. The secret is deliberately NOT included."""
+    """Outcome of provisioning one SP. The secret is deliberately NOT included."""
 
     display_name: str
     client_id: str
@@ -337,6 +343,25 @@ class ProvisionResult:
     stored_client_secret_key: Optional[str] = None
     stored: bool = False
     grant_plan: Optional["GrantPlan"] = None
+    # Config key of the service principal in ``service_principals``; "default"
+    # for a config that declares none.
+    name: str = "default"
+    # One of the ``SECRET_*`` constants, or None when storing was skipped.
+    secret_action: Optional[str] = None
+    # Keys that already held a value when we looked.
+    existing_keys: list[str] = field(default_factory=list)
+    # Set when nothing was done because it could not be done safely.
+    blocked_reason: Optional[str] = None
+
+
+@dataclass
+class MultiProvisionResult:
+    """Outcome of :func:`provision_all` across every declared service principal."""
+
+    results: list[ProvisionResult] = field(default_factory=list)
+    dry_run: bool = False
+    # (sp_name, reason) for targets that were deliberately not provisioned.
+    blocked: list[tuple[str, str]] = field(default_factory=list)
 
 
 def provision(
@@ -373,59 +398,396 @@ def provision(
             resolved. Validated BEFORE creating the service principal so a
             misconfigured call never leaves an orphaned SP behind.
     """
-    # Resolve + validate the store target up front — before we create anything —
-    # so an unresolvable config fails fast without orphaning a service principal.
-    resolved_scope: Optional[str] = None
-    cid_key: Optional[str] = None
-    csec_key: Optional[str] = None
-    if do_store:
-        resolved_scope, cid_key, csec_key = resolve_secret_target(
-            config,
-            scope_override=scope,
-            client_id_key_override=client_id_key,
-            client_secret_key_override=client_secret_key,
-        )
-        resolved_scope = resolved_scope or default_scope_from_config(config)
-        if not resolved_scope:
-            raise ValueError(
-                "Cannot determine a secret scope to store credentials. "
-                "Pass --scope, or add a service_principals block to the config."
-            )
-        if not (cid_key and csec_key):
-            raise ValueError(
-                "Cannot determine which secret keys to store the credentials under. "
-                "The config has no service_principals block or client_id/client_secret "
-                "variables to infer them from. Pass --client-id-key and "
-                "--client-secret-key (the keys your config reads its credentials from)."
-            )
+    target = ServicePrincipalTarget(name="default", display_name=display_name)
+    _resolve_secret_target_for(
+        target,
+        config,
+        scope_override=scope,
+        client_id_key_override=client_id_key,
+        client_secret_key_override=client_secret_key,
+    )
+    outcome = provision_all(
+        w,
+        config=config,
+        targets=[target],
+        lifetime=lifetime,
+        do_store=do_store,
+        do_grant=do_grant,
+    )
+    return outcome.results[0]
 
-    created = create(w, display_name=display_name, lifetime=lifetime)
 
-    result = ProvisionResult(
-        display_name=created.display_name,
-        client_id=created.client_id,
-        reused=created.reused,
+def _resolve_secret_target_for(
+    target: ServicePrincipalTarget,
+    config: "AppConfig",
+    *,
+    scope_override: Optional[str] = None,
+    client_id_key_override: Optional[str] = None,
+    client_secret_key_override: Optional[str] = None,
+) -> None:
+    """Fill in ``target``'s secret scope/keys/refs from the config (in place)."""
+    resolved_scope, cid_key, csec_key = resolve_secret_target(
+        config,
+        scope_override=scope_override,
+        client_id_key_override=client_id_key_override,
+        client_secret_key_override=client_secret_key_override,
+    )
+    target.scope = resolved_scope or default_scope_from_config(config)
+    target.client_id_key = cid_key
+    target.client_secret_key = csec_key
+    if target.scope and cid_key:
+        target.client_id_ref = SecretRef(scope=target.scope, key=cid_key)
+    if target.scope and csec_key:
+        target.client_secret_ref = SecretRef(scope=target.scope, key=csec_key)
+
+
+def resolve_sp_targets(
+    config: "AppConfig",
+    *,
+    app_display_name: Optional[str] = None,
+    scope_override: Optional[str] = None,
+    client_id_key_override: Optional[str] = None,
+    client_secret_key_override: Optional[str] = None,
+    only: Optional[Sequence[str]] = None,
+) -> list[ServicePrincipalTarget]:
+    """Work out which service principals a config wants provisioned.
+
+    One target per entry in ``service_principals``. A config that declares none
+    yields exactly one synthetic ``"default"`` target whose secret scope/keys come
+    from :func:`resolve_secret_target` — identical inputs to the single-SP path,
+    so such configs behave exactly as before.
+
+    Args:
+        config: The config to read.
+        app_display_name: Display name for the synthetic default target, and the
+            prefix for derived names (``<app_display_name>-<key>``). Falls back to
+            ``config.app.name``.
+        scope_override / client_id_key_override / client_secret_key_override:
+            Explicit secret target. Only valid for a single target — applying one
+            key pair to several SPs would make each overwrite the last.
+        only: Provision just these named service principals.
+
+    Raises:
+        ValueError: if ``only`` names a service principal the config does not
+            declare, or if overrides are combined with several targets.
+    """
+    app_name = app_display_name or (
+        config.app.name if config.app is not None and config.app.name else None
     )
 
-    if do_store:
-        assert resolved_scope and cid_key and csec_key  # validated above
-        store(
-            w,
-            scope=resolved_scope,
-            client_id_key=cid_key,
-            client_secret_key=csec_key,
-            client_id=created.client_id,
-            client_secret=created.client_secret,
+    declared = config.service_principals or {}
+    if not declared:
+        target = ServicePrincipalTarget(
+            name="default",
+            display_name=app_display_name or (f"{app_name}-sp" if app_name else ""),
         )
-        result.stored_scope = resolved_scope
-        result.stored_client_id_key = cid_key
-        result.stored_client_secret_key = csec_key
-        result.stored = True
+        _resolve_secret_target_for(
+            target,
+            config,
+            scope_override=scope_override,
+            client_id_key_override=client_id_key_override,
+            client_secret_key_override=client_secret_key_override,
+        )
+        return [target]
 
-    if do_grant:
-        result.grant_plan = grant(w, principal=created.client_id, config=config)
+    if only:
+        unknown = [name for name in only if name not in declared]
+        if unknown:
+            raise ValueError(
+                f"Unknown service principal(s): {', '.join(sorted(unknown))}. "
+                f"The config declares: {', '.join(sorted(declared))}."
+            )
 
-    return result
+    overrides = (scope_override, client_id_key_override, client_secret_key_override)
+    selected = {k: v for k, v in declared.items() if not only or k in only}
+    if len(selected) > 1 and any(overrides):
+        raise ValueError(
+            "--scope / --client-id-key / --client-secret-key apply to a single "
+            f"service principal, but {len(selected)} are selected "
+            f"({', '.join(sorted(selected))}). Each service principal needs its "
+            "own secret keys — one shared pair would make each overwrite the "
+            "last. Narrow the run with --sp <name>, or drop the overrides and "
+            "let each SP use the keys its config block declares."
+        )
+
+    targets: list[ServicePrincipalTarget] = []
+    for key, sp in selected.items():
+        default_name = f"{app_name}-{key}" if app_name else key
+        target = ServicePrincipalTarget(
+            name=key,
+            display_name=sp.name or default_name,
+            model=sp,
+        )
+        cid_scope, cid_key = _secret_ref(sp.client_id)
+        csec_scope, csec_key = _secret_ref(sp.client_secret)
+        target.scope = (
+            scope_override
+            or cid_scope
+            or csec_scope
+            or default_scope_from_config(config)
+        )
+        target.client_id_key = client_id_key_override or cid_key
+        target.client_secret_key = client_secret_key_override or csec_key
+        if target.scope and target.client_id_key:
+            target.client_id_ref = SecretRef(
+                scope=target.scope, key=target.client_id_key
+            )
+        if target.scope and target.client_secret_key:
+            target.client_secret_ref = SecretRef(
+                scope=target.scope, key=target.client_secret_key
+            )
+        # Best effort: this is a live secret read that legitimately fails when the
+        # scope isn't populated yet (the common case on a first provision), and
+        # must not abort target resolution. Ownership matching doesn't need it.
+        try:
+            raw = value_of(sp.client_id) if sp.client_id is not None else None
+            # NB: an unresolvable secret yields None, and ``str(None)`` is the
+            # truthy string "None" — which would sail through every later
+            # ``if client_id:`` guard and get used as a real principal. Coerce
+            # only after the None check.
+            target.configured_client_id = str(raw) if raw is not None else None
+        except Exception as e:  # noqa: BLE001 — unreadable secret is expected
+            logger.debug(
+                "Could not resolve configured client_id",
+                service_principal=key,
+                error=str(e),
+            )
+        targets.append(target)
+
+    return targets
+
+
+def provision_all(
+    w: "WorkspaceClient",
+    *,
+    config: "AppConfig",
+    targets: Sequence[ServicePrincipalTarget],
+    lifetime: Optional[str] = None,
+    do_store: bool = True,
+    do_grant: bool = True,
+    dry_run: bool = False,
+    overwrite: bool = False,
+) -> MultiProvisionResult:
+    """Provision every service principal in ``targets``: create, store, grant.
+
+    Library-level and side-effect-reporting rather than printing, so the CLI and a
+    pipeline notebook drive the identical code path. Ordered in four phases so
+    that nothing is mutated until every target is known to be safe:
+
+    1. **Validate** — every target's secret scope/keys must resolve, and no two
+       targets may share a client-id key. Raises before any workspace change, so
+       a misconfigured run never leaves an orphaned service principal behind.
+    2. **Probe** (reads only) — does the SP exist, and do its secret keys already
+       hold values? This is what decides create-vs-reuse and
+       write/rotate/keep, and it is why ``dry_run`` can report the truth.
+    3. **Ownership** (pure) — which target owns which resource. Skipped for a
+       single target, where everything belongs to it anyway.
+    4. **Apply** — skipped entirely when ``dry_run``.
+
+    Args:
+        w: Workspace client. The caller chooses the identity: the CLI passes one
+            built from ``-p/--profile``, a notebook passes ambient auth.
+        config: The config being provisioned for.
+        targets: From :func:`resolve_sp_targets`.
+        lifetime: Optional OAuth secret lifetime.
+        do_store: Write credentials to the secret scope.
+        do_grant: Grant each SP the resources it owns.
+        dry_run: Report what would happen and change nothing.
+        overwrite: Replace secret keys that already hold a value. Without it an
+            existing key is reported and left alone, and no secret is minted —
+            so a re-run never rotates a credential out from under a live agent.
+
+    Raises:
+        ValueError: on an unresolvable secret target or conflicting keys.
+    """
+    outcome = MultiProvisionResult(dry_run=dry_run)
+
+    # ---- Phase 1: validate (no mutation, no reads) -------------------------
+    if do_store:
+        for target in targets:
+            if not target.scope:
+                raise ValueError(
+                    "Cannot determine a secret scope to store credentials. "
+                    "Pass --scope, or add a service_principals block to the config."
+                )
+            if not (target.client_id_key and target.client_secret_key):
+                raise ValueError(
+                    "Cannot determine which secret keys to store the credentials "
+                    "under. The config has no service_principals block or "
+                    "client_id/client_secret variables to infer them from. Pass "
+                    "--client-id-key and --client-secret-key (the keys your "
+                    "config reads its credentials from)."
+                )
+    for target in targets:
+        if not target.display_name:
+            raise ValueError(
+                f"No display name for service principal '{target.name}'. Set "
+                "`name:` on its service_principals entry, pass --name, or give "
+                "the config an app.name to derive one from."
+            )
+
+    # ---- Phase 2: probe (reads only) --------------------------------------
+    present_by_scope: dict[str, frozenset[str]] = {}
+    for target in targets:
+        if do_store and target.scope and target.scope not in present_by_scope:
+            present_by_scope[target.scope] = secret_keys_present(w, target.scope)
+
+        existing_sp = find_service_principal(w, display_name=target.display_name)
+        target.exists = existing_sp is not None
+        target.resolved_client_id = (
+            existing_sp.application_id if existing_sp is not None else None
+        ) or None
+
+        keys = {target.client_id_key, target.client_secret_key} - {None}
+        present = present_by_scope.get(target.scope or "", frozenset())
+        existing_keys = sorted(keys & present)
+
+        if not do_store:
+            secret_action = None
+        elif not existing_keys:
+            secret_action = SECRET_WRITE
+        elif overwrite:
+            secret_action = SECRET_ROTATE
+        else:
+            secret_action = SECRET_KEEP
+
+        result = ProvisionResult(
+            display_name=target.display_name,
+            client_id=target.resolved_client_id or "",
+            reused=bool(target.exists),
+            name=target.name,
+            secret_action=secret_action,
+            existing_keys=list(existing_keys),
+        )
+
+        # A populated key with no matching SP is the one case we refuse to guess
+        # at: the credential belongs to something, and minting a replacement
+        # without being told to would rotate it out from under whatever that is.
+        if secret_action == SECRET_KEEP and not target.exists:
+            result.blocked_reason = (
+                f"secret key(s) {', '.join(existing_keys)} in scope "
+                f"'{target.scope}' already hold a value, but no service "
+                f"principal named '{target.display_name}' exists. Pass "
+                f"--overwrite to replace them, or set `name:` on this "
+                f"service_principals entry to the SP that owns them."
+            )
+            outcome.blocked.append((target.name, result.blocked_reason))
+        outcome.results.append(result)
+
+    # ---- Phase 3: ownership (pure) ---------------------------------------
+    ownership = build_ownership_map(config, targets) if len(targets) > 1 else None
+
+    # ---- Phase 4: apply --------------------------------------------------
+    for target, result in zip(targets, outcome.results):
+        if result.blocked_reason:
+            continue
+
+        if dry_run:
+            principal = target.resolved_client_id or placeholder_principal(target.name)
+            if do_store and target.scope:
+                result.stored_scope = target.scope
+                result.stored_client_id_key = target.client_id_key
+                result.stored_client_secret_key = target.client_secret_key
+            if do_grant:
+                result.grant_plan = grant(
+                    w,
+                    principal=principal,
+                    config=config,
+                    dry_run=True,
+                    ownership=ownership,
+                    sp_name=target.name,
+                    targets=targets,
+                )
+            continue
+
+        if result.secret_action in (SECRET_WRITE, SECRET_ROTATE):
+            created = create(w, display_name=target.display_name, lifetime=lifetime)
+            target.resolved_client_id = created.client_id
+            result.client_id = created.client_id
+            result.reused = created.reused
+            assert target.scope and target.client_id_key and target.client_secret_key
+            store(
+                w,
+                scope=target.scope,
+                client_id_key=target.client_id_key,
+                client_secret_key=target.client_secret_key,
+                client_id=created.client_id,
+                client_secret=created.client_secret,
+                overwrite=True,  # decided in phase 2
+            )
+            result.stored_scope = target.scope
+            result.stored_client_id_key = target.client_id_key
+            result.stored_client_secret_key = target.client_secret_key
+            result.stored = True
+        elif result.secret_action is None and not target.exists:
+            # --no-store on a config whose SP doesn't exist yet: still create it,
+            # so `--no-store` means "don't write secrets", not "do nothing".
+            created = create(w, display_name=target.display_name, lifetime=lifetime)
+            target.resolved_client_id = created.client_id
+            result.client_id = created.client_id
+            result.reused = created.reused
+        # SECRET_KEEP: the SP exists and its credentials are already in place.
+        # Nothing to create, nothing to mint — grants below are still re-applied
+        # (they are additive and idempotent).
+
+        if do_grant:
+            result.grant_plan = grant(
+                w,
+                principal=target.resolved_client_id or result.client_id,
+                config=config,
+                ownership=ownership,
+                sp_name=target.name,
+                targets=targets,
+            )
+
+    return outcome
+
+
+def grant_all(
+    w: "WorkspaceClient",
+    *,
+    config: "AppConfig",
+    targets: Sequence[ServicePrincipalTarget],
+    dry_run: bool = False,
+) -> list[GrantPlan]:
+    """Grant every target the resources it owns, without provisioning anything.
+
+    Resolves each target's client id by looking the SP up — an SP must already
+    exist to be granted. Targets with no such SP get a plan whose grants are all
+    skipped rather than being silently dropped.
+    """
+    for target in targets:
+        existing = find_service_principal(w, display_name=target.display_name)
+        target.exists = existing is not None
+        if existing is not None and existing.application_id:
+            target.resolved_client_id = existing.application_id
+        elif target.configured_client_id:
+            target.resolved_client_id = target.configured_client_id
+
+    ownership = build_ownership_map(config, targets) if len(targets) > 1 else None
+    plans: list[GrantPlan] = []
+    for target in targets:
+        principal = target.resolved_client_id
+        if not principal:
+            logger.warning(
+                "No service principal to grant — skipping",
+                service_principal=target.name,
+                display_name=target.display_name,
+            )
+            plans.append(GrantPlan(principal=placeholder_principal(target.name)))
+            continue
+        plans.append(
+            grant(
+                w,
+                principal=principal,
+                config=config,
+                dry_run=dry_run,
+                ownership=ownership,
+                sp_name=target.name,
+                targets=targets,
+            )
+        )
+    return plans
 
 
 # =============================================================================

--- a/src/dao_ai/service_principal.py
+++ b/src/dao_ai/service_principal.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Optional, Sequence
+from typing import TYPE_CHECKING, Final, Optional, Sequence
 
 from loguru import logger
 
@@ -328,6 +328,190 @@ def provision(
         result.grant_plan = grant(w, principal=created.client_id, config=config)
 
     return result
+
+
+# =============================================================================
+# ownership — which declared service principal owns which resource
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class SecretRef:
+    """A ``(scope, key)`` pointer into a Databricks secret scope."""
+
+    scope: str
+    key: str
+
+
+@dataclass
+class ServicePrincipalTarget:
+    """One service principal to provision/grant, plus the keys identifying it.
+
+    ``client_id_ref`` is the *primary* identity key rather than
+    ``configured_client_id``: a config's ``client_id`` variable resolves to
+    whatever is currently in the secret scope, which on a first provision is
+    nothing and after a rotation is the *previous* SP's id. The ``(scope, key)``
+    pair is a property of the config itself, so it is stable across both.
+    """
+
+    name: str
+    display_name: str
+    model: Optional["ServicePrincipalModel"] = None
+    scope: Optional[str] = None
+    client_id_key: Optional[str] = None
+    client_secret_key: Optional[str] = None
+    client_id_ref: Optional[SecretRef] = None
+    client_secret_ref: Optional[SecretRef] = None
+    # Value of the config's client_id variable at load time. May be stale (a
+    # previous SP) or None (scope not populated yet) — never authoritative.
+    configured_client_id: Optional[str] = None
+    # The real client id, filled in once the SP is looked up or created.
+    resolved_client_id: Optional[str] = None
+    # Whether a workspace SP with ``display_name`` already exists (set by the
+    # dry-run-safe probe; None until probed).
+    exists: Optional[bool] = None
+
+
+@dataclass
+class OwnershipMap:
+    """Which named service principal owns which declared resource.
+
+    Keys are ``(collection, config_key)`` — e.g. ``("databases",
+    "retail_database")``. Plain string tuples, deliberately: the variable models
+    a resource's ``client_id`` holds are unhashable (``CompositeVariableModel``
+    wraps a list), so they cannot be used as keys.
+
+    A resource absent from :attr:`owners` is **shared** — no declared SP claims
+    it, so every SP is granted it.
+    """
+
+    owners: dict[tuple[str, str], str] = field(default_factory=dict)
+
+    def owner_of(self, collection: str, key: str) -> Optional[str]:
+        """Name of the SP owning ``collection[key]``, or None when shared."""
+        return self.owners.get((collection, key))
+
+    def owns(self, collection: str, key: str, sp_name: Optional[str]) -> bool:
+        """True if ``sp_name`` should be granted ``collection[key]``.
+
+        Shared resources (no owner) return True for every SP.
+        """
+        owner = self.owners.get((collection, key))
+        return owner is None or owner == sp_name
+
+
+# The ``IsDatabricksResource`` collections on ``ResourcesModel`` that can carry
+# per-resource credentials, and so can be owned by a specific SP. ``schemas``
+# is intentionally absent — ``SchemaModel`` is not an ``IsDatabricksResource``
+# and catalogs/schemas are shared infrastructure every SP needs USE_CATALOG on.
+_OWNABLE_COLLECTIONS: Final[tuple[str, ...]] = (
+    "tables",
+    "functions",
+    "volumes",
+    "connections",
+    "vector_stores",
+    "warehouses",
+    "genie_rooms",
+    "databases",
+)
+
+
+def resource_owner(
+    resource: object, targets: Sequence[ServicePrincipalTarget]
+) -> Optional[str]:
+    """Return the name of the target owning ``resource``, or None if shared.
+
+    Matching, cheapest and most exact first:
+
+    0. ``resource.service_principal`` equals the target's model. Pydantic
+       compares by value, so a shared YAML anchor matches even though each
+       occurrence re-validates into a distinct object.
+    1. The resource's ``client_id`` points at the same secret ``(scope, key)``
+       as the target. **This is the load-bearing case** — it needs no API call
+       and works before the SP exists, which is what makes single-pass
+       provisioning of a brand-new SP possible.
+    2. The resource's ``client_id`` resolves to the target's client id. Only
+       reached when step 1 found no secret ref (a literal or env-var
+       ``client_id``), because ``value_of`` on a secret-backed variable is a
+       live, uncached ``secrets.get_secret`` call — running it per
+       resource × target would multiply one API call into N×M.
+    """
+    model = getattr(resource, "service_principal", None)
+    if model is not None:
+        for target in targets:
+            if target.model is not None and model == target.model:
+                return target.name
+
+    client_id = getattr(resource, "client_id", None)
+    if client_id is None:
+        return None
+
+    scope, key = _secret_ref(client_id)
+    if scope is not None and key is not None:
+        for target in targets:
+            ref = target.client_id_ref
+            if ref is not None and ref.scope == scope and ref.key == key:
+                return target.name
+        # A secret-backed client_id that matches no target is genuinely
+        # unowned; do NOT fall through to value_of() — that would read the
+        # secret for nothing.
+        return None
+
+    resolved = value_of(client_id)
+    if not resolved:
+        return None
+    for target in targets:
+        if target.resolved_client_id and str(resolved) == target.resolved_client_id:
+            return target.name
+    for target in targets:
+        if target.configured_client_id and str(resolved) == target.configured_client_id:
+            return target.name
+    return None
+
+
+def build_ownership_map(
+    config: "AppConfig", targets: Sequence[ServicePrincipalTarget]
+) -> OwnershipMap:
+    """Map each declared resource to the service principal that owns it.
+
+    Only records matches — anything omitted is shared and granted to every SP.
+    ``app.experiment`` / ``app.endpoint_name`` are deliberately never owned:
+    ``AppModel.service_principal`` is the deploy/tracing identity, a different
+    concept from "which SP does this resource authenticate as", and every SP
+    should be able to query the endpoint.
+
+    Raises:
+        ValueError: if two targets share a secret ``(scope, client_id_key)``.
+            They would overwrite each other's credential and ownership matching
+            could not tell them apart. Raised before any workspace mutation.
+    """
+    seen_refs: dict[tuple[str, str], str] = {}
+    for target in targets:
+        ref = target.client_id_ref
+        if ref is None:
+            continue
+        conflict = seen_refs.get((ref.scope, ref.key))
+        if conflict is not None:
+            raise ValueError(
+                f"Service principals '{conflict}' and '{target.name}' both read "
+                f"client_id from secret '{ref.scope}/{ref.key}'. Give each its "
+                "own secret keys — otherwise they overwrite each other's "
+                "credentials and their resources cannot be told apart."
+            )
+        seen_refs[(ref.scope, ref.key)] = target.name
+
+    ownership = OwnershipMap()
+    resources = config.resources
+    if resources is None:
+        return ownership
+
+    for collection in _OWNABLE_COLLECTIONS:
+        for key, resource in (getattr(resources, collection, None) or {}).items():
+            owner = resource_owner(resource, targets)
+            if owner is not None:
+                ownership.owners[(collection, key)] = owner
+
+    return ownership
 
 
 # =============================================================================

--- a/src/dao_ai/service_principal.py
+++ b/src/dao_ai/service_principal.py
@@ -34,6 +34,7 @@ from dao_ai.config import value_of
 
 if TYPE_CHECKING:
     from databricks.sdk import WorkspaceClient
+    from databricks.sdk.service.iam import ServicePrincipal
 
     from dao_ai.config import (
         AiSearchVectorStoreModel,
@@ -118,11 +119,37 @@ class CreatedServicePrincipal:
     reused: bool = False
 
 
+def find_service_principal(
+    w: "WorkspaceClient", *, display_name: str
+) -> Optional["ServicePrincipal"]:
+    """Look up a workspace service principal by display name.
+
+    Read-only — mints nothing and creates nothing. Split out of :func:`create`
+    so the provisioning flow can report "would create" vs "would reuse (id …)"
+    during a dry run, and decide whether a secret needs minting at all, without
+    any side effect.
+
+    Returns:
+        The matching service principal, or None when no SP has that name.
+    """
+    return next(
+        (
+            sp
+            for sp in w.service_principals.list(
+                filter=f'displayName eq "{display_name}"'
+            )
+            if sp.display_name == display_name
+        ),
+        None,
+    )
+
+
 def create(
     w: "WorkspaceClient",
     *,
     display_name: str,
     lifetime: Optional[str] = None,
+    dry_run: bool = False,
 ) -> CreatedServicePrincipal:
     """Create (or reuse) a workspace service principal and mint an OAuth secret.
 
@@ -135,20 +162,25 @@ def create(
         display_name: Display name for the service principal.
         lifetime: Optional OAuth secret lifetime (e.g. ``"7776000s"``). Defaults
             to the workspace maximum when omitted.
+        dry_run: Report whether the SP exists without creating it or minting a
+            secret. Note that minting IS a mutation — it registers a new OAuth
+            secret on the principal — so a dry run must not reach it. Returns
+            ``client_secret=None`` and an empty ``client_id`` when the SP does
+            not exist yet.
 
     Returns:
         The created/reused principal plus the one-time client secret.
     """
-    existing = next(
-        (
-            sp
-            for sp in w.service_principals.list(
-                filter=f'displayName eq "{display_name}"'
-            )
-            if sp.display_name == display_name
-        ),
-        None,
-    )
+    existing = find_service_principal(w, display_name=display_name)
+
+    if dry_run:
+        return CreatedServicePrincipal(
+            display_name=display_name,
+            client_id=(existing.application_id or "") if existing else "",
+            sp_id=str(existing.id) if existing else "",
+            client_secret=None,
+            reused=existing is not None,
+        )
 
     if existing is not None:
         logger.info(
@@ -194,20 +226,86 @@ def store(
     client_secret_key: str,
     client_id: str,
     client_secret: str,
-) -> None:
+    overwrite: bool = True,
+    dry_run: bool = False,
+) -> "StoreResult":
     """Write the service-principal credentials into a Databricks secret scope.
 
     Creates the scope if it does not already exist (idempotent).
+
+    Args:
+        overwrite: When False, a key that already holds a value is left alone and
+            reported in :attr:`StoreResult.skipped`. Defaults to True, preserving
+            the original unconditional-write behaviour for existing callers.
+        dry_run: Report what would be written without writing anything.
+
+    Returns:
+        Which keys were (or would be) written, and which were left untouched.
     """
-    _ensure_scope(w, scope)
-    w.secrets.put_secret(scope=scope, key=client_id_key, string_value=client_id)
-    w.secrets.put_secret(scope=scope, key=client_secret_key, string_value=client_secret)
-    logger.info(
-        "Stored service-principal credentials",
-        scope=scope,
-        client_id_key=client_id_key,
-        client_secret_key=client_secret_key,
+    existing = (
+        secret_keys_present(w, scope) if (not overwrite or dry_run) else frozenset()
     )
+    pairs = ((client_id_key, client_id), (client_secret_key, client_secret))
+    written: list[str] = []
+    skipped: list[str] = []
+    for key, secret_value in pairs:
+        if not overwrite and key in existing:
+            skipped.append(key)
+            continue
+        written.append(key)
+        if not dry_run:
+            if len(written) == 1:
+                # Only touch the scope once we know we have something to write.
+                _ensure_scope(w, scope)
+            w.secrets.put_secret(scope=scope, key=key, string_value=secret_value)
+
+    if not dry_run and written:
+        logger.info(
+            "Stored service-principal credentials",
+            scope=scope,
+            keys=written,
+            skipped=skipped or None,
+        )
+    return StoreResult(
+        scope=scope,
+        written=written,
+        skipped=skipped,
+        scope_existed=scope in secret_scopes(w) if dry_run else None,
+    )
+
+
+@dataclass
+class StoreResult:
+    """Which secret keys :func:`store` wrote, and which it left alone."""
+
+    scope: str
+    written: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    # Only populated on a dry run, where "the scope will be created" is worth
+    # reporting; None on a real run (the scope is ensured as a side effect).
+    scope_existed: Optional[bool] = None
+
+
+def secret_keys_present(w: "WorkspaceClient", scope: str) -> frozenset[str]:
+    """Keys that already hold a value in ``scope`` (empty if the scope is absent).
+
+    Uses ``list_secrets``, which returns key names and timestamps only — never a
+    value. The SDK has no exists-check helper, and ``get_secret`` would
+    materialize the credential just to learn whether it is there.
+    """
+    from databricks.sdk.errors import NotFound
+
+    try:
+        return frozenset(
+            s.key for s in w.secrets.list_secrets(scope=scope) if s.key is not None
+        )
+    except NotFound:
+        return frozenset()
+
+
+def secret_scopes(w: "WorkspaceClient") -> frozenset[str]:
+    """Names of every secret scope in the workspace."""
+    return frozenset(s.name for s in w.secrets.list_scopes() if s.name is not None)
 
 
 def _ensure_scope(w: "WorkspaceClient", scope: str) -> None:

--- a/src/dao_ai/service_principal.py
+++ b/src/dao_ai/service_principal.py
@@ -60,6 +60,48 @@ def _looks_like_uuid(value: str) -> bool:
     return bool(_UUID_RE.match(value.strip()))
 
 
+# Why a grant did not apply. ``absent`` means the target isn't in this
+# workspace at all (a config/workspace mismatch — usually a wrong ``--var``
+# override or profile); ``denied`` means it exists but the calling identity
+# lacks GRANT/MANAGE on it. The distinction matters because the remedies are
+# completely different, and reporting every failure as a permissions problem
+# sends users chasing ACLs for a resource that was never there.
+GRANT_FAILURE_ABSENT: Final[str] = "absent"
+GRANT_FAILURE_DENIED: Final[str] = "denied"
+GRANT_FAILURE_ERROR: Final[str] = "error"
+
+
+def classify_grant_error(exc: BaseException) -> str:
+    """Bucket a grant failure into ``absent`` / ``denied`` / ``error``.
+
+    Prefers the SDK's typed exceptions, which are exact: a UC permissions PATCH
+    against a missing catalog raises :class:`NotFound` with
+    ``error_code='CATALOG_DOES_NOT_EXIST'``. Falls back to substring matching
+    only for non-SDK errors raised by provider helpers.
+    """
+    from databricks.sdk.errors import DatabricksError, NotFound, PermissionDenied
+
+    if isinstance(exc, NotFound):  # ResourceDoesNotExist subclasses NotFound
+        return GRANT_FAILURE_ABSENT
+    if isinstance(exc, PermissionDenied):
+        return GRANT_FAILURE_DENIED
+
+    error_code: str = ""
+    if isinstance(exc, DatabricksError):
+        error_code = str(getattr(exc, "error_code", "") or "")
+    if error_code.endswith("_DOES_NOT_EXIST") or error_code == "NOT_FOUND":
+        return GRANT_FAILURE_ABSENT
+    if error_code == "PERMISSION_DENIED":
+        return GRANT_FAILURE_DENIED
+
+    text: str = str(exc).lower()
+    if "does not exist" in text or "not found" in text:
+        return GRANT_FAILURE_ABSENT
+    if "permission_denied" in text or "not authorized" in text:
+        return GRANT_FAILURE_DENIED
+    return GRANT_FAILURE_ERROR
+
+
 # =============================================================================
 # create
 # =============================================================================
@@ -317,6 +359,11 @@ class Grant:
     # None if not attempted (dry-run).
     applied: Optional[bool] = None
     error: Optional[str] = None
+    # Why the grant failed, when ``applied is False`` — one of the
+    # ``GRANT_FAILURE_*`` constants. Lets the report separate "this resource
+    # isn't in the workspace" from "you lack GRANT on it", which need different
+    # fixes. See :func:`classify_grant_error`.
+    failure_kind: Optional[str] = None
 
 
 @dataclass
@@ -524,8 +571,18 @@ def grant(
         except Exception as e:  # noqa: BLE001 — warn-and-continue per resource
             g.applied = False
             g.error = str(e)
+            g.failure_kind = classify_grant_error(e)
+            # Say what actually went wrong. Blaming GRANT rights unconditionally
+            # sends users auditing ACLs for a resource that isn't in the
+            # workspace at all — usually a wrong ``--var`` override or profile.
+            if g.failure_kind == GRANT_FAILURE_ABSENT:
+                message = "Grant target does not exist in this workspace"
+            elif g.failure_kind == GRANT_FAILURE_DENIED:
+                message = "Grant denied — the calling identity lacks GRANT rights"
+            else:
+                message = "Grant failed"
             logger.warning(
-                "Grant failed — verify the calling identity has GRANT rights",
+                message,
                 kind=g.kind,
                 target=g.target,
                 error=str(e),

--- a/tests/dao_ai/test_config_source.py
+++ b/tests/dao_ai/test_config_source.py
@@ -1,0 +1,210 @@
+"""Tests for loading configs from an http(s) URL.
+
+``AppConfig.from_file`` was strictly a filesystem read — and ``Path()`` even
+mangles a URL (``Path("https://x/y").as_posix()`` drops a slash), so a URL
+failed at the read with a confusing error. These cover the URL branch plus the
+GitHub blob→raw rewrite, and pin that local paths behave exactly as before.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dao_ai.config_source import (
+    fetch_config_text,
+    is_remote_config,
+    normalize_config_url,
+)
+
+_BLOB = (
+    "https://github.com/natefleming/dao-ai-workshop/blob/main/"
+    "L100-foundations/lab-01-first-agent/greeter.yaml"
+)
+_RAW = (
+    "https://raw.githubusercontent.com/natefleming/dao-ai-workshop/"
+    "refs/heads/main/L100-foundations/lab-01-first-agent/greeter.yaml"
+)
+
+
+@pytest.mark.unit
+class TestIsRemoteConfig:
+    def test_detects_http_and_https(self) -> None:
+        assert is_remote_config("http://example.com/c.yaml")
+        assert is_remote_config("https://example.com/c.yaml")
+
+    def test_rejects_local_paths(self) -> None:
+        assert not is_remote_config("config.yaml")
+        assert not is_remote_config("/abs/path/config.yaml")
+        assert not is_remote_config("./rel/config.yaml")
+
+    def test_rejects_other_schemes(self) -> None:
+        """Only http(s) is handled; anything else is better reported as a path."""
+        assert not is_remote_config("file:///tmp/c.yaml")
+        assert not is_remote_config("s3://bucket/c.yaml")
+
+
+@pytest.mark.unit
+class TestNormalizeConfigUrl:
+    def test_rewrites_github_blob_to_raw(self) -> None:
+        """A blob URL serves HTML, so fetching it would yield markup, not YAML."""
+        assert normalize_config_url(_BLOB) == (
+            "https://raw.githubusercontent.com/natefleming/dao-ai-workshop/main/"
+            "L100-foundations/lab-01-first-agent/greeter.yaml"
+        )
+
+    def test_rewrites_github_raw_path_form(self) -> None:
+        url = "https://github.com/o/r/raw/main/c.yaml"
+        assert normalize_config_url(url) == (
+            "https://raw.githubusercontent.com/o/r/main/c.yaml"
+        )
+
+    def test_leaves_an_already_raw_url_unchanged(self) -> None:
+        assert normalize_config_url(_RAW) == _RAW
+
+    def test_is_idempotent(self) -> None:
+        once = normalize_config_url(_BLOB)
+        assert normalize_config_url(once) == once
+
+    def test_leaves_other_hosts_unchanged(self) -> None:
+        url = "https://gitlab.example.com/o/r/blob/main/c.yaml"
+        assert normalize_config_url(url) == url
+
+    def test_leaves_short_github_paths_unchanged(self) -> None:
+        """Not a file URL (no blob/raw segment) — nothing to rewrite."""
+        url = "https://github.com/natefleming/dao-ai-workshop"
+        assert normalize_config_url(url) == url
+
+
+@pytest.mark.unit
+class TestFetchConfigText:
+    def test_returns_body_on_success(self, monkeypatch) -> None:
+        import httpx
+
+        monkeypatch.setattr(
+            httpx, "get", lambda *a, **k: httpx.Response(200, text="app: {}")
+        )
+        assert fetch_config_text("https://example.com/c.yaml") == "app: {}"
+
+    def test_404_names_the_private_repo_possibility(self, monkeypatch) -> None:
+        """A private repo answers 404, not 401 — the error must not guess."""
+        import httpx
+
+        monkeypatch.setattr(
+            httpx, "get", lambda *a, **k: httpx.Response(404, text="404: Not Found")
+        )
+        with pytest.raises(ValueError, match="private repository"):
+            fetch_config_text("https://example.com/nope.yaml")
+
+    def test_403_is_also_treated_as_unreachable(self, monkeypatch) -> None:
+        import httpx
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **k: httpx.Response(403))
+        with pytest.raises(ValueError, match="private repository"):
+            fetch_config_text("https://example.com/c.yaml")
+
+    def test_other_errors_include_the_status(self, monkeypatch) -> None:
+        import httpx
+
+        monkeypatch.setattr(
+            httpx, "get", lambda *a, **k: httpx.Response(500, text="boom")
+        )
+        with pytest.raises(ValueError, match="HTTP 500"):
+            fetch_config_text("https://example.com/c.yaml")
+
+    def test_transport_failure_names_the_url(self, monkeypatch) -> None:
+        import httpx
+
+        def _raise(*a, **k):
+            raise httpx.ConnectError("no route to host")
+
+        monkeypatch.setattr(httpx, "get", _raise)
+        with pytest.raises(ValueError, match="example.com"):
+            fetch_config_text("https://example.com/c.yaml")
+
+
+@pytest.mark.unit
+class TestFromFileWithUrl:
+    _YAML = """
+app:
+  name: remote-app
+  agents:
+  - name: a
+    description: d
+    model:
+      name: databricks-gpt-5-4-mini
+"""
+
+    def _patch_fetch(self, monkeypatch, text: str) -> None:
+        monkeypatch.setattr(
+            "dao_ai.config_source.fetch_config_text", lambda url, **k: text
+        )
+
+    def test_loads_a_url_without_touching_the_filesystem(self, monkeypatch) -> None:
+        from dao_ai.config import AppConfig
+
+        self._patch_fetch(monkeypatch, self._YAML)
+        config = AppConfig.from_file(_RAW, initialize=False)
+        assert config.app is not None and config.app.name == "remote-app"
+
+    def test_records_the_url_as_the_source(self, monkeypatch) -> None:
+        from dao_ai.config import AppConfig
+
+        self._patch_fetch(monkeypatch, self._YAML)
+        config = AppConfig.from_file(_RAW, initialize=False)
+        assert config._source_config_path == _RAW
+
+    def test_from_url_rejects_a_local_path(self) -> None:
+        from dao_ai.config import AppConfig
+
+        with pytest.raises(ValueError, match="Not an http"):
+            AppConfig.from_url("config.yaml")
+
+    def test_rejects_relative_dataset_paths(self, monkeypatch) -> None:
+        """No local directory to resolve `ddl: functions/x.sql` against."""
+        from dao_ai.config import AppConfig
+
+        self._patch_fetch(
+            monkeypatch,
+            self._YAML
+            + """
+datasets:
+- table:
+    schema:
+      catalog_name: cat
+      schema_name: sch
+    name: t
+  ddl: functions/find_x.sql
+""",
+        )
+        with pytest.raises(ValueError, match="relative paths"):
+            AppConfig.from_file(_RAW, initialize=False)
+
+    def test_allows_volume_paths(self, monkeypatch) -> None:
+        """An absolute/Volume path is resolvable without a local directory."""
+        from dao_ai.config import AppConfig
+
+        self._patch_fetch(
+            monkeypatch,
+            self._YAML
+            + """
+datasets:
+- table:
+    schema:
+      catalog_name: cat
+      schema_name: sch
+    name: t
+  ddl: /Volumes/cat/sch/vol/find_x.sql
+""",
+        )
+        config = AppConfig.from_file(_RAW, initialize=False)
+        assert config.datasets
+
+    def test_local_path_behaviour_is_unchanged(self, tmp_path) -> None:
+        """The filesystem branch still stamps _base_path for relative assets."""
+        from dao_ai.config import AppConfig
+
+        cfg = tmp_path / "c.yaml"
+        cfg.write_text(self._YAML)
+        config = AppConfig.from_file(str(cfg), initialize=False)
+        assert config.app is not None and config.app.name == "remote-app"
+        assert config._source_config_path == cfg.as_posix()

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -3234,3 +3234,98 @@ def test_create_lakebase_role_creates_when_absent(monkeypatch):
     # The role hint is sanitized from the client_id and 'sp-' prefixed.
     assert kwargs["role_id"] == f"sp-{_LB_CLIENT_ID}"
     assert kwargs["role"].spec.postgres_role == _LB_CLIENT_ID
+
+
+@pytest.mark.unit
+def test_create_lakebase_role_uses_the_caller_client_not_the_sp_client(monkeypatch):
+    """The Postgres control plane runs as the CALLER, never as the SP itself.
+
+    Regression test: the provider used to read ``database.workspace_client``,
+    which builds an oauth-m2m client from the DatabaseModel's own credentials —
+    so the SP tried to create its own role and the workspace rejected it with
+    "not authorized ... assign the user <sp> 'Can Manage' for Database project".
+    Constructing the SP client at all is the bug, so we make it raise.
+    """
+
+    def _explode(**kwargs):
+        raise AssertionError(
+            "create_lakebase_autoscaling_role must not build a service-principal "
+            f"WorkspaceClient; got kwargs={sorted(kwargs)}"
+        )
+
+    w = _mock_lakebase_ws(existing_postgres_roles=[])
+    monkeypatch.setattr("dao_ai.config.WorkspaceClient", _explode)
+    db = DatabaseModel(
+        name="lb", project="proj", client_id=_LB_CLIENT_ID, client_secret="s"
+    )
+    DatabricksProvider(w=w).create_lakebase_autoscaling_role(db)
+
+    # Every control-plane call went through the injected caller client.
+    w.postgres.list_branches.assert_called_once()
+    w.postgres.list_roles.assert_called_once()
+    w.postgres.create_role.assert_called_once()
+
+
+@pytest.mark.unit
+def test_create_lakebase_role_subject_is_still_the_sp_client_id(monkeypatch):
+    """Caller identity changed; the role SUBJECT must remain the SP."""
+    w = _mock_lakebase_ws(existing_postgres_roles=[])
+    monkeypatch.setattr("dao_ai.config.WorkspaceClient", lambda **kwargs: w)
+    db = DatabaseModel(
+        name="lb", project="proj", client_id=_LB_CLIENT_ID, client_secret="s"
+    )
+    DatabricksProvider(w=w).create_lakebase_autoscaling_role(db)
+
+    _, kwargs = w.postgres.create_role.call_args
+    assert kwargs["role"].spec.postgres_role == _LB_CLIENT_ID
+
+
+@pytest.mark.unit
+def test_create_lakebase_role_honours_explicit_client_id_override(monkeypatch):
+    """An explicit client_id wins over the model's — the one-pass provision path.
+
+    ``dao-ai sp provision`` mints an SP and must create its Postgres role in the
+    same run, before the secret scope the config reads ``client_id`` from has
+    been populated. The override carries the freshly minted id.
+    """
+    fresh_id = "de6db65b-59f0-4368-87ed-9b06f6054da0"
+    w = _mock_lakebase_ws(existing_postgres_roles=[])
+    monkeypatch.setattr("dao_ai.config.WorkspaceClient", lambda **kwargs: w)
+    db = DatabaseModel(
+        name="lb", project="proj", client_id=_LB_CLIENT_ID, client_secret="s"
+    )
+    DatabricksProvider(w=w).create_lakebase_autoscaling_role(db, client_id=fresh_id)
+
+    _, kwargs = w.postgres.create_role.call_args
+    assert kwargs["role"].spec.postgres_role == fresh_id
+    assert kwargs["role_id"] == f"sp-{fresh_id}"
+
+
+@pytest.mark.unit
+def test_create_lakebase_role_override_works_when_model_client_id_unset(monkeypatch):
+    """With an override, an unresolvable model client_id no longer blocks the role.
+
+    This is what removes the old two-pass "provision the SP and populate the
+    scope, then re-run" round-trip.
+    """
+    fresh_id = "de6db65b-59f0-4368-87ed-9b06f6054da0"
+    w = _mock_lakebase_ws(existing_postgres_roles=[])
+    monkeypatch.setattr("dao_ai.config.WorkspaceClient", lambda **kwargs: w)
+    db = DatabaseModel(name="lb", project="proj")
+    DatabricksProvider(w=w).create_lakebase_autoscaling_role(db, client_id=fresh_id)
+
+    w.postgres.create_role.assert_called_once()
+    _, kwargs = w.postgres.create_role.call_args
+    assert kwargs["role"].spec.postgres_role == fresh_id
+
+
+@pytest.mark.unit
+def test_create_lakebase_role_without_override_still_skips_unset_client_id(monkeypatch):
+    """Legacy path unchanged: no override + no model client_id → warn and skip."""
+    w = _mock_lakebase_ws(existing_postgres_roles=[])
+    monkeypatch.setattr("dao_ai.config.WorkspaceClient", lambda **kwargs: w)
+    db = DatabaseModel(name="lb", project="proj")
+    DatabricksProvider(w=w).create_lakebase_autoscaling_role(db)
+
+    w.postgres.create_role.assert_not_called()
+    w.postgres.list_roles.assert_not_called()

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -3320,6 +3320,32 @@ def test_create_lakebase_role_override_works_when_model_client_id_unset(monkeypa
 
 
 @pytest.mark.unit
+def test_create_lakebase_project_uses_the_caller_client_not_the_sp_client(monkeypatch):
+    """Creating the project is control-plane work → the caller's identity.
+
+    The SP has no standing to create the project it is about to be granted a
+    role on, so building its oauth-m2m client here is the bug. Keeps
+    ``DatabaseModel.create()``'s ``w`` honoured by BOTH provisioning helpers.
+    """
+
+    def _explode(**kwargs):
+        raise AssertionError(
+            "create_lakebase_autoscaling must not build a service-principal "
+            f"WorkspaceClient; got kwargs={sorted(kwargs)}"
+        )
+
+    w = _mock_lakebase_ws(existing_postgres_roles=[])
+    w.postgres.get_project.return_value = None
+    monkeypatch.setattr("dao_ai.config.WorkspaceClient", _explode)
+    db = DatabaseModel(
+        name="lb", project="proj", client_id=_LB_CLIENT_ID, client_secret="s"
+    )
+    DatabricksProvider(w=w).create_lakebase_autoscaling(db)
+
+    w.postgres.get_project.assert_called_once_with("projects/proj")
+
+
+@pytest.mark.unit
 def test_create_lakebase_role_without_override_still_skips_unset_client_id(monkeypatch):
     """Legacy path unchanged: no override + no model client_id → warn and skip."""
     w = _mock_lakebase_ws(existing_postgres_roles=[])

--- a/tests/dao_ai/test_service_principal.py
+++ b/tests/dao_ai/test_service_principal.py
@@ -22,20 +22,26 @@ from dao_ai.service_principal import (
     GRANT_FAILURE_ABSENT,
     GRANT_FAILURE_DENIED,
     GRANT_FAILURE_ERROR,
+    SECRET_KEEP,
+    SECRET_ROTATE,
+    SECRET_WRITE,
     SecretRef,
     ServicePrincipalTarget,
     build_grant_plan,
     build_ownership_map,
     classify_grant_error,
     create,
-    find_service_principal,
-    secret_keys_present,
     default_scope_from_config,
+    find_service_principal,
     grant,
+    grant_all,
     provision,
+    provision_all,
     resolve_principal_from_config,
     resolve_secret_target,
+    resolve_sp_targets,
     resource_owner,
+    secret_keys_present,
     store,
 )
 
@@ -1379,3 +1385,349 @@ def test_create_dry_run_reports_would_create_for_absent_sp() -> None:
     assert result.client_secret is None
     w.service_principals.create.assert_not_called()
     w.service_principal_secrets_proxy.create.assert_not_called()
+
+
+# =============================================================================
+# resolve_sp_targets / provision_all / grant_all — multi-SP
+# =============================================================================
+
+
+def _app(name: str = "myapp", **kwargs) -> AppModel:
+    """A minimal valid AppModel — AppModel requires at least one agent."""
+    from dao_ai.config import AgentModel, InferenceEndpointModel
+
+    return AppModel(
+        name=name,
+        agents=[
+            AgentModel(
+                name="a",
+                description="d",
+                model=InferenceEndpointModel(name="databricks-gpt-5-4-mini"),
+            )
+        ],
+        **kwargs,
+    )
+
+
+def _multi_sp_config() -> AppConfig:
+    """A config declaring two SPs with distinct secret keys in one scope."""
+    from dao_ai.config import ResourcesModel
+
+    memory_sp = ServicePrincipalModel(
+        client_id=SecretVariableModel(scope="sc", secret="M_CID"),
+        client_secret=SecretVariableModel(scope="sc", secret="M_CSEC"),
+    )
+    tools_sp = ServicePrincipalModel(
+        client_id=SecretVariableModel(scope="sc", secret="T_CID"),
+        client_secret=SecretVariableModel(scope="sc", secret="T_CSEC"),
+    )
+    schema = _schema()
+    return AppConfig(
+        schemas={"s": schema},
+        service_principals={"memory_sp": memory_sp, "tools_sp": tools_sp},
+        resources=ResourcesModel(
+            tables={
+                "owned_by_tools": TableModel(
+                    schema=schema, name="tool_table", service_principal=tools_sp
+                ),
+                "shared": TableModel(schema=schema, name="shared_table"),
+            }
+        ),
+        app=_app(),
+    )
+
+
+def _ws_for_provision(
+    existing_sps: dict[str, str] | None = None, existing_keys: tuple[str, ...] = ()
+) -> MagicMock:
+    """Mock client: ``existing_sps`` maps display_name -> application_id."""
+    existing_sps = existing_sps or {}
+    w = MagicMock()
+
+    def _list(filter: str = "", **kwargs):
+        for name, app_id in existing_sps.items():
+            if f'"{name}"' in filter:
+                sp = MagicMock(**{"display_name": name, "application_id": app_id})
+                sp.id = "42"
+                return [sp]
+        return []
+
+    w.service_principals.list.side_effect = _list
+    w.secrets.list_secrets.return_value = [
+        MagicMock(**{"key": k}) for k in existing_keys
+    ]
+    scope_obj = MagicMock()
+    scope_obj.name = "sc"
+    w.secrets.list_scopes.return_value = [scope_obj]
+    created = MagicMock(**{"application_id": "new-app-id"})
+    created.id = "99"
+    w.service_principals.create.return_value = created
+    w.service_principal_secrets_proxy.create.return_value = MagicMock(
+        secret="minted-secret"
+    )
+    return w
+
+
+def test_resolve_sp_targets_one_per_declared_sp() -> None:
+    targets = resolve_sp_targets(_multi_sp_config())
+    assert [t.name for t in targets] == ["memory_sp", "tools_sp"]
+    # Display names derive from app.name + the config key.
+    assert [t.display_name for t in targets] == ["myapp-memory_sp", "myapp-tools_sp"]
+    assert targets[0].client_id_ref == SecretRef(scope="sc", key="M_CID")
+
+
+def test_resolve_sp_targets_prefers_explicit_name() -> None:
+    sp = ServicePrincipalModel(
+        name="pinned-sp",
+        client_id=SecretVariableModel(scope="sc", secret="CID"),
+        client_secret=SecretVariableModel(scope="sc", secret="CSEC"),
+    )
+    config = AppConfig(service_principals={"a": sp}, app=_app())
+    assert resolve_sp_targets(config)[0].display_name == "pinned-sp"
+
+
+def test_resolve_sp_targets_without_block_yields_one_default() -> None:
+    """A config with no service_principals behaves exactly as the single-SP path."""
+    config = AppConfig(
+        variables={
+            "client_id": SecretVariableModel(scope="sc", secret="CID"),
+            "client_secret": SecretVariableModel(scope="sc", secret="CSEC"),
+        },
+        app=_app(),
+    )
+    targets = resolve_sp_targets(config)
+    assert len(targets) == 1
+    assert targets[0].name == "default"
+    assert targets[0].client_id_key == "CID"
+
+
+def test_resolve_sp_targets_only_filters() -> None:
+    targets = resolve_sp_targets(_multi_sp_config(), only=["tools_sp"])
+    assert [t.name for t in targets] == ["tools_sp"]
+
+
+def test_resolve_sp_targets_rejects_unknown_name() -> None:
+    import pytest
+
+    with pytest.raises(ValueError, match="Unknown service principal"):
+        resolve_sp_targets(_multi_sp_config(), only=["nope"])
+
+
+def test_resolve_sp_targets_rejects_overrides_with_multiple_targets() -> None:
+    """One key pair across two SPs would make the second clobber the first."""
+    import pytest
+
+    with pytest.raises(ValueError, match="single"):
+        resolve_sp_targets(_multi_sp_config(), client_id_key_override="CID")
+
+
+def test_provision_all_creates_every_declared_service_principal() -> None:
+    config = _multi_sp_config()
+    w = _ws_for_provision()
+    targets = resolve_sp_targets(config)
+    outcome = provision_all(w, config=config, targets=targets)
+
+    assert [r.name for r in outcome.results] == ["memory_sp", "tools_sp"]
+    assert w.service_principals.create.call_count == 2
+    assert all(r.stored for r in outcome.results)
+
+
+def test_provision_all_grants_each_sp_only_its_own_resources() -> None:
+    config = _multi_sp_config()
+    w = _ws_for_provision()
+    targets = resolve_sp_targets(config)
+    outcome = provision_all(w, config=config, targets=targets)
+
+    plans = {r.name: r.grant_plan for r in outcome.results}
+    memory_targets = {g.target for g in plans["memory_sp"].grants}
+    tools_targets = {g.target for g in plans["tools_sp"].grants}
+
+    # tools_sp owns tool_table; memory_sp must not be granted it.
+    assert "cat.sch.tool_table" in tools_targets
+    assert "cat.sch.tool_table" not in memory_targets
+    # The shared table goes to both.
+    assert "cat.sch.shared_table" in memory_targets
+    assert "cat.sch.shared_table" in tools_targets
+
+
+def test_provision_all_dry_run_makes_no_mutating_calls() -> None:
+    """THE DRY-RUN CONTRACT: nothing that changes state may be reached."""
+    config = _multi_sp_config()
+    w = _ws_for_provision()
+    targets = resolve_sp_targets(config)
+    outcome = provision_all(w, config=config, targets=targets, dry_run=True)
+
+    assert outcome.dry_run
+    w.service_principals.create.assert_not_called()
+    w.service_principal_secrets_proxy.create.assert_not_called()  # no secret minted
+    w.secrets.create_scope.assert_not_called()
+    w.secrets.put_secret.assert_not_called()
+    w.api_client.do.assert_not_called()
+    w.warehouses.update_permissions.assert_not_called()
+    w.permissions.update.assert_not_called()
+    w.serving_endpoints.update_permissions.assert_not_called()
+    # Reads still happen — that is what makes the preview truthful.
+    assert w.service_principals.list.called
+    # And the plan is still complete.
+    assert all(r.grant_plan is not None for r in outcome.results)
+
+
+def test_provision_all_dry_run_reports_create_vs_reuse() -> None:
+    config = _multi_sp_config()
+    w = _ws_for_provision(existing_sps={"myapp-memory_sp": PRINCIPAL})
+    targets = resolve_sp_targets(config)
+    outcome = provision_all(w, config=config, targets=targets, dry_run=True)
+
+    by_name = {r.name: r for r in outcome.results}
+    assert by_name["memory_sp"].reused is True
+    assert by_name["memory_sp"].client_id == PRINCIPAL
+    assert by_name["tools_sp"].reused is False
+
+
+def test_provision_all_dry_run_reports_existing_secret_keys() -> None:
+    config = _multi_sp_config()
+    w = _ws_for_provision(
+        existing_sps={"myapp-memory_sp": PRINCIPAL}, existing_keys=("M_CID", "M_CSEC")
+    )
+    targets = resolve_sp_targets(config)
+    outcome = provision_all(w, config=config, targets=targets, dry_run=True)
+
+    by_name = {r.name: r for r in outcome.results}
+    assert by_name["memory_sp"].secret_action == SECRET_KEEP
+    assert by_name["memory_sp"].existing_keys == ["M_CID", "M_CSEC"]
+    assert by_name["tools_sp"].secret_action == SECRET_WRITE
+
+
+def test_provision_all_skips_minting_when_key_exists_and_no_overwrite() -> None:
+    """THE ORPHAN GUARD.
+
+    ``create`` always mints a fresh OAuth secret. If we minted and then declined
+    to store it, the workspace would hold a live secret nothing references while
+    the scope still held a credential for a possibly-rotated SP. Probing first
+    means the reuse path never mints at all.
+    """
+    config = _multi_sp_config()
+    w = _ws_for_provision(
+        existing_sps={"myapp-memory_sp": PRINCIPAL, "myapp-tools_sp": "tid"},
+        existing_keys=("M_CID", "M_CSEC", "T_CID", "T_CSEC"),
+    )
+    targets = resolve_sp_targets(config)
+    outcome = provision_all(w, config=config, targets=targets, overwrite=False)
+
+    w.service_principal_secrets_proxy.create.assert_not_called()
+    w.secrets.put_secret.assert_not_called()
+    assert all(r.secret_action == SECRET_KEEP for r in outcome.results)
+    # Grants are still re-applied — they're additive and idempotent.
+    assert all(r.grant_plan is not None for r in outcome.results)
+
+
+def test_provision_all_overwrite_rotates_and_stores() -> None:
+    config = _multi_sp_config()
+    w = _ws_for_provision(
+        existing_sps={"myapp-memory_sp": PRINCIPAL, "myapp-tools_sp": "tid"},
+        existing_keys=("M_CID", "M_CSEC", "T_CID", "T_CSEC"),
+    )
+    targets = resolve_sp_targets(config)
+    outcome = provision_all(w, config=config, targets=targets, overwrite=True)
+
+    assert all(r.secret_action == SECRET_ROTATE for r in outcome.results)
+    assert w.service_principal_secrets_proxy.create.call_count == 2
+    assert w.secrets.put_secret.call_count == 4
+
+
+def test_provision_all_blocks_when_key_exists_but_no_such_sp() -> None:
+    """A populated key with no matching SP: refuse rather than guess."""
+    config = _multi_sp_config()
+    w = _ws_for_provision(existing_keys=("M_CID", "M_CSEC"))
+    targets = resolve_sp_targets(config)
+    outcome = provision_all(w, config=config, targets=targets)
+
+    blocked = dict(outcome.blocked)
+    assert "memory_sp" in blocked
+    assert "--overwrite" in blocked["memory_sp"]
+    # tools_sp is unaffected and still provisioned.
+    by_name = {r.name: r for r in outcome.results}
+    assert by_name["tools_sp"].blocked_reason is None
+    assert by_name["memory_sp"].blocked_reason
+
+
+def test_provision_all_validates_before_creating_anything() -> None:
+    """Fail-fast spans all targets — SP #1 must not exist if #2 is unresolvable."""
+    import pytest
+
+    config = AppConfig(
+        service_principals={
+            "a": ServicePrincipalModel(client_id="literal-id", client_secret="literal"),
+        },
+        app=_app(),
+    )
+    w = _ws_for_provision()
+    targets = resolve_sp_targets(config)
+    # Literal (non-secret) credentials give no scope/keys to store under.
+    with pytest.raises(ValueError, match="secret keys"):
+        provision_all(w, config=config, targets=targets)
+    w.service_principals.create.assert_not_called()
+
+
+def test_provision_all_single_target_passes_no_ownership() -> None:
+    """Single-SP configs traverse the same code as before ownership existed."""
+    config = AppConfig(
+        variables={
+            "client_id": SecretVariableModel(scope="sc", secret="CID"),
+            "client_secret": SecretVariableModel(scope="sc", secret="CSEC"),
+        },
+        schemas={"s": _schema()},
+        app=_app(),
+    )
+    w = _ws_for_provision()
+    targets = resolve_sp_targets(config)
+    outcome = provision_all(w, config=config, targets=targets)
+    assert len(outcome.results) == 1
+    assert outcome.results[0].grant_plan is not None
+
+
+def test_grant_all_grants_existing_sps_only() -> None:
+    config = _multi_sp_config()
+    w = _ws_for_provision(existing_sps={"myapp-tools_sp": "tid"})
+    targets = resolve_sp_targets(config)
+    plans = grant_all(w, config=config, targets=targets)
+
+    # memory_sp doesn't exist → empty placeholder plan, nothing applied.
+    by_principal = {p.principal: p for p in plans}
+    assert any(p.startswith("<new-sp:") for p in by_principal)
+    assert "tid" in by_principal
+    w.service_principals.create.assert_not_called()
+
+
+def test_resolve_sp_targets_unresolvable_secret_is_none_not_the_string_None(
+    monkeypatch,
+) -> None:
+    """Regression: ``str(None)`` is the truthy string "None".
+
+    An unreadable secret (the normal case before a first provision) must leave
+    ``configured_client_id`` as None. Coercing before the None check produced
+    "None", which passed every later ``if client_id:`` guard and got used as a
+    real principal — grants were applied for a service principal called "None".
+    """
+    monkeypatch.setattr("dao_ai.config.SecretVariableModel.as_value", lambda self: None)
+    sp = ServicePrincipalModel(
+        client_id=SecretVariableModel(scope="sc", secret="CID"),
+        client_secret=SecretVariableModel(scope="sc", secret="CSEC"),
+    )
+    config = AppConfig(service_principals={"a": sp}, app=_app())
+    target = resolve_sp_targets(config)[0]
+    assert target.configured_client_id is None
+
+
+def test_grant_all_never_grants_a_null_principal() -> None:
+    """No SP and no resolvable id → nothing is applied for that target."""
+    config = _multi_sp_config()
+    w = _ws_for_provision(existing_sps={})
+    targets = resolve_sp_targets(config)
+    for t in targets:
+        t.configured_client_id = None
+    plans = grant_all(w, config=config, targets=targets)
+
+    assert all(p.principal.startswith("<new-sp:") for p in plans)
+    assert all(p.grants == [] for p in plans)
+    w.api_client.do.assert_not_called()

--- a/tests/dao_ai/test_service_principal.py
+++ b/tests/dao_ai/test_service_principal.py
@@ -354,7 +354,11 @@ def test_grant_lakebase_role_resolves_by_key_not_project(monkeypatch) -> None:
     plan = grant(w, principal=PRINCIPAL, config=config, dry_run=False)
 
     # Exactly one role created, and it's the model whose client_id == principal.
-    provider.create_lakebase_autoscaling_role.assert_called_once_with(match_db)
+    # ``client_id=None`` on the single-SP path: no ownership map, so the provider
+    # falls back to reading DatabaseModel.client_id itself (legacy behaviour).
+    provider.create_lakebase_autoscaling_role.assert_called_once_with(
+        match_db, client_id=None
+    )
     lb = {g.resource_key: g for g in plan.grants if g.kind == "lakebase_role"}
     assert lb["match"].applied is True and lb["match"].note is None
     assert lb["mismatch"].applied is None and lb["mismatch"].note
@@ -999,3 +1003,211 @@ def test_ownership_map_empty_when_no_resources() -> None:
     assert ownership.owners == {}
     # Everything is shared when nothing is owned.
     assert ownership.owns("tables", "anything", "memory_sp")
+
+
+# =============================================================================
+# build_grant_plan — ownership filtering (multi-SP)
+# =============================================================================
+
+
+def _owned_table(name: str, cid_key: str = "CID"):
+    schema = _schema()
+    return TableModel(
+        schema=schema,
+        name=name,
+        client_id=SecretVariableModel(scope="sc", secret=cid_key),
+        client_secret=SecretVariableModel(scope="sc", secret="CSEC"),
+    )
+
+
+def test_grant_plan_without_ownership_is_unchanged() -> None:
+    """Backward compat: ownership=None grants the whole config, as before."""
+    from dao_ai.config import ResourcesModel
+
+    schema = _schema()
+    config = AppConfig(
+        schemas={"s": schema},
+        resources=ResourcesModel(
+            tables={
+                "a": _owned_table("a"),
+                "b": TableModel(schema=schema, name="b"),
+            }
+        ),
+    )
+    plan = build_grant_plan(config, PRINCIPAL)
+    targets_granted = {g.target for g in plan.grants}
+    assert "cat.sch.a" in targets_granted
+    assert "cat.sch.b" in targets_granted
+
+
+def test_grant_plan_owned_table_granted_only_to_its_owner() -> None:
+    from dao_ai.config import ResourcesModel
+
+    config = AppConfig(
+        schemas={"s": _schema()},
+        resources=ResourcesModel(tables={"a": _owned_table("a")}),
+    )
+    targets = [_target("memory_sp"), _target("tools_sp", cid_key="T_CID")]
+    ownership = build_ownership_map(config, targets)
+
+    owner_plan = build_grant_plan(
+        config, PRINCIPAL, ownership=ownership, sp_name="memory_sp", targets=targets
+    )
+    other_plan = build_grant_plan(
+        config, PRINCIPAL, ownership=ownership, sp_name="tools_sp", targets=targets
+    )
+    assert "cat.sch.a" in {g.target for g in owner_plan.grants}
+    assert "cat.sch.a" not in {g.target for g in other_plan.grants}
+
+
+def test_grant_plan_shared_resource_granted_to_every_sp() -> None:
+    from dao_ai.config import ResourcesModel
+
+    config = AppConfig(
+        schemas={"s": _schema()},
+        resources=ResourcesModel(
+            tables={"shared": TableModel(schema=_schema(), name="shared")}
+        ),
+    )
+    targets = [_target("memory_sp"), _target("tools_sp", cid_key="T_CID")]
+    ownership = build_ownership_map(config, targets)
+
+    for sp_name in ("memory_sp", "tools_sp"):
+        plan = build_grant_plan(
+            config, PRINCIPAL, ownership=ownership, sp_name=sp_name, targets=targets
+        )
+        assert "cat.sch.shared" in {g.target for g in plan.grants}
+
+
+def test_grant_plan_owned_resource_still_grants_its_catalog_and_schema() -> None:
+    """An owner needs USE_CATALOG/USE_SCHEMA to reach the table it owns."""
+    from dao_ai.config import ResourcesModel
+
+    config = AppConfig(resources=ResourcesModel(tables={"a": _owned_table("a")}))
+    targets = [_target("memory_sp")]
+    ownership = build_ownership_map(config, targets)
+    plan = build_grant_plan(
+        config, PRINCIPAL, ownership=ownership, sp_name="memory_sp", targets=targets
+    )
+    by_type = {g.securable_type for g in plan.grants}
+    assert "catalog" in by_type and "schema" in by_type
+
+
+def test_grant_plan_top_level_schemas_are_shared_across_sps() -> None:
+    """Catalogs/schemas are shared infrastructure — never owned by one SP."""
+    config = AppConfig(schemas={"s": _schema()})
+    targets = [_target("memory_sp"), _target("tools_sp", cid_key="T_CID")]
+    ownership = build_ownership_map(config, targets)
+
+    for sp_name in ("memory_sp", "tools_sp"):
+        plan = build_grant_plan(
+            config, PRINCIPAL, ownership=ownership, sp_name=sp_name, targets=targets
+        )
+        assert ("catalog", "cat") in {(g.securable_type, g.target) for g in plan.grants}
+
+
+def test_grant_plan_lakebase_role_planned_only_for_owning_sp() -> None:
+    """The non-owner gets NO lakebase entry at all — not even a SKIP note.
+
+    With N service principals, a per-SP mismatch note would print N-1 alarming
+    SKIPs per project per run; the owner's grant already tells the story.
+    """
+    from dao_ai.config import ResourcesModel
+
+    db = _lakebase_db(PRINCIPAL)
+    config = AppConfig(resources=ResourcesModel(databases={"d": db}))
+    targets = [
+        _target("memory_sp", resolved=PRINCIPAL),
+        _target(
+            "tools_sp", cid_key="T_CID", resolved="99999999-9999-9999-9999-999999999999"
+        ),
+    ]
+    ownership = build_ownership_map(config, targets)
+
+    owner_plan = build_grant_plan(
+        config, PRINCIPAL, ownership=ownership, sp_name="memory_sp", targets=targets
+    )
+    other_plan = build_grant_plan(
+        config, PRINCIPAL, ownership=ownership, sp_name="tools_sp", targets=targets
+    )
+    owner_lb = [g for g in owner_plan.grants if g.kind == "lakebase_role"]
+    other_lb = [g for g in other_plan.grants if g.kind == "lakebase_role"]
+
+    assert len(owner_lb) == 1 and owner_lb[0].note is None
+    assert other_lb == []
+
+
+def test_grant_plan_lakebase_role_carries_owning_sp_client_id() -> None:
+    """The role subject comes from the target, not from re-reading the config."""
+    from dao_ai.config import ResourcesModel
+
+    db = _lakebase_db(PRINCIPAL)
+    config = AppConfig(resources=ResourcesModel(databases={"d": db}))
+    # The target's resolved id deliberately differs from the ``principal``
+    # argument, so this can only pass if the target — not the argument — is the
+    # source of the role subject.
+    from_target = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    targets = [_target("memory_sp", resolved=from_target)]
+    ownership = build_ownership_map(config, targets)
+    plan = build_grant_plan(
+        config, PRINCIPAL, ownership=ownership, sp_name="memory_sp", targets=targets
+    )
+    lb = next(g for g in plan.grants if g.kind == "lakebase_role")
+    assert lb.principal_override == from_target
+
+
+def test_grant_plan_lakebase_role_planned_when_scope_unpopulated(monkeypatch) -> None:
+    """THE ONE-PASS PROOF.
+
+    A brand-new SP's client_id is not in the secret scope yet, so
+    ``value_of(database.client_id)`` yields nothing. Under ownership the role is
+    still planned, with the freshly minted id as its subject — no second run.
+    """
+    from dao_ai.config import DatabaseModel, ResourcesModel
+
+    fresh_id = "de6db65b-59f0-4368-87ed-9b06f6054da0"
+    db = DatabaseModel(
+        name="lb",
+        project="my-proj",
+        client_id=SecretVariableModel(scope="sc", secret="CID"),
+        client_secret=SecretVariableModel(scope="sc", secret="CSEC"),
+    )
+    config = AppConfig(resources=ResourcesModel(databases={"d": db}))
+    targets = [_target("memory_sp", configured=None, resolved=fresh_id)]
+    ownership = build_ownership_map(config, targets)
+
+    # Reading the secret would fail here (scope not populated) — the plan must
+    # not need it.
+    def _boom(*args, **kwargs):
+        raise AssertionError("the one-pass path must not read the secret scope")
+
+    monkeypatch.setattr("dao_ai.config.SecretVariableModel.as_value", _boom)
+    plan = build_grant_plan(
+        config, fresh_id, ownership=ownership, sp_name="memory_sp", targets=targets
+    )
+    lb = next(g for g in plan.grants if g.kind == "lakebase_role")
+    assert lb.note is None
+    assert lb.principal_override == fresh_id
+
+
+def test_grant_plan_dry_run_placeholder_principal_emits_no_skip_note() -> None:
+    """A dry run of a not-yet-created SP must not print a bogus mismatch SKIP."""
+    from dao_ai.config import ResourcesModel
+    from dao_ai.service_principal import placeholder_principal
+
+    db = _lakebase_db(PRINCIPAL)
+    config = AppConfig(resources=ResourcesModel(databases={"d": db}))
+    targets = [_target("memory_sp", resolved=None, configured=None)]
+    ownership = build_ownership_map(config, targets)
+    plan = build_grant_plan(
+        config,
+        placeholder_principal("memory_sp"),
+        ownership=ownership,
+        sp_name="memory_sp",
+        targets=targets,
+    )
+    lb = next(g for g in plan.grants if g.kind == "lakebase_role")
+    # It reports "no id yet", which is honest, and never claims an id mismatch.
+    assert lb.note is not None
+    assert "does not exist yet" in lb.note
+    assert "configured for client_id" not in lb.note

--- a/tests/dao_ai/test_service_principal.py
+++ b/tests/dao_ai/test_service_principal.py
@@ -28,6 +28,8 @@ from dao_ai.service_principal import (
     build_ownership_map,
     classify_grant_error,
     create,
+    find_service_principal,
+    secret_keys_present,
     default_scope_from_config,
     grant,
     provision,
@@ -1211,3 +1213,169 @@ def test_grant_plan_dry_run_placeholder_principal_emits_no_skip_note() -> None:
     assert lb.note is not None
     assert "does not exist yet" in lb.note
     assert "configured for client_id" not in lb.note
+
+
+# =============================================================================
+# secret existence probe + --overwrite + dry-run plumbing
+# =============================================================================
+
+
+def _ws_with_secrets(scope: str = "sc", keys: tuple[str, ...] = ()) -> MagicMock:
+    """A mock WorkspaceClient whose ``scope`` holds ``keys``."""
+    w = MagicMock()
+    w.secrets.list_secrets.return_value = [MagicMock(**{"key": k}) for k in keys]
+    # ``name`` is a reserved MagicMock constructor kwarg (it names the mock), so
+    # the attribute has to be assigned after construction.
+    scope_obj = MagicMock()
+    scope_obj.name = scope
+    w.secrets.list_scopes.return_value = [scope_obj]
+    return w
+
+
+def test_secret_keys_present_lists_existing_keys() -> None:
+    w = _ws_with_secrets(keys=("CID", "CSEC"))
+    assert secret_keys_present(w, "sc") == frozenset({"CID", "CSEC"})
+    # Never reads a value — list_secrets returns metadata only.
+    w.secrets.get_secret.assert_not_called()
+
+
+def test_secret_keys_present_returns_empty_set_for_absent_scope() -> None:
+    from databricks.sdk.errors import ResourceDoesNotExist
+
+    w = MagicMock()
+    w.secrets.list_secrets.side_effect = ResourceDoesNotExist(
+        "Scope nope does not exist!"
+    )
+    assert secret_keys_present(w, "nope") == frozenset()
+
+
+def test_store_overwrites_by_default() -> None:
+    """Default overwrite=True preserves the original unconditional behaviour."""
+    w = _ws_with_secrets(keys=("CID", "CSEC"))
+    result = store(
+        w,
+        scope="sc",
+        client_id_key="CID",
+        client_secret_key="CSEC",
+        client_id="new-id",
+        client_secret="new-secret",
+    )
+    assert result.written == ["CID", "CSEC"]
+    assert result.skipped == []
+    assert w.secrets.put_secret.call_count == 2
+
+
+def test_store_refuses_existing_keys_without_overwrite() -> None:
+    w = _ws_with_secrets(keys=("CID", "CSEC"))
+    result = store(
+        w,
+        scope="sc",
+        client_id_key="CID",
+        client_secret_key="CSEC",
+        client_id="new-id",
+        client_secret="new-secret",
+        overwrite=False,
+    )
+    assert result.written == []
+    assert result.skipped == ["CID", "CSEC"]
+    w.secrets.put_secret.assert_not_called()
+    # A live credential must not be clobbered, and the scope is left alone.
+    w.secrets.create_scope.assert_not_called()
+
+
+def test_store_writes_absent_keys_without_overwrite() -> None:
+    """Only the keys that already hold a value are protected."""
+    w = _ws_with_secrets(keys=("CID",))
+    result = store(
+        w,
+        scope="sc",
+        client_id_key="CID",
+        client_secret_key="CSEC",
+        client_id="i",
+        client_secret="s",
+        overwrite=False,
+    )
+    assert result.written == ["CSEC"]
+    assert result.skipped == ["CID"]
+
+
+def test_store_dry_run_writes_nothing() -> None:
+    w = _ws_with_secrets(keys=())
+    result = store(
+        w,
+        scope="sc",
+        client_id_key="CID",
+        client_secret_key="CSEC",
+        client_id="i",
+        client_secret="s",
+        dry_run=True,
+    )
+    assert result.written == ["CID", "CSEC"]
+    w.secrets.put_secret.assert_not_called()
+    w.secrets.create_scope.assert_not_called()
+
+
+def test_store_dry_run_reports_whether_scope_exists() -> None:
+    w = _ws_with_secrets(scope="sc", keys=())
+    assert store(
+        w,
+        scope="sc",
+        client_id_key="CID",
+        client_secret_key="CSEC",
+        client_id="i",
+        client_secret="s",
+        dry_run=True,
+    ).scope_existed
+    assert not store(
+        w,
+        scope="other",
+        client_id_key="CID",
+        client_secret_key="CSEC",
+        client_id="i",
+        client_secret="s",
+        dry_run=True,
+    ).scope_existed
+
+
+def test_find_service_principal_mints_nothing() -> None:
+    w = MagicMock()
+    w.service_principals.list.return_value = [
+        MagicMock(**{"display_name": "app-sp", "application_id": PRINCIPAL, "id": "42"})
+    ]
+    found = find_service_principal(w, display_name="app-sp")
+    assert found is not None and found.application_id == PRINCIPAL
+    w.service_principals.create.assert_not_called()
+    w.service_principal_secrets_proxy.create.assert_not_called()
+
+
+def test_find_service_principal_returns_none_when_absent() -> None:
+    w = MagicMock()
+    w.service_principals.list.return_value = []
+    assert find_service_principal(w, display_name="nope") is None
+
+
+def test_create_dry_run_mints_no_secret_for_existing_sp() -> None:
+    """Minting registers a new OAuth secret — itself a mutation. Dry run must not."""
+    w = MagicMock()
+    w.service_principals.list.return_value = [
+        MagicMock(**{"display_name": "app-sp", "application_id": PRINCIPAL, "id": "42"})
+    ]
+    result = create(w, display_name="app-sp", dry_run=True)
+
+    assert result.reused is True
+    assert result.client_id == PRINCIPAL
+    assert result.client_secret is None
+    w.service_principals.create.assert_not_called()
+    w.service_principal_secrets_proxy.create.assert_not_called()
+
+
+def test_create_dry_run_reports_would_create_for_absent_sp() -> None:
+    w = MagicMock()
+    w.service_principals.list.return_value = []
+    result = create(w, display_name="brand-new", dry_run=True)
+
+    assert result.reused is False
+    assert result.client_id == ""  # unknown until actually created
+    assert result.client_secret is None
+    w.service_principals.create.assert_not_called()
+    w.service_principal_secrets_proxy.create.assert_not_called()

--- a/tests/dao_ai/test_service_principal.py
+++ b/tests/dao_ai/test_service_principal.py
@@ -22,7 +22,10 @@ from dao_ai.service_principal import (
     GRANT_FAILURE_ABSENT,
     GRANT_FAILURE_DENIED,
     GRANT_FAILURE_ERROR,
+    SecretRef,
+    ServicePrincipalTarget,
     build_grant_plan,
+    build_ownership_map,
     classify_grant_error,
     create,
     default_scope_from_config,
@@ -30,6 +33,7 @@ from dao_ai.service_principal import (
     provision,
     resolve_principal_from_config,
     resolve_secret_target,
+    resource_owner,
     store,
 )
 
@@ -821,3 +825,177 @@ def test_grant_records_failure_kind_denied() -> None:
 
     catalog_grant = next(g for g in plan.grants if g.securable_type == "catalog")
     assert catalog_grant.failure_kind == GRANT_FAILURE_DENIED
+
+
+# =============================================================================
+# ownership — which declared SP owns which resource
+# =============================================================================
+
+
+def _target(
+    name: str,
+    scope: str = "sc",
+    cid_key: str = "CID",
+    csec_key: str = "CSEC",
+    model: object = None,
+    configured: str | None = None,
+    resolved: str | None = None,
+) -> ServicePrincipalTarget:
+    return ServicePrincipalTarget(
+        name=name,
+        display_name=f"app-{name}",
+        model=model,
+        scope=scope,
+        client_id_key=cid_key,
+        client_secret_key=csec_key,
+        client_id_ref=SecretRef(scope=scope, key=cid_key),
+        client_secret_ref=SecretRef(scope=scope, key=csec_key),
+        configured_client_id=configured,
+        resolved_client_id=resolved,
+    )
+
+
+def test_ownership_matches_resource_by_secret_ref() -> None:
+    """The load-bearing case: same (scope, key) → same owner. No API calls."""
+    schema = _schema()
+    table = TableModel(
+        schema=schema,
+        name="t",
+        client_id=SecretVariableModel(scope="sc", secret="CID"),
+        client_secret=SecretVariableModel(scope="sc", secret="CSEC"),
+    )
+    targets = [_target("memory_sp"), _target("tools_sp", cid_key="T_CID")]
+    assert resource_owner(table, targets) == "memory_sp"
+
+
+def test_ownership_matches_resource_by_shared_service_principal_model() -> None:
+    """A shared YAML anchor re-validates into distinct objects but compares equal."""
+    sp = ServicePrincipalModel(
+        client_id=SecretVariableModel(scope="sc", secret="CID"),
+        client_secret=SecretVariableModel(scope="sc", secret="CSEC"),
+    )
+    schema = _schema()
+    table = TableModel(schema=schema, name="t", service_principal=sp)
+    targets = [_target("tools_sp", cid_key="T_CID"), _target("memory_sp", model=sp)]
+    assert resource_owner(table, targets) == "memory_sp"
+
+
+def test_ownership_matches_resource_by_literal_client_id() -> None:
+    """A literal client_id falls through to value comparison."""
+    schema = _schema()
+    table = TableModel(schema=schema, name="t", client_id=PRINCIPAL, client_secret="s")
+    targets = [_target("memory_sp", resolved=PRINCIPAL)]
+    assert resource_owner(table, targets) == "memory_sp"
+
+
+def test_ownership_treats_resource_without_client_id_as_shared() -> None:
+    table = TableModel(schema=_schema(), name="t")
+    assert resource_owner(table, [_target("memory_sp")]) is None
+
+
+def test_ownership_unmatched_secret_ref_is_shared_without_reading_it(
+    monkeypatch,
+) -> None:
+    """A secret-backed client_id matching no target must NOT be resolved.
+
+    This is the case that actually leaks API calls: the ref lookup misses, and a
+    naive implementation falls through to ``value_of`` — a live, uncached
+    ``get_secret`` — for every unowned resource on every target.
+    """
+
+    def _boom(*args, **kwargs):
+        raise AssertionError(
+            "an unmatched secret-backed client_id must not be resolved"
+        )
+
+    monkeypatch.setattr("dao_ai.config.SecretVariableModel.as_value", _boom)
+    table = TableModel(
+        schema=_schema(),
+        name="t",
+        client_id=SecretVariableModel(scope="other", secret="NOPE"),
+        client_secret=SecretVariableModel(scope="other", secret="NOPE2"),
+    )
+    assert resource_owner(table, [_target("memory_sp")]) is None
+
+
+def test_ownership_secret_ref_match_never_reads_the_secret(monkeypatch) -> None:
+    """Guardrail: value_of() on a secret is a live uncached get_secret call.
+
+    Matching by (scope, key) must not trigger it — otherwise one API call
+    becomes N_resources x N_sps per plan.
+    """
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("ownership matching must not read secret values")
+
+    monkeypatch.setattr("dao_ai.config.SecretVariableModel.as_value", _boom)
+    table = TableModel(
+        schema=_schema(),
+        name="t",
+        client_id=SecretVariableModel(scope="sc", secret="CID"),
+        client_secret=SecretVariableModel(scope="sc", secret="CSEC"),
+    )
+    assert resource_owner(table, [_target("memory_sp")]) == "memory_sp"
+
+
+def test_ownership_matches_fresh_sp_before_client_id_is_resolvable() -> None:
+    """A brand-new SP has no id yet; the secret ref still identifies its resources."""
+    table = TableModel(
+        schema=_schema(),
+        name="t",
+        client_id=SecretVariableModel(scope="sc", secret="CID"),
+        client_secret=SecretVariableModel(scope="sc", secret="CSEC"),
+    )
+    fresh = _target("memory_sp", configured=None, resolved=None)
+    assert resource_owner(table, [fresh]) == "memory_sp"
+
+
+def test_ownership_map_records_only_owned_resources() -> None:
+    from dao_ai.config import ResourcesModel
+
+    schema = _schema()
+    owned = TableModel(
+        schema=schema,
+        name="owned",
+        client_id=SecretVariableModel(scope="sc", secret="CID"),
+        client_secret=SecretVariableModel(scope="sc", secret="CSEC"),
+    )
+    shared = TableModel(schema=schema, name="shared")
+    config = AppConfig(
+        schemas={"s": schema},
+        resources=ResourcesModel(tables={"owned": owned, "shared": shared}),
+    )
+    ownership = build_ownership_map(config, [_target("memory_sp")])
+
+    assert ownership.owner_of("tables", "owned") == "memory_sp"
+    assert ownership.owner_of("tables", "shared") is None
+    # Shared resources are granted to every SP; owned ones only to their owner.
+    assert ownership.owns("tables", "shared", "memory_sp")
+    assert ownership.owns("tables", "shared", "tools_sp")
+    assert ownership.owns("tables", "owned", "memory_sp")
+    assert not ownership.owns("tables", "owned", "tools_sp")
+
+
+def test_ownership_map_covers_databases() -> None:
+    from dao_ai.config import ResourcesModel
+
+    db = _lakebase_db(PRINCIPAL)
+    config = AppConfig(resources=ResourcesModel(databases={"d": db}))
+    ownership = build_ownership_map(config, [_target("memory_sp", resolved=PRINCIPAL)])
+    assert ownership.owner_of("databases", "d") == "memory_sp"
+
+
+def test_ownership_rejects_two_sps_sharing_one_client_id_key() -> None:
+    import pytest
+
+    config = AppConfig()
+    targets = [_target("a"), _target("b")]  # same scope + CID key
+    with pytest.raises(ValueError, match="both read"):
+        build_ownership_map(config, targets)
+
+
+def test_ownership_map_empty_when_no_resources() -> None:
+    ownership = build_ownership_map(AppConfig(), [_target("memory_sp")])
+    assert ownership.owners == {}
+    # Everything is shared when nothing is owned.
+    assert ownership.owns("tables", "anything", "memory_sp")

--- a/tests/dao_ai/test_service_principal.py
+++ b/tests/dao_ai/test_service_principal.py
@@ -19,7 +19,11 @@ from dao_ai.config import (
     WarehouseModel,
 )
 from dao_ai.service_principal import (
+    GRANT_FAILURE_ABSENT,
+    GRANT_FAILURE_DENIED,
+    GRANT_FAILURE_ERROR,
     build_grant_plan,
+    classify_grant_error,
     create,
     default_scope_from_config,
     grant,
@@ -747,3 +751,73 @@ def test_resolve_secret_target_override_wins() -> None:
         config, scope_override="flag-scope"
     )
     assert scope == "flag-scope"  # override wins over config
+
+
+# =============================================================================
+# classify_grant_error — absent vs denied vs error
+# =============================================================================
+
+
+def test_classify_grant_error_absent_from_sdk_not_found() -> None:
+    from databricks.sdk.errors import NotFound
+
+    assert classify_grant_error(NotFound("nope")) == GRANT_FAILURE_ABSENT
+
+
+def test_classify_grant_error_absent_from_resource_does_not_exist() -> None:
+    """``ResourceDoesNotExist`` subclasses ``NotFound`` — same bucket."""
+    from databricks.sdk.errors import ResourceDoesNotExist
+
+    assert classify_grant_error(ResourceDoesNotExist("gone")) == GRANT_FAILURE_ABSENT
+
+
+def test_classify_grant_error_absent_from_catalog_does_not_exist_message() -> None:
+    """The real-world shape: a UC PATCH against a catalog that isn't there."""
+    err = RuntimeError("Catalog 'hardware_store' does not exist.")
+    assert classify_grant_error(err) == GRANT_FAILURE_ABSENT
+
+
+def test_classify_grant_error_denied_from_sdk_permission_denied() -> None:
+    from databricks.sdk.errors import PermissionDenied
+
+    assert classify_grant_error(PermissionDenied("no")) == GRANT_FAILURE_DENIED
+
+
+def test_classify_grant_error_denied_from_not_authorized_message() -> None:
+    """The Lakebase 'Can Manage' shape, which is not an SDK-typed error here."""
+    err = RuntimeError(
+        "The user is not authorized to make the request, please contact the "
+        "workspace admin to assign 'Can Manage' for Database project"
+    )
+    assert classify_grant_error(err) == GRANT_FAILURE_DENIED
+
+
+def test_classify_grant_error_falls_back_to_generic() -> None:
+    assert classify_grant_error(RuntimeError("kaboom")) == GRANT_FAILURE_ERROR
+
+
+def test_grant_records_failure_kind_absent_for_missing_catalog() -> None:
+    """A failed grant carries both the error text and its classification."""
+    from databricks.sdk.errors import NotFound
+
+    w = MagicMock()
+    w.api_client.do.side_effect = NotFound("Catalog 'nope' does not exist.")
+    config = AppConfig(schemas={"s": _schema()})
+    plan = grant(w, principal=PRINCIPAL, config=config, dry_run=False)
+
+    catalog_grant = next(g for g in plan.grants if g.securable_type == "catalog")
+    assert catalog_grant.applied is False
+    assert catalog_grant.failure_kind == GRANT_FAILURE_ABSENT
+    assert "does not exist" in catalog_grant.error
+
+
+def test_grant_records_failure_kind_denied() -> None:
+    from databricks.sdk.errors import PermissionDenied
+
+    w = MagicMock()
+    w.api_client.do.side_effect = PermissionDenied("PERMISSION_DENIED on catalog")
+    config = AppConfig(schemas={"s": _schema()})
+    plan = grant(w, principal=PRINCIPAL, config=config, dry_run=False)
+
+    catalog_grant = next(g for g in plan.grants if g.securable_type == "catalog")
+    assert catalog_grant.failure_kind == GRANT_FAILURE_DENIED

--- a/tests/dao_ai/test_sp_cli.py
+++ b/tests/dao_ai/test_sp_cli.py
@@ -259,6 +259,25 @@ class TestProvisionReporting:
         assert "Not provisioned: memory_sp" in out
         assert "are ready for this config" not in out
 
+    def test_blocked_target_is_not_labelled_created(self, capsys) -> None:
+        """Regression: a blocked target printed "Created service principal".
+
+        Nothing is created when a target is blocked (verified against the live
+        workspace — the SP really was absent), so claiming otherwise is a lie in
+        the one place a user most needs the truth.
+        """
+        from dao_ai.cli import _print_provision_results
+
+        outcome = self._outcome(
+            reused=False, client_id="", blocked_reason="keys held by something else"
+        )
+        outcome.blocked = [("memory_sp", "keys held by something else")]
+        _print_provision_results(outcome, dry_run=False)
+        out = capsys.readouterr().out
+        assert "Created service principal" not in out
+        assert "Reused service principal" not in out
+        assert "✗ BLOCKED" in out
+
     def test_no_store_is_reported(self, capsys) -> None:
         from dao_ai.cli import _print_provision_results
 

--- a/tests/dao_ai/test_sp_cli.py
+++ b/tests/dao_ai/test_sp_cli.py
@@ -1,0 +1,144 @@
+"""Tests for the ``dao-ai service-principal`` CLI reporting.
+
+Focused on ``_print_grants``, which is what a user actually reads after a
+provision/grant run. The regression these guard against: a real run reported
+
+    grants (1 applied, 10 failed):
+      [uc] catalog hardware_store -> USE_CATALOG  ✗ FAILED
+
+ten times, while the underlying errors — already captured on each ``Grant`` —
+were never printed. The true cause was that the catalog did not exist in that
+workspace, but the output (and the log line) pointed at GRANT rights instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dao_ai.cli import _print_grants
+from dao_ai.service_principal import (
+    GRANT_FAILURE_ABSENT,
+    GRANT_FAILURE_DENIED,
+    GRANT_FAILURE_ERROR,
+    Grant,
+    GrantPlan,
+)
+
+PRINCIPAL = "11111111-1111-1111-1111-111111111111"
+
+
+def _plan(*grants: Grant) -> GrantPlan:
+    return GrantPlan(principal=PRINCIPAL, grants=list(grants))
+
+
+def _absent_catalog(name: str = "hardware_store") -> Grant:
+    return Grant(
+        kind="uc",
+        target=name,
+        privileges=["USE_CATALOG"],
+        securable_type="catalog",
+        applied=False,
+        error=f"Catalog '{name}' does not exist.",
+        failure_kind=GRANT_FAILURE_ABSENT,
+    )
+
+
+@pytest.mark.unit
+class TestPrintGrantsFailureReporting:
+    def test_prints_the_error_for_a_failed_grant(self, capsys) -> None:
+        """The whole bug: ``Grant.error`` was recorded but never rendered."""
+        _print_grants(_plan(_absent_catalog()), applied=True)
+        out = capsys.readouterr().out
+        assert "Catalog 'hardware_store' does not exist." in out
+
+    def test_labels_absent_and_denied_differently(self, capsys) -> None:
+        denied = Grant(
+            kind="uc",
+            target="cat.sch.fn",
+            privileges=["EXECUTE"],
+            securable_type="function",
+            applied=False,
+            error="PERMISSION_DENIED: user lacks GRANT",
+            failure_kind=GRANT_FAILURE_DENIED,
+        )
+        _print_grants(_plan(_absent_catalog(), denied), applied=True)
+        out = capsys.readouterr().out
+        assert "⚠ ABSENT" in out
+        assert "✗ DENIED" in out
+
+    def test_generic_failure_still_reads_failed(self, capsys) -> None:
+        boom = Grant(
+            kind="warehouse",
+            target="wh-1",
+            privileges=["CAN_USE"],
+            applied=False,
+            error="kaboom",
+            failure_kind=GRANT_FAILURE_ERROR,
+        )
+        _print_grants(_plan(boom), applied=True)
+        out = capsys.readouterr().out
+        assert "✗ FAILED" in out
+        assert "kaboom" in out
+
+    def test_summary_separates_absent_from_failed(self, capsys) -> None:
+        """An absent target is a config/workspace mismatch, not a failure.
+
+        ``_grant_serving_endpoint`` already no-ops silently on an absent
+        endpoint, so counting an absent catalog as "failed" was inconsistent.
+        """
+        ok = Grant(
+            kind="uc",
+            target="cat.sch",
+            privileges=["USE_SCHEMA"],
+            securable_type="schema",
+            applied=True,
+        )
+        _print_grants(_plan(ok, _absent_catalog()), applied=True)
+        out = capsys.readouterr().out
+        assert "1 applied" in out
+        assert "1 absent" in out
+        assert "failed" not in out.split("\n")[0]
+
+    def test_suggests_a_var_override_when_a_catalog_is_absent(self, capsys) -> None:
+        _print_grants(_plan(_absent_catalog()), applied=True)
+        out = capsys.readouterr().out
+        assert "--var catalog=" in out
+        assert "hardware_store" in out
+
+    def test_absent_hint_points_at_config_not_permissions(self, capsys) -> None:
+        """The old output blamed GRANT rights for a resource that wasn't there."""
+        _print_grants(_plan(_absent_catalog()), applied=True)
+        out = capsys.readouterr().out
+        assert "-p profile" in out or "-p " in out
+        # The absent hint must not send the user auditing ACLs.
+        absent_block = out.split("⚠ ABSENT")[1]
+        assert "GRANT/MANAGE" not in absent_block.split("\n\n")[0]
+
+    def test_dry_run_prints_no_failure_labels(self, capsys) -> None:
+        planned = Grant(
+            kind="uc",
+            target="cat",
+            privileges=["USE_CATALOG"],
+            securable_type="catalog",
+        )
+        _print_grants(_plan(planned), applied=False)
+        out = capsys.readouterr().out
+        assert "dry-run — nothing applied" in out
+        assert "ABSENT" not in out
+        assert "FAILED" not in out
+
+    def test_skip_note_is_still_rendered(self, capsys) -> None:
+        skipped = Grant(
+            kind="lakebase_role",
+            target="my-proj",
+            privileges=["DATABRICKS_SUPERUSER"],
+            note="SKIP: no declared service principal owns this project",
+        )
+        _print_grants(_plan(skipped), applied=True)
+        out = capsys.readouterr().out
+        assert "⚠ SKIP" in out
+        assert "no declared service principal" in out
+
+    def test_empty_plan_reports_nothing_to_grant(self, capsys) -> None:
+        _print_grants(_plan(), applied=True)
+        assert "no grantable resources found" in capsys.readouterr().out

--- a/tests/dao_ai/test_sp_cli.py
+++ b/tests/dao_ai/test_sp_cli.py
@@ -142,3 +142,125 @@ class TestPrintGrantsFailureReporting:
     def test_empty_plan_reports_nothing_to_grant(self, capsys) -> None:
         _print_grants(_plan(), applied=True)
         assert "no grantable resources found" in capsys.readouterr().out
+
+
+@pytest.mark.unit
+class TestSpParsing:
+    def test_provision_accepts_dry_run_overwrite_and_sp(self) -> None:
+        from dao_ai.cli import parse_args
+
+        opts = parse_args(
+            [
+                "sp",
+                "provision",
+                "-c",
+                "c.yaml",
+                "--dry-run",
+                "--overwrite",
+                "--sp",
+                "memory_sp",
+                "--sp",
+                "tools_sp",
+            ]
+        )
+        assert opts.dry_run is True
+        assert opts.overwrite is True
+        assert opts.sp_names == ["memory_sp", "tools_sp"]
+
+    def test_provision_defaults_are_conservative(self) -> None:
+        """Nothing destructive by default: no overwrite, and all SPs."""
+        from dao_ai.cli import parse_args
+
+        opts = parse_args(["sp", "provision", "-c", "c.yaml"])
+        assert opts.dry_run is False
+        assert opts.overwrite is False
+        assert opts.sp_names is None
+
+    def test_grant_accepts_sp_selector(self) -> None:
+        from dao_ai.cli import parse_args
+
+        opts = parse_args(["sp", "grant", "-c", "c.yaml", "--sp", "tools_sp"])
+        assert opts.sp_names == ["tools_sp"]
+
+    def test_store_accepts_overwrite(self) -> None:
+        from dao_ai.cli import parse_args
+
+        opts = parse_args(
+            ["sp", "store", "-c", "c.yaml", "--client-id", "i", "--client-secret", "s"]
+        )
+        assert opts.overwrite is False
+
+
+@pytest.mark.unit
+class TestProvisionReporting:
+    def _outcome(self, **kwargs):
+        from dao_ai.service_principal import MultiProvisionResult, ProvisionResult
+
+        defaults = dict(
+            display_name="app-memory_sp",
+            client_id="cid-1",
+            reused=True,
+            name="memory_sp",
+        )
+        defaults.update(kwargs)
+        return MultiProvisionResult(results=[ProvisionResult(**defaults)])
+
+    def test_dry_run_says_nothing_changed(self, capsys) -> None:
+        from dao_ai.cli import _print_provision_results
+
+        _print_provision_results(self._outcome(), dry_run=True)
+        out = capsys.readouterr().out
+        assert "would REUSE existing" in out
+        assert "nothing was created, written, or granted" in out
+
+    def test_dry_run_flags_a_new_sp_as_would_create(self, capsys) -> None:
+        from dao_ai.cli import _print_provision_results
+
+        _print_provision_results(
+            self._outcome(reused=False, client_id=""), dry_run=True
+        )
+        out = capsys.readouterr().out
+        assert "would CREATE new" in out
+        assert "assigned at creation" in out
+
+    def test_reports_existing_keys_as_not_overwritten(self, capsys) -> None:
+        from dao_ai.cli import _print_provision_results
+        from dao_ai.service_principal import SECRET_KEEP
+
+        outcome = self._outcome(
+            secret_action=SECRET_KEEP,
+            existing_keys=["M_CID", "M_CSEC"],
+            stored_scope="sc",
+        )
+        _print_provision_results(outcome, dry_run=False)
+        out = capsys.readouterr().out
+        assert "already contains a value" in out
+        assert "--overwrite to replace" in out
+
+    def test_blocked_target_is_reported_and_not_claimed_as_ready(self, capsys) -> None:
+        from dao_ai.cli import _print_provision_results
+        from dao_ai.service_principal import MultiProvisionResult, ProvisionResult
+
+        outcome = MultiProvisionResult(
+            results=[
+                ProvisionResult(
+                    display_name="app-memory_sp",
+                    client_id="",
+                    reused=False,
+                    name="memory_sp",
+                    blocked_reason="keys hold a value but no such SP exists",
+                )
+            ],
+            blocked=[("memory_sp", "keys hold a value but no such SP exists")],
+        )
+        _print_provision_results(outcome, dry_run=False)
+        out = capsys.readouterr().out
+        assert "✗ BLOCKED" in out
+        assert "Not provisioned: memory_sp" in out
+        assert "are ready for this config" not in out
+
+    def test_no_store_is_reported(self, capsys) -> None:
+        from dao_ai.cli import _print_provision_results
+
+        _print_provision_results(self._outcome(secret_action=None), dry_run=False)
+        assert "skipped (--no-store)" in capsys.readouterr().out

--- a/uv.lock
+++ b/uv.lock
@@ -958,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "dao-ai"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "argcomplete" },


### PR DESCRIPTION
## Why

`dao-ai sp` exists to give a user one easy way to provision a service principal that is ready to go for a specific config. A real run showed it falling short:

```
dao-ai -p fevm sp provision -c hardware_store_lakebase_test.yaml
  grants (1 applied, 10 failed):
    [uc] catalog hardware_store -> USE_CATALOG  ✗ FAILED
    ... 8 more bare ✗ FAILED ...
    [lakebase_role] retail-consumer-goods -> DATABRICKS_SUPERUSER  ✗ FAILED
```

Two separate bugs, plus a feature gap.

## Bug 1 — Lakebase Postgres role used the wrong identity

`create_lakebase_autoscaling_role` read `database.workspace_client`, which builds an `oauth-m2m` client from the DatabaseModel's own credentials — so the service principal tried to create *its own* Postgres role and the workspace refused (`not authorized ... assign the user <sp> 'Can Manage' for Database project`).

The Postgres control plane (`list_branches` / `list_roles` / `create_role`) needs `Can Manage`, so it now runs as the caller's identity. `postgres_role` still names the SP — that is the role *subject* and was never the problem. **Runtime agent→Lakebase connections are untouched** and still authenticate as the configured SP via `_lakebase_pool_kwargs`.

`create_lakebase_autoscaling` (project creation) had the same bug, which left `DatabaseModel.create(w)` half-honoured: the ambient client it passed was ignored when creating the project and respected when creating the role. Both now use the caller. `DatabaseModel.create()` also defaulted `w` to the SP client, and `pipeline/notebooks/03_provision_lakebase.py` calls it with no argument — so the notebook hit the identical failure. It now defaults to ambient auth.

A try-SP-then-fall-back-to-ambient chain was considered and rejected: for provisioning, ambient is the *more* privileged identity, so the SP attempt fails first on every healthy run, and retrying a partially-applied mutating call risks landing on a half-created project. It also recreates the silent SP→ambient footgun documented at `config.py:498`.

## Bug 2 — failures didn't say why

All nine UC failures above were "that catalog doesn't exist in this workspace" — the config targeted `hardware_store`, which isn't in that workspace. `Grant.error` was being recorded and never printed, and the log said *"verify the calling identity has GRANT rights"* while the user was a workspace admin.

Failures are now classified into `absent` / `denied` / `error`, preferring the SDK's typed exceptions (a UC PATCH against a missing catalog raises `NotFound` with `error_code=CATALOG_DOES_NOT_EXIST`). Absent is counted separately from failed — `_grant_serving_endpoint` already no-ops silently on an absent endpoint, so treating an absent catalog as a hard failure was internally inconsistent.

```
grants (8 applied, 1 absent):
  [uc] function ....find_product_by_sku -> EXECUTE  ⚠ ABSENT
      Routine or Model '...find_product_by_sku' does not exist.
      hint: not found in this workspace — check the config's --var overrides and the -p profile

1 grant(s) targeted a catalog that does not exist here: hardware_store
If the config parameterizes the catalog, point it at a real one, e.g. --var catalog=<existing_catalog>.
```

## Feature — provision every declared service principal

`service_principals` has always been a `dict`, but only the first entry was ever used. Now every declared SP is provisioned and granted **the resources it owns**.

Ownership is resolved by matching a resource's credentials against each SP's secret `(scope, key)` pair — no schema change, and no API calls. That ordering is deliberate: a config's `client_id` variable resolves to whatever is currently in the scope (nothing on a first provision, the *previous* SP's id after a rotation), so comparing resolved values cannot identify a brand-new SP's resources. The `(scope, key)` pair is a property of the config and stable across both, which is what makes single-pass provisioning of a fresh SP possible. Resources matching no SP are shared and granted to all.

Multi-SP is automatic, not opt-in — a config declaring two SPs *is* the statement of intent, and requiring a flag to honour your own config is what produced the original bug. `--sp NAME` narrows.

New flags: `--dry-run`, `--overwrite`, `--sp NAME`.

`--dry-run` suppresses every state-mutating call, including secret **minting** — `create` always mints a fresh OAuth secret, so a naive `--overwrite` that minted and then declined to store would leave a live secret nothing references. Existence is probed before any minting; the reuse path never mints. Defaults stay conservative: a re-run without `--overwrite` rotates nothing, and a populated secret key with no matching SP is *blocked* rather than guessed at.

## Also

- **`provision-service-principal` pipeline task.** There was no SP provisioning in the pipeline at all, yet `03_provision_lakebase` needs the SP's client_id as its Postgres role subject. Wired first, gating `provision-lakebase` and `unity-catalog-tools`. All logic stays in `service_principal.py` and reports via return values, so the CLI and a notebook drive the identical path.
- **`ServicePrincipalModel.name` + `description`.** `name` lets a config bind to an SP that already exists, reusing its stored secrets with no rotation. It also makes an already-written field work — `examples/.../brick_store.yaml:79` has declared `name:` all along and the model silently discarded it.
- **`-c/--config` accepts an http(s) URL**, via a new `AppConfig.from_url`. GitHub `/blob/` links are rewritten to raw content. A remote config has no local directory, so relative `ddl`/`data`/`code_paths` entries now raise immediately rather than resolving against CWD — also a security boundary, since `code_paths` from a remote document would otherwise reach `sys.path`.

## Verification

134 unit tests pass. Two guardrail invariants are mutation-verified — breaking the secret-ref early return or the `targets` lookup fails the corresponding test.

Validated live on FEVM, checking Unity Catalog rather than trusting the report:

- Two SPs provisioned in one command; `tools_sp` has `EXECUTE` on its owned functions and `memory_sp` **does not**; the shared function is granted to **both**
- Authenticated *as* the provisioned SP with its stored credential and read its owned functions — the credential works, not just the grant
- The Postgres role now exists (Bug 1 fixed)
- Dry run left secret timestamps and the SP list untouched
- Re-run without `--overwrite` reused both SPs and rotated nothing; `--overwrite` did rotate
- `03_provision_lakebase` against an already-existing project: `create_project` attempts = 0, no failure
- Both GitHub URL forms load; `databricks bundle validate` passes on the generated bundle

Live testing caught two reporting bugs unit tests missed: a blocked target printed "Created service principal" (the SP genuinely wasn't created — only the label lied), and a grammar error. Both fixed with a regression test.

## Example config

`hardware_store_lakebase.yaml` now declares its service principal. It is the only example with a Lakebase project, so it is where the SP actually matters — the Postgres SUPERUSER role is created for whichever SP owns the `DatabaseModel`. It previously wired the database to bare `client_id`/`client_secret` variables with no `service_principals` block, leaving `sp provision` nothing to name.

`name: dao-ai-sp` is load-bearing there: the `retail_consumer_goods` scope already holds credentials for `dao-ai-sp` (`ad1118d0-…`), which also owns the `retail-consumer-goods` Lakebase project. Without `name` the display name derives to `<app.name>-retail_consumer_goods_sp`, matches nothing, and provisioning correctly refuses rather than rotating a credential a deployed agent is using.

Kept to a single SP: the UC functions stay `on_behalf_of_user`, and every other resource is unchanged. With one target the ownership map is skipped, so this traverses the same code path as before.

## Local dev environment

`make install` was a bare `uv sync --frozen`, installing no optional extras. Validating an example config that uses long-term memory therefore failed with

```
Configuration validation failed: Long-term memory tools requires the 'memory'
extra, which is not installed.
```

which reads like a config problem but is a packaging gap — `langmem` simply was not in the venv. Confirmed pre-existing by validating the config from before this branch's example change: identical error. `SYNC` now passes `--extra all` (a2a, rerank, deepagents, memory, search, excel), since a local environment is expected to run and validate any example.

Side benefit: eight test modules could not previously even be *collected* (`ModuleNotFoundError: No module named 'deepagents'`). 80 previously-unrunnable tests now pass.

Deployment artifacts are unaffected — `dao_ai._extras` still selects the minimal set per config, so the published wheel and generated requirements stay lean. `make check-lock` is clean and the committed lock is untouched.

With this, `dao-ai -p fevm validate -c examples/.../hardware_store_lakebase.yaml` exits 0 and the supervisor graph compiles with all 7 agents, checkpointer and store attached.

## Note on ABSENT in the output above

The `⚠ ABSENT` on `find_product_by_sku` is expected on a first run and is not a config defect — the function is declared with DDL (`unity_catalog_functions`, `ddl: functions/find_product_by_sku.sql`) and is created by `dao-ai workflow up` / the pipeline. It showed as absent only because `sp provision` was run in isolation against a workspace where the pipeline had not yet run.

That ordering is safe: `build_grant_plan` grants `EXECUTE` at the **schema** level (`USE_SCHEMA, SELECT, EXECUTE`), and Unity Catalog schema privileges are inherited by objects created later, so functions the pipeline creates after the SP is provisioned are covered. Verified live — the provisioned SP holds `['EXECUTE', 'SELECT', 'USE_SCHEMA']` on the schema. The per-function grants are belt-and-braces.
