### PR TITLE
fix(vs): don't fail a Delta-Sync recreate that is still making progress

### DIFF
--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -318,6 +318,23 @@ def _warn_if_stale_dev_wheel(dev_wheel: Path | None) -> None:
 # can't hang provisioning indefinitely (the failure mode was a ~2h stall).
 _VS_INDEX_READY_TIMEOUT_SECONDS: int = 1200  # 20 min
 
+# How long a full initial snapshot may run without visible progress before we
+# give up. A recreate re-embeds the entire source table, which for a large table
+# legitimately exceeds the plain readiness timeout above — a 38k-row table was
+# observed taking ~22 min. The bound that matters there is "no rows indexed for
+# this long", not total elapsed, so a big table gets the time it needs while a
+# genuinely stuck index still fails fast.
+_VS_SNAPSHOT_STALL_TIMEOUT_SECONDS: int = 900  # 15 min with no new rows
+
+# Absolute ceiling on an initial snapshot, however much progress it is making.
+_VS_SNAPSHOT_MAX_TIMEOUT_SECONDS: int = 7200  # 2h
+
+# Index states that mean "a full initial snapshot is in flight".
+_VS_SNAPSHOT_STATES: tuple[str, ...] = (
+    "PROVISIONING_INITIAL_SNAPSHOT",
+    "PROVISIONING",
+)
+
 
 def _describe_index_safe(index: VectorSearchIndex) -> dict[str, Any]:
     """``index.describe()`` wrapped so callers never crash on transient errors."""
@@ -454,6 +471,81 @@ def _wait_until_index_absent(
         "Index still present after delete wait — proceeding anyway",
         index_name=index_full_name,
     )
+
+
+def _wait_for_initial_snapshot(
+    index: VectorSearchIndex,
+    index_name: str,
+    *,
+    stall_timeout_seconds: int = _VS_SNAPSHOT_STALL_TIMEOUT_SECONDS,
+    max_timeout_seconds: int = _VS_SNAPSHOT_MAX_TIMEOUT_SECONDS,
+    poll_seconds: int = 15,
+) -> str:
+    """Wait out a full initial snapshot, bounding on *stalled progress* not elapsed.
+
+    A freshly recreated Delta-Sync index re-embeds the whole source table, and for
+    a large table that legitimately runs longer than
+    ``_VS_INDEX_READY_TIMEOUT_SECONDS``. Timing out on total elapsed there fails a
+    task whose recovery is still working — and tells the user to delete and
+    recreate the index, which is exactly what just happened, so following the
+    advice loops.
+
+    Watching ``indexed_row_count`` instead separates the two cases: rising means
+    the snapshot is progressing and deserves more time; flat for
+    ``stall_timeout_seconds`` means it really is stuck.
+
+    Returns:
+        The terminal ``detailed_state`` observed — the caller decides whether it
+        is acceptable.
+    """
+    deadline = time.monotonic() + max_timeout_seconds
+    last_rows = -1
+    last_progress_at = time.monotonic()
+    state = "UNKNOWN"
+
+    while time.monotonic() < deadline:
+        status = _describe_index_safe(index).get("status") or {}
+        state = str(status.get("detailed_state", "UNKNOWN")).upper()
+        rows = int(status.get("indexed_row_count") or 0)
+
+        if not any(s in state for s in _VS_SNAPSHOT_STATES):
+            # Snapshot finished (well or badly) — hand the state back.
+            logger.info(
+                "Initial snapshot settled",
+                index_name=index_name,
+                detailed_state=state,
+                indexed_rows=rows,
+            )
+            return state
+
+        if rows > last_rows:
+            logger.info(
+                "Initial snapshot progressing",
+                index_name=index_name,
+                indexed_rows=rows,
+                detailed_state=state,
+            )
+            last_rows = rows
+            last_progress_at = time.monotonic()
+        elif time.monotonic() - last_progress_at >= stall_timeout_seconds:
+            logger.warning(
+                "Initial snapshot stalled — no new rows indexed",
+                index_name=index_name,
+                indexed_rows=rows,
+                detailed_state=state,
+                stall_timeout_seconds=stall_timeout_seconds,
+            )
+            return state
+
+        time.sleep(poll_seconds)
+
+    logger.warning(
+        "Initial snapshot exceeded its absolute ceiling",
+        index_name=index_name,
+        detailed_state=state,
+        max_timeout_seconds=max_timeout_seconds,
+    )
+    return state
 
 
 def _sync_when_pipeline_idle(
@@ -2933,6 +3025,25 @@ class DatabricksProvider(ServiceProvider):
                     "detailed_state", "UNKNOWN"
                 )
             )
