### PR TITLE
feat(genie): deterministic supervisor handback for Genie-brain agents

### DIFF
--- a/examples/10_agent_integrations/genie_agent_supervisor_handback.yaml
+++ b/examples/10_agent_integrations/genie_agent_supervisor_handback.yaml
@@ -1,0 +1,154 @@
+# yaml-language-server: $schema=../../../schemas/model_config_schema.json
+
+# ==============================================================================
+# Genie brain under a supervisor — deterministic handback (handoff: true)
+# ==============================================================================
+# A Genie-specialist agent whose reasoning model is a GenieAgentModel, composed
+# under a SUPERVISOR with a second agent that formats the final answer.
+#
+# The problem this solves
+# -----------------------
+# A Genie brain runs its tool loop server-side and never emits a client tool
+# call, so by default it is a graph *sink* under a supervisor: it answers and
+# the turn ends, and the supervisor can never take Genie's answer and route on
+# to another agent in the same turn.
+#
+# Setting `handoff: true` on the Genie agent opts it into a deterministic
+# handback: after Genie answers, GenieAgentMiddleware injects a
+# `handoff_to_supervisor` tool call, so control returns to the supervisor —
+# which can then delegate to the `composer` for a polished reply. LLM-free: no
+# extra model call is made to decide the handoff.
+#
+#   user_msg -> supervisor -> genie_specialist -> supervisor -> composer -> END
+#
+# Note (swarm): the equivalent in a swarm is a normal `is_deterministic: true`
+# handoff route out of the Genie agent — that already works and needs no flag,
+# because swarm deterministic handoffs route at the graph level.
+#
+# Preview status: the Genie Agent Mode API is in Beta. A workspace admin must
+# enable "Genie Agents Agent Mode API" from the Previews menu.
+#
+# Deploy (fevm), both surfaces:
+#   dao-ai agent up -c examples/10_agent_integrations/genie_agent_supervisor_handback.yaml --mode model_serving -p fevm
+#   dao-ai agent up -c examples/10_agent_integrations/genie_agent_supervisor_handback.yaml --mode apps          -p fevm
+# ==============================================================================
+
+parameters:
+  catalog:
+    description: Unity Catalog catalog for the registered model + trace tables
+    default: retail_consumer_goods
+  schema:
+    description: Schema within the catalog for the registered model + trace tables
+    default: dao_ai
+  llm:
+    description: Chat/reasoning serving endpoint for the supervisor and composer
+    default: databricks-claude-sonnet-5
+  genie_space_id:
+    description: Genie space (agent) id backing the Genie specialist brain
+    default: 01f153992389158da23cbf54fd8eb89d
+  warehouse_id:
+    description: SQL warehouse used to export MLflow traces to UC OTEL tables
+    default: d58e5fb998498840
+
+schemas:
+  agent_schema: &agent_schema
+    catalog_name: ${var.catalog}
+    schema_name: ${var.schema}
+
+resources:
+  genie_rooms:
+    # `agent_id` is an alias of `space_id` (Genie Spaces were renamed to Genie
+    # Agents; same 32-char hex). Registering the room here makes the bundle emit
+    # the genie-space grant; a GenieAgentModel config-load fails otherwise.
+    sporting_goods_genie: &sporting_goods_genie
+      name: "Sales and Pricing Analytics - Sporting Goods"
+      description: "Sales performance, pricing, margin, and revenue analytics"
+      agent_id: ${var.genie_space_id}
+
+  llms:
+    default_llm: &default_llm
+      name: ${var.llm}
+
+agents:
+  genie_specialist: &genie_specialist
+    name: genie_specialist
+    description: >-
+      Answers questions about sporting-goods sales, pricing, margins, and
+      revenue by querying the data warehouse with Databricks Genie.
+    # The Genie Agent IS this agent's brain (a GenieAgentModel, defined inline).
+    model:
+      genie_room: *sporting_goods_genie
+      timeout_seconds: 300
+    tools: []
+    # Opt into deterministic handback so the supervisor regains control after
+    # Genie answers and can chain the composer in the same turn.
+    handoff: true
+    prompt: |
+      You are a sporting-goods data specialist backed by Databricks Genie.
+      Relay Genie's answer clearly, preserving any SQL, result tables, and
+      citations Genie includes.
+
+  composer: &composer
+    name: composer
+    description: >-
+      Turns a specialist's raw findings into a concise, well-formatted,
+      customer-facing answer.
+    model: *default_llm
+    tools: []
+    prompt: |
+      You are the composer. Rewrite the prior specialist's findings into a
+      clear, friendly answer for the end user. Keep any figures and tables
+      accurate. When the question is fully answered, stop.
+
+app:
+  name: genie_supervisor_handback_dao
+  description: >
+    A Genie brain composed under a supervisor via deterministic handback,
+    then formatted by a composer agent.
+  log_level: INFO
+
+  # Deploy to BOTH Databricks Apps (chat UI + agent server) AND Model Serving
+  # (UC-registered model). Model Serving traces land in the MLflow experiment
+  # automatically; Apps needs trace_location (below) for durable traces.
+  registered_model:
+    schema: *agent_schema
+    name: genie_supervisor_handback_dao
+
+  endpoint_name: genie_supervisor_handback_dao
+
+  # MLflow trace persistence on Databricks Apps requires trace_location — Apps
+  # containers cannot reach the default control-plane trace storage host, so
+  # exports are routed through a SQL warehouse to UC OTEL tables. Do NOT set
+  # table_prefix (MLflow's V4 search_traces hardcodes the default table name).
+  trace_location:
+    schema: *agent_schema
+    warehouse: ${var.warehouse_id}
+
+  permissions:
+  - principals: [users]
+    entitlements:
+    - CAN_QUERY
+
+  tags:
+    pattern: supervisor
+    streaming: true
+    feature: genie_handback
+
+  agents:
+  - *genie_specialist
+  - *composer
+
+  orchestration:
+    supervisor:
+      model: *default_llm
+      tools: []
+      prompt: |
+        You are the supervisor. Route data questions to `genie_specialist`.
+        When it hands back with an answer, delegate to `composer` to produce
+        the final customer-facing reply, then stop. Do not re-route to
+        `genie_specialist` unless the user asks a new data question.
+
+  input_example:
+    messages:
+    - role: user
+      content: "What were the total sales by store, and which store sold the most?"

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -8146,6 +8146,22 @@ class AgentModel(BaseModel):
             return {"run_limit": value}
         return value
 
