### PR TITLE
fix(genie): let a Genie-brain agent live under an orchestrator

### DIFF
--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -10108,9 +10108,26 @@ class AppModel(BaseModel):
         ):
             default_agent: AgentModel = self.agents[0]
             if len(self.agents) > 1:
-                self.orchestration.supervisor = SupervisorModel(
-                    model=default_agent.model
+                # The supervisor routes with an LLM. A Genie-brain agent
+                # (GenieAgentModel) has none, so borrow the first agent's model
+                # that is one; with no such agent there is nothing to route
+                # with and the config has to say what it wants.
+                supervisor_model: InferenceEndpointModel | None = next(
+                    (
+                        agent.model
+                        for agent in self.agents
+                        if isinstance(agent.model, InferenceEndpointModel)
+                    ),
+                    None,
                 )
+                if supervisor_model is None:
+                    raise ValueError(
+                        "No default orchestration: every agent's model is a Genie "
+                        "space, so there is no LLM for a supervisor to route with. "
+                        "Declare `orchestration.supervisor.model` (or "
+                        "`orchestration.swarm`) explicitly."
+                    )
+                self.orchestration.supervisor = SupervisorModel(model=supervisor_model)
             else:
                 self.orchestration.swarm = SwarmModel(default_agent=default_agent)
 

--- a/src/dao_ai/genie/agent_chat_model.py
+++ b/src/dao_ai/genie/agent_chat_model.py
@@ -45,7 +45,7 @@ together (see ``GenieAgentModel.chat_model_for_workspace_client``).
 from __future__ import annotations
 
 import json
-from typing import Any, AsyncIterator, Iterator, Optional
+from typing import Any, AsyncIterator, Iterator, Optional, Sequence
 
 import httpx
 import mlflow
@@ -53,6 +53,7 @@ from langchain_core.callbacks import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
 )
