### PR TITLE
fix(obo): adapt user API scopes to Model Serving's allowlist

### DIFF
--- a/examples/99_complete_applications/hardware_store/hardware_store_lakebase.yaml
+++ b/examples/99_complete_applications/hardware_store/hardware_store_lakebase.yaml
@@ -176,34 +176,42 @@ resources:
   # FUNCTIONS
   # ---------------------------------------------------------------------------
   # Define Unity Catalog functions for data operations
+  # NOTE: these run as the service principal, not on behalf of the caller.
+  # `on_behalf_of_user: true` works in Databricks Apps but fails at inference
+  # time in Model Serving: UC function execution goes through
+  # DatabricksFunctionClient -> Databricks Connect, which needs the
+  # `databricks-connect` OAuth scope, and that scope is not in Model Serving's
+  # user_api_scopes allowlist (so it cannot even be declared). Keeping these
+  # SP-backed lets the same config deploy and run on both planes. OBO on the
+  # LLMs, vector search and Genie is unaffected — see products_vector_store.
   functions:
     # Product lookup functions
     find_product_by_sku: &find_product_by_sku
       schema: *retail_schema
       name: find_product_by_sku                     # Function to find products by SKU
-      on_behalf_of_user: True
+      on_behalf_of_user: false
     find_product_by_upc: &find_product_by_upc
       schema: *retail_schema
       name: find_product_by_upc                     # Function to find products by UPC
-      on_behalf_of_user: True
+      on_behalf_of_user: false
     # Inventory lookup functions
     find_inventory_by_sku: &find_inventory_by_sku
       schema: *retail_schema
       name: find_inventory_by_sku                   # Function to find inventory by SKU
-      on_behalf_of_user: True
+      on_behalf_of_user: false
     find_inventory_by_upc: &find_inventory_by_upc
       schema: *retail_schema
       name: find_inventory_by_upc                   # Function to find inventory by UPC
-      on_behalf_of_user: True
+      on_behalf_of_user: false
     # Store-specific inventory functions
     find_store_inventory_by_upc: &find_store_inventory_by_upc
       schema: *retail_schema
       name: find_store_inventory_by_upc             # Store-specific UPC inventory lookup
-      on_behalf_of_user: True
+      on_behalf_of_user: false
     find_store_inventory_by_sku: &find_store_inventory_by_sku
       schema: *retail_schema
       name: find_store_inventory_by_sku             # Store-specific SKU inventory lookup
-      on_behalf_of_user: True
+      on_behalf_of_user: false
 
 
 