+    handoff: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Only meaningful when ``model`` is a Genie space (``GenieAgentModel``). "
+            "A Genie brain runs its tool loop server-side and never emits a client "
+            "tool call, so under a supervisor it is normally a graph sink: it "
+            "answers and the turn ends, and the supervisor cannot use its answer "
+            "and then route on. Set ``handoff: true`` to opt this Genie worker into "
+            "a deterministic handback: after it answers, control returns to the "
+            "supervisor (via an injected ``handoff_to_supervisor`` tool call) so the "
+            "supervisor can chain another agent in the same turn. LLM-free. Ignored "
+            "for non-Genie models (they hand off through their own tool loop) and in "
+            "the swarm pattern (use a swarm ``is_deterministic`` handoff route "
+            "instead, which already routes a Genie source at the graph level)."
+        ),
+    )
     requires: list[str] = Field(
         default_factory=list,
         description=(
@@ -8275,6 +8291,13 @@ class AgentModel(BaseModel):
         where the message can name the agent and the offending tools.
         """
         if not isinstance(self.model, GenieAgentModel):
+            if self.handoff is not None:
+                raise ValueError(
+                    f"Agent '{self.name}' sets 'handoff' but its model is not a "
+                    f"Genie space. 'handoff' opts a Genie brain into deterministic "
+                    f"handback to a supervisor; a non-Genie agent already hands off "
+                    f"through its own tool loop. Remove 'handoff'."
+                )
             return self
 
         if self.tools:

--- a/src/dao_ai/middleware/genie_agent.py
+++ b/src/dao_ai/middleware/genie_agent.py
@@ -35,6 +35,7 @@ Flow per call:
 from __future__ import annotations
 
 from typing import Any, Awaitable, Callable, Optional
+from uuid import uuid4
 
 from langchain.agents.middleware.types import (
     ExtendedModelResponse,
@@ -43,6 +44,7 @@ from langchain.agents.middleware.types import (
 )
 from langchain_core.language_models import LanguageModelLike
 from langchain_core.messages import AIMessage
+from langchain_core.tools import BaseTool
 from langgraph.types import Command
 from loguru import logger
 
@@ -52,13 +54,30 @@ from dao_ai.middleware.base import AgentMiddleware
 from dao_ai.state import AgentState, Context, SessionState
 from dao_ai.tools.tracing import ResourceInfo, set_resource_attributes
 
+# Prefix shared by every handoff tool created by ``create_handoff_tool`` /
+# ``_create_handoff_back_to_supervisor_tool`` (orchestration). The deterministic
+# handback discovers the bound handback tool by this prefix rather than
+# hardcoding its name, so a rename in orchestration cannot silently break it.
+_HANDOFF_TOOL_PREFIX: str = "handoff_to_"
+
+# Fallback summary when Genie's answer has no usable text to summarize.
+_DEFAULT_HANDBACK_SUMMARY: str = "Genie provided a data analysis above."
+
+# Longest summary string synthesized for the injected handback tool call.
+_MAX_HANDBACK_SUMMARY_CHARS: int = 500
+
 
 class GenieAgentMiddleware(AgentMiddleware[AgentState, Context]):
     """Rebuild a Genie chat model per request with OBO + prior conversation_id,
     and persist the newly-issued conversation_id back to ``session``."""
 
-    def __init__(self, genie_model: GenieAgentModel) -> None:
+    def __init__(self, genie_model: GenieAgentModel, handback: bool = False) -> None:
         self.genie_model = genie_model
+        # When True (set from ``AgentModel.handoff`` for a Genie brain under a
+        # supervisor), inject a ``handoff_to_supervisor`` tool call into Genie's
+        # answer so the worker returns control to the supervisor instead of
+        # being a graph sink. LLM-free.
+        self.handback = handback
 
     # -- helpers -------------------------------------------------------
 
@@ -96,6 +115,89 @@ class GenieAgentMiddleware(AgentMiddleware[AgentState, Context]):
                     return str(conv_id)
         return None
 
+    # -- deterministic handback ----------------------------------------
+
+    @staticmethod
+    def _handback_tool_name(request: ModelRequest) -> Optional[str]:
+        """Return the name of the bound handoff/handback tool, if any.
+
+        A Genie worker opted into handback is given exactly one such tool by the
+        supervisor (``_create_handoff_back_to_supervisor_tool``); we discover it
+        by the shared ``handoff_to_`` prefix rather than hardcoding the name.
+        Returns ``None`` when no handoff tool is bound (e.g. the Genie agent is a
+        single-agent app), in which case injection is skipped.
+        """
+        for tool in request.tools or []:
+            if isinstance(tool, BaseTool) and tool.name.startswith(
+                _HANDOFF_TOOL_PREFIX
+            ):
+                return tool.name
+        return None
+
+    @staticmethod
+    def _synthesize_summary(message: AIMessage) -> str:
+        """Build a non-empty ``summary`` arg from Genie's answer text.
+
+        ``handoff_to_supervisor(summary: str)`` rejects an empty summary at
+        ToolNode schema validation, so always return something.
+        """
+        content: Any = message.content
+        text: str = ""
+        if isinstance(content, str):
+            text = content.strip()
+        elif isinstance(content, list):
+            parts: list[str] = [
+                block.get("text", "")
+                for block in content
+                if isinstance(block, dict)
+                and block.get("type") in {"text", "output_text"}
+            ]
+            text = "\n".join(p for p in parts if p).strip()
+        if not text:
+            return _DEFAULT_HANDBACK_SUMMARY
+        return text[:_MAX_HANDBACK_SUMMARY_CHARS]
+
+    def _maybe_inject_handback(
+        self, request: ModelRequest, response: ModelResponse
+    ) -> None:
+        """Attach a handback tool call to Genie's answer, in place.
+
+        Genie never emits a client tool call, so under a supervisor its turn ends
+        unless we route control back. We rewrite the final ``AIMessage`` to carry
+        a ``handoff_to_supervisor`` tool call; langchain's agent loop then routes
+        to the ToolNode, which runs the handback tool → ``Command(goto=...,
+        graph=PARENT)`` — the same return path every normal worker uses.
+        """
+        tool_name: Optional[str] = self._handback_tool_name(request)
+        if tool_name is None:
+            logger.warning(
+                "Genie handback enabled but no handoff tool is bound; "
+                "skipping injection (the worker will remain a graph sink)",
+                agent_id=self.genie_model.name,
+            )
+            return
+
+        result: list[Any] = response.result or []
+        for index in range(len(result) - 1, -1, -1):
+            message: Any = result[index]
+            if not isinstance(message, AIMessage):
+                continue
+            if message.tool_calls:
+                return  # Genie unexpectedly emitted a tool call; leave it be.
+            tool_call: dict[str, Any] = {
+                "name": tool_name,
+                "args": {"summary": self._synthesize_summary(message)},
+                "id": f"genie_handback_{uuid4().hex}",
+                "type": "tool_call",
+            }
+            result[index] = message.model_copy(update={"tool_calls": [tool_call]})
+            logger.debug(
+                "Injected deterministic Genie handback tool call",
+                agent_id=self.genie_model.name,
+                tool=tool_name,
+            )
+            return
+
     def _session_command(
         self,
         state: AgentState,
@@ -130,9 +232,10 @@ class GenieAgentMiddleware(AgentMiddleware[AgentState, Context]):
         prior: Optional[str] = self._prior_conversation_id(request.state)
         model: LanguageModelLike = self._build_model(context, prior)
         response: ModelResponse = handler(request.override(model=model))
-        command: Command | None = self._session_command(
-            request.state, self._issued_conversation_id(response), prior
-        )
+        issued: Optional[str] = self._issued_conversation_id(response)
+        if self.handback:
+            self._maybe_inject_handback(request, response)
+        command: Command | None = self._session_command(request.state, issued, prior)
         if command is None:
             return response
         return ExtendedModelResponse(model_response=response, command=command)
@@ -148,9 +251,10 @@ class GenieAgentMiddleware(AgentMiddleware[AgentState, Context]):
         prior: Optional[str] = self._prior_conversation_id(request.state)
         model: LanguageModelLike = self._build_model(context, prior)
         response: ModelResponse = await handler(request.override(model=model))
-        command: Command | None = self._session_command(
-            request.state, self._issued_conversation_id(response), prior
-        )
+        issued: Optional[str] = self._issued_conversation_id(response)
+        if self.handback:
+            self._maybe_inject_handback(request, response)
+        command: Command | None = self._session_command(request.state, issued, prior)
         if command is None:
             return response
         return ExtendedModelResponse(model_response=response, command=command)

--- a/src/dao_ai/nodes.py
+++ b/src/dao_ai/nodes.py
@@ -439,12 +439,17 @@ def create_agent_node(
     if isinstance(agent.model, GenieAgentModel):
         from dao_ai.middleware.genie_agent import GenieAgentMiddleware
 
-        middleware_list.append(GenieAgentMiddleware(genie_model=agent.model))
+        middleware_list.append(
+            GenieAgentMiddleware(
+                genie_model=agent.model, handback=bool(agent.handoff)
+            )
+        )
         logger.info(
             "Genie agent middleware enabled",
             agent=agent.name,
             model=agent.model.name,
             on_behalf_of_user=agent.model.on_behalf_of_user,
+            handback=bool(agent.handoff),
         )
     elif agent.model.on_behalf_of_user:
         from dao_ai.middleware.obo import OBOModelMiddleware

--- a/src/dao_ai/orchestration/supervisor.py
+++ b/src/dao_ai/orchestration/supervisor.py
@@ -351,12 +351,20 @@ def create_supervisor_graph(config: AppConfig) -> CompiledStateGraph:
         # Genie-brain worker (GenieAgentModel), whose model runs its own tool
         # loop server-side and never calls a client tool. Its turn ends when it
         # answers, which is the only way control ever leaves that worker anyway,
-        # so the tool would be dead weight in its graph and its logs.
+        # so the tool would be dead weight in its graph and its logs — unless the
+        # author opts in with ``handoff: true`` (see ``genie_handback`` below).
         is_genie_brain: bool = isinstance(registered_agent.model, GenieAgentModel)
+        # A Genie brain cannot emit a client tool call, so it is normally a graph
+        # sink. Opting in via ``handoff: true`` gives it the handback tool anyway:
+        # that creates the worker's ToolNode + model→tools edge, and
+        # GenieAgentMiddleware injects a ``handoff_to_supervisor`` tool call into
+        # Genie's answer so control deterministically returns to the supervisor.
+        genie_handback: bool = is_genie_brain and bool(registered_agent.handoff)
         additional_tools: list[BaseTool] = (
-            [] if is_genie_brain else [_create_handoff_back_to_supervisor_tool()]
+            [] if (is_genie_brain and not genie_handback)
+            else [_create_handoff_back_to_supervisor_tool()]
         )
-        if is_genie_brain:
+        if is_genie_brain and not genie_handback:
             # Without the handoff tool, and with no worker -> supervisor edge,
             # this worker is a graph sink. That is correct, but it silently
             # rules out something a config author may well expect: the

--- a/tests/dao_ai/test_genie_agent_middleware.py
+++ b/tests/dao_ai/test_genie_agent_middleware.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 
 from langchain.agents.middleware.types import ExtendedModelResponse, ModelResponse
 from langchain_core.messages import AIMessage
+from langchain_core.tools import BaseTool, tool
 
 from dao_ai.config import GenieAgentModel, GenieRoomModel
 from dao_ai.genie.agent_chat_model import CONVERSATION_ID_METADATA_KEY
@@ -30,7 +31,15 @@ from dao_ai.state import Context, SessionState
 AGENT_ID = "01f05dd06c421ad6b522bf7a517cf6d2"
 
 
-def _middleware(monkeypatch: Any) -> tuple[GenieAgentMiddleware, dict[str, Any]]:
+@tool
+def handoff_to_supervisor(summary: str) -> str:
+    """Hand control back to the supervisor."""
+    return "ok"
+
+
+def _middleware(
+    monkeypatch: Any, handback: bool = False
+) -> tuple[GenieAgentMiddleware, dict[str, Any]]:
     """Build a middleware whose model-build is stubbed to record its args."""
     model = GenieAgentModel(genie_room=GenieRoomModel(space_id=AGENT_ID))
     built: dict[str, Any] = {}
@@ -50,13 +59,16 @@ def _middleware(monkeypatch: Any) -> tuple[GenieAgentMiddleware, dict[str, Any]]
         return MagicMock(name="GenieAgentChatModel")
 
     monkeypatch.setattr(GenieAgentModel, "chat_model_for_workspace_client", _fake_build)
-    return GenieAgentMiddleware(genie_model=model), built
+    return GenieAgentMiddleware(genie_model=model, handback=handback), built
 
 
-def _request(session: SessionState | None) -> MagicMock:
+def _request(
+    session: SessionState | None, tools: list[BaseTool] | None = None
+) -> MagicMock:
     request = MagicMock(name="ModelRequest")
     request.state = {"session": session} if session is not None else {}
     request.runtime.context = Context(user_id="u", thread_id="thr-1")
+    request.tools = tools if tools is not None else []
     request.override.return_value = request
     return request
 
@@ -122,6 +134,93 @@ class TestPersistIssuedId:
         merged: SessionState = result.command.update["session"]
         assert merged.genie.get_conversation_id(AGENT_ID) == "conv-new"
         assert merged.genie.get_conversation_id("other-agent") == "other-conv"
+
+
+def _final_ai_message(result: Any) -> AIMessage:
+    """Pull the last AIMessage off a wrap result (ModelResponse or Extended)."""
+    response = (
+        result.model_response
+        if isinstance(result, ExtendedModelResponse)
+        else result
+    )
+    for message in reversed(response.result):
+        if isinstance(message, AIMessage):
+            return message
+    raise AssertionError("no AIMessage in response")
+
+
+class TestDeterministicHandback:
+    def test_injects_handback_tool_call(self, monkeypatch: Any) -> None:
+        mw, _ = _middleware(monkeypatch, handback=True)
+        request = _request(None, tools=[handoff_to_supervisor])
+        result = mw.wrap_model_call(request, _handler_returning(None))
+
+        message = _final_ai_message(result)
+        assert len(message.tool_calls) == 1
+        call = message.tool_calls[0]
+        assert call["name"] == "handoff_to_supervisor"
+        assert call["args"]["summary"]  # non-empty
+        assert call["id"]
+
+    def test_preserves_content_and_conversation_id(self, monkeypatch: Any) -> None:
+        mw, _ = _middleware(monkeypatch, handback=True)
+        request = _request(None, tools=[handoff_to_supervisor])
+
+        def _handler(_req: Any) -> ModelResponse:
+            return ModelResponse(
+                result=[
+                    AIMessage(
+                        "Top 10 suppliers are ...",
+                        response_metadata={CONVERSATION_ID_METADATA_KEY: "conv-new"},
+                    )
+                ]
+            )
+
+        result = mw.wrap_model_call(request, _handler)
+
+        # Injection must not disturb the conversation-id persistence path.
+        assert isinstance(result, ExtendedModelResponse)
+        assert (
+            result.command.update["session"].genie.get_conversation_id(AGENT_ID)
+            == "conv-new"
+        )
+        message = _final_ai_message(result)
+        assert message.content == "Top 10 suppliers are ..."
+        assert message.response_metadata[CONVERSATION_ID_METADATA_KEY] == "conv-new"
+        assert message.tool_calls[0]["args"]["summary"].startswith("Top 10 suppliers")
+
+    def test_no_injection_when_disabled(self, monkeypatch: Any) -> None:
+        mw, _ = _middleware(monkeypatch, handback=False)
+        request = _request(None, tools=[handoff_to_supervisor])
+        result = mw.wrap_model_call(request, _handler_returning(None))
+        assert _final_ai_message(result).tool_calls == []
+
+    def test_no_injection_when_no_handoff_tool_bound(self, monkeypatch: Any) -> None:
+        mw, _ = _middleware(monkeypatch, handback=True)
+        request = _request(None, tools=[])
+        result = mw.wrap_model_call(request, _handler_returning(None))
+        assert _final_ai_message(result).tool_calls == []
+
+    def test_summary_falls_back_when_answer_empty(self, monkeypatch: Any) -> None:
+        mw, _ = _middleware(monkeypatch, handback=True)
+        request = _request(None, tools=[handoff_to_supervisor])
+
+        def _empty(_req: Any) -> ModelResponse:
+            return ModelResponse(result=[AIMessage("")])
+
+        result = mw.wrap_model_call(request, _empty)
+        assert _final_ai_message(result).tool_calls[0]["args"]["summary"]
+
+    def test_awrap_injects_handback(self, monkeypatch: Any) -> None:
+        mw, _ = _middleware(monkeypatch, handback=True)
+        request = _request(None, tools=[handoff_to_supervisor])
+
+        async def _ahandler(_req: Any) -> ModelResponse:
+            return ModelResponse(result=[AIMessage("async answer")])
+
+        result = asyncio.run(mw.awrap_model_call(request, _ahandler))
+        call = _final_ai_message(result).tool_calls[0]
+        assert call["name"] == "handoff_to_supervisor"
 
 
 class TestAsync:

--- a/tests/dao_ai/test_genie_brain_orchestration.py
+++ b/tests/dao_ai/test_genie_brain_orchestration.py
@@ -56,6 +56,11 @@ def _brain(name: str, space_id: str) -> dict[str, Any]:
     return {"name": name, "model": {"genie_room": {"agent_id": space_id}}, "tools": []}
 
 
+def _brain_handback(name: str, space_id: str) -> dict[str, Any]:
+    """A Genie brain opted into deterministic handback (``handoff: true``)."""
+    return {**_brain(name, space_id), "handoff": True}
+
+
 def _llm(name: str) -> dict[str, Any]:
     return {"name": name, "model": {"name": "test-model"}, "tools": []}
 
@@ -115,6 +120,45 @@ class TestSupervisorGivesBrainNoHandoffTool:
         assert additional_tools_by_agent == {
             "billing": ["handoff_to_supervisor"],
             "sellout": [],
+        }
+
+    def test_brain_with_handoff_true_gets_the_handback_tool(self) -> None:
+        """Opting in with ``handoff: true`` gives the brain worker the handback
+        tool — which is what creates its ToolNode + model→tools edge so the
+        middleware-injected ``handoff_to_supervisor`` call has somewhere to go."""
+        from dao_ai.orchestration.supervisor import create_supervisor_graph
+
+        config = _config(
+            [_llm("billing"), _brain_handback("sellout", SPACE_A)],
+            orchestration={"supervisor": {"model": {"name": "test-model"}}},
+        )
+        additional_tools_by_agent: dict[str, list[str]] = {}
+
+        def _fake_create_agent_node(agent: Any, **kwargs: Any) -> Any:
+            additional_tools_by_agent[agent.name] = [
+                t.name for t in kwargs.get("additional_tools") or []
+            ]
+            return MagicMock(name=f"subgraph:{agent.name}")
+
+        with (
+            patch(
+                "dao_ai.orchestration.supervisor.create_checkpointer", return_value=None
+            ),
+            patch("dao_ai.orchestration.supervisor.create_store", return_value=None),
+            patch(
+                "dao_ai.orchestration.supervisor.create_extraction_manager_and_executor",
+                return_value=(None, None),
+            ),
+            patch(
+                "dao_ai.orchestration.supervisor.create_agent_node",
+                side_effect=_fake_create_agent_node,
+            ),
+        ):
+            create_supervisor_graph(config)
+
+        assert additional_tools_by_agent == {
+            "billing": ["handoff_to_supervisor"],
+            "sellout": ["handoff_to_supervisor"],
         }
 
 
@@ -360,3 +404,11 @@ class TestSupervisorWarnsBrainIsASink:
     def test_an_all_llm_supervisor_names_no_agent(self) -> None:
         msgs = _capture_warnings(self._build([_llm("billing"), _llm("returns")]))
         assert not [m for m in msgs if "billing" in m or "returns" in m], msgs
+
+    def test_a_brain_with_handoff_true_is_not_warned(self) -> None:
+        """Opting into handback removes the sink limitation, so the sink warning
+        must not fire for that worker."""
+        msgs = _capture_warnings(
+            self._build([_llm("billing"), _brain_handback("sellout", SPACE_A)])
+        )
+        assert not [m for m in msgs if "sellout" in m], msgs


### PR DESCRIPTION
## Problem

A `GenieAgentModel` brain runs its tool loop server-side and never emits a client tool call, so under a **supervisor** it was a graph *sink*: it answered and the turn ended. The supervisor could not take Genie's answer and route on to another agent in the same turn (there is even a `logger.warning` acknowledging this in `supervisor.py`).

External research confirms client tool calling is not supported by the Genie API and is not on the Databricks roadmap — Databricks' own guidance is to orchestrate Genie externally — so dao-ai must supply the return path itself.

## Change

Opt-in `handoff: true` on `AgentModel`. For a Genie brain, `GenieAgentMiddleware` injects a `handoff_to_supervisor` tool call into Genie's answer after it responds. LangChain's agent loop then routes to the ToolNode, which runs the **existing** handback tool → `Command(goto=SUPERVISOR, graph=PARENT)` — the identical return path every normal worker uses. **LLM-free** (no extra model call), which is also architecturally correct: the supervisor is already the router, so a per-Genie router would be redundant.

- **`config.py`** — `handoff` field + validator (rejected on non-Genie models).
- **`middleware/genie_agent.py`** — `handback` flag; discovers the bound handoff tool by the `handoff_to_` prefix (no hardcoded name), synthesizes a non-empty `summary`, preserves Genie's `content` + conversation-id metadata; applied to both sync and async paths.
- **`supervisor.py`** — a `handoff: true` Genie worker is given the handback tool (creating its ToolNode + model→tools edge, the load-bearing prerequisite); otherwise unchanged (sink + warning).
- **`nodes.py`** — passes `agent.handoff` into the middleware.

**Swarm** already composes a Genie source via `is_deterministic: true` (graph-level routing), so this targets the supervisor pattern. The dynamic LLM-router variant is intentionally deferred; `handoff` can widen from `bool` to a model later without a breaking change.

## Tests

- Middleware unit tests: injection produces a valid `handoff_to_supervisor` call; content + `genie_conversation_id` preserved; no-op when disabled or when no handoff tool is bound; async parity.
- Supervisor wiring tests: a `handoff: true` brain gets the handback tool; the sink warning is suppressed for it.
- Full Genie suite green (207 passed).

## Live validation (fevm)

Deployed the included example (`examples/10_agent_integrations/genie_agent_supervisor_handback.yaml`) to **both** Model Serving and Databricks Apps. Queried the Model Serving endpoint and inspected the MLflow trace. The span chain confirms the mechanism:

```
supervisor → tools → handoff_to_genie_specialist
  genie_specialist → GenieAgentChatModel          (Genie room responded, real data)
                   → tools → handoff_to_supervisor (injected handback fired)
  supervisor → tools → handoff_to_composer
  composer  → ChatDatabricks                       (final formatted answer)
```

This pull request and its description were written by Isaac.