### PR TITLE
fix(genie)!: reject the Genie-brain configs an orchestrator silently discards

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -1312,9 +1312,10 @@ agents:
     # model:                             # explicit wrapper form (custom knobs):
     #   genie_room: *retail_genie
     #   timeout_seconds: 600
-    tools: []                            # Genie IS the brain; no tools
-    prompt: |
-      Relay Genie's answer, preserving SQL, tables, and citations.
+    tools: []                            # Genie IS the brain; no tools (required)
+    # No `prompt:` — Genie receives only the latest user turn, so a system
+    # prompt would be dropped. Steer the answer with the space's own
+    # `text_instructions` instead. Likewise no `response_format:`.
 ```
 
 **Assignment forms.** `model:` accepts either a bare Genie room (a
@@ -1357,6 +1358,51 @@ persisting the newly-issued one after (via the `merge_session` reducer).
 Databricks Apps, or `ModelServingUserCredentials` on Model Serving. When OBO is
 set, also set the room's `workspace_host` unless `DATABRICKS_HOST` is in the
 environment (it is on Apps/MS deploys).
+
+### Under an orchestrator
+
+One fact drives all of the following: Genie Agent Mode runs its **own tool loop
+server-side** and offers no way to declare client tools, so
+`GenieAgentChatModel.bind_tools` returns the model unchanged. Anything handed to
+a Genie brain to *call* is discarded — silently, at runtime, in the middle of a
+graph that compiled cleanly. dao-ai therefore rejects those shapes at config
+load, naming the agent.
+
+**Rejected at config load:**
+
+| Config on a Genie-brain agent | Why |
+| --- | --- |
+| `tools:` non-empty | Registered in the agent's ToolNode and never callable. Use an LLM-backed agent with a `type: genie` tool instead. |
+| `response_format:` | The binding is dropped; Genie streams narrative markdown regardless. |
+| Swarm handoff *out of* the brain without `is_deterministic: true` | The handoff tool is discarded, so no tool call is emitted, `active_agent` is never written, and the swarm router lands **every later turn back on the same agent** — the rest of the swarm becomes unreachable with no error. |
+
+**Silently ignored (not an error):** `prompt:`. Only the latest `HumanMessage`
+reaches Genie — prior turns and system prompts are not replayed, because the
+server owns history via `conversation_id`. Put the guidance in the space's
+`text_instructions`.
+
+**Per orchestration mode:**
+
+- **`supervisor` — works.** The supervisor routes to the brain like any other
+  worker. The brain gets no `handoff_to_supervisor` (it could never call it), and
+  there is no worker→supervisor edge, so it is a **graph sink**: it answers and
+  the turn ends. A supervisor therefore cannot chain a brain with another agent
+  *within one turn* — it re-routes on the next turn. Graph build logs a warning
+  naming each brain worker.
+- **`swarm` — works with deterministic handoffs only.** `is_deterministic: true`
+  compiles to a real parent-graph edge, which needs no tool call. A brain as a
+  swarm **leaf** (no outbound handoffs) is also fine — it ends the turn.
+  Handoffs *into* a brain are unrestricted.
+- **`deep_agent` — not supported.** `_resolve_model` in
+  `src/dao_ai/orchestration/deep_agent.py` is typed
+  `InferenceEndpointModel | str | None`, so a `GenieAgentModel` passes straight
+  through to `deepagents`, which expects `str | BaseChatModel`. Reach Genie from
+  a deep agent with a `type: genie` **tool** instead.
+
+Because a supervisor cannot see inside a brain, give the agent a good
+`description` — it is the only thing the supervisor routes on (`get_handoff_description`
+falls back to `"Handles <name> related tasks and inquiries"`, which carries no
+signal).
 
 ### See Also
 

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -8143,6 +8143,42 @@ class AgentModel(BaseModel):
             f"got {type(self.response_format)}"
         )
 
+    @model_validator(mode="after")
+    def validate_genie_brain_bindings(self) -> Self:
+        """Reject config a Genie brain would silently discard.
+
+        ``GenieAgentChatModel.bind_tools`` returns the model unchanged — Genie
+        Agent Mode runs its own tool loop server-side and exposes no way to
+        declare client tools — so declared ``tools`` are registered in the
+        agent's ToolNode and can never be called, and a ``response_format``
+        binding is dropped on the floor. Either config builds cleanly and
+        surfaces only as a wrong answer at runtime, so both are refused here,
+        where the message can name the agent and the offending tools.
+        """
+        if not isinstance(self.model, GenieAgentModel):
+            return self
+
+        if self.tools:
+            tool_names: str = ", ".join(tool.name for tool in self.tools)
+            raise ValueError(
+                f"Agent '{self.name}' uses a Genie space as its model, which "
+                f"runs its own tool loop server-side and can never call a "
+                f"client tool — but it declares tools: {tool_names}. Remove "
+                f"them, or give the agent an LLM model and reach Genie through "
+                f"a `type: genie` tool instead."
+            )
+
+        if self.response_format is not None:
+            raise ValueError(
+                f"Agent '{self.name}' uses a Genie space as its model, which "
+                f"streams narrative markdown and cannot be bound to a "
+                f"response_format. Remove response_format, or give the agent "
+                f"an LLM model and reach Genie through a `type: genie` tool "
+                f"instead."
+            )
+
+        return self
+
     def as_runnable(self) -> RunnableLike:
         from dao_ai.nodes import create_agent_node
 
@@ -10129,12 +10165,58 @@ class AppModel(BaseModel):
                     raise ValueError(
                         "No default orchestration: every agent's model is a Genie "
                         "space, so there is no LLM for a supervisor to route with. "
-                        "Declare `orchestration.supervisor.model` (or "
-                        "`orchestration.swarm`) explicitly."
+                        "Declare `orchestration.supervisor.model` explicitly. A "
+                        "swarm of Genie brains routes only with "
+                        "`is_deterministic: true` handoffs — a Genie model "
+                        "discards the agentic handoff tools, so `active_agent` "
+                        "would never be written and every turn would land on the "
+                        "default agent."
                     )
                 self.orchestration.supervisor = SupervisorModel(model=supervisor_model)
             else:
                 self.orchestration.swarm = SwarmModel(default_agent=default_agent)
+
+        return self
+
+    @model_validator(mode="after")
+    def validate_swarm_brain_handoffs(self) -> Self:
+        """Reject an agentic handoff *out of* a Genie-brain agent in a swarm.
+
+        ``_handoffs_for_agent`` gives the source agent its agentic handoff tools
+        as ``additional_tools``. A Genie model discards them, so the brain emits
+        no tool call, ``active_agent`` is never written, and the swarm router
+        lands every later turn back on the same agent — everything past the brain
+        is unreachable, with no error anywhere. A deterministic handoff is a real
+        parent-graph edge and still works; so does a brain with no outbound
+        handoffs, which is simply a leaf that ends the turn.
+        """
+        if self.orchestration is None or self.orchestration.swarm is None:
+            return self
+
+        handoffs = self.orchestration.swarm.handoffs or {}
+        brain_names: set[str] = {
+            agent.name
+            for agent in self.agents
+            if isinstance(agent.model, GenieAgentModel)
+        }
+        if not handoffs or not brain_names:
+            return self
+
+        for source_name, entries in handoffs.items():
+            if source_name not in brain_names:
+                continue
+            for entry in entries or ():
+                if isinstance(entry, HandoffRouteModel) and entry.is_deterministic:
+                    continue
+                raise ValueError(
+                    f"Swarm agent '{source_name}' uses a Genie space as its "
+                    f"model, which discards the agentic handoff tools it is "
+                    f"given — it could never route away, so every later turn "
+                    f"would land back on it and the rest of the swarm would be "
+                    f"unreachable. Declare the handoff with "
+                    f"`is_deterministic: true`, or give the agent an LLM model "
+                    f"and reach Genie through a `type: genie` tool instead."
+                )
 
         return self
 

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -10187,36 +10187,66 @@ class AppModel(BaseModel):
         no tool call, ``active_agent`` is never written, and the swarm router
         lands every later turn back on the same agent — everything past the brain
         is unreachable, with no error anywhere. A deterministic handoff is a real
-        parent-graph edge and still works; so does a brain with no outbound
-        handoffs, which is simply a leaf that ends the turn.
+        parent-graph edge and still works; so does a brain that is a leaf.
+
+        The check must mirror how the runtime resolves handoffs, not just the
+        keys the author spelled out: ``_handoffs_for_agent`` defaults an agent
+        *absent* from the dict (and every agent when the dict is empty) to
+        agentic handoffs to all agents (``handoffs.get(name, config.app.agents)``).
+        So a brain is a leaf only when its outbound list is declared *empty* —
+        omission is the dead-swarm case, and is rejected the same as an explicit
+        agentic handoff. A self-handoff is not a route away, so a lone-brain
+        swarm (whose default resolves to just itself) is left alone.
         """
         if self.orchestration is None or self.orchestration.swarm is None:
             return self
 
-        handoffs = self.orchestration.swarm.handoffs or {}
         brain_names: set[str] = {
             agent.name
             for agent in self.agents
             if isinstance(agent.model, GenieAgentModel)
         }
-        if not handoffs or not brain_names:
+        if not brain_names:
             return self
 
-        for source_name, entries in handoffs.items():
-            if source_name not in brain_names:
-                continue
-            for entry in entries or ():
+        handoffs = self.orchestration.swarm.handoffs or {}
+
+        def _target_names(
+            entry: "AgentModel | str | HandoffRouteModel",
+        ) -> set[str]:
+            def _name(a: "AgentModel | str") -> str:
+                return a.name if isinstance(a, AgentModel) else a
+
+            if isinstance(entry, HandoffRouteModel):
+                if entry.agents:
+                    return {_name(a) for a in entry.agents}
+                return {_name(entry.agent)} if entry.agent is not None else set()
+            return {_name(entry)}
+
+        for brain_name in brain_names:
+            # Resolve exactly as the runtime does: a missing key defaults to
+            # every agent (legacy peer-to-peer swarm), an explicit list is used
+            # verbatim, and an explicit None/[] makes the brain a leaf.
+            effective = handoffs.get(brain_name, self.agents)
+            for entry in effective or ():
                 if isinstance(entry, HandoffRouteModel) and entry.is_deterministic:
                     continue
-                raise ValueError(
-                    f"Swarm agent '{source_name}' uses a Genie space as its "
-                    f"model, which discards the agentic handoff tools it is "
-                    f"given — it could never route away, so every later turn "
-                    f"would land back on it and the rest of the swarm would be "
-                    f"unreachable. Declare the handoff with "
-                    f"`is_deterministic: true`, or give the agent an LLM model "
-                    f"and reach Genie through a `type: genie` tool instead."
-                )
+                # A self-handoff is not a route away, so it does not strand the
+                # swarm; only an agentic handoff to another agent does.
+                if _target_names(entry) - {brain_name}:
+                    raise ValueError(
+                        f"Swarm agent '{brain_name}' uses a Genie space as its "
+                        f"model, which discards the agentic handoff tools it is "
+                        f"given — it could never route away, so every later turn "
+                        f"would land back on it and the rest of the swarm would "
+                        f"be unreachable. Declare each handoff out of it with "
+                        f"`is_deterministic: true`, declare its handoffs empty "
+                        f"(`{brain_name}: []`) to make it a leaf, or give the "
+                        f"agent an LLM model and reach Genie through a "
+                        f"`type: genie` tool instead. (An agent omitted from "
+                        f"`handoffs` defaults to agentic handoffs to every "
+                        f"agent, so omission is not leaf-ness.)"
+                    )
 
         return self
 

--- a/src/dao_ai/orchestration/supervisor.py
+++ b/src/dao_ai/orchestration/supervisor.py
@@ -352,11 +352,22 @@ def create_supervisor_graph(config: AppConfig) -> CompiledStateGraph:
         # loop server-side and never calls a client tool. Its turn ends when it
         # answers, which is the only way control ever leaves that worker anyway,
         # so the tool would be dead weight in its graph and its logs.
+        is_genie_brain: bool = isinstance(registered_agent.model, GenieAgentModel)
         additional_tools: list[BaseTool] = (
-            []
-            if isinstance(registered_agent.model, GenieAgentModel)
-            else [_create_handoff_back_to_supervisor_tool()]
+            [] if is_genie_brain else [_create_handoff_back_to_supervisor_tool()]
         )
+        if is_genie_brain:
+            # Without the handoff tool, and with no worker -> supervisor edge,
+            # this worker is a graph sink. That is correct, but it silently
+            # rules out something a config author may well expect: the
+            # supervisor cannot collect this agent's answer and then route on
+            # to another agent inside the same turn.
+            logger.warning(
+                "Genie-brain worker is a graph sink: it answers and the turn "
+                "ends. The supervisor cannot chain it with another agent in the "
+                "same turn — it re-routes on the next turn instead.",
+                agent=registered_agent.name,
+            )
 
         agent_subgraph: CompiledStateGraph = create_agent_node(
             agent=registered_agent,

--- a/tests/dao_ai/test_genie_brain_orchestration.py
+++ b/tests/dao_ai/test_genie_brain_orchestration.py
@@ -254,13 +254,43 @@ class TestSwarmBrainHandoffs:
         )
         assert config.app.orchestration.swarm is not None
 
-    def test_a_brain_with_no_outbound_handoffs_is_allowed(self) -> None:
-        """A brain as a swarm leaf is fine — it answers and the turn ends."""
-        config = self._swarm({"billing": ["sellout"]}, default_agent="billing")
+    def test_a_brain_as_an_explicit_leaf_is_allowed(self) -> None:
+        """A brain as a swarm leaf is fine — but *only* when its outbound
+        handoffs are declared empty. Omission is not leaf-ness (see below)."""
+        config = self._swarm(
+            {"sellout": [], "billing": ["sellout"]}, default_agent="billing"
+        )
+        assert config.app.orchestration.swarm is not None
+
+    def test_a_brain_omitted_from_handoffs_is_rejected(self) -> None:
+        """The hole this closes: ``_handoffs_for_agent`` defaults an agent that
+        is *absent* from the handoffs dict to agentic handoffs to every agent
+        (``handoffs.get(name, config.app.agents)``). So omitting the brain is
+        not leaf-ness — it is the dead-swarm case, and must be rejected exactly
+        like an explicit agentic handoff."""
+        with pytest.raises(ValueError) as excinfo:
+            self._swarm({"billing": ["sellout"]}, default_agent="billing")
+        message = str(excinfo.value)
+        assert "sellout" in message
+        assert "is_deterministic" in message
+
+    def test_an_empty_handoffs_dict_still_rejects_a_brain(self) -> None:
+        """An empty ``handoffs`` dict defaults *every* agent to all-agents
+        agentic — the brain included — so it is not a free pass."""
+        with pytest.raises(ValueError):
+            self._swarm({}, default_agent="sellout")
+
+    def test_a_lone_brain_swarm_is_allowed(self) -> None:
+        """The default resolves to ``config.app.agents``, which for a single
+        brain is just itself — a self-handoff is not a route away, so there is
+        no dead-swarm and nothing to reject."""
+        config = _config([_brain("solo", SPACE_A)])
         assert config.app.orchestration.swarm is not None
 
     def test_agentic_handoff_out_of_an_llm_agent_is_untouched(self) -> None:
-        config = self._swarm({"billing": ["sellout"]}, default_agent="billing")
+        config = self._swarm(
+            {"sellout": [], "billing": ["sellout"]}, default_agent="billing"
+        )
         handoffs = config.app.orchestration.swarm.handoffs or {}
         assert "billing" in handoffs
 

--- a/tests/dao_ai/test_genie_brain_orchestration.py
+++ b/tests/dao_ai/test_genie_brain_orchestration.py
@@ -17,16 +17,36 @@ multi-turn tests (in-memory checkpointer, no store, no extraction, a recorded
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
+from loguru import logger
 
 from dao_ai.config import (
     AppConfig,
     GenieAgentModel,
     InferenceEndpointModel,
 )
+
+
+def _capture_warnings(fn: Callable[[], Any]) -> list[str]:
+    """Run ``fn`` with a temporary WARNING sink; return captured messages.
+
+    The sink renders ``{extra}`` explicitly: the agent name is a structured
+    field, and loguru's default format drops it. This mirrors the real stderr
+    sink (``dao_ai.logging.configure_logging``), which also ends in ``{extra}``.
+    """
+    msgs: list[str] = []
+    sink_id = logger.add(
+        lambda m: msgs.append(m), level="WARNING", format="{message}{extra}"
+    )
+    try:
+        fn()
+    finally:
+        logger.remove(sink_id)
+    return msgs
+
 
 SPACE_A: str = "01f05dd06c421ad6b522bf7a517cf6d2"
 SPACE_B: str = "01f05dd06c421ad6b522bf7a517cf6d3"
@@ -129,3 +149,184 @@ class TestDefaultOrchestrationSkipsGenieBrain:
         config = _config([_brain("sellout", SPACE_A)])
         assert config.app.orchestration.supervisor is None
         assert config.app.orchestration.swarm is not None
+
+
+# =============================================================================
+# 3. A brain cannot use what it is handed — say so at config load
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestBrainRejectsUnusableConfig:
+    """``bind_tools`` silently discards everything it is handed, so a config
+    that declares client tools or structured output on a Genie brain builds
+    cleanly and then can never honor either. Both are rejected at config load
+    instead, where the message can name the agent."""
+
+    def test_declared_tools_are_rejected(self) -> None:
+        brain = _brain("sellout", SPACE_A)
+        brain["tools"] = [{"name": "order_lookup", "function": {"name": "a.b.c"}}]
+        with pytest.raises(ValueError, match="sellout"):
+            _config([brain])
+
+    def test_declared_tools_message_names_tools_and_the_alternative(self) -> None:
+        brain = _brain("sellout", SPACE_A)
+        brain["tools"] = [{"name": "order_lookup", "function": {"name": "a.b.c"}}]
+        with pytest.raises(ValueError) as excinfo:
+            _config([brain])
+        message = str(excinfo.value)
+        assert "order_lookup" in message
+        # Points at the shape that does support tools: a `type: genie` tool
+        # hanging off an LLM-backed agent.
+        assert "type: genie" in message
+
+    def test_response_format_is_rejected(self) -> None:
+        brain = _brain("sellout", SPACE_A)
+        brain["response_format"] = {"response_schema": '{"type": "object"}'}
+        with pytest.raises(ValueError, match="response_format"):
+            _config([brain])
+
+    def test_an_llm_agent_keeps_tools_and_response_format(self) -> None:
+        agent = _llm("billing")
+        agent["tools"] = [{"name": "order_lookup", "function": {"name": "a.b.c"}}]
+        agent["response_format"] = {"response_schema": '{"type": "object"}'}
+        config = _config([agent])
+        assert len(config.app.agents[0].tools) == 1
+        assert config.app.agents[0].response_format is not None
+
+
+# =============================================================================
+# 4. The all-brains message must not steer at a swarm that cannot work
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestAllBrainsMessageIsActionable:
+    def test_points_at_supervisor_model(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            _config([_brain("sellout", SPACE_A), _brain("inventory", SPACE_B)])
+        assert "orchestration.supervisor.model" in str(excinfo.value)
+
+    def test_any_swarm_suggestion_is_qualified_as_deterministic(self) -> None:
+        """A bare swarm of brains is a silently dead app: the handoff tools are
+        discarded, ``active_agent`` is never written, and every turn routes to
+        the default agent forever. Only deterministic handoffs work."""
+        with pytest.raises(ValueError) as excinfo:
+            _config([_brain("sellout", SPACE_A), _brain("inventory", SPACE_B)])
+        message = str(excinfo.value)
+        if "swarm" in message:
+            assert "is_deterministic" in message
+
+
+# =============================================================================
+# 5. Swarm: an agentic handoff out of a brain is a dead end
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSwarmBrainHandoffs:
+    """In a swarm, ``_handoffs_for_agent`` passes agentic handoff tools as the
+    worker's ``additional_tools``. A Genie model discards them, so it emits no
+    tool call, ``active_agent`` is never written, and the swarm router sends
+    every subsequent turn back to the same agent — a dead app with no error.
+    A deterministic handoff is a real graph edge, so it still works.
+    """
+
+    def _swarm(self, handoffs: dict[str, Any], default_agent: str) -> AppConfig:
+        return _config(
+            [_brain("sellout", SPACE_A), _llm("billing")],
+            orchestration={
+                "swarm": {"default_agent": default_agent, "handoffs": handoffs}
+            },
+        )
+
+    def test_agentic_handoff_out_of_a_brain_is_rejected(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            self._swarm({"sellout": ["billing"]}, default_agent="sellout")
+        message = str(excinfo.value)
+        assert "sellout" in message
+        assert "is_deterministic" in message
+
+    def test_deterministic_handoff_out_of_a_brain_is_allowed(self) -> None:
+        config = self._swarm(
+            {"sellout": [{"agent": "billing", "is_deterministic": True}]},
+            default_agent="sellout",
+        )
+        assert config.app.orchestration.swarm is not None
+
+    def test_a_brain_with_no_outbound_handoffs_is_allowed(self) -> None:
+        """A brain as a swarm leaf is fine — it answers and the turn ends."""
+        config = self._swarm({"billing": ["sellout"]}, default_agent="billing")
+        assert config.app.orchestration.swarm is not None
+
+    def test_agentic_handoff_out_of_an_llm_agent_is_untouched(self) -> None:
+        config = self._swarm({"billing": ["sellout"]}, default_agent="billing")
+        handoffs = config.app.orchestration.swarm.handoffs or {}
+        assert "billing" in handoffs
+
+
+# =============================================================================
+# 6. Supervisor: say out loud that a brain worker is a graph sink
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSupervisorWarnsBrainIsASink:
+    """A brain worker has no ``handoff_to_supervisor`` and no outgoing edge, so
+    control cannot return to the supervisor mid-turn: the brain answers and the
+    turn ends. That is intended, but it means a supervisor cannot compose a
+    brain with another agent inside one turn — and nothing in the build says so.
+    Warn once per brain worker, naming it.
+    """
+
+    def _build(self, agents: list[dict[str, Any]]) -> Callable[[], Any]:
+        from dao_ai.orchestration.supervisor import create_supervisor_graph
+
+        config = _config(
+            agents,
+            orchestration={"supervisor": {"model": {"name": "test-model"}}},
+        )
+
+        def _run() -> None:
+            with (
+                patch(
+                    "dao_ai.orchestration.supervisor.create_checkpointer",
+                    return_value=None,
+                ),
+                patch(
+                    "dao_ai.orchestration.supervisor.create_store", return_value=None
+                ),
+                patch(
+                    "dao_ai.orchestration.supervisor.create_extraction_manager_and_executor",
+                    return_value=(None, None),
+                ),
+                patch(
+                    "dao_ai.orchestration.supervisor.create_agent_node",
+                    side_effect=lambda agent, **kwargs: MagicMock(
+                        name=f"subgraph:{agent.name}"
+                    ),
+                ),
+            ):
+                create_supervisor_graph(config)
+
+        return _run
+
+    def test_brain_worker_is_named_in_a_warning(self) -> None:
+        msgs = _capture_warnings(
+            self._build([_llm("billing"), _brain("sellout", SPACE_A)])
+        )
+        assert any("sellout" in m for m in msgs), msgs
+
+    def test_the_warning_says_control_cannot_return_mid_turn(self) -> None:
+        msgs = _capture_warnings(
+            self._build([_llm("billing"), _brain("sellout", SPACE_A)])
+        )
+        brain_msgs = [m for m in msgs if "sellout" in m]
+        assert brain_msgs, msgs
+        # The point is the consequence, not the mechanism: a reader has to learn
+        # that the turn ends here rather than routing on.
+        assert any("turn" in m for m in brain_msgs), brain_msgs
+
+    def test_an_all_llm_supervisor_names_no_agent(self) -> None:
+        msgs = _capture_warnings(self._build([_llm("billing"), _llm("returns")]))
+        assert not [m for m in msgs if "billing" in m or "returns" in m], msgs


### PR DESCRIPTION
## Summary

Follow-up to #289. That PR made `GenieAgentChatModel.bind_tools` return `self`, so a Genie-brain agent (`model: {genie_room: ...}`) *survives* under an orchestrator instead of dying in `bind_tools`. But ignoring a binding is only correct when nothing depended on it. Three config shapes still build cleanly and are silently wrong at runtime, because Genie Agent Mode runs its tool loop server-side and can never call a client tool. Breaking change (`fix!`): configs that used to load now fail at config load with an actionable message.

| Config on a Genie-brain agent | What happened before |
| --- | --- |
| non-empty `tools:` | registered in the ToolNode, never callable; the agent answers without them |
| `response_format:` | binding dropped; narrative markdown returned |
| swarm agentic handoff *out of* the brain | handoff tool discarded, so no tool call, so `active_agent` is never written, so the swarm router lands every later turn back on the same agent — everything past the brain is unreachable, with no error |

All three are now refused at config load, where the message can name the agent (and, for tools, name them) and point at the shape that does work: an LLM-backed agent reaching Genie through a `type: genie` tool.

## The swarm rule specifically

A **deterministic** handoff (`is_deterministic: true`) compiles to a real parent-graph edge and needs no tool call, so it stays legal — the rule requires that spelling rather than forbidding the topology. A brain as a swarm leaf, and handoffs *into* a brain, are untouched.

## Also

- The all-brains error from #289 offered `orchestration.swarm` as the escape hatch, which is exactly the silently-dead configuration. It now names `orchestration.supervisor.model` and qualifies any swarm suggestion with `is_deterministic: true`.
- `create_supervisor_graph` warns per brain worker that it is a graph sink: it answers and the turn ends, so a supervisor cannot chain it with another agent inside one turn (it re-routes on the next). By design per #289, but until now invisible.
- Docs get an "Under an orchestrator" subsection covering the rejected shapes, the per-mode matrix (supervisor works; swarm needs deterministic handoffs; deep_agent is unsupported because `_resolve_model` passes a `GenieAgentModel` straight through to deepagents), and the fact that `prompt:` on a brain is a no-op — only the latest `HumanMessage` reaches Genie. The example carried such a `prompt:`; it now says so instead.

## Verification

`test_genie_brain_orchestration.py` extended 4 → 18. No schema change (validator logic only, no field or description edits).

This pull request and its description were written by Isaac.