--- a/src/dao_ai/apps/resources.py
+++ b/src/dao_ai/apps/resources.py
@@ -32,6 +32,7 @@ Usage:
     resources = generate_app_resources(config)
 """
 
+from collections.abc import Iterable
 from typing import Any
 
 from databricks.sdk.service.apps import (
@@ -162,9 +163,24 @@ VALID_USER_API_SCOPES: set[str] = {
 #   - bare ``mcp.*`` strings  (companions are derived from the native scope;
 #                              listing them on a resource is now a no-op)
 API_SCOPE_TO_USER_SCOPES: dict[str, frozenset[str]] = {
-    # SQL family — companion is mcp.functions
+    # SQL family — companion is mcp.functions.
+    #
+    # ``sql.statement-execution`` is what TableModel and FunctionModel declare,
+    # so it also carries the UC read scopes an OBO table/function lookup needs
+    # (``catalog.*:read`` on the Apps platform, translated to the coarser
+    # ``unity-catalog`` for Model Serving by
+    # ``adapt_user_api_scopes_for_model_serving``). Routing them through this map
+    # rather than bolting them on afterwards is what lets them vary by target.
     "sql.warehouses": frozenset({"sql", "mcp.functions"}),
-    "sql.statement-execution": frozenset({"sql", "mcp.functions"}),
+    "sql.statement-execution": frozenset(
+        {
+            "sql",
+            "mcp.functions",
+            "catalog.catalogs:read",
+            "catalog.schemas:read",
+            "catalog.tables:read",
+        }
+    ),
     # Vector Search — companion is mcp.vectorsearch
     "vectorsearch.vector-search-indexes": frozenset(
         {"vector-search", "mcp.vectorsearch"}
@@ -188,6 +204,93 @@ API_SCOPE_TO_USER_SCOPES: dict[str, frozenset[str]] = {
     # Lakebase Postgres — now a first-class OBO scope
     "postgres": frozenset({"postgres"}),
 }
+
+# Model Serving's OBO allowlist, which is NOT the same as the Apps platform's.
+# Verbatim from the platform's own rejection message, so the two can be
+# reconciled by intersection rather than by guesswork:
+#
+#   InvalidParameterValue: Invalid user API scope(s) specified for model: ...
+#   Invalid scopes: catalog.catalogs:read, catalog.schemas:read,
+#   catalog.tables:read. Allowed scopes are: <this set>
+#
+# Model Serving expresses OBO Unity Catalog access as the single coarse
+# ``unity-catalog`` scope rather than the Apps platform's per-securable
+# ``catalog.*:read`` triple.
+MODEL_SERVING_USER_API_SCOPES: frozenset[str] = frozenset(
+    {
+        "sql",
+        "sql.statement-execution",
+        "sql.warehouses",
+        "mcp.genie",
+        "mcp.external",
+        "mcp.sql",
+        "mcp.vectorsearch",
+        "mcp.functions",
+        "catalog.connections",
+        "vector-search",
+        "vectorsearch.vector-search-indexes",
+        "vectorsearch.vector-search-endpoints",
+        "iam.current-user:read",
+        "iam.access-control:read",
+        "dashboards.genie",
+        "genie",
+        "ai-gateway",
+        "unity-catalog",
+        "apps.apps",
+        "apps",
+        "model-serving",
+        "serving.serving-endpoints",
+        "workspace.workspace",
+    }
+)
+
+# Apps scopes with a Model Serving equivalent. The ``catalog.*:read`` triple is
+# how the Apps platform grants OBO reads on UC securables; Model Serving takes
+# ``unity-catalog`` for the same thing. Dropping them without substituting would
+# produce a deploy that succeeds and then fails at inference time when the
+# forwarded user token tries to reach a table or function.
+_MODEL_SERVING_SCOPE_SUBSTITUTIONS: dict[str, str] = {
+    "catalog.catalogs:read": "unity-catalog",
+    "catalog.schemas:read": "unity-catalog",
+    "catalog.tables:read": "unity-catalog",
+}
+
+
+def adapt_user_api_scopes_for_model_serving(scopes: Iterable[str]) -> list[str]:
+    """Translate Apps-platform OBO scopes into the set Model Serving accepts.
+
+    The two planes' allowlists genuinely differ in both directions, so scopes are
+    substituted where an equivalent exists and dropped where none does, rather
+    than passed through and rejected at deploy time.
+
+    Args:
+        scopes: User API scopes as generated for the Apps platform.
+
+    Returns:
+        Sorted scopes valid for a Model Serving ``UserAuthPolicy``.
+    """
+    adapted: set[str] = set()
+    dropped: set[str] = set()
+    for scope in scopes:
+        substitute = _MODEL_SERVING_SCOPE_SUBSTITUTIONS.get(scope)
+        if substitute is not None:
+            adapted.add(substitute)
+        elif scope in MODEL_SERVING_USER_API_SCOPES:
+            adapted.add(scope)
+        else:
+            dropped.add(scope)
+
+    if dropped:
+        logger.warning(
+            "Dropped user API scopes that Model Serving does not accept",
+            dropped=sorted(dropped),
+            note=(
+                "No Model Serving equivalent is known for these. If the deployed "
+                "agent needs the access they represent, add a substitution to "
+                "_MODEL_SERVING_SCOPE_SUBSTITUTIONS."
+            ),
+        )
+    return sorted(adapted)
 
 
 def _extract_llm_resources(
@@ -894,11 +997,12 @@ def generate_user_api_scopes(config: AppConfig) -> list[str]:
             scopes.add("ai-gateway")
             break
 
-    # Always add catalog read scopes if we have any table or function access
-    if any(isinstance(r, (TableModel, FunctionModel)) for r in obo_resources):
-        scopes.add("catalog.catalogs:read")
-        scopes.add("catalog.schemas:read")
-        scopes.add("catalog.tables:read")
+    # NOTE: the catalog read scopes a UC table/function needs are declared by
+    # ``TableModel.api_scopes`` / ``FunctionModel.api_scopes`` and mapped through
+    # API_SCOPE_TO_USER_SCOPES above, like every other resource. They used to be
+    # bolted on here with an isinstance check, which bypassed that map and so
+    # could not vary by deployment target — the cause of Model Serving deploys
+    # failing with "Invalid scopes: catalog.catalogs:read, ...".
 
     # Sort for consistent ordering
     result = sorted(scopes)

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -253,14 +253,23 @@ def build_auth_policy(config: AppConfig) -> AuthPolicy:
 
     # Translate resource-level api_scopes to canonical OBO user scopes — the
     # same translation used by the Databricks Apps path — so the deployed
-    # model's forwarded user token carries the strings the Apps platform
-    # recognizes (e.g. ``sql``, ``genie``, ``files``, ``vector-search``).
-    # Without this, the user token would claim dao-ai's internal
-    # ``sql.warehouses`` / ``dashboards.genie`` strings, which the platform
-    # rejects.
-    from dao_ai.apps.resources import generate_user_api_scopes
+    # model's forwarded user token carries the strings the platform recognizes
+    # (e.g. ``sql``, ``genie``, ``files``, ``vector-search``). Without this, the
+    # user token would claim dao-ai's internal ``sql.warehouses`` /
+    # ``dashboards.genie`` strings, which the platform rejects.
+    #
+    # Then adapt for Model Serving, whose OBO allowlist differs from the Apps
+    # platform's: it takes the single coarse ``unity-catalog`` scope where Apps
+    # takes the per-securable ``catalog.*:read`` triple. Passing the Apps set
+    # through unchanged fails the deploy outright with InvalidParameterValue.
+    from dao_ai.apps.resources import (
+        adapt_user_api_scopes_for_model_serving,
+        generate_user_api_scopes,
+    )
 
-    api_scopes: list[str] = generate_user_api_scopes(config)
+    api_scopes: list[str] = adapt_user_api_scopes_for_model_serving(
+        generate_user_api_scopes(config)
+    )
 
     return AuthPolicy(
         system_auth_policy=SystemAuthPolicy(resources=system_resources),

--- a/tests/dao_ai/test_ms_obo_scope_adaptation.py
+++ b/tests/dao_ai/test_ms_obo_scope_adaptation.py
@@ -1,0 +1,180 @@
+"""Tests for adapting OBO user API scopes to Model Serving's allowlist.
+
+The Apps platform and Model Serving accept *different* OBO scope sets. Apps
+grants UC reads per securable (``catalog.catalogs:read`` / ``.schemas:read`` /
+``.tables:read``); Model Serving takes the single coarse ``unity-catalog``.
+
+Passing the Apps set to Model Serving fails the deploy outright:
+
+    InvalidParameterValue: Invalid user API scope(s) specified for model: ...
+    Invalid scopes: catalog.catalogs:read, catalog.schemas:read,
+    catalog.tables:read
+
+Observed on FEVM deploying hardware_store_lakebase (`--mode ms`), whose UC
+functions are all ``on_behalf_of_user: true``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dao_ai.apps.resources import (
+    API_SCOPE_TO_USER_SCOPES,
+    MODEL_SERVING_USER_API_SCOPES,
+    VALID_USER_API_SCOPES,
+    adapt_user_api_scopes_for_model_serving,
+    generate_user_api_scopes,
+)
+from dao_ai.config import (
+    AgentModel,
+    AppConfig,
+    AppModel,
+    FunctionModel,
+    InferenceEndpointModel,
+    ResourcesModel,
+    SchemaModel,
+    TableModel,
+)
+
+
+def _schema() -> SchemaModel:
+    return SchemaModel(catalog_name="cat", schema_name="sch")
+
+
+def _app() -> AppModel:
+    return AppModel(
+        name="myapp",
+        agents=[
+            AgentModel(
+                name="a",
+                description="d",
+                model=InferenceEndpointModel(name="databricks-gpt-5-4-mini"),
+            )
+        ],
+    )
+
+
+@pytest.mark.unit
+class TestModelServingScopeAdaptation:
+    def test_catalog_read_scopes_become_unity_catalog(self) -> None:
+        """The exact scopes Model Serving rejected, and its accepted equivalent."""
+        adapted = adapt_user_api_scopes_for_model_serving(
+            ["catalog.catalogs:read", "catalog.schemas:read", "catalog.tables:read"]
+        )
+        assert adapted == ["unity-catalog"]
+
+    def test_scopes_valid_on_both_planes_pass_through(self) -> None:
+        scopes = ["sql", "vector-search", "serving.serving-endpoints", "mcp.functions"]
+        assert adapt_user_api_scopes_for_model_serving(scopes) == sorted(scopes)
+
+    def test_unknown_scopes_are_dropped_not_forwarded(self) -> None:
+        """Anything Model Serving would reject must not reach the deploy call."""
+        adapted = adapt_user_api_scopes_for_model_serving(
+            ["sql", "definitely-not-a-real-scope"]
+        )
+        assert adapted == ["sql"]
+
+    def test_output_is_always_within_the_model_serving_allowlist(self) -> None:
+        """Every scope dao-ai can emit for Apps must adapt to something valid."""
+        every_apps_scope = sorted(VALID_USER_API_SCOPES)
+        adapted = adapt_user_api_scopes_for_model_serving(every_apps_scope)
+        assert adapted, "adaptation dropped everything"
+        assert not set(adapted) - MODEL_SERVING_USER_API_SCOPES
+
+    def test_result_is_sorted_and_deduped(self) -> None:
+        adapted = adapt_user_api_scopes_for_model_serving(
+            ["catalog.tables:read", "sql", "catalog.schemas:read", "sql"]
+        )
+        assert adapted == ["sql", "unity-catalog"]
+
+    def test_empty_input_yields_empty_output(self) -> None:
+        assert adapt_user_api_scopes_for_model_serving([]) == []
+
+
+@pytest.mark.unit
+class TestCatalogScopesComeFromTheResourceMap:
+    def test_sql_statement_execution_carries_the_catalog_read_scopes(self) -> None:
+        """They belong to the declared api_scope, not to an isinstance check.
+
+        TableModel and FunctionModel both declare ``sql.statement-execution``, so
+        routing the UC read scopes through this map is what lets them be
+        translated per deployment target.
+        """
+        mapped = API_SCOPE_TO_USER_SCOPES["sql.statement-execution"]
+        assert {
+            "catalog.catalogs:read",
+            "catalog.schemas:read",
+            "catalog.tables:read",
+        } <= mapped
+
+    def test_obo_function_still_emits_catalog_scopes_for_apps(self) -> None:
+        """Backward compatibility: the Apps path is unchanged."""
+        schema = _schema()
+        config = AppConfig(
+            schemas={"s": schema},
+            resources=ResourcesModel(
+                functions={
+                    "f": FunctionModel(
+                        schema=schema, name="find_x", on_behalf_of_user=True
+                    )
+                }
+            ),
+            app=_app(),
+        )
+        scopes = set(generate_user_api_scopes(config))
+        assert "catalog.catalogs:read" in scopes
+        assert "catalog.tables:read" in scopes
+        assert "sql" in scopes
+
+    def test_obo_table_still_emits_catalog_scopes_for_apps(self) -> None:
+        schema = _schema()
+        config = AppConfig(
+            schemas={"s": schema},
+            resources=ResourcesModel(
+                tables={
+                    "t": TableModel(
+                        schema=schema, name="products", on_behalf_of_user=True
+                    )
+                }
+            ),
+            app=_app(),
+        )
+        assert "catalog.tables:read" in set(generate_user_api_scopes(config))
+
+    def test_config_without_obo_emits_no_catalog_scopes(self) -> None:
+        """A non-OBO table needs no user scopes at all — it is SP-backed."""
+        schema = _schema()
+        config = AppConfig(
+            schemas={"s": schema},
+            resources=ResourcesModel(
+                tables={
+                    "t": TableModel(
+                        schema=schema, name="products", on_behalf_of_user=False
+                    )
+                }
+            ),
+            app=_app(),
+        )
+        scopes = set(generate_user_api_scopes(config))
+        assert not {s for s in scopes if s.startswith("catalog.")}
+
+    def test_obo_function_adapts_to_unity_catalog_for_model_serving(self) -> None:
+        """End to end: the failing config's shape now deploys to Model Serving."""
+        schema = _schema()
+        config = AppConfig(
+            schemas={"s": schema},
+            resources=ResourcesModel(
+                functions={
+                    "f": FunctionModel(
+                        schema=schema, name="find_x", on_behalf_of_user=True
+                    )
+                }
+            ),
+            app=_app(),
+        )
+        ms_scopes = adapt_user_api_scopes_for_model_serving(
+            generate_user_api_scopes(config)
+        )
+        assert "unity-catalog" in ms_scopes
+        assert not [s for s in ms_scopes if s.startswith("catalog.")]
+        assert not set(ms_scopes) - MODEL_SERVING_USER_API_SCOPES