+            # A full initial snapshot re-embeds the entire source table and can
+            # outlast the timeout above while still making progress. Don't fail a
+            # recovery that is working — switch to bounding on stalled progress.
+            if any(s in final_state for s in _VS_SNAPSHOT_STATES):
+                logger.info(
+                    "Readiness timeout hit while an initial snapshot is still "
+                    "progressing — waiting on row progress instead of elapsed time",
+                    index_name=index_name,
+                    detailed_state=final_state,
+                )
+                final_state = _wait_for_initial_snapshot(index, index_name)
+                if "ONLINE" in final_state and "FAILED" not in final_state:
+                    logger.success(
+                        "Vector search index ready after initial snapshot",
+                        index_name=index_name,
+                        source_table=source_table,
+                        detailed_state=final_state,
+                    )
+                    return
             logger.error(
                 "Vector search index failed to reach ONLINE",
                 index_name=index_name,
@@ -2942,12 +3053,16 @@ class DatabricksProvider(ServiceProvider):
                 error=str(exc),
             )
             raise RuntimeError(
-                f"Vector search index {index_name} did not reach ONLINE within "
-                f"{_VS_INDEX_READY_TIMEOUT_SECONDS}s (last state: {final_state}). "
-                f"The source table's Delta history may be unrecoverable from the "
-                f"index checkpoint (e.g. VACUUM / retention exceeded). Delete the "
-                f"index and re-run provisioning: "
-                f"databricks vector-search-indexes delete-index {index_name}"
+                f"Vector search index {index_name} did not reach ONLINE "
+                f"(last state: {final_state}). Provisioning already dropped and "
+                f"recreated the index, so recreating it again will not help. The "
+                f"source table's Delta history is likely unrecoverable — its "
+                f"change data aged out of "
+                f"delta.deletedFileRetentionDuration (default 168h), or the table "
+                f"was replaced. Rewrite {source_table} to give it fresh history, "
+                f"and raise its retention to stop this recurring:\n"
+                f"  ALTER TABLE {source_table} SET TBLPROPERTIES "
+                f"('delta.deletedFileRetentionDuration' = 'interval 30 days');"
             ) from exc
 
         logger.success(

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -3355,3 +3355,173 @@ def test_create_lakebase_role_without_override_still_skips_unset_client_id(monke
 
     w.postgres.create_role.assert_not_called()
     w.postgres.list_roles.assert_not_called()
+
+
+# =============================================================================
+# _wait_for_initial_snapshot — bound on stalled progress, not elapsed time
+# =============================================================================
+
+
+def _snapshot_index(states_and_rows):
+    """A mock index whose describe() walks the given (state, rows) sequence."""
+    idx = Mock()
+    seq = list(states_and_rows)
+
+    def _describe():
+        state, rows = seq[0] if len(seq) == 1 else seq.pop(0)
+        return {"status": {"detailed_state": state, "indexed_row_count": rows}}
+
+    idx.describe.side_effect = _describe
+    return idx
+
+
+@pytest.mark.unit
+def test_snapshot_wait_returns_when_snapshot_completes(monkeypatch):
+    """Rising row counts then ONLINE → return the terminal state."""
+    from dao_ai.providers.databricks import _wait_for_initial_snapshot
+
+    monkeypatch.setattr("dao_ai.providers.databricks.time.sleep", lambda s: None)
+    idx = _snapshot_index(
+        [
+            ("PROVISIONING_INITIAL_SNAPSHOT", 100),
+            ("PROVISIONING_INITIAL_SNAPSHOT", 20000),
+            ("ONLINE_NO_PENDING_UPDATE", 38291),
+        ]
+    )
+    state = _wait_for_initial_snapshot(idx, "cat.sch.idx", poll_seconds=0)
+    assert state == "ONLINE_NO_PENDING_UPDATE"
+
+
+@pytest.mark.unit
+def test_snapshot_wait_keeps_waiting_while_rows_climb(monkeypatch):
+    """A long-but-progressing snapshot is not cut short.
+
+    The regression: a full re-embed outlasted the flat 20-minute readiness
+    timeout, so provisioning failed a recovery that was still working — and told
+    the user to recreate the index, which is what it had just done.
+    """
+    from dao_ai.providers.databricks import _wait_for_initial_snapshot
+
+    # Advance a fake clock on every poll so the stall timer is genuinely live:
+    # 40 polls x 60s = 40 min of wall time, well past both the 20-min readiness
+    # timeout and the 15-min stall window. Only resetting the stall timer on each
+    # row increase keeps this alive to completion.
+    clock = {"t": 0.0}
+    monkeypatch.setattr(
+        "dao_ai.providers.databricks.time.monotonic", lambda: clock["t"]
+    )
+
+    def _advance(_s):
+        clock["t"] += 60.0
+
+    monkeypatch.setattr("dao_ai.providers.databricks.time.sleep", _advance)
+    seq = [("PROVISIONING_INITIAL_SNAPSHOT", n * 1000) for n in range(1, 41)]
+    seq.append(("ONLINE_NO_PENDING_UPDATE", 41000))
+    idx = _snapshot_index(seq)
+    assert (
+        _wait_for_initial_snapshot(
+            idx, "cat.sch.idx", stall_timeout_seconds=900, poll_seconds=1
+        )
+        == "ONLINE_NO_PENDING_UPDATE"
+    )
+
+
+@pytest.mark.unit
+def test_snapshot_wait_polls_past_the_readiness_timeout(monkeypatch):
+    """The behaviour that matters: a snapshot may run longer than the flat
+    20-minute readiness timeout, provided it keeps indexing rows.
+
+    Asserted on wall-clock rather than just the return value, since a loop that
+    bailed early would also return ONLINE — it would simply do so too soon.
+    """
+    from dao_ai.providers.databricks import (
+        _VS_INDEX_READY_TIMEOUT_SECONDS,
+        _wait_for_initial_snapshot,
+    )
+
+    clock = {"t": 0.0}
+    monkeypatch.setattr(
+        "dao_ai.providers.databricks.time.monotonic", lambda: clock["t"]
+    )
+
+    def _advance(_s):
+        clock["t"] += 60.0
+
+    monkeypatch.setattr("dao_ai.providers.databricks.time.sleep", _advance)
+    seq = [("PROVISIONING_INITIAL_SNAPSHOT", n * 1000) for n in range(1, 41)]
+    seq.append(("ONLINE_NO_PENDING_UPDATE", 41000))
+    idx = _snapshot_index(seq)
+
+    state = _wait_for_initial_snapshot(
+        idx, "cat.sch.idx", stall_timeout_seconds=900, poll_seconds=1
+    )
+    assert state == "ONLINE_NO_PENDING_UPDATE"
+    # It stayed in the loop well past the timeout that used to fail the task.
+    assert clock["t"] > _VS_INDEX_READY_TIMEOUT_SECONDS
+
+
+@pytest.mark.unit
+def test_snapshot_wait_gives_up_when_progress_stalls(monkeypatch):
+    """Flat row count for the stall window → return, don't wait forever."""
+    from dao_ai.providers.databricks import _wait_for_initial_snapshot
+
+    clock = {"t": 0.0}
+    monkeypatch.setattr(
+        "dao_ai.providers.databricks.time.monotonic", lambda: clock["t"]
+    )
+
+    def _advance(_s):
+        clock["t"] += 60.0
+
+    monkeypatch.setattr("dao_ai.providers.databricks.time.sleep", _advance)
+    idx = _snapshot_index([("PROVISIONING_INITIAL_SNAPSHOT", 500)])
+    state = _wait_for_initial_snapshot(
+        idx, "cat.sch.idx", stall_timeout_seconds=300, poll_seconds=1
+    )
+    assert state == "PROVISIONING_INITIAL_SNAPSHOT"
+
+
+@pytest.mark.unit
+def test_snapshot_wait_returns_a_failed_state_immediately(monkeypatch):
+    """A snapshot that lands in FAILED is terminal — hand it back to the caller."""
+    from dao_ai.providers.databricks import _wait_for_initial_snapshot
+
+    monkeypatch.setattr("dao_ai.providers.databricks.time.sleep", lambda s: None)
+    idx = _snapshot_index([("ONLINE_PIPELINE_FAILED", 38291)])
+    assert (
+        _wait_for_initial_snapshot(idx, "cat.sch.idx", poll_seconds=0)
+        == "ONLINE_PIPELINE_FAILED"
+    )
+
+
+@pytest.mark.unit
+def test_snapshot_wait_honours_the_absolute_ceiling(monkeypatch):
+    """Even with progress every poll, the hard ceiling still applies."""
+    from dao_ai.providers.databricks import _wait_for_initial_snapshot
+
+    clock = {"t": 0.0}
+    monkeypatch.setattr(
+        "dao_ai.providers.databricks.time.monotonic", lambda: clock["t"]
+    )
+
+    def _advance(_s):
+        clock["t"] += 100.0
+
+    monkeypatch.setattr("dao_ai.providers.databricks.time.sleep", _advance)
+    n = {"rows": 0}
+
+    def _describe():
+        n["rows"] += 1000
+        return {
+            "status": {
+                "detailed_state": "PROVISIONING_INITIAL_SNAPSHOT",
+                "indexed_row_count": n["rows"],
+            }
+        }
+
+    idx = Mock()
+    idx.describe.side_effect = _describe
+    state = _wait_for_initial_snapshot(
+        idx, "cat.sch.idx", max_timeout_seconds=500, poll_seconds=1
+    )
+    assert state == "PROVISIONING_INITIAL_SNAPSHOT"


### PR DESCRIPTION
## Why

Vector-search provisioning can fail a recovery that is actively succeeding, and then advise the exact action it just took — so a user following the advice loops.

Observed on FEVM while running the `hardware_store_lakebase_dao` pipeline. `retail_consumer_goods.hardware_store.products_index` was in `ONLINE_PIPELINE_FAILED`:

```
[DLT ERROR CODE: VECTOR_SEARCH_SOURCE_HISTORY_OUT_OF_RETENTION]
the source table's change history is no longer available (it aged out of
retention, or the table was deleted and recreated)

[DELTA_UNSUPPORTED_TIME_TRAVEL_BEYOND_DELETED_FILE_RETENTION_DURATION]
Cannot time travel beyond delta.deletedFileRetentionDuration (168 HOURS)
```

The index had last processed commit version 82 on 2026-07-28 — 8 days earlier, past the 7-day default retention.

**The existing self-heal worked.** I tested `_index_is_stale` against the live index and it returned `True`, correctly firing detector 1 on `FAILED`; the old sync pipeline no longer exists, confirming a genuine drop-and-recreate.

The problem is what happens next. A recreate re-embeds the **entire** source table, and that full snapshot outran the flat 20-minute `_VS_INDEX_READY_TIMEOUT_SECONDS`. The task failed while the snapshot was still climbing. Polling by hand:

```
00:10:36  PROVISIONING_INITIAL_SNAPSHOT | rows: 32462
00:11:22  PROVISIONING_INITIAL_SNAPSHOT | rows: 36500
00:12:08  ONLINE_NO_PENDING_UPDATE      | rows: 38291   <- 2 min after the task gave up
```

And the raised error said:

> *"Delete the index and re-run provisioning: `databricks vector-search-indexes delete-index …`"*

which is precisely what dao-ai had already done. Following it recreates the index, the snapshot again exceeds 20 minutes, and it fails again.

## What changed

`_wait_for_initial_snapshot` bounds an initial snapshot on **stalled progress** rather than elapsed time. While `indexed_row_count` rises, the snapshot gets more time; flat for 15 minutes (or a 2-hour absolute ceiling) and it gives up. The readiness handler routes into it only when the timeout lands while the index is still in `PROVISIONING_INITIAL_SNAPSHOT`, so:

- a large table gets the time a full re-embed genuinely needs
- a genuinely stuck index still fails fast

The flat `_VS_INDEX_READY_TIMEOUT_SECONDS` is unchanged for every other path — this adds a fallback, it does not loosen the existing bound.

The error message now states that a recreate has already been attempted, so recreating again will not help, and points at the real remedy — rewrite the source table, and raise its retention so it stops recurring — including the `ALTER TABLE` to do it.

## Verification

6 new unit tests. `test_databricks.py` goes from 89 to 95 passing; the 8 failures are pre-existing (`AttributeError: Mock object has no attribute '_source_config_path'`, identical count with these changes stashed). Lint unchanged at baseline (23 findings, all pre-existing).

Worth flagging how the tests got here, since it affects how much to trust them. My first mutation check was a no-op: removing the stall-timer reset leaves the `elif` branch unreachable while rows keep rising, so the test passed against broken code. The tests now assert on elapsed wall-clock — that the loop stays alive past `_VS_INDEX_READY_TIMEOUT_SECONDS` — which **does** fail when progress recognition is disabled, i.e. when the old elapsed-only behaviour is restored:

```
FAILED test_snapshot_wait_keeps_waiting_while_rows_climb
FAILED test_snapshot_wait_polls_past_the_readiness_timeout
```

## Related workspace fix (not in this PR)

The underlying trigger was retention. I raised it on the affected table so this stops recurring:

```sql
ALTER TABLE retail_consumer_goods.hardware_store.products SET TBLPROPERTIES (
  'delta.deletedFileRetentionDuration' = 'interval 30 days',
  'delta.logRetentionDuration'         = 'interval 30 days');
```

At the 7-day default, any gap longer than a week between pipeline runs guarantees this failure. Worth considering whether dao-ai should set a longer retention on the Delta-Sync source tables it provisions — I have not done that here, since it changes storage behaviour for every user's tables and deserves its own discussion.
