### PR TITLE
feat(genie)!: derive tool descriptions from the space, gate example questions

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -243,7 +243,8 @@ agents:
     model: *model_name          # InferenceEndpointModel (serving endpoint) OR a
                                 # GenieAgentModel (Genie Agent as a streaming brain —
                                 # see "Genie Agent as a model" below). A bare Genie
-                                # room anchor is auto-wrapped into a GenieAgentModel.
+                                # room anchor is auto-wrapped into a GenieAgentModel;
+                                # a name-only room cannot be (see that section).
     tools: [*tool_name]
     guardrails: [*guardrail_ref]
     prompt: string | *prompt_ref
@@ -1103,6 +1104,136 @@ See [`examples/99_complete_applications/procurement_supplier_a2a/README.md`](htt
 
 ---
 
+## Genie tool descriptions
+
+The description of a `type: genie` tool is what a supervisor reads to decide
+whether to route a question to *that* Genie space. It is resolved in this order:
+
+1. the tool's own `description`, when set;
+2. the room's `description` — either declared under `resources.genie_rooms` or
+   back-filled from the live Genie space by discovery (see below), which never
+   overwrites a value you declared;
+3. a generic fallback naming the space (`"…chat with tabular data about <space name>"`),
+   or naming nothing if the space has no name.
+
+**Why this matters.** With neither (1) nor (2), every description-less Genie tool
+in a config used to advertise the same subject-free text, so a supervisor with two
+Genie tools had no signal to route on and picked more or less at random. Giving
+each space a `description` — or letting it be discovered — is the fix.
+
+**Example questions.** When the room has `sample_questions` (else the `question`
+of each `example_sqls` pair), up to ten are appended as few-shot routing hints:
+
+```
+Example questions this tool can answer:
+- How many stores are in each state?
+- Which SKUs led revenue last quarter?
+```
+
+SQL bodies are deliberately never included: the description is read by the
+calling LLM for routing, Genie already holds the SQL on its own space, and the
+bodies would cost hundreds of tokens on every LLM call for no routing gain.
+
+**Writing the tool's `description` suppresses the block.** That string is the
+prompt surface, so authoring it means "this is my text, don't editorialize". A
+*room* description keeps the questions: it is resource metadata that the
+questions exist to enrich, and suppressing there would hand the customer who
+documented their space *less* routing signal than one who documented nothing,
+while silently discarding `sample_questions` written into the config.
+
+`include_example_questions` overrides that in either direction — it is tri-state,
+and unset is not the same as `false`:
+
+| tool `description` | `include_example_questions` | base text | example block |
+|---|---|---|---|
+| set | unset (default) | your text | **no** — your string wins |
+| set | `true` | your text | **yes**, if questions exist |
+| set | `false` | your text | no |
+| — | unset (default) | room / discovered / fallback | **yes**, if questions exist |
+| — | `true` | room / discovered / fallback | yes |
+| — | `false` | room / discovered / fallback | no |
+
+`true` is the state the flag exists for: your own wording *and* the auto-appended
+questions.
+
+```yaml
+tools:
+  store_sales_genie:
+    name: store_sales_genie
+    function:
+      type: genie
+      genie_room: *retail_genie
+      description: Store sales, inventory and returns for North America.
+      include_example_questions: true    # keep my wording, append the questions too
+```
+
+The flag is deliberately tri-state rather than a boolean defaulting to true
+because intent has to survive the deploy bake. Model Serving dumps the config
+with `exclude_none=True` into the logged `model_config` and Apps ships rendered
+YAML text, so `model_fields_set` — which is how a plain boolean would tell "unset"
+from "explicitly true" — does not round-trip. A tri-state carries the intent as a
+*value*: unset drops out and re-parses as the default, while `true`/`false` are
+preserved literally, and the tool description comes out byte-identical in local,
+Apps, and Model Serving.
+
+**`preserve_question`** (default `false`) is a separate knob on the same tool. It
+constrains the question sent *to* Genie, not Genie's answer: when Genie is a tool,
+the calling LLM writes the `question` argument, and stronger models rephrase or
+decompose it — quietly dropping a refining qualifier and changing the scope Genie
+answers. Setting it stamps a preserve-exact instruction onto both surfaces the
+model reads (the tool description and the `question` argument annotation), while
+still allowing a genuinely multi-tool request to be split across tools.
+
+```yaml
+      preserve_question: true            # send the user's wording through unedited
+```
+
+**Discovery, and why it is identical in all three runtimes.** A room declared
+with only a `space_id` — the common case, since Genie titles are not unique —
+carries no local text at all. `GenieRoomModel.ensure_resolved()` back-fills
+`name`, `description`, and `sample_questions` from the live space. Each runtime
+gets that same result, by a different route:
+
+| Runtime | How the discovered text reaches the tool |
+|---|---|
+| Local | `ensure_resolved()` runs during `AppConfig.from_file(initialize=True)`. |
+| Model Serving | Discovery runs at deploy time and the resolved config is baked into the logged MLflow `model_config`; the container needs **no** Genie call at model load. |
+| Databricks Apps | Discovery runs at **bundle** time and the three fields are written into the config YAML the bundle ships. |
+
+Apps needs its own bake because the bundle carries the rendered config as *text*,
+not as a resolved object — nothing `ensure_resolved()` produced at deploy time
+would otherwise reach the container. So `dao-ai agent up -m apps` looks each
+distinct `space_id` up once with the deploying identity's credentials and writes
+the result into the emitted YAML. Fields you declared are never overwritten, a
+`${var.…}` space id (one provisioned later in the same run) is skipped, and a
+space that cannot be read leaves its room exactly as written — the deploy is
+never blocked by discovery.
+
+**What each Genie permission level can discover.** The two halves of discovery
+need different grants, which is why the deploy-time bake matters even though the
+container can read *something*:
+
+| Grant | `title` / `description` | `sample_questions` |
+|---|---|---|
+| `CAN_EDIT` | yes | yes (needs the serialized space) |
+| `CAN_RUN` | yes | **no** |
+
+A deployed identity usually holds `CAN_RUN` — that is all an app's Genie resource
+confers. `_get_space_details()` asks for the serialized space (the only source of
+sample questions) and retries without it when that read is denied, so a
+`CAN_RUN`-only identity still recovers the space's own description instead of
+losing everything to one failed call. The questions still come from the bake.
+
+Tool construction itself never calls the Genie API; if discovery was unavailable,
+the fallback text is used rather than an error.
+
+Locally-declared `sample_questions` and `example_sqls` always win over discovered
+ones. Only the question fields are hydrated — the other provisioning inputs
+(`table_sources`, `function_sources`, …) are left alone, unlike
+`GenieRoomModel.refresh()`.
+
+---
+
 ## Genie Agent as a model
 
 The Databricks **Genie Agent Mode API** (`POST /api/2.0/genie/agents/{agent_id}/responses`,
@@ -1139,12 +1270,26 @@ agents:
 ```
 
 **Assignment forms.** `model:` accepts either a bare Genie room (a
-`genie_rooms` anchor or a dict with `agent_id`/`space_id` — auto-wrapped into a
+`genie_rooms` anchor, or a dict carrying any room-only key — `agent_id`/`space_id`
+as well as the provisioning fields `warehouse`, `table_sources`,
+`text_instructions`, `sample_questions`, … — auto-wrapped into a
 `GenieAgentModel` with default `timeout_seconds`) or the explicit
 `{genie_room: <room>, timeout_seconds: <int>}` wrapper. A `{name: <endpoint>}`
-config has no `agent_id`/`space_id` and stays an `InferenceEndpointModel`, so
-there is no ambiguity. A `GenieAgentModel` is **not** a serving endpoint — do
-not place it under `resources.models`.
+config carries no room-only key and stays an `InferenceEndpointModel`. A
+`GenieAgentModel` is **not** a serving endpoint — do not place it under
+`resources.models`.
+
+**One shape stays ambiguous: a name-only room.** `{name: X}` is valid for *both*
+union members, so it cannot be coerced by shape and resolves to an
+`InferenceEndpointModel`. If that name matches a room registered under
+`resources.genie_rooms`, config-load fails with an explanatory error rather than
+letting the agent point at a serving endpoint that does not exist. Use the
+explicit `model: {genie_room: *your_room_anchor}` wrapper, or give the room an
+`agent_id`/`space_id` so it can be assigned bare. Note that a room used as a
+model resolves its id **statically** (`space_id`/`agent_id`, else
+`DATABRICKS_GENIE_SPACE_ID`) — a name is resolved to an id during
+`AppConfig.initialize()`, which is why the room must be registered and shared by
+anchor.
 
 **Room registration (required).** A `GenieAgentModel` is a wrapper, not a
 deploy resource. Its `genie_room` **must** be registered under

--- a/examples/10_agent_integrations/README.md
+++ b/examples/10_agent_integrations/README.md
@@ -78,7 +78,10 @@ specialist" a supervisor can route to. Contrast `type: genie` (the tool), which
 is atomic and returns one `ToolMessage`. Key points:
 
 - **Assignment** — `model: *genie_room_anchor` (bare room auto-wraps) or the
-  explicit `model: {genie_room: *anchor, timeout_seconds: N}` wrapper.
+  explicit `model: {genie_room: *anchor, timeout_seconds: N}` wrapper. A room
+  with only a `name` and no `agent_id`/`space_id` cannot auto-wrap — `{name: X}`
+  is a valid serving-endpoint shape too — so it must use the explicit wrapper;
+  config-load says so rather than silently resolving to an endpoint.
 - **Registration** — the room MUST be under `resources.genie_rooms` (deploy
   grant + OBO scope); config-load fails otherwise.
 - **Multi-turn / OBO** — `GenieAgentMiddleware` caches the Genie

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -5722,11 +5722,24 @@
           "title": "Truncate Results",
           "type": "boolean"
         },
-        "verbatim": {
+        "preserve_question": {
           "default": false,
-          "description": "When true, instruct the calling LLM to pass the user's question to Genie exactly as asked \u2014 no rephrasing, decomposition, or added qualifiers. Shapes the tool description and the question-argument annotation. Default false preserves the existing 'ask simple, clear questions' behavior.",
-          "title": "Verbatim",
+          "description": "When true, instruct the calling LLM to pass the user's question to Genie exactly as asked \u2014 no rephrasing, decomposition, or added qualifiers. Constrains the question sent *to* Genie, not Genie's answer. Shapes the tool description and the question-argument annotation. Default false preserves the existing 'ask simple, clear questions' behavior.",
+          "title": "Preserve Question",
           "type": "boolean"
+        },
+        "include_example_questions": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether the Genie space's example questions are appended to the tool description, giving the supervisor concrete routing signal. Null (default) appends them only when no 'description' is set on this tool \u2014 that string is the prompt surface, so authoring it means 'this is my text'. True appends them even alongside your own description; false never appends them.",
+          "title": "Include Example Questions"
         },
         "lru_cache": {
           "anyOf": [

--- a/src/dao_ai/apps/bundle.py
+++ b/src/dao_ai/apps/bundle.py
@@ -259,6 +259,119 @@ def _retain_only_parameters(rendered_yaml: str, keep: set[str]) -> str:
     return buf.getvalue()
 
 
+def _bake_genie_room_details(rendered_yaml: str) -> str:
+    """Back-fill each Genie room's ``name``/``description``/``sample_questions``
+    from its live space, so the deployed app does not have to discover them.
+
+    Why this is needed for Apps specifically. Those three fields feed the Genie
+    *tool* description, which is how a supervisor tells two Genie tools apart.
+    :meth:`GenieRoomModel.ensure_resolved` back-fills them from the space, and
+    for Model Serving the result is baked into the logged ``model_config``. The
+    Apps bundle instead ships the rendered YAML *text*, so nothing resolved at
+    deploy time reaches the container — and in-container discovery cannot cover
+    for it, because an app's Genie resource grants only ``CAN_RUN`` while
+    reading space details requires ``CAN_EDIT``. Without this bake, a room
+    declared by bare ``space_id`` — the common shape, since Genie titles are not
+    unique — advertises only generic text once deployed.
+
+    Baked values are properties of the *space*, so they are looked up once per
+    distinct ``space_id`` using the deploying identity's credentials. Fields the
+    user declared are never overwritten, and a space that cannot be read is
+    skipped, leaving that room exactly as written.
+
+    Args:
+        rendered_yaml: YAML text after ``${param.NAME}`` substitution.
+
+    Returns:
+        YAML text with the discoverable fields filled in. On any failure the
+        input is returned unchanged so a deploy is never blocked by discovery.
+    """
+    from collections.abc import MutableMapping
+
+    from dao_ai.config import GenieRoomModel
+
+    rt = YAML(typ="rt")
+    rt.preserve_quotes = True
+    rt.width = 4096
+
+    try:
+        data = rt.load(rendered_yaml)
+    except Exception as exc:
+        logger.warning(f"ruamel parse failed; emitting rendered YAML unchanged: {exc}")
+        return rendered_yaml
+
+    # Collect every mapping that names a Genie space. Rooms appear both under
+    # `resources.genie_rooms` and inline under a tool's `genie_room`, and YAML
+    # anchors mean the same node can be reached more than once — dedupe by id().
+    rooms: dict[int, MutableMapping] = {}
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, MutableMapping):
+            if ("space_id" in node or "agent_id" in node) and id(node) not in rooms:
+                rooms[id(node)] = node
+            for value in node.values():
+                _walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item)
+
+    _walk(data)
+    if not rooms:
+        return rendered_yaml
+
+    # One lookup per distinct space, not per room.
+    details: dict[str, GenieRoomModel] = {}
+
+    def _details_for(space_id: str) -> GenieRoomModel | None:
+        if space_id not in details:
+            probe = GenieRoomModel(space_id=space_id)
+            try:
+                probe.ensure_resolved()
+            except Exception as exc:  # noqa: BLE001 - discovery is best-effort
+                logger.debug(f"Could not resolve Genie space {space_id}: {exc}")
+            details[space_id] = probe
+        return details[space_id]
+
+    baked: int = 0
+    for room in rooms.values():
+        space_id = room.get("space_id", room.get("agent_id"))
+        # A deferred `${var.X}` space_id is not resolvable yet (the space is
+        # provisioned later in the same run), and neither is a composite
+        # env/secret reference. Only literal ids are looked up.
+        if not isinstance(space_id, str) or "${" in space_id:
+            continue
+        probe = _details_for(space_id)
+        if probe is None:
+            continue
+        # Insert at the top of the block rather than appending. ruamel attaches
+        # a block's trailing comment to its *last* key, and a bare room's last
+        # key is the space_id we are baking onto — so appending would displace
+        # that comment into the middle of the block.
+        position = 0
+        for field in ("name", "description", "sample_questions"):
+            if room.get(field):
+                continue  # user-declared wins
+            value = getattr(probe, field, None)
+            if not value:
+                continue
+            try:
+                room.insert(position, field, value)
+            except AttributeError:  # plain dict, not a ruamel CommentedMap
+                room[field] = value
+            position += 1
+            baked += 1
+
+    if not baked:
+        return rendered_yaml
+
+    logger.info(
+        f"Baked {baked} discovered Genie room field(s) into the deployed config"
+    )
+    buf = io.StringIO()
+    rt.dump(data, buf)
+    return buf.getvalue()
+
+
 def _convert_single_resource(resource: dict[str, Any]) -> dict[str, Any] | None:
     """Convert a single flat app.yaml resource dict to bundle nested format."""
     resource_type: str = resource.get("type", "")
@@ -849,7 +962,9 @@ def write_bundle(
             # a plain copy if the config wasn't loaded via from_file.
             rendered: str | None = config._rendered_yaml
             if rendered is not None:
-                dest.write_text(_strip_parameters_block(rendered))
+                dest.write_text(
+                    _bake_genie_room_details(_strip_parameters_block(rendered))
+                )
                 logger.info(
                     f"Wrote rendered config as {config_filename} (parameters baked in)"
                 )

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -5,6 +5,7 @@ import re
 import sys
 from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager, contextmanager
+from functools import cache
 from enum import Enum
 from os import PathLike
 from pathlib import Path
@@ -1785,6 +1786,15 @@ _GENIE_SORT_KEY_PRIORITY: tuple[str, ...] = (
 )
 
 
+GENIE_AGENT_DEFAULT_TIMEOUT_SECONDS: int = 300
+"""Default httpx client timeout for the Genie Agent Mode streaming call.
+
+The Databricks server-side response timeout is 90 minutes; this bounds the
+client only. Shared by :meth:`GenieRoomModel.as_chat_model` and the
+:attr:`GenieAgentModel.timeout_seconds` field default so the two cannot drift.
+"""
+
+
 class GenieRoomModel(IsDatabricksResource, ManagedResource):
     """Databricks Genie space configuration for natural-language SQL exploration.
 
@@ -1929,7 +1939,24 @@ class GenieRoomModel(IsDatabricksResource, ManagedResource):
                     space_id=self.space_id,
                     error=str(e),
                 )
-                return None
+                # The serialized payload requires CAN_EDIT, while ``title`` and
+                # ``description`` need only CAN_RUN — the level a deployed
+                # identity typically holds. Retry without it so the tool
+                # description still gets the space's own text; only the sample
+                # questions are lost, and ``_parse_serialized_space`` already
+                # treats an absent payload as "no questions".
+                try:
+                    self._space_details = self.workspace_client.genie.get_space(
+                        space_id=self.space_id
+                    )
+                except Exception as retry_error:
+                    logger.debug(
+                        "Could not fetch Genie space details without the "
+                        "serialized payload either",
+                        space_id=self.space_id,
+                        error=str(retry_error),
+                    )
+                    return None
         return self._space_details
 
     def _resolve_space_id_by_name(self, name: str) -> str:
@@ -2244,8 +2271,15 @@ class GenieRoomModel(IsDatabricksResource, ManagedResource):
                     )
                 else:
                     raise
-        # Populate name and description from space details if missing
-        if self.space_id and (not self.name or not self.description):
+        # Populate name, description and sample questions from space details if
+        # missing. All three feed the Genie *tool* description, which is how a
+        # supervisor tells two Genie tools apart — so back-filling them lets a
+        # bare-``space_id`` room still advertise itself usefully. This also runs
+        # at deploy time, which bakes the values into the logged model_config so
+        # Model Serving needs no Genie call at model load.
+        if self.space_id and (
+            not self.name or not self.description or not self.sample_questions
+        ):
             try:
                 space_details = self._get_space_details()
                 if space_details:
@@ -2253,8 +2287,71 @@ class GenieRoomModel(IsDatabricksResource, ManagedResource):
                         self.name = space_details.title
                     if not self.description and space_details.description:
                         self.description = space_details.description
+                if not self.sample_questions:
+                    # Reads the same cached _space_details, so no extra API call.
+                    discovered: list[str] | None = self._sample_questions_from_payload(
+                        self._parse_serialized_space()
+                    )
+                    if discovered:
+                        self.sample_questions = discovered
             except Exception as e:
                 logger.debug(f"Could not fetch details from Genie space: {e}")
+
+    @property
+    def _agent_id(self) -> str:
+        """Resolve this room's Genie agent/space id, or raise if unset.
+
+        Static-only by design: ``space_id`` (or its ``agent_id`` alias), else
+        the ``DATABRICKS_GENIE_SPACE_ID`` env var. Deliberately does *not* fall
+        back to :meth:`_resolve_space_id_by_name` — that is a live Genie call,
+        and this runs on the chat-model build path, including Model Serving
+        startup where it cannot authenticate.
+        """
+        space_id: AnyVariable = self.space_id or os.environ.get(
+            "DATABRICKS_GENIE_SPACE_ID"
+        )
+        if isinstance(space_id, dict):
+            space_id = CompositeVariableModel(**space_id)
+        resolved: Any = value_of(space_id)
+        if not resolved:
+            raise ValueError(
+                "GenieRoomModel: unable to resolve agent_id. Set space_id (or "
+                "its alias agent_id), or the DATABRICKS_GENIE_SPACE_ID env var."
+            )
+        return str(resolved)
+
+    def chat_model_for_workspace_client(
+        self,
+        workspace_client: WorkspaceClient,
+        *,
+        conversation_id: "str | None" = None,
+        timeout_seconds: int = GENIE_AGENT_DEFAULT_TIMEOUT_SECONDS,
+    ) -> LanguageModelLike:
+        """Build a Genie Agent chat model bound to a specific workspace client.
+
+        Consumed via :class:`GenieAgentModel` by
+        :class:`dao_ai.middleware.genie_agent.GenieAgentMiddleware`, which swaps
+        in a user-scoped client (OBO) and the prior Genie ``conversation_id``
+        per request, in one step.
+        """
+        from dao_ai.genie.agent_chat_model import GenieAgentChatModel
+
+        return GenieAgentChatModel(
+            agent_id=self._agent_id,
+            workspace_client=workspace_client,
+            conversation_id=conversation_id,
+            timeout_seconds=timeout_seconds,
+        )
+
+    def as_chat_model(
+        self,
+        *,
+        timeout_seconds: int = GENIE_AGENT_DEFAULT_TIMEOUT_SECONDS,
+    ) -> LanguageModelLike:
+        """Build the streaming Genie chat model using the ambient/room client."""
+        return self.chat_model_for_workspace_client(
+            self.workspace_client, timeout_seconds=timeout_seconds
+        )
 
     def _build_serialized_space(self) -> dict[str, Any]:
         """Build the ``serialized_space`` JSON payload from this model's fields.
@@ -2505,21 +2602,34 @@ class GenieRoomModel(IsDatabricksResource, ManagedResource):
         self._apply_serialized_space(payload)
         return self
 
+    @staticmethod
+    def _sample_questions_from_payload(payload: dict[str, Any]) -> list[str] | None:
+        """Read ``config.sample_questions`` out of a ``serialized_space`` payload.
+
+        Returns ``None`` when the payload carries no sample-question block, so
+        callers can tell "not present" from "present but empty". Shared by
+        :meth:`_apply_serialized_space` and :meth:`ensure_resolved` so the two
+        cannot drift.
+        """
+        cfg = payload.get("config")
+        if not isinstance(cfg, dict):
+            return None
+        sample = cfg.get("sample_questions")
+        if not isinstance(sample, list):
+            return None
+        questions: list[str | None] = [
+            _unwrap_text(item.get("question")) if isinstance(item, dict) else None
+            for item in sample
+        ]
+        return [q for q in questions if q]
+
     def _apply_serialized_space(self, payload: dict[str, Any]) -> None:
         """Write a parsed ``serialized_space`` payload into the model fields."""
 
         # config.sample_questions
-        cfg = payload.get("config")
-        if isinstance(cfg, dict):
-            sample = cfg.get("sample_questions")
-            if isinstance(sample, list):
-                self.sample_questions = [
-                    _unwrap_text(item.get("question"))
-                    if isinstance(item, dict)
-                    else None
-                    for item in sample
-                ]
-                self.sample_questions = [q for q in self.sample_questions if q]
+        sample_questions = self._sample_questions_from_payload(payload)
+        if sample_questions is not None:
+            self.sample_questions = sample_questions
 
         data_sources = payload.get("data_sources")
         if isinstance(data_sources, dict):
@@ -2888,7 +2998,7 @@ class GenieAgentModel(BaseModel):
         ),
     )
     timeout_seconds: int = Field(
-        default=300,
+        default=GENIE_AGENT_DEFAULT_TIMEOUT_SECONDS,
         description=(
             "httpx client timeout in seconds for the streaming call. The "
             "Databricks server-side response timeout is 90 minutes."
@@ -2898,19 +3008,7 @@ class GenieAgentModel(BaseModel):
     @property
     def _agent_id(self) -> str:
         """Resolve the wrapped room's agent/space id, or raise if unset."""
-        space_id: AnyVariable = self.genie_room.space_id or os.environ.get(
-            "DATABRICKS_GENIE_SPACE_ID"
-        )
-        if isinstance(space_id, dict):
-            space_id = CompositeVariableModel(**space_id)
-        resolved: Any = value_of(space_id)
-        if not resolved:
-            raise ValueError(
-                "GenieAgentModel: unable to resolve agent_id. Set "
-                "genie_room.space_id (or its alias agent_id), or the "
-                "DATABRICKS_GENIE_SPACE_ID env var."
-            )
-        return str(resolved)
+        return self.genie_room._agent_id
 
     @property
     def name(self) -> str:
@@ -2938,20 +3036,18 @@ class GenieAgentModel(BaseModel):
 
         Consumed by :class:`dao_ai.middleware.genie_agent.GenieAgentMiddleware`
         to swap in a user-scoped client (OBO) and the prior Genie
-        ``conversation_id`` per request, in one step.
+        ``conversation_id`` per request, in one step. Delegates to the room,
+        adding only this wrapper's ``timeout_seconds`` override.
         """
-        from dao_ai.genie.agent_chat_model import GenieAgentChatModel
-
-        return GenieAgentChatModel(
-            agent_id=self._agent_id,
-            workspace_client=workspace_client,
+        return self.genie_room.chat_model_for_workspace_client(
+            workspace_client,
             conversation_id=conversation_id,
             timeout_seconds=self.timeout_seconds,
         )
 
     def as_chat_model(self) -> LanguageModelLike:
         """Build the streaming Genie chat model using the ambient/room client."""
-        return self.chat_model_for_workspace_client(self.genie_room.workspace_client)
+        return self.genie_room.as_chat_model(timeout_seconds=self.timeout_seconds)
 
 
 def _unwrap_text(value: Any) -> str | None:
@@ -6619,14 +6715,26 @@ class GenieToolModel(BaseFunctionModel):
         default=False,
         description="Truncate large query results returned by Genie.",
     )
-    verbatim: bool = Field(
+    preserve_question: bool = Field(
         default=False,
         description=(
             "When true, instruct the calling LLM to pass the user's question to "
             "Genie exactly as asked — no rephrasing, decomposition, or added "
-            "qualifiers. Shapes the tool description and the question-argument "
+            "qualifiers. Constrains the question sent *to* Genie, not Genie's "
+            "answer. Shapes the tool description and the question-argument "
             "annotation. Default false preserves the existing 'ask simple, clear "
             "questions' behavior."
+        ),
+    )
+    include_example_questions: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Whether the Genie space's example questions are appended to the tool "
+            "description, giving the supervisor concrete routing signal. Null "
+            "(default) appends them only when no 'description' is set on this "
+            "tool — that string is the prompt surface, so authoring it means "
+            "'this is my text'. True appends them even alongside your own "
+            "description; false never appends them."
         ),
     )
     lru_cache: Optional[GenieLRUCacheParametersModel] = Field(
@@ -6668,7 +6776,8 @@ class GenieToolModel(BaseFunctionModel):
             description=self.description,
             persist_conversation=self.persist_conversation,
             truncate_results=self.truncate_results,
-            verbatim=self.verbatim,
+            preserve_question=self.preserve_question,
+            include_example_questions=self.include_example_questions,
             lru_cache_parameters=self.lru_cache,
             context_aware_cache_parameters=self.context_aware_cache,
             in_memory_context_aware_cache_parameters=self.in_memory_context_aware_cache,
@@ -7757,6 +7866,38 @@ class ResponseFormatModel(BaseModel):
         return isinstance(self.response_schema, str)
 
 
+def _accepted_keys(field_name: str, field: Any) -> set[str]:
+    """Every YAML key that populates ``field`` — its name plus any alias."""
+    keys: set[str] = {field_name}
+    alias: Any = getattr(field, "validation_alias", None)
+    if isinstance(alias, str):
+        keys.add(alias)
+    elif isinstance(alias, AliasChoices):
+        keys.update(choice for choice in alias.choices if isinstance(choice, str))
+    return keys
+
+
+@cache
+def _genie_room_only_keys() -> frozenset[str]:
+    """Keys that can only belong to a ``GenieRoomModel``, never an endpoint.
+
+    Derived from the two models' fields — including each field's accepted
+    aliases, which is what contributes ``agent_id`` (the alias of
+    ``space_id``) — so the set cannot drift as fields are added to either
+    class. Shared keys (``name``, ``description``, ``on_behalf_of_user``, the
+    auth fields) are excluded by construction: they cannot disambiguate.
+    """
+    endpoint_keys: set[str] = set()
+    for field_name, field in InferenceEndpointModel.model_fields.items():
+        endpoint_keys |= _accepted_keys(field_name, field)
+
+    room_keys: set[str] = set()
+    for field_name, field in GenieRoomModel.model_fields.items():
+        room_keys |= _accepted_keys(field_name, field)
+
+    return frozenset(room_keys - endpoint_keys)
+
+
 class AgentModel(BaseModel):
     """
     Configuration model for an agent in the DAO AI framework.
@@ -7908,20 +8049,28 @@ class AgentModel(BaseModel):
         Coercion is by shape, not by smart-union guessing:
 
         * a :class:`GenieRoomModel` instance, or
-        * a dict carrying ``agent_id`` / ``space_id`` but not already the
-          wrapper key ``genie_room`` (and not a serving-endpoint ``name``-only
-          shape),
+        * a dict that is not already the wrapper shape (no ``genie_room`` key)
+          and carries at least one key only a room can have — see
+          :func:`_genie_room_only_keys`, which covers ``space_id``/``agent_id``
+          as well as the provisioning fields (``table_sources``, ``warehouse``,
+          ``text_instructions``, …) that a managed room is declared with,
 
-        is rewritten to ``{"genie_room": value}``. Everything else (notably a
-        ``{"name": ...}`` serving-endpoint config, which has no
-        ``agent_id``/``space_id``) is left untouched for the normal union to
-        resolve. The bare form uses the default ``timeout_seconds``; use the
-        explicit ``{genie_room: ...}`` wrapper to set invocation knobs.
+        is rewritten to ``{"genie_room": value}``. Everything else is left
+        untouched for the normal union to resolve.
+
+        A dict of only *shared* keys (notably ``{"name": ...}``, valid for both
+        classes) stays ambiguous and resolves to ``InferenceEndpointModel``;
+        :meth:`AppConfig._validate_genie_agent_rooms_registered` catches that
+        case by cross-referencing ``resources.genie_rooms``, since shape alone
+        cannot decide it.
+
+        The bare form uses the default ``timeout_seconds``; use the explicit
+        ``{genie_room: ...}`` wrapper to set invocation knobs.
         """
         if isinstance(value, GenieRoomModel):
             return {"genie_room": value}
         if isinstance(value, dict) and "genie_room" not in value:
-            if "agent_id" in value or "space_id" in value:
+            if _genie_room_only_keys() & value.keys():
                 return {"genie_room": value}
         return value
 
@@ -11070,14 +11219,26 @@ class AppConfig(BaseModel):
         written inline with the same id. Rooms whose id cannot be resolved
         statically (name-only, resolved by a live lookup) are skipped — they
         cannot be checked without an API call.
+
+        Also catches the inverse mistake: a name-only room assigned bare to
+        ``model:``. ``{name: X}`` is a valid shape for *both* union members, so
+        :meth:`AgentModel._wrap_bare_genie_room` cannot coerce it and it lands
+        as an ``InferenceEndpointModel`` pointing at a serving endpoint that
+        does not exist — clean at load, a runtime failure later. Here the room
+        registry is visible, so a name that matches a registered room is
+        reported instead.
         """
         registered_ids: set[str] = set()
+        registered_names: set[str] = set()
         if self.resources and self.resources.genie_rooms:
             for room in self.resources.genie_rooms.values():
                 raw_id: Any = room.space_id
                 resolved: Any = value_of(raw_id) if raw_id is not None else None
                 if resolved:
                     registered_ids.add(str(resolved))
+                room_name: Any = value_of(room.name) if room.name is not None else None
+                if room_name:
+                    registered_names.add(str(room_name))
 
         seen: set[int] = set()
 
@@ -11086,6 +11247,25 @@ class AppConfig(BaseModel):
                 return
             seen.add(id(agent))
             model = agent.model
+            if isinstance(model, InferenceEndpointModel):
+                # Only the genuinely ambiguous shape: a bare ``{name: X}``. Any
+                # endpoint-specific key (temperature, max_tokens, …) means the
+                # user meant an endpoint, so leave those alone.
+                if model.model_fields_set == {"name"} and (
+                    str(value_of(model.name)) in registered_names
+                ):
+                    raise ValueError(
+                        f"Agent '{agent.name}' assigns model: "
+                        f"{{name: '{value_of(model.name)}'}}, which matches the "
+                        f"Genie room of that name under resources.genie_rooms — "
+                        f"but a bare {{name: ...}} is indistinguishable from a "
+                        f"serving endpoint, so it resolved to an inference "
+                        f"endpoint and will fail at runtime. Write "
+                        f"'model: {{genie_room: *your_room_anchor}}' to use the "
+                        f"room as a Genie Agent, or give the room an "
+                        f"agent_id/space_id so it can be assigned bare."
+                    )
+                return
             if not isinstance(model, GenieAgentModel):
                 return
             raw_id = model.genie_room.space_id

--- a/src/dao_ai/tools/genie.py
+++ b/src/dao_ai/tools/genie.py
@@ -217,13 +217,26 @@ def _response_to_json_with_cache(
     return json.dumps(data)
 
 
-_DEFAULT_DESCRIPTION: str = dedent("""
-    This tool lets you have a conversation and chat with tabular data about <topic>. You should ask
+_DEFAULT_DESCRIPTION_TEMPLATE: str = dedent("""
+    This tool lets you have a conversation and chat with tabular data{topic}. You should ask
     questions about the data and the tool will try to answer them.
     Please ask simple clear questions that can be answer by sql queries. If you need to do statistics or other forms of testing defer to using another tool.
     Try to ask for aggregations on the data and ask very simple questions.
     Prefer to call this tool multiple times rather than asking a complex question.
     """)
+
+
+def _default_description(topic: str | None) -> str:
+    """Last-resort tool description, naming ``topic`` when one is known.
+
+    Reached only when neither the tool nor the Genie space supplies a
+    description. The topic slot is filled from the space's display name; with
+    no name the clause is dropped entirely rather than left as an unfilled
+    placeholder.
+    """
+    return _DEFAULT_DESCRIPTION_TEMPLATE.format(
+        topic=f" about {topic}" if topic else ""
+    )
 
 _FUNCTION_DOCS: str = """
 
@@ -234,44 +247,114 @@ Returns:
 GenieResponse: A response object containing the conversation ID and result from Genie."""
 
 # Question-argument annotations. The default nudges the model to shape the
-# question; the verbatim variant instructs it to preserve every qualifier and
-# scope statement that belongs to the portion routed to THIS tool — while still
-# allowing a genuinely multi-tool request to be split across tools.
+# question; the preserve variant tells it to pass the user's own wording through
+# untouched for the portion routed to THIS tool — while still allowing a
+# genuinely multi-tool request to be split across tools.
 _QUESTION_ARG_DEFAULT: str = "The question to ask Genie about your data"
-_QUESTION_ARG_VERBATIM: str = (
-    "The user's question for this tool, kept COMPLETE and word-for-word. "
-    "Preserve every qualifier, scope statement, constraint, and clarification "
-    "the user attached to it (e.g. 'include the entire team organization, not "
-    "just direct reports') — do NOT drop, rephrase, or summarize that refining "
-    "context. If the overall request spans multiple tools, you may route each "
-    "part to its tool, but the part sent here must stay verbatim and complete."
+_QUESTION_ARG_PRESERVE: str = (
+    "The user's question for this tool, word-for-word and complete. Keep every "
+    "qualifier, scope, and constraint; do not rephrase, summarize, or trim. If "
+    "the request spans several tools, route each part to its tool but send this "
+    "part unchanged."
 )
 
-# Appended to the tool description when ``verbatim=True`` so the preserve-exact
-# instruction is present on both surfaces the LLM reads at tool-call time.
-_VERBATIM_TOOL_CLAUSE: str = (
-    "IMPORTANT — question handling: send this tool the user's COMPLETE question "
-    "for its topic, preserving every qualifier, scope statement, constraint, and "
-    "clarification exactly as written (e.g. a trailing 'this should include the "
-    "entire team organization, not just direct reports' must be kept, not "
-    "dropped). Do NOT summarize, truncate, or strip refining context. You MAY "
-    "split a request that genuinely spans multiple tools and route each part to "
-    "the appropriate tool — but the portion you pass here must remain verbatim "
-    "and complete, never reduced to a shorter paraphrase."
+# Appended to the tool description when ``preserve_question=True``. Deliberately
+# only a pointer: this clause and the question-argument annotation above land in
+# the *same* serialized tool schema, re-sent on every LLM call for the whole
+# conversation, so restating the full instruction here bought redundancy rather
+# than reinforcement.
+_PRESERVE_QUESTION_TOOL_CLAUSE: str = (
+    "Pass this tool the user's own words for its part of the request — complete "
+    "and unedited (see the `question` argument)."
 )
 
 
-def _build_tool_description(description: str | None, verbatim: bool) -> str:
+_MAX_EXAMPLE_QUESTIONS: int = 10
+
+_EXAMPLE_QUESTIONS_HEADER: str = "Example questions this tool can answer:"
+
+
+def _example_questions(genie_room: GenieRoomModel | None) -> list[str]:
+    """Few-shot example questions to advertise, in preference order.
+
+    Prefers the space's ``sample_questions``, falling back to the *questions*
+    of its trusted ``example_sqls`` pairs. SQL bodies are deliberately never
+    included: this text is read by the calling LLM to decide routing, and Genie
+    already holds the SQL on its own space, so the bodies would cost hundreds
+    of tokens on every LLM call for no routing gain.
+    """
+    if genie_room is None:
+        return []
+
+    candidates: list[Any] = list(genie_room.sample_questions or [])
+    if not candidates:
+        candidates = [
+            getattr(example, "question", None)
+            for example in genie_room.example_sqls or []
+        ]
+
+    questions: list[str] = []
+    for candidate in candidates:
+        if not isinstance(candidate, str):
+            continue
+        question: str = candidate.strip()
+        if question and question not in questions:
+            questions.append(question)
+        if len(questions) == _MAX_EXAMPLE_QUESTIONS:
+            break
+    return questions
+
+
+def _build_tool_description(
+    description: str | None,
+    preserve_question: bool,
+    genie_room: GenieRoomModel | None = None,
+    include_example_questions: bool | None = None,
+) -> str:
     """Assemble the ``@tool`` description string.
 
-    Starts from the caller-supplied ``description`` (or ``_DEFAULT_DESCRIPTION``),
-    appends the verbatim clause when ``verbatim`` is set — even for a
-    user-supplied description, so the flag always takes effect — then the
-    function-args docs. Shared by both tool-builder impls.
+    Base text precedence: the caller-supplied ``description``, else the Genie
+    space's own ``description``, else :func:`_default_description`. Falling back
+    to the space description is what lets a supervisor tell two Genie tools
+    apart — with neither set, every description-less Genie tool in a config
+    advertises byte-identical, subject-free text and routing becomes a coin
+    flip.
+
+    Example questions are appended by default only when no ``description`` was
+    supplied: that string is the prompt surface, so authoring it means "this is
+    my text, don't editorialize", whereas a room/space description is resource
+    metadata that the questions are meant to enrich.
+    ``include_example_questions`` overrides that either way — ``True`` appends
+    them even alongside a hand-written description, ``False`` never appends.
+
+    Then appends the preserve-question clause when ``preserve_question`` is set
+    — even for a user-supplied description, so the flag always takes effect —
+    and finally the function-args docs. Shared by both tool-builder impls.
     """
-    base: str = description if description is not None else _DEFAULT_DESCRIPTION
-    if verbatim:
-        base = base + "\n" + _VERBATIM_TOOL_CLAUSE
+    room_description: str | None = getattr(genie_room, "description", None)
+    base: str = (
+        description
+        if description is not None
+        else room_description or _default_description(getattr(genie_room, "name", None))
+    )
+
+    append_questions: bool = (
+        include_example_questions
+        if include_example_questions is not None
+        else description is None
+    )
+    questions: list[str] = _example_questions(genie_room) if append_questions else []
+    if questions:
+        base = "\n".join(
+            [
+                base.rstrip("\n") + "\n",
+                _EXAMPLE_QUESTIONS_HEADER,
+                *(f"- {q}" for q in questions),
+            ]
+        )
+
+    if preserve_question:
+        base = base + "\n" + _PRESERVE_QUESTION_TOOL_CLAUSE
     return base + _FUNCTION_DOCS
 
 
@@ -302,7 +385,8 @@ def create_genie_tool(
     description: str | None = None,
     persist_conversation: bool = True,
     truncate_results: bool = False,
-    verbatim: bool = False,
+    preserve_question: bool = False,
+    include_example_questions: bool | None = None,
     lru_cache_parameters: GenieLRUCacheParametersModel | dict[str, Any] | None = None,
     context_aware_cache_parameters: (
         GenieContextAwareCacheParametersModel | dict[str, Any] | None
@@ -341,11 +425,15 @@ def create_genie_tool(
         description: Custom tool description. Defaults to a generic prompt.
         persist_conversation: Persist conversation IDs across calls for multi-turn.
         truncate_results: Truncate large query results.
-        verbatim: When ``True``, instruct the calling LLM (via the tool
+        preserve_question: When ``True``, instruct the calling LLM (via the tool
             description and the ``question`` argument annotation) to pass the
             user's question through exactly as asked — no rephrasing,
             decomposition, or added qualifiers. Default ``False`` preserves the
             existing behavior.
+        include_example_questions: Whether the Genie space's example questions
+            are appended to the tool description. ``None`` (default) appends
+            them only when no ``description`` was supplied; ``True`` appends them
+            even alongside a supplied description; ``False`` never appends.
         lru_cache_parameters: LRU cache config for fast exact-match SQL caching.
         context_aware_cache_parameters: PostgreSQL/Lakebase context-aware cache config.
         in_memory_context_aware_cache_parameters: In-memory context-aware cache config.
@@ -376,7 +464,8 @@ def create_genie_tool(
             description=description,
             persist_conversation=persist_conversation,
             truncate_results=truncate_results,
-            verbatim=verbatim,
+            preserve_question=preserve_question,
+            include_example_questions=include_example_questions,
         )
 
     return _create_genie_toolkit_impl(
@@ -385,7 +474,8 @@ def create_genie_tool(
         description=description,
         persist_conversation=persist_conversation,
         truncate_results=truncate_results,
-        verbatim=verbatim,
+        preserve_question=preserve_question,
+        include_example_questions=include_example_questions,
         lru_cache_parameters=lru_cache_parameters,
         context_aware_cache_parameters=context_aware_cache_parameters,
         in_memory_context_aware_cache_parameters=in_memory_context_aware_cache_parameters,
@@ -399,7 +489,8 @@ def create_genie_toolkit(
     description: str | None = None,
     persist_conversation: bool = True,
     truncate_results: bool = False,
-    verbatim: bool = False,
+    preserve_question: bool = False,
+    include_example_questions: bool | None = None,
     lru_cache_parameters: GenieLRUCacheParametersModel | dict[str, Any] | None = None,
     context_aware_cache_parameters: (
         GenieContextAwareCacheParametersModel | dict[str, Any] | None
@@ -421,7 +512,8 @@ def create_genie_toolkit(
         description=description,
         persist_conversation=persist_conversation,
         truncate_results=truncate_results,
-        verbatim=verbatim,
+        preserve_question=preserve_question,
+        include_example_questions=include_example_questions,
         lru_cache_parameters=lru_cache_parameters,
         context_aware_cache_parameters=context_aware_cache_parameters,
         in_memory_context_aware_cache_parameters=in_memory_context_aware_cache_parameters,
@@ -443,7 +535,8 @@ def _create_simple_genie_tool(
     description: str | None,
     persist_conversation: bool,
     truncate_results: bool,
-    verbatim: bool = False,
+    preserve_question: bool = False,
+    include_example_questions: bool | None = None,
 ) -> Callable[..., Command]:
     """Build the uncached single-tool variant (no cache, no feedback tool)."""
     logger.debug(
@@ -451,14 +544,19 @@ def _create_simple_genie_tool(
         genie_room_type=type(genie_room).__name__,
         persist_conversation=persist_conversation,
         name=name,
-        verbatim=verbatim,
+        preserve_question=preserve_question,
+        include_example_questions=include_example_questions,
     )
 
     genie_room_model, space_id_str = _resolve_genie_room(genie_room)
 
     tool_name: str = name if name is not None else "genie_tool"
-    tool_description: str = _build_tool_description(description, verbatim)
-    question_desc: str = _QUESTION_ARG_VERBATIM if verbatim else _QUESTION_ARG_DEFAULT
+    tool_description: str = _build_tool_description(
+        description, preserve_question, genie_room_model, include_example_questions
+    )
+    question_desc: str = (
+        _QUESTION_ARG_PRESERVE if preserve_question else _QUESTION_ARG_DEFAULT
+    )
 
     _cached_genie_service: GenieServiceBase | None = None
 
@@ -549,7 +647,8 @@ def _create_genie_toolkit_impl(
         GenieInMemoryContextAwareCacheParametersModel | dict[str, Any] | None
     ),
     max_consecutive_cache_hits: int | None,
-    verbatim: bool = False,
+    preserve_question: bool = False,
+    include_example_questions: bool | None = None,
 ) -> GenieToolkit:
     """Build the cached toolkit variant (query + feedback, optional cache layers)."""
     logger.debug(
@@ -558,7 +657,8 @@ def _create_genie_toolkit_impl(
         persist_conversation=persist_conversation,
         truncate_results=truncate_results,
         name=name,
-        verbatim=verbatim,
+        preserve_question=preserve_question,
+        include_example_questions=include_example_questions,
         has_lru_cache=lru_cache_parameters is not None,
         has_context_aware_cache=context_aware_cache_parameters is not None,
         has_in_memory_context_aware_cache=in_memory_context_aware_cache_parameters
@@ -582,8 +682,12 @@ def _create_genie_toolkit_impl(
         )
 
     tool_name: str = name if name is not None else "genie_tool"
-    tool_description: str = _build_tool_description(description, verbatim)
-    question_desc: str = _QUESTION_ARG_VERBATIM if verbatim else _QUESTION_ARG_DEFAULT
+    tool_description: str = _build_tool_description(
+        description, preserve_question, genie_room_model, include_example_questions
+    )
+    question_desc: str = (
+        _QUESTION_ARG_PRESERVE if preserve_question else _QUESTION_ARG_DEFAULT
+    )
 
     # ---- Shared service stack (one LRU, one closure) ----
 

--- a/src/dao_ai/tools/genie.py
+++ b/src/dao_ai/tools/genie.py
@@ -238,6 +238,7 @@ def _default_description(topic: str | None) -> str:
         topic=f" about {topic}" if topic else ""
     )
 
+
 _FUNCTION_DOCS: str = """
 
 Args:

--- a/tests/dao_ai/test_config_vars.py
+++ b/tests/dao_ai/test_config_vars.py
@@ -1739,6 +1739,275 @@ def test_strip_parameters_block_handles_top_level_list() -> None:
 
 
 # ---------------------------------------------------------------------------
+# _bake_genie_room_details: back-fill discoverable Genie room fields into the
+# YAML the Apps bundle ships, since that bundle carries text rather than a
+# resolved config and an app's Genie grant is too narrow to discover in-container.
+# ---------------------------------------------------------------------------
+
+# Stand-in for the live spaces. Only ids present here are "readable".
+_FAKE_SPACES: dict[str, dict[str, object]] = {
+    "space-a": {
+        "name": "Orders Space",
+        "description": "Answers questions about retail orders.",
+        "sample_questions": ["How many orders shipped late?", "Revenue by region?"],
+    },
+    "space-b": {"name": "Bare Space"},
+}
+
+
+@pytest.fixture
+def fake_genie_discovery(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Replace live Genie discovery with `_FAKE_SPACES`.
+
+    Patches ``ensure_resolved`` — the seam the baker actually uses — so no
+    workspace client is constructed. Returns the list of looked-up space ids so
+    tests can assert the lookup is deduped per distinct space.
+    """
+    from dao_ai.config import GenieRoomModel
+
+    looked_up: list[str] = []
+
+    def _fake_ensure_resolved(self: GenieRoomModel) -> None:
+        space_id = self.space_id
+        looked_up.append(str(space_id))
+        details = _FAKE_SPACES.get(str(space_id))
+        if details is None:
+            raise ValueError(f"space {space_id} is not readable")
+        for field, value in details.items():
+            setattr(self, field, value)
+
+    monkeypatch.setattr(GenieRoomModel, "ensure_resolved", _fake_ensure_resolved)
+    return looked_up
+
+
+def _assert_additive_only(before: object, after: object, path: str = "") -> None:
+    """Every value present before must survive unchanged; keys may only be added."""
+    if isinstance(before, dict):
+        assert isinstance(after, dict), f"{path}: mapping became {type(after)}"
+        for key, value in before.items():
+            assert key in after, f"{path}.{key} was dropped"
+            _assert_additive_only(value, after[key], f"{path}.{key}")
+    elif isinstance(before, list):
+        assert isinstance(after, list), f"{path}: list became {type(after)}"
+        assert len(before) == len(after), f"{path}: list length changed"
+        for index, value in enumerate(before):
+            _assert_additive_only(value, after[index], f"{path}[{index}]")
+    else:
+        assert before == after, f"{path}: {before!r} became {after!r}"
+
+
+@pytest.mark.unit
+def test_bake_genie_room_fills_discoverable_fields(
+    fake_genie_discovery: list[str],
+) -> None:
+    """A bare `space_id` room — the common shape, since Genie titles are not
+    unique — gains the space's name, description and sample questions."""
+    from dao_ai.apps.bundle import _bake_genie_room_details
+
+    src = dedent(
+        """
+        resources:
+          genie_rooms:
+            orders:
+              space_id: space-a
+        """
+    ).lstrip()
+    room = yaml.safe_load(_bake_genie_room_details(src))["resources"]["genie_rooms"][
+        "orders"
+    ]
+    assert room["name"] == "Orders Space"
+    assert room["description"] == "Answers questions about retail orders."
+    assert room["sample_questions"] == [
+        "How many orders shipped late?",
+        "Revenue by region?",
+    ]
+    assert room["space_id"] == "space-a"
+
+
+@pytest.mark.unit
+def test_bake_genie_room_does_not_overwrite_declared_fields(
+    fake_genie_discovery: list[str],
+) -> None:
+    """What the user wrote always wins; only absent fields are filled in."""
+    from dao_ai.apps.bundle import _bake_genie_room_details
+
+    src = dedent(
+        """
+        resources:
+          genie_rooms:
+            orders:
+              space_id: space-a
+              description: MY-OWN-DESCRIPTION
+        """
+    ).lstrip()
+    room = yaml.safe_load(_bake_genie_room_details(src))["resources"]["genie_rooms"][
+        "orders"
+    ]
+    assert room["description"] == "MY-OWN-DESCRIPTION"
+    # The fields the user left out are still filled in.
+    assert room["name"] == "Orders Space"
+    assert room["sample_questions"]
+
+
+@pytest.mark.unit
+def test_bake_genie_room_bakes_partial_details(
+    fake_genie_discovery: list[str],
+) -> None:
+    """A space that only exposes a title contributes only `name`; the absent
+    fields must not be emitted as empty values."""
+    from dao_ai.apps.bundle import _bake_genie_room_details
+
+    src = "resources:\n  genie_rooms:\n    bare:\n      space_id: space-b\n"
+    room = yaml.safe_load(_bake_genie_room_details(src))["resources"]["genie_rooms"][
+        "bare"
+    ]
+    assert room["name"] == "Bare Space"
+    assert "description" not in room
+    assert "sample_questions" not in room
+
+
+@pytest.mark.unit
+def test_bake_genie_room_honours_agent_id_alias(
+    fake_genie_discovery: list[str],
+) -> None:
+    """`agent_id` is a validation alias for `space_id`, so rooms written that
+    way must be baked too."""
+    from dao_ai.apps.bundle import _bake_genie_room_details
+
+    src = "resources:\n  genie_rooms:\n    orders:\n      agent_id: space-a\n"
+    room = yaml.safe_load(_bake_genie_room_details(src))["resources"]["genie_rooms"][
+        "orders"
+    ]
+    assert room["description"] == "Answers questions about retail orders."
+
+
+@pytest.mark.unit
+def test_bake_genie_room_skips_deferred_space_id(
+    fake_genie_discovery: list[str],
+) -> None:
+    """A `${var.X}` space id names a space that does not exist yet (it is
+    provisioned later in the same run), so it must not be looked up."""
+    from dao_ai.apps.bundle import _bake_genie_room_details
+
+    src = "resources:\n  genie_rooms:\n    later:\n      space_id: ${var.genie_space_id}\n"
+    out = _bake_genie_room_details(src)
+    assert out == src
+    assert fake_genie_discovery == []
+
+
+@pytest.mark.unit
+def test_bake_genie_room_leaves_unreadable_space_untouched(
+    fake_genie_discovery: list[str],
+) -> None:
+    """Discovery is best-effort: a space the deployer cannot read leaves that
+    room exactly as written rather than failing the deploy."""
+    from dao_ai.apps.bundle import _bake_genie_room_details
+
+    src = "resources:\n  genie_rooms:\n    secret:\n      space_id: no-such-space\n"
+    assert _bake_genie_room_details(src) == src
+    assert fake_genie_discovery == ["no-such-space"]
+
+
+@pytest.mark.unit
+def test_bake_genie_room_looks_each_space_up_once(
+    fake_genie_discovery: list[str],
+) -> None:
+    """Baked values are properties of the space, so N rooms on one space cost
+    one lookup — and an anchored room reached twice is still one node."""
+    from dao_ai.apps.bundle import _bake_genie_room_details
+
+    src = dedent(
+        """
+        resources:
+          genie_rooms:
+            orders: &orders
+              space_id: space-a
+            orders_again:
+              space_id: space-a
+        tools:
+          ask_orders:
+            function:
+              type: genie
+              genie_room: *orders
+        """
+    ).lstrip()
+    parsed = yaml.safe_load(_bake_genie_room_details(src))
+    assert fake_genie_discovery == ["space-a"]
+    rooms = parsed["resources"]["genie_rooms"]
+    assert rooms["orders"]["description"] == "Answers questions about retail orders."
+    assert rooms["orders_again"]["description"] == (
+        "Answers questions about retail orders."
+    )
+    # The aliased room and the anchor are the same node, baked once.
+    assert parsed["tools"]["ask_orders"]["function"]["genie_room"] == rooms["orders"]
+
+
+@pytest.mark.unit
+def test_bake_genie_room_no_op_without_genie_rooms(
+    fake_genie_discovery: list[str],
+) -> None:
+    from dao_ai.apps.bundle import _bake_genie_room_details
+
+    src = "app:\n  name: x\nagents:\n  a:\n    name: a\n"
+    assert _bake_genie_room_details(src) == src
+    assert fake_genie_discovery == []
+
+
+@pytest.mark.unit
+def test_bake_genie_room_returns_input_on_parse_error(
+    fake_genie_discovery: list[str],
+) -> None:
+    """Malformed YAML comes back unchanged rather than corrupted."""
+    from dao_ai.apps.bundle import _bake_genie_room_details
+
+    bad = "key: [unclosed\n"
+    assert _bake_genie_room_details(bad) == bad
+
+
+@pytest.mark.unit
+def test_bake_genie_room_preserves_comments_anchors_and_is_additive(
+    fake_genie_discovery: list[str],
+) -> None:
+    """The bake rides on the same round-trip guarantees as the rest of the
+    bundler: anchors, aliases, merge keys and comments survive, and nothing
+    that was already in the document changes."""
+    from dao_ai.apps.bundle import _bake_genie_room_details
+
+    src = dedent(
+        """
+        # top of file
+        schemas:
+          s: &s
+            catalog_name: c
+            schema_name: d
+        resources:
+          genie_rooms:
+            # the orders room
+            orders: &orders
+              space_id: space-a  # trailing comment on the id
+            clothing:
+              <<: *s
+              space_id: space-b
+        tools:
+          ask_orders:
+            function:
+              type: genie
+              genie_room: *orders
+        """
+    ).lstrip()
+    out = _bake_genie_room_details(src)
+
+    assert "# top of file" in out
+    assert "# the orders room" in out
+    assert "# trailing comment on the id" in out
+    assert "&orders" in out
+    assert "*orders" in out
+    assert "<<: *s" in out
+
+    _assert_additive_only(yaml.safe_load(src), yaml.safe_load(out))
+
+
+# ---------------------------------------------------------------------------
 # CLI integration: parse_args + handler call against tmp configs.
 # ---------------------------------------------------------------------------
 

--- a/tests/dao_ai/test_genie.py
+++ b/tests/dao_ai/test_genie.py
@@ -3371,9 +3371,7 @@ class TestLRUPlusContextAwareCacheIntegration:
 SPACE_ID: str = "0" * 32
 
 
-def _description_of(
-    room: GenieRoomModel, **kwargs: object
-) -> str:
+def _description_of(room: GenieRoomModel, **kwargs: object) -> str:
     """Build a Genie tool from ``room`` and return its description."""
     tool = create_genie_tool(genie_room=room, **kwargs)  # type: ignore[arg-type]
     assert isinstance(tool, StructuredTool)

--- a/tests/dao_ai/test_genie.py
+++ b/tests/dao_ai/test_genie.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
 from dao_ai.config import (
     GenieContextAwareCacheParametersModel,
+    GenieExampleSql,
     GenieLRUCacheParametersModel,
     GenieRoomModel,
 )
@@ -197,18 +198,14 @@ def test_create_genie_tool_parameters() -> None:
     # Create tool with defaults (no name or description override)
     tool_default = create_genie_tool(genie_room=genie_room_default)
 
-    # Verify defaults were applied
+    # Verify defaults were applied. With no tool-level description, the room's
+    # own description becomes the tool description.
     assert isinstance(tool_default, StructuredTool)
     assert tool_default.name == "genie_tool"  # Default name from function
-    assert (
-        "This tool lets you have a conversation and chat with tabular data"
-        in tool_default.description
-    )
+    assert "Minimal configuration test" in tool_default.description
     assert "question" in tool_default.args_schema.model_fields
-    assert "ask simple clear questions" in tool_default.description
-    assert (
-        "multiple times rather than asking a complex question"
-        in tool_default.description
+    assert "question (str): The question to ask to ask Genie" in (
+        tool_default.description
     )
 
     # Test 2: Custom parameters
@@ -242,86 +239,110 @@ def _question_arg_description(tool: StructuredTool) -> str:
     return getattr(field, "description", "") or ""
 
 
-def test_create_genie_tool_verbatim_default_off() -> None:
-    """Default (verbatim=False) must not add any verbatim wording — the
+def test_create_genie_tool_preserve_question_default_off() -> None:
+    """Default (preserve_question=False) must not add any preserve wording — the
     tool description and question-arg annotation stay byte-for-byte as before."""
-    from dao_ai.tools.genie import _QUESTION_ARG_VERBATIM, _VERBATIM_TOOL_CLAUSE
+    from dao_ai.tools.genie import (
+        _PRESERVE_QUESTION_TOOL_CLAUSE,
+        _QUESTION_ARG_PRESERVE,
+    )
 
     room = GenieRoomModel(name="Room", space_id="0" * 32)
 
     tool = create_genie_tool(genie_room=room, name="ask_genie")
     assert isinstance(tool, StructuredTool)
-    assert _VERBATIM_TOOL_CLAUSE not in tool.description
-    assert _QUESTION_ARG_VERBATIM not in _question_arg_description(tool)
+    assert _PRESERVE_QUESTION_TOOL_CLAUSE not in tool.description
+    assert _QUESTION_ARG_PRESERVE not in _question_arg_description(tool)
     # The default question-arg wording is preserved.
     assert "The question to ask Genie about your data" == _question_arg_description(
         tool
     )
 
 
-def test_create_genie_tool_verbatim_on_simple_path() -> None:
-    """verbatim=True stamps the preserve-exact instruction onto BOTH the tool
-    description and the question-arg annotation (uncached simple-tool path)."""
-    from dao_ai.tools.genie import _QUESTION_ARG_VERBATIM, _VERBATIM_TOOL_CLAUSE
+def test_create_genie_tool_preserve_question_on_simple_path() -> None:
+    """preserve_question=True stamps the preserve-exact instruction onto BOTH the
+    tool description and the question-arg annotation (uncached simple-tool path)."""
+    from dao_ai.tools.genie import (
+        _PRESERVE_QUESTION_TOOL_CLAUSE,
+        _QUESTION_ARG_PRESERVE,
+    )
 
     room = GenieRoomModel(name="Room", space_id="0" * 32)
 
-    tool = create_genie_tool(genie_room=room, name="ask_genie", verbatim=True)
+    tool = create_genie_tool(genie_room=room, name="ask_genie", preserve_question=True)
     assert isinstance(tool, StructuredTool)
-    assert _VERBATIM_TOOL_CLAUSE in tool.description
-    assert _QUESTION_ARG_VERBATIM == _question_arg_description(tool)
+    assert _PRESERVE_QUESTION_TOOL_CLAUSE in tool.description
+    assert _QUESTION_ARG_PRESERVE == _question_arg_description(tool)
     # Multi-tool routing is still explicitly permitted (not a hard "never split").
-    assert "multiple tools" in tool.description or "spans multiple tools" in (
-        tool.description
-    )
+    # That permission lives on the question annotation, where the model writes the
+    # value; the description clause is only a pointer to it.
+    assert "spans several tools" in _question_arg_description(tool)
 
 
-def test_create_genie_tool_verbatim_on_toolkit_path() -> None:
-    """verbatim=True flows through the toolkit path too (enable_feedback forces
-    toolkit mode). The query tool carries the verbatim wording."""
+def test_create_genie_tool_preserve_question_on_toolkit_path() -> None:
+    """preserve_question=True flows through the toolkit path too (enable_feedback
+    forces toolkit mode). The query tool carries the preserve wording."""
     from dao_ai.tools.genie import (
-        _QUESTION_ARG_VERBATIM,
-        _VERBATIM_TOOL_CLAUSE,
+        _PRESERVE_QUESTION_TOOL_CLAUSE,
+        _QUESTION_ARG_PRESERVE,
         GenieToolkit,
     )
 
     room = GenieRoomModel(name="Room", space_id="0" * 32)
 
     result = create_genie_tool(
-        genie_room=room, name="ask_genie", verbatim=True, enable_feedback=True
+        genie_room=room, name="ask_genie", preserve_question=True, enable_feedback=True
     )
     assert isinstance(result, GenieToolkit)
     query_tool = result.get_tools()[0]
-    assert _VERBATIM_TOOL_CLAUSE in query_tool.description
-    assert _QUESTION_ARG_VERBATIM == _question_arg_description(query_tool)
+    assert _PRESERVE_QUESTION_TOOL_CLAUSE in query_tool.description
+    assert _QUESTION_ARG_PRESERVE == _question_arg_description(query_tool)
 
 
-def test_create_genie_tool_verbatim_appends_to_custom_description() -> None:
-    """A user-supplied description still gets the verbatim clause appended, so
+def test_create_genie_tool_preserve_question_appends_to_custom_description() -> None:
+    """A user-supplied description still gets the preserve clause appended, so
     the flag always takes effect regardless of custom wording."""
-    from dao_ai.tools.genie import _VERBATIM_TOOL_CLAUSE
+    from dao_ai.tools.genie import _PRESERVE_QUESTION_TOOL_CLAUSE
 
     room = GenieRoomModel(name="Room", space_id="0" * 32)
     custom = "Answers questions about GSS indirect procurement spend."
 
     tool = create_genie_tool(
-        genie_room=room, name="ask_genie", description=custom, verbatim=True
+        genie_room=room, name="ask_genie", description=custom, preserve_question=True
     )
     assert custom in tool.description
-    assert _VERBATIM_TOOL_CLAUSE in tool.description
+    assert _PRESERVE_QUESTION_TOOL_CLAUSE in tool.description
 
 
-def test_genie_tool_model_verbatim_field() -> None:
-    """GenieToolModel exposes verbatim (default False) and passes it through."""
+def test_genie_tool_model_preserve_question_field() -> None:
+    """GenieToolModel exposes preserve_question (default False) and passes it on."""
     from dao_ai.config import GenieToolModel
 
     m = GenieToolModel(genie_room=GenieRoomModel(name="Room", space_id="0" * 32))
-    assert m.verbatim is False
+    assert m.preserve_question is False
 
     m_on = GenieToolModel(
-        genie_room=GenieRoomModel(name="Room", space_id="0" * 32), verbatim=True
+        genie_room=GenieRoomModel(name="Room", space_id="0" * 32),
+        preserve_question=True,
     )
-    assert m_on.verbatim is True
+    assert m_on.preserve_question is True
+
+
+def test_genie_tool_model_rejects_legacy_verbatim_key() -> None:
+    """``verbatim`` was renamed with no alias — the old key must not load.
+
+    ``extra="forbid"`` turns a stale config into a load-time error rather than a
+    silently ignored flag.
+    """
+    from pydantic import ValidationError
+
+    from dao_ai.config import GenieToolModel
+
+    with pytest.raises(ValidationError):
+        GenieToolModel(
+            genie_room=GenieRoomModel(name="Room", space_id="0" * 32),
+            verbatim=True,
+        )
 
 
 @pytest.mark.integration
@@ -3335,3 +3356,371 @@ class TestLRUPlusContextAwareCacheIntegration:
 
         assert result.cache_hit is False
         assert mock_genie_service.call_count == 1  # Had to call Genie
+
+
+# ---------------------------------------------------------------------------
+# Tool-description derivation (room description + few-shot example questions)
+# ---------------------------------------------------------------------------
+#
+# A description-less Genie tool used to fall back to a single topic-free
+# constant, so every such tool in a config advertised byte-identical text and a
+# supervisor had no signal to route on. These cover the precedence chain and the
+# example-question block that replaced it.
+
+
+SPACE_ID: str = "0" * 32
+
+
+def _description_of(
+    room: GenieRoomModel, **kwargs: object
+) -> str:
+    """Build a Genie tool from ``room`` and return its description."""
+    tool = create_genie_tool(genie_room=room, **kwargs)  # type: ignore[arg-type]
+    assert isinstance(tool, StructuredTool)
+    return tool.description
+
+
+def test_room_description_used_when_tool_description_omitted() -> None:
+    """Precedence step 2: the space's own description describes the tool."""
+    room = GenieRoomModel(
+        space_id=SPACE_ID,
+        name="Retail Sales",
+        description="Answers questions about store sales, inventory and returns.",
+    )
+    description = _description_of(room)
+    assert "Answers questions about store sales, inventory and returns." in description
+    # The generic fallback is not also glued on.
+    assert "This tool lets you have a conversation" not in description
+
+
+def test_explicit_tool_description_wins_over_room_description() -> None:
+    """Precedence step 1: an explicit description suppresses the room's."""
+    room = GenieRoomModel(
+        space_id=SPACE_ID, name="Retail Sales", description="ROOM TEXT"
+    )
+    description = _description_of(room, description="EXPLICIT TEXT")
+    assert "EXPLICIT TEXT" in description
+    assert "ROOM TEXT" not in description
+
+
+def test_default_description_names_the_room_and_drops_placeholder() -> None:
+    """Precedence step 3 substitutes the room name for the ``<topic>`` slot.
+
+    The literal placeholder must never reach the LLM — it was the reason every
+    description-less Genie tool read identically.
+    """
+    room = GenieRoomModel(space_id=SPACE_ID, name="Retail Sales")
+    description = _description_of(room)
+    assert "<topic>" not in description
+    assert "chat with tabular data about Retail Sales" in description
+
+
+def test_default_description_omits_topic_clause_when_room_unnamed() -> None:
+    """With no name to substitute, the ``about ...`` clause is dropped whole."""
+    room = GenieRoomModel(space_id=SPACE_ID)
+    description = _description_of(room)
+    assert "<topic>" not in description
+    assert "chat with tabular data. You should ask" in description
+
+
+def test_sample_questions_appended_and_sql_never_leaks() -> None:
+    """``sample_questions`` win over ``example_sqls``, and no SQL body appears.
+
+    The description is read by the *calling* LLM for routing; Genie already
+    holds the SQL on its own space, so bodies would cost tokens on every call
+    for no routing gain.
+    """
+    room = GenieRoomModel(
+        space_id=SPACE_ID,
+        description="Retail sales.",
+        sample_questions=["How many stores per state?", "Top 5 SKUs last quarter?"],
+        example_sqls=[
+            GenieExampleSql(
+                question="What is total revenue?",
+                sql="SELECT sum(amount) FROM sales",
+            )
+        ],
+    )
+    description = _description_of(room)
+    assert "Example questions this tool can answer:" in description
+    assert "- How many stores per state?" in description
+    assert "- Top 5 SKUs last quarter?" in description
+    # sample_questions take precedence, and the SQL never appears either way.
+    assert "What is total revenue?" not in description
+    assert "SELECT sum(amount)" not in description
+    assert "FROM sales" not in description
+
+
+def test_example_sql_questions_used_when_no_sample_questions() -> None:
+    """Fallback source: the ``question`` of each example pair, never its ``sql``."""
+    room = GenieRoomModel(
+        space_id=SPACE_ID,
+        description="Retail sales.",
+        example_sqls=[
+            GenieExampleSql(
+                question="What is total revenue?", sql="SELECT sum(amount) FROM sales"
+            ),
+            GenieExampleSql(
+                question="Which store leads?", sql="SELECT store FROM sales LIMIT 1"
+            ),
+        ],
+    )
+    description = _description_of(room)
+    assert "- What is total revenue?" in description
+    assert "- Which store leads?" in description
+    assert "SELECT" not in description
+
+
+def test_example_questions_are_capped_and_deduplicated() -> None:
+    """The block cannot grow unboundedly, and repeats are collapsed."""
+    from dao_ai.tools.genie import _MAX_EXAMPLE_QUESTIONS
+
+    room = GenieRoomModel(
+        space_id=SPACE_ID,
+        description="Retail sales.",
+        sample_questions=["dupe", "dupe", *[f"q{i}" for i in range(20)]],
+    )
+    description = _description_of(room)
+    assert description.count("- dupe") == 1
+    listed = [line for line in description.splitlines() if line.startswith("- ")]
+    assert len(listed) == _MAX_EXAMPLE_QUESTIONS
+
+
+def test_no_question_block_when_room_has_no_questions() -> None:
+    """Regression guard: rooms without questions keep the previous shape."""
+    room = GenieRoomModel(space_id=SPACE_ID, description="Retail sales.")
+    description = _description_of(room)
+    assert "Example questions" not in description
+
+
+def test_two_rooms_yield_distinct_tool_descriptions() -> None:
+    """The reported bug: description-less tools were indistinguishable.
+
+    Two rooms, no tool descriptions — the supervisor must have different text
+    to route on.
+    """
+    sales = GenieRoomModel(
+        space_id="1" * 32,
+        name="Retail Sales",
+        description="Store sales, inventory and returns.",
+    )
+    finance = GenieRoomModel(
+        space_id="2" * 32,
+        name="Finance",
+        description="General ledger, AP/AR and cost centers.",
+    )
+    sales_description = _description_of(sales)
+    finance_description = _description_of(finance)
+
+    assert sales_description != finance_description
+    assert "<topic>" not in sales_description
+    assert "<topic>" not in finance_description
+
+
+def test_description_derivation_reaches_the_toolkit_path() -> None:
+    """Both builders share ``_build_tool_description`` — cover the cached one."""
+    room = GenieRoomModel(
+        space_id=SPACE_ID,
+        description="Store sales, inventory and returns.",
+        sample_questions=["How many stores per state?"],
+    )
+    result = create_genie_tool(genie_room=room, enable_feedback=True)
+    assert isinstance(result, GenieToolkit)
+    query_description = result.get_tools()[0].description
+    assert "Store sales, inventory and returns." in query_description
+    assert "- How many stores per state?" in query_description
+
+
+def test_tool_build_makes_no_genie_api_call() -> None:
+    """Building a tool must never hit the Genie API.
+
+    This is the serving-container guarantee: descriptions are resolved at deploy
+    time and baked into the logged ``model_config``, so tool construction stays
+    offline. A room whose client raises must still produce its description.
+    """
+    room = GenieRoomModel(
+        space_id=SPACE_ID,
+        name="Retail Sales",
+        description="Store sales, inventory and returns.",
+        sample_questions=["How many stores per state?"],
+    )
+    with patch.object(
+        GenieRoomModel,
+        "workspace_client",
+        new_callable=lambda: property(
+            lambda self: (_ for _ in ()).throw(AssertionError("Genie API called"))
+        ),
+    ):
+        description = _description_of(room)
+
+    assert "Store sales, inventory and returns." in description
+    assert "- How many stores per state?" in description
+
+
+# ---------------------------------------------------------------------------
+# Example-question gating (include_example_questions)
+# ---------------------------------------------------------------------------
+#
+# The tool ``description`` is the prompt surface: authoring it means "this is my
+# text, don't editorialize", so the example block is suppressed. A room/space
+# description is resource metadata that the questions are there to enrich, so it
+# keeps them. ``include_example_questions`` overrides that in either direction.
+
+
+def test_explicit_tool_description_suppresses_example_questions() -> None:
+    """Writing the tool description suppresses the block by default."""
+    room = GenieRoomModel(
+        space_id=SPACE_ID,
+        description="ROOM TEXT",
+        sample_questions=["How many stores per state?"],
+    )
+    description = _description_of(room, description="EXPLICIT TEXT")
+    assert "EXPLICIT TEXT" in description
+    assert "Example questions" not in description
+    assert "How many stores per state?" not in description
+
+
+def test_room_description_keeps_example_questions() -> None:
+    """A config-declared room description still gets the questions appended.
+
+    Suppressing here would give the customer who documented their space *less*
+    routing signal than one who documented nothing, and would silently discard
+    ``sample_questions`` written into the config.
+    """
+    room = GenieRoomModel(
+        space_id=SPACE_ID,
+        description="Store sales, inventory and returns.",
+        sample_questions=["How many stores per state?"],
+    )
+    description = _description_of(room)
+    assert "Store sales, inventory and returns." in description
+    assert "- How many stores per state?" in description
+
+
+def test_room_description_with_example_sqls_only_keeps_questions() -> None:
+    """Same rule for the fallback question source, and still no SQL."""
+    room = GenieRoomModel(
+        space_id=SPACE_ID,
+        description="Store sales, inventory and returns.",
+        example_sqls=[
+            GenieExampleSql(
+                question="What is total revenue?", sql="SELECT sum(amount) FROM sales"
+            )
+        ],
+    )
+    description = _description_of(room)
+    assert "- What is total revenue?" in description
+    assert "SELECT" not in description
+
+
+def test_include_example_questions_true_overrides_explicit_description() -> None:
+    """``True`` appends the block even alongside a hand-written description.
+
+    This is the case the tri-state exists for: my own wording *plus* the
+    questions.
+    """
+    room = GenieRoomModel(
+        space_id=SPACE_ID,
+        description="ROOM TEXT",
+        sample_questions=["How many stores per state?"],
+    )
+    description = _description_of(
+        room, description="EXPLICIT TEXT", include_example_questions=True
+    )
+    assert "EXPLICIT TEXT" in description
+    assert "- How many stores per state?" in description
+    assert "ROOM TEXT" not in description
+
+
+def test_include_example_questions_false_suppresses_everywhere() -> None:
+    """``False`` wins over both description sources."""
+    room = GenieRoomModel(
+        space_id=SPACE_ID,
+        description="Store sales, inventory and returns.",
+        sample_questions=["How many stores per state?"],
+    )
+    from_room = _description_of(room, include_example_questions=False)
+    assert "Store sales, inventory and returns." in from_room
+    assert "Example questions" not in from_room
+
+    explicit = _description_of(
+        room, description="EXPLICIT TEXT", include_example_questions=False
+    )
+    assert "Example questions" not in explicit
+
+
+def test_include_example_questions_gating_reaches_the_toolkit_path() -> None:
+    """Both builders share ``_build_tool_description`` — cover the cached one."""
+    room = GenieRoomModel(
+        space_id=SPACE_ID,
+        description="Store sales, inventory and returns.",
+        sample_questions=["How many stores per state?"],
+    )
+    suppressed = create_genie_tool(
+        genie_room=room,
+        description="EXPLICIT TEXT",
+        enable_feedback=True,
+    )
+    assert isinstance(suppressed, GenieToolkit)
+    assert "Example questions" not in suppressed.get_tools()[0].description
+
+    forced = create_genie_tool(
+        genie_room=room,
+        description="EXPLICIT TEXT",
+        include_example_questions=True,
+        enable_feedback=True,
+    )
+    assert isinstance(forced, GenieToolkit)
+    assert "- How many stores per state?" in forced.get_tools()[0].description
+
+
+def test_genie_tool_model_include_example_questions_defaults_to_none() -> None:
+    """The field is tri-state, and ``as_tools()`` carries all three values."""
+    from dao_ai.config import GenieToolModel
+
+    room = GenieRoomModel(
+        space_id=SPACE_ID,
+        description="ROOM TEXT",
+        sample_questions=["How many stores per state?"],
+    )
+
+    unset = GenieToolModel(genie_room=room, description="EXPLICIT TEXT")
+    assert unset.include_example_questions is None
+    assert "Example questions" not in unset.as_tools()[0].description
+
+    forced = GenieToolModel(
+        genie_room=room, description="EXPLICIT TEXT", include_example_questions=True
+    )
+    assert "- How many stores per state?" in forced.as_tools()[0].description
+
+    off = GenieToolModel(genie_room=room, include_example_questions=False)
+    assert "Example questions" not in off.as_tools()[0].description
+
+
+@pytest.mark.parametrize("flag", [None, True, False])
+def test_include_example_questions_survives_the_config_bake(flag: bool | None) -> None:
+    """The tri-state must round-trip through the deploy bake.
+
+    Deploy dumps the config with ``exclude_none=True`` into the logged
+    ``model_config`` (Model Serving) / rendered YAML (Apps), so intent has to
+    travel as a *value*: ``None`` drops out and re-parses as the default, while
+    ``True``/``False`` are preserved. (``model_fields_set`` would not survive,
+    which is why the field is tri-state rather than a bool defaulting to true.)
+    """
+    from dao_ai.config import GenieToolModel
+
+    room = GenieRoomModel(
+        space_id=SPACE_ID,
+        description="ROOM TEXT",
+        sample_questions=["How many stores per state?"],
+    )
+    model = GenieToolModel(
+        genie_room=room,
+        description="EXPLICIT TEXT",
+        include_example_questions=flag,
+    )
+    baked = model.model_dump(mode="json", by_alias=True, exclude_none=True)
+    rebuilt = GenieToolModel(**baked)
+
+    assert rebuilt.include_example_questions == flag
+    assert rebuilt.as_tools()[0].description == model.as_tools()[0].description

--- a/tests/dao_ai/test_genie_agent_model.py
+++ b/tests/dao_ai/test_genie_agent_model.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import asyncio
 import json
 from typing import Any, Iterable
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -503,4 +503,218 @@ class TestGenieRoomRegistrationValidator:
             }
         }
         # A non-Genie model is never subject to the genie_rooms check.
+        AppConfig(**cfg)
+
+
+# ---------------------------------------------------------------------------
+# Bare-room coercion: shape test breadth
+# ---------------------------------------------------------------------------
+
+
+class TestBareRoomCoercion:
+    """``AgentModel.model`` coerces a bare Genie room into a ``GenieAgentModel``.
+
+    The coercion is by *shape*: a dict carrying any key only a room can have.
+    Testing ``space_id``/``agent_id`` alone is not enough — a managed room is
+    declared with provisioning fields and may legitimately have neither, and a
+    YAML anchor expands to a plain dict, so those rooms take the dict path.
+    """
+
+    @staticmethod
+    def _model_for(shape: object) -> object:
+        return AgentModel.model_validate(
+            {"name": "a", "model": shape, "tools": []}
+        ).model
+
+    def test_provisioning_room_without_space_id_is_wrapped(self) -> None:
+        """A managed room declared by table_sources/warehouse — no space_id."""
+        model = self._model_for(
+            {
+                "name": "Retail Genie",
+                "warehouse": {"name": "shared-wh"},
+                "table_sources": [{"table": {"name": "cat.sch.sales"}}],
+            }
+        )
+        assert isinstance(model, GenieAgentModel)
+
+    def test_text_instructions_only_room_is_wrapped(self) -> None:
+        model = self._model_for(
+            {"name": "Retail Genie", "text_instructions": ["Prefer aggregates."]}
+        )
+        assert isinstance(model, GenieAgentModel)
+
+    def test_sample_questions_room_is_wrapped(self) -> None:
+        model = self._model_for(
+            {"name": "Retail Genie", "sample_questions": ["How many stores?"]}
+        )
+        assert isinstance(model, GenieAgentModel)
+
+    def test_plain_endpoint_name_still_resolves_to_endpoint(self) -> None:
+        """The shared-key shape must not be stolen from serving endpoints."""
+        model = self._model_for({"name": "databricks-claude-sonnet-4"})
+        assert isinstance(model, InferenceEndpointModel)
+
+    def test_endpoint_with_inference_knobs_still_resolves_to_endpoint(self) -> None:
+        model = self._model_for(
+            {"name": "databricks-claude-sonnet-4", "temperature": 0.1, "max_tokens": 100}
+        )
+        assert isinstance(model, InferenceEndpointModel)
+
+    def test_room_only_keys_exclude_shared_keys(self) -> None:
+        """The derived key set must never contain a key both classes accept.
+
+        Deriving it from ``model_fields`` keeps it from drifting as fields are
+        added; this pins the property that makes it safe to test against.
+        """
+        from dao_ai.config import _genie_room_only_keys
+
+        room_only = _genie_room_only_keys()
+        for shared in (
+            "name",
+            "description",
+            "on_behalf_of_user",
+            "pat",
+            "service_principal",
+            "client_id",
+            "client_secret",
+            "workspace_host",
+        ):
+            assert shared not in room_only
+        # And the keys the coercion depends on are present.
+        for room_key in ("space_id", "agent_id", "table_sources", "warehouse"):
+            assert room_key in room_only
+
+
+# ---------------------------------------------------------------------------
+# Chat-model surface lives on GenieRoomModel; the wrapper only overrides timeout
+# ---------------------------------------------------------------------------
+
+
+class TestRoomChatModelSurface:
+    def test_room_builds_chat_model_with_default_timeout(self) -> None:
+        from dao_ai.config import GENIE_AGENT_DEFAULT_TIMEOUT_SECONDS
+
+        room = GenieRoomModel(space_id=AGENT_ID)
+        chat = room.chat_model_for_workspace_client(_fake_workspace_client())
+        assert isinstance(chat, GenieAgentChatModel)
+        assert chat.agent_id == AGENT_ID
+        assert chat.timeout_seconds == GENIE_AGENT_DEFAULT_TIMEOUT_SECONDS
+
+    def test_as_chat_model_uses_room_client(self) -> None:
+        room = GenieRoomModel(space_id=AGENT_ID)
+        ws = _fake_workspace_client()
+        with patch.object(
+            GenieRoomModel, "workspace_client", new_callable=lambda: property(lambda s: ws)
+        ):
+            chat = room.as_chat_model()
+        assert isinstance(chat, GenieAgentChatModel)
+        assert chat.workspace_client is ws
+
+    def test_wrapper_forwards_its_timeout_override(self) -> None:
+        agent = AgentModel.model_validate(
+            {
+                "name": "g",
+                "model": {"genie_room": {"agent_id": AGENT_ID}, "timeout_seconds": 600},
+                "tools": [],
+            }
+        )
+        chat = agent.model.chat_model_for_workspace_client(_fake_workspace_client())
+        assert chat.timeout_seconds == 600
+
+    def test_wrapper_name_is_agent_id_not_room_title(self) -> None:
+        """``nodes.py`` and trace ``ResourceInfo`` log this — it must stay the id."""
+        m = GenieAgentModel(
+            genie_room=GenieRoomModel(name="Retail Sales", space_id=AGENT_ID)
+        )
+        assert m.name == AGENT_ID
+
+    def test_room_agent_id_does_not_fall_back_to_name_lookup(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Resolution is static-only: no Genie API call on the model-build path.
+
+        A name-only room therefore cannot serve as a model, which is why
+        ``AppConfig`` reports the bare-assignment case loudly instead.
+        """
+        monkeypatch.delenv("DATABRICKS_GENIE_SPACE_ID", raising=False)
+        room = GenieRoomModel(name="Some Room")
+        with patch.object(
+            GenieRoomModel,
+            "_resolve_space_id_by_name",
+            side_effect=AssertionError("live lookup on the model-build path"),
+        ):
+            with pytest.raises(ValueError, match="unable to resolve agent_id"):
+                _ = room._agent_id
+
+
+# ---------------------------------------------------------------------------
+# AppConfig catches the shape coercion cannot decide
+# ---------------------------------------------------------------------------
+
+
+class TestBareNameOnlyRoomRejected:
+    """``{name: X}`` is valid for both union members, so shape cannot decide it.
+
+    It silently resolves to an ``InferenceEndpointModel`` — the config loads
+    clean and the agent then points at a serving endpoint that does not exist.
+    ``AppConfig`` sees the room registry, so it can catch this.
+    """
+
+    def test_name_only_room_bare_assigned_raises(self) -> None:
+        from dao_ai.config import AppConfig
+
+        cfg = {
+            "resources": {"genie_rooms": {"retail": {"name": "Retail Genie"}}},
+            "agents": {
+                "g": {"name": "g", "model": {"name": "Retail Genie"}, "tools": []}
+            },
+        }
+        with pytest.raises(ValueError, match="indistinguishable from a serving"):
+            AppConfig(**cfg)
+
+    def test_explicit_wrapper_is_not_flagged(self) -> None:
+        from dao_ai.config import AppConfig
+
+        cfg = {
+            "resources": {"genie_rooms": {"retail": {"name": "Retail Genie"}}},
+            "agents": {
+                "g": {
+                    "name": "g",
+                    "model": {"genie_room": {"name": "Retail Genie"}},
+                    "tools": [],
+                }
+            },
+        }
+        # Name-only rooms cannot be id-matched, so the registration check skips.
+        AppConfig(**cfg)
+
+    def test_unrelated_endpoint_name_is_untouched(self) -> None:
+        from dao_ai.config import AppConfig
+
+        cfg = {
+            "resources": {"genie_rooms": {"retail": {"name": "Retail Genie"}}},
+            "agents": {
+                "g": {
+                    "name": "g",
+                    "model": {"name": "databricks-claude-sonnet-4"},
+                    "tools": [],
+                }
+            },
+        }
+        AppConfig(**cfg)
+
+    def test_endpoint_with_knobs_sharing_a_room_name_is_untouched(self) -> None:
+        """Any endpoint-specific key means the user meant an endpoint."""
+        from dao_ai.config import AppConfig
+
+        cfg = {
+            "resources": {"genie_rooms": {"retail": {"name": "Retail Genie"}}},
+            "agents": {
+                "g": {
+                    "name": "g",
+                    "model": {"name": "Retail Genie", "temperature": 0.1},
+                    "tools": [],
+                }
+            },
+        }
         AppConfig(**cfg)

--- a/tests/dao_ai/test_genie_provisioning.py
+++ b/tests/dao_ai/test_genie_provisioning.py
@@ -1081,3 +1081,169 @@ class TestProvisionGenieNotebookGuard:
         config = AppConfig(resources=None)
         # The outer guard `if config.resources is not None and ...` is False.
         assert config.resources is None
+
+
+# ---------------------------------------------------------------------------
+# ensure_resolved() hydration of sample questions
+# ---------------------------------------------------------------------------
+
+
+class TestSampleQuestionHydration:
+    """``ensure_resolved()`` back-fills a bare room's sample questions.
+
+    Customers overwhelmingly declare rooms by ``space_id`` rather than ``name``
+    (Genie titles are not unique), so those rooms carry no local text at all.
+    Hydrating here — the same place ``name``/``description`` are already
+    back-filled — is what makes the Genie tool description identical whether the
+    agent runs locally, in Apps, or in Model Serving: deploy resolves it, and
+    ``model_dump`` bakes it into the logged ``model_config``.
+    """
+
+    SPACE_ID: str = "a" * 32
+
+    @staticmethod
+    def _space_details(
+        *,
+        title: str = "Retail Sales",
+        description: str | None = "Store sales, inventory and returns.",
+        sample_questions: list[str] | None = None,
+    ) -> Mock:
+        """A stub ``GenieSpace`` carrying a ``serialized_space`` payload."""
+        payload: dict = {"version": 2}
+        if sample_questions is not None:
+            payload["config"] = {
+                "sample_questions": [
+                    {"id": f"id{i}", "question": [q]}
+                    for i, q in enumerate(sample_questions)
+                ]
+            }
+        details = Mock()
+        details.title = title
+        details.description = description
+        details.serialized_space = json.dumps(payload)
+        return details
+
+    def _room(self, **kwargs) -> GenieRoomModel:
+        return GenieRoomModel(space_id=self.SPACE_ID, **kwargs)
+
+    def test_hydrates_description_and_questions_from_live_space(self) -> None:
+        """The bare-``space_id`` path customers actually use.
+
+        Nothing is declared locally, so both the description and the sample
+        questions must come from the space and reach the tool description.
+        """
+        room = self._room()
+        details = self._space_details(
+            sample_questions=["How many stores per state?", "Top 5 SKUs last quarter?"]
+        )
+        with patch.object(GenieRoomModel, "_get_space_details", return_value=details):
+            room.ensure_resolved()
+
+        assert room.name == "Retail Sales"
+        assert room.description == "Store sales, inventory and returns."
+        assert room.sample_questions == [
+            "How many stores per state?",
+            "Top 5 SKUs last quarter?",
+        ]
+
+        from dao_ai.tools.genie import create_genie_tool
+
+        tool = create_genie_tool(genie_room=room)
+        assert "Store sales, inventory and returns." in tool.description
+        assert "- How many stores per state?" in tool.description
+        assert "- Top 5 SKUs last quarter?" in tool.description
+
+    def test_declared_questions_are_not_overwritten(self) -> None:
+        """User-declared values always win over discovered ones."""
+        room = self._room(sample_questions=["MY OWN QUESTION"])
+        details = self._space_details(sample_questions=["FROM THE SPACE"])
+        with patch.object(GenieRoomModel, "_get_space_details", return_value=details):
+            room.ensure_resolved()
+
+        assert room.sample_questions == ["MY OWN QUESTION"]
+
+    def test_hydration_touches_only_question_fields(self) -> None:
+        """Guard against drifting into full ``refresh()`` behavior.
+
+        ``refresh()`` also rewrites ``table_sources``/``function_sources``,
+        which are provisioning *inputs* — rewriting them here would bloat the
+        baked ``model_config`` and risk perturbing a later re-provision.
+        """
+        room = self._room()
+        payload = {
+            "version": 2,
+            "config": {
+                "sample_questions": [{"id": "i1", "question": ["Discovered?"]}]
+            },
+            "data_sources": {
+                "tables": [{"identifier": "cat.sch.tbl"}],
+                "metric_views": [{"identifier": "cat.sch.mv"}],
+            },
+            "instructions": {
+                "text_instructions": [{"content": ["Never do that."]}],
+                "sql_functions": [{"identifier": "cat.sch.fn"}],
+                "join_specs": [{"sql": "a.id = b.id"}],
+            },
+        }
+        details = Mock()
+        details.title = "Retail Sales"
+        details.description = "Store sales."
+        details.serialized_space = json.dumps(payload)
+
+        with patch.object(GenieRoomModel, "_get_space_details", return_value=details):
+            room.ensure_resolved()
+
+        assert room.sample_questions == ["Discovered?"]
+        assert room.table_sources is None
+        assert room.metric_view_sources is None
+        assert room.function_sources is None
+        assert room.join_specs is None
+        assert room.text_instructions is None
+        assert room.benchmarks is None
+
+    def test_unavailable_space_is_not_fatal(self) -> None:
+        """The Model Serving case: ``_get_space_details`` returns ``None``.
+
+        Hydration must fail soft — no exception, and the tool simply carries no
+        example-question block.
+        """
+        room = self._room()
+        with patch.object(GenieRoomModel, "_get_space_details", return_value=None):
+            room.ensure_resolved()
+
+        assert room.sample_questions is None
+
+        from dao_ai.tools.genie import create_genie_tool
+
+        tool = create_genie_tool(genie_room=room)
+        assert "Example questions" not in tool.description
+        assert "<topic>" not in tool.description
+
+    def test_hydrated_values_survive_the_model_config_bake(self) -> None:
+        """The local / Apps / Model Serving parity guarantee.
+
+        Deploy dumps the resolved config into the MLflow artifact; the serving
+        container rebuilds from that dict. So a room rebuilt from the dump must
+        still produce the same tool description with **no** further Genie call.
+        """
+        room = self._room()
+        details = self._space_details(sample_questions=["How many stores per state?"])
+        with patch.object(GenieRoomModel, "_get_space_details", return_value=details):
+            room.ensure_resolved()
+
+        baked = room.model_dump(mode="json", by_alias=True, exclude_none=True)
+        assert baked["sample_questions"] == ["How many stores per state?"]
+
+        rebuilt = GenieRoomModel.model_validate(baked)
+
+        from dao_ai.tools.genie import create_genie_tool
+
+        with patch.object(
+            GenieRoomModel,
+            "_get_space_details",
+            side_effect=AssertionError("Genie API called in the serving container"),
+        ):
+            tool = create_genie_tool(genie_room=rebuilt)
+
+        assert "Store sales, inventory and returns." in tool.description
+        assert "- How many stores per state?" in tool.description

--- a/tests/dao_ai/test_genie_room_model.py
+++ b/tests/dao_ai/test_genie_room_model.py
@@ -404,6 +404,53 @@ class TestGenieRoomModelSerialization:
             assert len(tables1) == len(tables2)
             assert tables1[0].name == tables2[0].name
 
+    def test_space_details_falls_back_when_serialized_read_is_denied(
+        self, mock_workspace_client
+    ):
+        """CAN_RUN can read a space's title and description but not its
+        serialized payload, so a denied serialized read must be retried without
+        it — the description is the whole point of discovery, and losing it to an
+        all-or-nothing call is what left deployed tools advertising generic text.
+        """
+        from databricks.sdk.service.dashboards import GenieSpace
+
+        plain = GenieSpace(
+            space_id="test-space-123",
+            title="Discovered Title",
+            description="Discovered description.",
+        )
+
+        def _get_space(space_id: str, include_serialized_space: bool = False):
+            if include_serialized_space:
+                raise PermissionError('You need "Can Edit" permission')
+            return plain
+
+        with patch("dao_ai.config.WorkspaceClient", return_value=mock_workspace_client):
+            mock_workspace_client.genie.get_space.side_effect = _get_space
+
+            genie_room = GenieRoomModel(space_id="test-space-123")
+            genie_room.ensure_resolved()
+
+            assert genie_room.name == "Discovered Title"
+            assert genie_room.description == "Discovered description."
+            # No serialized payload means no questions, not an error.
+            assert not genie_room.sample_questions
+
+    def test_space_details_returns_none_when_both_reads_are_denied(
+        self, mock_workspace_client
+    ):
+        """When even the plain read fails, discovery stays soft — the room is
+        left as declared rather than raising."""
+        with patch("dao_ai.config.WorkspaceClient", return_value=mock_workspace_client):
+            mock_workspace_client.genie.get_space.side_effect = PermissionError("denied")
+
+            genie_room = GenieRoomModel(space_id="test-space-123")
+            genie_room.ensure_resolved()
+
+            assert genie_room._get_space_details() is None
+            assert genie_room.name is None
+            assert genie_room.description is None
+
     def test_genie_room_model_api_scopes(self, mock_workspace_client):
         """Test that GenieRoomModel returns correct API scopes."""
         with patch("dao_ai.config.WorkspaceClient", return_value=mock_workspace_client):
@@ -639,15 +686,20 @@ class TestGenieRoomModelSerialization:
             assert genie_room.name is None
             assert genie_room.description is None
 
-    def test_populate_name_and_description_not_called_when_both_provided(
+    def test_populate_not_called_when_all_discoverable_fields_provided(
         self, mock_workspace_client
     ):
-        """Test that API is not called when both name and description are provided."""
+        """No API call when everything discovery would supply is already declared.
+
+        Discovery back-fills name, description *and* sample questions — all three
+        feed the Genie tool description — so all three must be present for the
+        fetch to be skippable.
+        """
         with patch("dao_ai.config.WorkspaceClient", return_value=mock_workspace_client):
-            # Create with both name and description
             genie_room = GenieRoomModel(
                 name="Custom Name",
                 description="Custom Description",
+                sample_questions=["Custom question?"],
                 space_id="test-space-123",
             )
             genie_room.ensure_resolved()
@@ -656,6 +708,24 @@ class TestGenieRoomModelSerialization:
             mock_workspace_client.genie.get_space.assert_not_called()
 
             # Values should be preserved
+            assert genie_room.name == "Custom Name"
+            assert genie_room.description == "Custom Description"
+            assert genie_room.sample_questions == ["Custom question?"]
+
+    def test_populate_still_fetches_for_missing_sample_questions(
+        self, mock_workspace_client
+    ):
+        """Name and description declared, questions absent → still one fetch, and
+        the declared text is not overwritten by the space's."""
+        with patch("dao_ai.config.WorkspaceClient", return_value=mock_workspace_client):
+            genie_room = GenieRoomModel(
+                name="Custom Name",
+                description="Custom Description",
+                space_id="test-space-123",
+            )
+            genie_room.ensure_resolved()
+
+            mock_workspace_client.genie.get_space.assert_called_once()
             assert genie_room.name == "Custom Name"
             assert genie_room.description == "Custom Description"
 


### PR DESCRIPTION
A supervisor picks between Genie tools by reading their descriptions, and a
room declared by bare `space_id` — the common shape, since Genie titles are not
unique — used to advertise the same subject-free boilerplate as every other
description-less Genie tool. Routing became a coin flip.

Tool descriptions now resolve tool `description` -> room `description` ->
generic fallback, with `GenieRoomModel.ensure_resolved()` back-filling `name`,
`description`, and `sample_questions` from the live space when they are not
declared. Up to ten example questions are appended as few-shot routing hints,
sourced from `sample_questions` or the `question` of each `example_sqls` pair.
SQL bodies are never included: the text is read by the calling LLM for routing,
Genie already holds the SQL, and the bodies would cost hundreds of tokens on
every LLM call for no routing gain.

Discovery had to land identically in all three runtimes. Model Serving bakes
the resolved config into the logged `model_config`, but the Apps bundle ships
the rendered config as *text*, so nothing resolved at deploy time would reach
the container — and in-container discovery cannot cover for it, because an
app's Genie resource grants only CAN_RUN while reading space details requires
CAN_EDIT. Hence `_bake_genie_room_details`, which looks each distinct
`space_id` up once at bundle time, never overwrites a declared field, skips a
deferred `${var....}` id, and leaves an unreadable space untouched so a deploy
is never blocked by discovery.

Writing the tool `description` suppresses the example block: that string is the
prompt surface, so authoring it means "this is my text, don't editorialize". A
room description keeps the questions — it is resource metadata the questions
exist to enrich, and suppressing there would hand the customer who documented
their space *less* routing signal than one who documented nothing, while
silently discarding `sample_questions` written into the config.

`include_example_questions` overrides that in either direction. It is
tri-state, not a bool defaulting to true, because intent has to survive the
deploy bake: `model_fields_set` does not round-trip through
`exclude_none=True` into `model_config` or rendered YAML, so "unset" and
"explicitly true" would be indistinguishable in the container. As a value,
`None` drops out and re-parses as the default while `true`/`false` are
preserved literally, and the description comes out byte-identical everywhere.

BREAKING CHANGE: `verbatim` on a `type: genie` tool is renamed
`preserve_question`, with no `validation_alias` — `extra="forbid"` rejects the
old key at config load. The bare adjective read as "return Genie's answer
verbatim" when the flag governs the question sent *to* Genie, and it was the
only boolean on `GenieToolModel` that was not `<verb>_<object>`. The field was
absent from every `examples/**.yaml` and from the docs, so the clean rename is
preferable to carrying an alias.

The preserve-question prompt text is also cut by ~two thirds (~240 -> ~78
estimated tokens per flagged tool per LLM call). The clause and the
question-argument annotation land in the *same* serialized tool schema, re-sent
on every call for the whole conversation, so the near-duplicate wording bought
redundancy rather than reinforcement; the substance now lives on the argument
annotation, where the model actually writes the value, and the description
carries only a pointer. All three load-bearing parts survive: word-for-word and
complete, keep every qualifier, and a genuinely multi-tool request may still be
split.

Verified end-to-end in FEVM across local, Databricks Apps, and Model Serving
over a fourteen-row permutation matrix: 107/107 assertions in each runtime, tool
descriptions byte-identical across all three, and the preserve-question
qualifier surviving into the `genie_core_ask_question` span in every runtime on
the compressed prompt.

---

This pull request and its description were written by Isaac.