### PR DESCRIPTION
## Why

Deploying an OBO config to Model Serving failed outright:

```
InvalidParameterValue: Invalid user API scope(s) specified for model:
retail_consumer_goods.hardware_store.hardware_store_lakebase_dao.
Invalid scopes: catalog.catalogs:read, catalog.schemas:read, catalog.tables:read
```

Observed on FEVM running the `hardware_store_lakebase` pipeline with `--mode ms`: `deploy-agents` failed all three attempts, so `run-evaluation` was skipped and no endpoint existed.

`generate_user_api_scopes` lives under `dao_ai/apps/` and was written for the Apps platform. The Model Serving auth-policy builder (`providers/databricks.py:263`) reused it verbatim — but **the two planes' OBO allowlists genuinely differ, in both directions**:

| Apps-only — Model Serving rejects | Emitted by |
|---|---|
| `catalog.catalogs:read`, `.schemas:read`, `.tables:read` | any OBO `TableModel` / `FunctionModel` |
| `files`, `files.files` | OBO `VolumeModel` |
| `postgres` | OBO `DatabaseModel` (Lakebase) |

Model Serving also accepts eight scopes dao-ai never emits (`unity-catalog`, `mcp.sql`, `sql.statement-execution`, `iam.current-user:read`, …). It expresses OBO Unity Catalog access as the single coarse **`unity-catalog`** rather than the per-securable triple.