+from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import (
     AIMessage,
@@ -61,6 +62,7 @@ from langchain_core.messages import (
     HumanMessage,
 )
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+from langchain_core.runnables import Runnable
 from loguru import logger
 
 from dao_ai.auth import WorkspaceBearerAuth
@@ -303,6 +305,34 @@ class GenieAgentChatModel(BaseChatModel):
     @property
     def _identifying_params(self) -> dict[str, Any]:
         return {"agent_id": self.agent_id, "timeout_seconds": self.timeout_seconds}
+
+    def bind_tools(
+        self,
+        tools: Sequence[Any],
+        *,
+        tool_choice: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Runnable[LanguageModelInput, AIMessage]:
+        """Return ``self`` unchanged: Genie owns its tool loop.
+
+        Agent Mode runs its own tools (``execute_sql`` and friends) server-side
+        and exposes no way to declare client tools, so there is nothing to bind
+        and this model never emits a client tool call. Orchestration still hands
+        an agent tools it expects it to be able to call — the supervisor's
+        ``handoff_to_supervisor``, a swarm's handoff tools — and langchain's
+        agent loop calls ``bind_tools`` whenever that list is non-empty. Without
+        this override that call lands on ``BaseChatModel.bind_tools``, a bare
+        ``NotImplementedError``, and a Genie-brain agent can only ever be an
+        app's single agent. Ignoring the tools is the correct behavior: the
+        agent answers, no tool call is emitted, the turn ends.
+        """
+        if tools:
+            logger.debug(
+                "Ignoring tools bound to a Genie agent model",
+                agent_id=self.agent_id,
+                tool_count=len(tools),
+            )
+        return self
 
     # -- request helpers ------------------------------------------------
 

--- a/src/dao_ai/orchestration/supervisor.py
+++ b/src/dao_ai/orchestration/supervisor.py
@@ -24,6 +24,7 @@ from loguru import logger
 
 from dao_ai.config import (
     AppConfig,
+    GenieAgentModel,
     MemoryModel,
     OrchestrationModel,
     PromptModel,
@@ -346,16 +347,23 @@ def create_supervisor_graph(config: AppConfig) -> CompiledStateGraph:
             internal_agents=sorted(internal_agents),
         )
     for registered_agent in config.app.agents:
-        # Create handoff back to supervisor tool
-        supervisor_handoff: BaseTool = _create_handoff_back_to_supervisor_tool()
+        # Every worker gets a handoff back to the supervisor — except a
+        # Genie-brain worker (GenieAgentModel), whose model runs its own tool
+        # loop server-side and never calls a client tool. Its turn ends when it
+        # answers, which is the only way control ever leaves that worker anyway,
+        # so the tool would be dead weight in its graph and its logs.
+        additional_tools: list[BaseTool] = (
+            []
+            if isinstance(registered_agent.model, GenieAgentModel)
+            else [_create_handoff_back_to_supervisor_tool()]
+        )
 
-        # Create the worker agent with handoff back to supervisor
         agent_subgraph: CompiledStateGraph = create_agent_node(
             agent=registered_agent,
             memory=memory,
             store=store,
             chat_history=config.app.chat_history,
-            additional_tools=[supervisor_handoff],
+            additional_tools=additional_tools,
             extraction_manager=extraction_manager,
             checkpointer=checkpointer,
         )

--- a/tests/dao_ai/test_genie_agent_model.py
+++ b/tests/dao_ai/test_genie_agent_model.py
@@ -13,6 +13,9 @@ Covers :class:`dao_ai.genie.agent_chat_model.GenieAgentChatModel` and
    typed surface (``name``, ``on_behalf_of_user``, ``workspace_client_from``,
    ``chat_model_for_workspace_client``, ``as_chat_model``) and parses through
    the ``AgentModel.model`` union.
+6. ``bind_tools`` is a no-op returning the model itself, so a langchain agent
+   loop that hands the brain a tool (supervisor handoff, swarm handoff) runs
+   instead of dying in ``BaseChatModel.bind_tools``.
 
 httpx is driven with a real ``MockTransport`` so the SSE parsing exercises the
 genuine ``iter_lines``/``aiter_lines`` code paths. The WorkspaceClient is a
@@ -28,7 +31,9 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
+from langchain.agents import create_agent
 from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.tools import tool
 
 from dao_ai.config import (
     AgentModel,
@@ -556,7 +561,11 @@ class TestBareRoomCoercion:
 
     def test_endpoint_with_inference_knobs_still_resolves_to_endpoint(self) -> None:
         model = self._model_for(
-            {"name": "databricks-claude-sonnet-4", "temperature": 0.1, "max_tokens": 100}
+            {
+                "name": "databricks-claude-sonnet-4",
+                "temperature": 0.1,
+                "max_tokens": 100,
+            }
         )
         assert isinstance(model, InferenceEndpointModel)
 
@@ -604,7 +613,9 @@ class TestRoomChatModelSurface:
         room = GenieRoomModel(space_id=AGENT_ID)
         ws = _fake_workspace_client()
         with patch.object(
-            GenieRoomModel, "workspace_client", new_callable=lambda: property(lambda s: ws)
+            GenieRoomModel,
+            "workspace_client",
+            new_callable=lambda: property(lambda s: ws),
         ):
             chat = room.as_chat_model()
         assert isinstance(chat, GenieAgentChatModel)
@@ -718,3 +729,56 @@ class TestBareNameOnlyRoomRejected:
             },
         }
         AppConfig(**cfg)
+
+
+# ---------------------------------------------------------------------------
+# bind_tools: Genie owns its tool loop, client tools are ignored
+# ---------------------------------------------------------------------------
+
+
+class TestBindTools:
+    def test_returns_self(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        model = _model_with_transport(
+            lambda req: httpx.Response(200, content=_sse(_happy_events())),
+            monkeypatch,
+        )
+
+        @tool
+        def handoff_to_supervisor() -> str:
+            """Hand control back to the supervisor."""
+            return "ok"
+
+        assert model.bind_tools([handoff_to_supervisor]) is model
+        assert model.bind_tools([]) is model
+        assert model.bind_tools([handoff_to_supervisor], tool_choice="any") is model
+
+    def test_agent_loop_with_a_tool_answers_from_genie(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The failure this guards: ``create_agent(model, tools=[...])`` calls
+        ``bind_tools`` on the first model call whenever the tool list is
+        non-empty. The brain must take that turn, answer with Genie's text and
+        emit no tool call, so the loop ends after one model call."""
+        record: dict[str, Any] = {}
+        model = _model_with_transport(
+            lambda req: httpx.Response(200, content=_sse(_happy_events())),
+            monkeypatch,
+            record=record,
+        )
+        calls: list[str] = []
+
+        @tool
+        def handoff_to_supervisor() -> str:
+            """Hand control back to the supervisor."""
+            calls.append("handoff")
+            return "ok"
+
+        agent = create_agent(model=model, tools=[handoff_to_supervisor])
+        result = agent.invoke({"messages": [HumanMessage("How many stores by state?")]})
+
+        last = result["messages"][-1]
+        assert isinstance(last, AIMessage)
+        assert "California leads with 42 stores." in last.content
+        assert not last.tool_calls
+        assert calls == []
+        assert record["url"].endswith(f"/api/2.0/genie/agents/{AGENT_ID}/responses")

--- a/tests/dao_ai/test_genie_brain_orchestration.py
+++ b/tests/dao_ai/test_genie_brain_orchestration.py
@@ -1,0 +1,131 @@
+"""A Genie-brain agent (``model: {genie_room: ...}``) under an orchestrator.
+
+The brain's model runs its own tool loop server-side and never calls a client
+tool, so orchestration must not hand it one it cannot use — and must not try
+to route *with* it:
+
+1. ``create_supervisor_graph`` gives every worker ``handoff_to_supervisor``
+   except a Genie-brain worker, which gets no additional tools.
+2. ``AppModel.set_default_orchestration`` never picks a ``GenieAgentModel`` as
+   the supervisor's model: it borrows the first LLM-backed agent's, and with
+   none it raises a message that says what to declare.
+
+Hermetic: the supervisor graph is built with the same stubs as the swarm
+multi-turn tests (in-memory checkpointer, no store, no extraction, a recorded
+``create_agent_node`` fake). No LLM, no workspace, no I/O.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dao_ai.config import (
+    AppConfig,
+    GenieAgentModel,
+    InferenceEndpointModel,
+)
+
+SPACE_A: str = "01f05dd06c421ad6b522bf7a517cf6d2"
+SPACE_B: str = "01f05dd06c421ad6b522bf7a517cf6d3"
+
+
+def _brain(name: str, space_id: str) -> dict[str, Any]:
+    return {"name": name, "model": {"genie_room": {"agent_id": space_id}}, "tools": []}
+
+
+def _llm(name: str) -> dict[str, Any]:
+    return {"name": name, "model": {"name": "test-model"}, "tools": []}
+
+
+def _config(agents: list[dict[str, Any]], **app_extra: Any) -> AppConfig:
+    return AppConfig(
+        **{
+            "resources": {
+                "genie_rooms": {
+                    "a": {"agent_id": SPACE_A},
+                    "b": {"agent_id": SPACE_B},
+                }
+            },
+            "app": {"name": "genie_brain_test", "agents": agents, **app_extra},
+        }
+    )
+
+
+# =============================================================================
+# 1. Supervisor: no handoff tool for a brain worker
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSupervisorGivesBrainNoHandoffTool:
+    def test_llm_worker_gets_handoff_brain_gets_none(self) -> None:
+        from dao_ai.orchestration.supervisor import create_supervisor_graph
+
+        config = _config(
+            [_llm("billing"), _brain("sellout", SPACE_A)],
+            orchestration={"supervisor": {"model": {"name": "test-model"}}},
+        )
+        additional_tools_by_agent: dict[str, list[str]] = {}
+
+        def _fake_create_agent_node(agent: Any, **kwargs: Any) -> Any:
+            additional_tools_by_agent[agent.name] = [
+                t.name for t in kwargs.get("additional_tools") or []
+            ]
+            return MagicMock(name=f"subgraph:{agent.name}")
+
+        with (
+            patch(
+                "dao_ai.orchestration.supervisor.create_checkpointer", return_value=None
+            ),
+            patch("dao_ai.orchestration.supervisor.create_store", return_value=None),
+            patch(
+                "dao_ai.orchestration.supervisor.create_extraction_manager_and_executor",
+                return_value=(None, None),
+            ),
+            patch(
+                "dao_ai.orchestration.supervisor.create_agent_node",
+                side_effect=_fake_create_agent_node,
+            ),
+        ):
+            create_supervisor_graph(config)
+
+        assert additional_tools_by_agent == {
+            "billing": ["handoff_to_supervisor"],
+            "sellout": [],
+        }
+
+
+# =============================================================================
+# 2. Default orchestration never routes with a brain
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestDefaultOrchestrationSkipsGenieBrain:
+    def test_llm_first_is_unchanged(self) -> None:
+        config = _config([_llm("billing"), _brain("sellout", SPACE_A)])
+        supervisor = config.app.orchestration.supervisor
+        assert supervisor is not None
+        assert isinstance(supervisor.model, InferenceEndpointModel)
+        assert supervisor.model.name == "test-model"
+
+    def test_brain_first_borrows_the_llm_agents_model(self) -> None:
+        config = _config([_brain("sellout", SPACE_A), _llm("billing")])
+        supervisor = config.app.orchestration.supervisor
+        assert supervisor is not None
+        assert isinstance(supervisor.model, InferenceEndpointModel)
+        assert supervisor.model.name == "test-model"
+        # The brains stay brains.
+        assert isinstance(config.app.agents[0].model, GenieAgentModel)
+
+    def test_only_brains_raises_with_what_to_declare(self) -> None:
+        with pytest.raises(ValueError, match="no LLM for a supervisor to route with"):
+            _config([_brain("sellout", SPACE_A), _brain("inventory", SPACE_B)])
+
+    def test_single_brain_still_defaults_to_swarm(self) -> None:
+        config = _config([_brain("sellout", SPACE_A)])
+        assert config.app.orchestration.supervisor is None
+        assert config.app.orchestration.swarm is not None


### PR DESCRIPTION
## What

An agent whose model is a Genie space (`model: {genie_room: ...}`, `GenieAgentModel`) works as an app's single agent and dies the moment it has a sibling. Every orchestration hands it a tool — swarm its handoff tools, supervisor `handoff_to_supervisor` — and langchain's agent loop calls `bind_tools` as soon as that list is non-empty (`agents/factory.py`, `_get_bound_model`, `if final_tools:`). `GenieAgentChatModel` did not implement it, so the call landed on `BaseChatModel.bind_tools`, which is a bare `raise NotImplementedError`. `dao-ai chat` shows an empty `❌ Error:`; Genie is never reached.

Measured on 0.2.7 with two Genie brains:

- no `orchestration` block: `set_default_orchestration` passes the first agent's model to `SupervisorModel`, a `GenieAgentModel` where `InferenceEndpointModel` is required. Fails validation, reported against `app.model` — a field that does not exist.
- `orchestration.swarm`: dies in the default agent's first model call.
- `orchestration.supervisor` (real LLM): routes correctly, then dies in the worker — `During task with name 'inventory'`.

```
  File "langchain/agents/factory.py", line 1399, in _get_bound_model
    request.model.bind_tools(
  File "langchain_core/language_models/chat_models.py", line 2355, in bind_tools
    raise NotImplementedError
```

## Why ignoring the tools is right

Genie Agent Mode runs its own tool loop server-side (`execute_sql` and friends) and exposes no way to declare client tools, so this model never emits a client tool call. Under a supervisor that is exactly the behavior wanted: the brain answers, no tool call, the turn ends — the worker has no edge back to the supervisor anyway, and the supervisor is the entry point on the next turn. Under a swarm the brain cannot hand off; that is the swarm trade-off, not a Genie one, and it is unchanged here.

## Changes

- `GenieAgentChatModel.bind_tools` returns `self` (debug-logs the ignored tool count). This alone makes both supervisor and swarm work.
- `create_supervisor_graph` gives a `GenieAgentModel` worker no `handoff_to_supervisor`. It could never call it, and leaving it out keeps the tool node and the `tools_count` log honest.
- `AppModel.set_default_orchestration` borrows the first LLM-backed agent's model for the auto-picked supervisor instead of the first agent's blindly; with only Genie brains it raises a message that says what to declare (`orchestration.supervisor.model` or `orchestration.swarm`).

## Verification

Unit: `tests/dao_ai/test_genie_agent_model.py::TestBindTools` (returns self; a `create_agent(model, tools=[...])` loop takes its turn from Genie through the httpx `MockTransport` and emits no tool call — fails with `NotImplementedError` without the fix) and `tests/dao_ai/test_genie_brain_orchestration.py` (supervisor: LLM worker gets `handoff_to_supervisor`, brain gets none; default orchestration: LLM-first unchanged, brain-first borrows the LLM, only-brains raises, single brain still swarm). The rest of `tests/dao_ai` has the same pass/fail set as `main` in my environment.

Live, nonprod workspace: two Genie brains under a `databricks-claude-sonnet-4-5` supervisor with an in-memory checkpointer, `dao-ai chat`, two turns. Each routed to the right space (`Handoff tool invoked | target_agent=inventory`, then `sellout`), both answered in Agent Mode with SQL, table and prose, workers built with `tools_count=0`.
