### PR TITLE
ci(release): bump gh-action-pypi-publish to v1.14.2 for Metadata-Version 2.5

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -55,7 +55,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
       with:
         verbose: true
 


### PR DESCRIPTION
## Why

The `v0.2.8` PyPI publish [failed](https://github.com/natefleming/dao-ai/actions/runs/32163393111): the GitHub Release was created but nothing landed on PyPI.

Root cause: `hatchling` 1.29 stamps wheels with `Metadata-Version: 2.5`, but the pinned `pypa/gh-action-pypi-publish@ed0c539` bundles an older twine/pkginfo that rejects it:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

## Fix

Bump the publish action to `v1.14.2` (`dc37677`), which bundles twine 15 / packaging 26 and accepts metadata 2.5 (verified locally: `twine check` PASSES the 2.5 wheel).

This unblocks 0.2.9+ releases. The `v0.2.8` tag is being re-cut onto a commit carrying this same fix so `dao_ai-0.2.8` publishes.

This pull request and its description were written by Isaac.