**This is broader than it first appears.** A config containing a single OBO **table** — no UC functions at all — also fails the MS deploy today, because `TableModel.api_scopes` returns `sql.statement-execution`, which carries the `catalog.*:read` triple.

## What changed

**1. The UC read scopes now hang off the declared api_scope.** They were previously bolted on after the mapping loop with an `isinstance(r, (TableModel, FunctionModel))` check, which bypassed `API_SCOPE_TO_USER_SCOPES` entirely — and that bypass is precisely why the code could not vary by target. They now map from `sql.statement-execution`, the api_scope `TableModel` and `FunctionModel` actually declare, so the per-target translation becomes possible at all.

**2. `adapt_user_api_scopes_for_model_serving`** substitutes the triple for `unity-catalog` and drops anything MS does not accept. `MODEL_SERVING_USER_API_SCOPES` is transcribed verbatim from the platform's own rejection message, so the sets are reconciled by intersection rather than guesswork.

Substituting rather than merely filtering matters: dropping the catalog scopes alone would give a deploy that succeeds and then fails at *inference* time when the forwarded user token reaches a table — worse than today's clean deploy-time failure.

## Live validation — both planes, same YAML

`dao-ai -p fevm agent up -c examples/.../hardware_store_lakebase.yaml` with and without `--mode ms`.

| | Model Serving | Apps |
|---|---|---|
| Deploy | ✅ SUCCESS *(was FAILED ×3)* | ✅ SUCCEEDED |
| Declared scopes | `unity-catalog` + 5 | `catalog.*:read` ×3 + 5 — **unchanged** |
| Real inference | ✅ trace OK | ✅ HTTP 200 |
| Tool execution | ✅ `[TOOL] retail_consumer_goods__hardware_store__find_pr…` OK | ✅ exact record returned |

Scopes were read from the deployed artifacts, not the logs — MS from the registered model's `MLmodel` (`auth_policy.user_auth_policy.api_scopes`), Apps from `databricks apps get` (`user_api_scopes`). Apps is byte-identical to before; only MS is adapted.

Tool execution is verified against ground truth: both planes returned `Wrap-It MagSnap 12.25 in. L X 3.25 in. W Black Magnetic Tool Holder 1 pk` / `WRAP-IT`, matching `SELECT * FROM find_product_by_sku(ARRAY('00176279'))` run directly on a warehouse — including the UPC, so the UC function really ran rather than the vector index answering.

MS trace `tr-860c8f29451aba9b58bff97f00863528`: state OK, 25 spans, with `handoff_to_product` and the UC function tool span both OK.

## Separate platform limitation found while validating

`on_behalf_of_user: true` on a UC function **works in Apps but not Model Serving**:

```
Apps            HTTP 200, real record
Model Serving   PERMISSION_DENIED: Invalid scope, required scopes: databricks-connect
```

`DatabricksFunctionClient` supports only `serverless` and `local` execution modes; both run `spark.sql(...)` over Databricks Connect, needing the `databricks-connect` scope, which is **not in MS's allowlist** and so cannot be declared. The warehouse path that would avoid Spark was removed upstream — *"no longer supported … This API only functions with a serverless compute resource."* No dao-ai change can fix this.

The example config's six UC functions are therefore flipped to SP-backed, with a comment explaining why, so one config deploys and runs on both planes. OBO stays on the vector store, where it works on both. Workaround for callers who need per-user UC enforcement in MS: `type: sql` tools, which use the Statement Execution API instead of Spark Connect and whose scopes are all MS-valid.

## Tests

11 new tests, including one asserting every scope dao-ai can emit for Apps adapts to something MS accepts. 58 existing OBO/Apps tests pass unchanged, confirming the Apps path is untouched.

Note: 5 tests in `test_apps_obo_partition.py` error at *setup* without a configured Databricks profile (ambient auth for the integration fixtures). They pass with `DATABRICKS_CONFIG_PROFILE` set — 42/42 — and are unrelated to this change.
