### PR TITLE
feat(genie): make supervisor handback the default for Genie brains (opt-out)

### DIFF
--- a/examples/10_agent_integrations/genie_agent_supervisor_handback.yaml
+++ b/examples/10_agent_integrations/genie_agent_supervisor_handback.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=../../../schemas/model_config_schema.json
 
 # ==============================================================================
-# Genie brain under a supervisor — deterministic handback (handoff: true)
+# Genie brain under a supervisor — deterministic handback (default)
 # ==============================================================================
 # A Genie-specialist agent whose reasoning model is a GenieAgentModel, composed
 # under a SUPERVISOR with a second agent that formats the final answer.
@@ -9,15 +9,15 @@
 # The problem this solves
 # -----------------------
 # A Genie brain runs its tool loop server-side and never emits a client tool
-# call, so by default it is a graph *sink* under a supervisor: it answers and
-# the turn ends, and the supervisor can never take Genie's answer and route on
-# to another agent in the same turn.
-#
-# Setting `handoff: true` on the Genie agent opts it into a deterministic
-# handback: after Genie answers, GenieAgentMiddleware injects a
+# call. Under a supervisor, dao-ai hands it back deterministically — like every
+# other worker: after Genie answers, GenieAgentMiddleware injects a
 # `handoff_to_supervisor` tool call, so control returns to the supervisor —
 # which can then delegate to the `composer` for a polished reply. LLM-free: no
 # extra model call is made to decide the handoff.
+#
+# This is the DEFAULT. `handoff: true` below states it explicitly for clarity;
+# to instead make the Genie brain a terminal graph sink (it answers and the turn
+# ends), set `handoff: false`.
 #
 #   user_msg -> supervisor -> genie_specialist -> supervisor -> composer -> END
 #
@@ -80,8 +80,8 @@ agents:
       genie_room: *sporting_goods_genie
       timeout_seconds: 300
     tools: []
-    # Opt into deterministic handback so the supervisor regains control after
-    # Genie answers and can chain the composer in the same turn.
+    # Deterministic handback is the default for a Genie brain under a supervisor;
+    # shown explicitly here. Set `handoff: false` to make it a terminal sink.
     handoff: true
     prompt: |
       You are a sporting-goods data specialist backed by Databricks Genie.

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -8149,19 +8149,20 @@ class AgentModel(BaseModel):
     handoff: Optional[bool] = Field(
         default=None,
         description=(
-            "Only meaningful when ``model`` is a Genie space (``GenieAgentModel``). "
-            "A Genie brain runs its tool loop server-side and never emits a client "
-            "tool call. Under a supervisor, dao-ai makes it hand control back "
-            "deterministically — like every other worker — by injecting a "
-            "``handoff_to_supervisor`` tool call after it answers, so the supervisor "
-            "can chain another agent in the same turn. LLM-free. This is the DEFAULT "
-            "(``None``): a Genie worker hands back. Set ``handoff: false`` to opt OUT "
-            "and make the brain a terminal graph sink (it answers and the turn ends; "
-            "the supervisor only re-routes on the next turn). ``handoff: true`` is "
-            "the same as the default, stated explicitly. Ignored for non-Genie models "
-            "(they hand off through their own tool loop) and in the swarm pattern "
-            "(use a swarm ``is_deterministic`` handoff route instead, which already "
-            "routes a Genie source at the graph level)."
+            "Only meaningful when ``model`` is a Genie space (``GenieAgentModel``) "
+            "used as a worker under a SUPERVISOR. A Genie brain runs its tool loop "
+            "server-side and never emits a client tool call; under a supervisor, "
+            "dao-ai makes it hand control back deterministically — like every other "
+            "worker — by injecting a ``handoff_to_supervisor`` tool call after it "
+            "answers, so the supervisor can chain another agent in the same turn. "
+            "LLM-free. Under a supervisor this is the DEFAULT (``None`` and ``true`` "
+            "both hand back); set ``handoff: false`` to opt OUT and make the brain a "
+            "terminal graph sink (it answers and the turn ends; the supervisor only "
+            "re-routes on the next turn). It has NO effect outside the supervisor "
+            "pattern: a standalone single-agent Genie has nothing to hand back to, "
+            "and swarm routing uses an ``is_deterministic`` handoff route at the "
+            "graph level instead. Ignored for non-Genie models (they hand off "
+            "through their own tool loop)."
         ),
     )
     requires: list[str] = Field(

--- a/src/dao_ai/config.py
+++ b/src/dao_ai/config.py
@@ -8151,15 +8151,17 @@ class AgentModel(BaseModel):
         description=(
             "Only meaningful when ``model`` is a Genie space (``GenieAgentModel``). "
             "A Genie brain runs its tool loop server-side and never emits a client "
-            "tool call, so under a supervisor it is normally a graph sink: it "
-            "answers and the turn ends, and the supervisor cannot use its answer "
-            "and then route on. Set ``handoff: true`` to opt this Genie worker into "
-            "a deterministic handback: after it answers, control returns to the "
-            "supervisor (via an injected ``handoff_to_supervisor`` tool call) so the "
-            "supervisor can chain another agent in the same turn. LLM-free. Ignored "
-            "for non-Genie models (they hand off through their own tool loop) and in "
-            "the swarm pattern (use a swarm ``is_deterministic`` handoff route "
-            "instead, which already routes a Genie source at the graph level)."
+            "tool call. Under a supervisor, dao-ai makes it hand control back "
+            "deterministically — like every other worker — by injecting a "
+            "``handoff_to_supervisor`` tool call after it answers, so the supervisor "
+            "can chain another agent in the same turn. LLM-free. This is the DEFAULT "
+            "(``None``): a Genie worker hands back. Set ``handoff: false`` to opt OUT "
+            "and make the brain a terminal graph sink (it answers and the turn ends; "
+            "the supervisor only re-routes on the next turn). ``handoff: true`` is "
+            "the same as the default, stated explicitly. Ignored for non-Genie models "
+            "(they hand off through their own tool loop) and in the swarm pattern "
+            "(use a swarm ``is_deterministic`` handoff route instead, which already "
+            "routes a Genie source at the graph level)."
         ),
     )
     requires: list[str] = Field(

--- a/src/dao_ai/middleware/genie_agent.py
+++ b/src/dao_ai/middleware/genie_agent.py
@@ -73,10 +73,12 @@ class GenieAgentMiddleware(AgentMiddleware[AgentState, Context]):
 
     def __init__(self, genie_model: GenieAgentModel, handback: bool = False) -> None:
         self.genie_model = genie_model
-        # When True (set from ``AgentModel.handoff`` for a Genie brain under a
-        # supervisor), inject a ``handoff_to_supervisor`` tool call into Genie's
-        # answer so the worker returns control to the supervisor instead of
-        # being a graph sink. LLM-free.
+        # When True, inject a ``handoff_to_supervisor`` tool call into Genie's
+        # answer so the worker returns control to the supervisor instead of being
+        # a graph sink. LLM-free. The caller decides this: the supervisor builder
+        # derives it from ``AgentModel.handoff`` (unless ``handoff: false``) and
+        # passes it as ``create_agent_node(genie_handback=...)``; swarm /
+        # single-agent / deep_agent callers leave it False.
         self.handback = handback
 
     # -- helpers -------------------------------------------------------

--- a/src/dao_ai/middleware/genie_agent.py
+++ b/src/dao_ai/middleware/genie_agent.py
@@ -155,7 +155,9 @@ class GenieAgentMiddleware(AgentMiddleware[AgentState, Context]):
             text = "\n".join(p for p in parts if p).strip()
         if not text:
             return _DEFAULT_HANDBACK_SUMMARY
-        return text[:_MAX_HANDBACK_SUMMARY_CHARS]
+        if len(text) > _MAX_HANDBACK_SUMMARY_CHARS:
+            return text[: _MAX_HANDBACK_SUMMARY_CHARS - 1].rstrip() + "…"
+        return text
 
     def _maybe_inject_handback(
         self, request: ModelRequest, response: ModelResponse
@@ -197,6 +199,17 @@ class GenieAgentMiddleware(AgentMiddleware[AgentState, Context]):
                 tool=tool_name,
             )
             return
+
+        # Reached only if the response carried no AIMessage to attach to (e.g.
+        # an empty result). Handback was requested and a tool was bound, so the
+        # worker unexpectedly stays a graph sink this turn — say so, mirroring
+        # the no-tool-bound branch above rather than failing silently.
+        logger.warning(
+            "Genie handback enabled and a handoff tool is bound, but the response "
+            "contained no AIMessage to attach the handback to; the worker remains "
+            "a graph sink for this turn",
+            agent_id=self.genie_model.name,
+        )
 
     def _session_command(
         self,

--- a/src/dao_ai/nodes.py
+++ b/src/dao_ai/nodes.py
@@ -309,6 +309,12 @@ def create_agent_node(
         checkpointer: Optional persistent checkpointer for HITL subgraph state.
             Required for Model Serving where multiple workers need shared state.
             Falls back to InMemorySaver if not provided.
+        genie_handback: When the agent's model is a GenieAgentModel, controls
+            whether GenieAgentMiddleware injects a ``handoff_to_supervisor`` tool
+            call so the Genie worker hands control back. Only the supervisor
+            pattern sets this True (and binds the matching handback tool via
+            ``additional_tools``); swarm / single-agent / deep_agent callers
+            leave it False so no injection occurs. No effect for non-Genie models.
 
     Returns:
         A compiled agent node that processes state and returns responses

--- a/src/dao_ai/nodes.py
+++ b/src/dao_ai/nodes.py
@@ -288,6 +288,7 @@ def create_agent_node(
     additional_tools: Optional[Sequence[BaseTool]] = None,
     extraction_manager: Optional[MemoryStoreManager] = None,
     checkpointer: Optional[BaseCheckpointSaver] = None,
+    genie_handback: bool = False,
 ) -> CompiledStateGraph:
     """
     Factory function that creates a LangGraph node for a specialized agent.
@@ -439,9 +440,14 @@ def create_agent_node(
     if isinstance(agent.model, GenieAgentModel):
         from dao_ai.middleware.genie_agent import GenieAgentMiddleware
 
+        # ``genie_handback`` is decided by the caller: only the supervisor
+        # pattern hands a Genie worker back (and binds the handback tool that
+        # makes the injection land). Swarm / single-agent / deep_agent callers
+        # leave it False, so the middleware performs no injection there and
+        # emits no "no handoff tool bound" warning.
         middleware_list.append(
             GenieAgentMiddleware(
-                genie_model=agent.model, handback=bool(agent.handoff)
+                genie_model=agent.model, handback=genie_handback
             )
         )
         logger.info(
@@ -449,7 +455,7 @@ def create_agent_node(
             agent=agent.name,
             model=agent.model.name,
             on_behalf_of_user=agent.model.on_behalf_of_user,
-            handback=bool(agent.handoff),
+            handback=genie_handback,
         )
     elif agent.model.on_behalf_of_user:
         from dao_ai.middleware.obo import OBOModelMiddleware

--- a/src/dao_ai/orchestration/supervisor.py
+++ b/src/dao_ai/orchestration/supervisor.py
@@ -347,33 +347,30 @@ def create_supervisor_graph(config: AppConfig) -> CompiledStateGraph:
             internal_agents=sorted(internal_agents),
         )
     for registered_agent in config.app.agents:
-        # Every worker gets a handoff back to the supervisor — except a
-        # Genie-brain worker (GenieAgentModel), whose model runs its own tool
-        # loop server-side and never calls a client tool. Its turn ends when it
-        # answers, which is the only way control ever leaves that worker anyway,
-        # so the tool would be dead weight in its graph and its logs — unless the
-        # author opts in with ``handoff: true`` (see ``genie_handback`` below).
+        # Every worker hands control back to the supervisor. A Genie-brain
+        # worker (GenieAgentModel) cannot emit a client tool call on its own, so
+        # dao-ai hands it back deterministically: it gets the handback tool (which
+        # creates its ToolNode + model→tools edge) and GenieAgentMiddleware injects
+        # a ``handoff_to_supervisor`` call into Genie's answer. This is the default
+        # — a Genie worker behaves like every other worker — and is opt-OUT: set
+        # ``handoff: false`` to make the brain a terminal graph sink instead (it
+        # answers and the turn ends; the supervisor only re-routes next turn).
         is_genie_brain: bool = isinstance(registered_agent.model, GenieAgentModel)
-        # A Genie brain cannot emit a client tool call, so it is normally a graph
-        # sink. Opting in via ``handoff: true`` gives it the handback tool anyway:
-        # that creates the worker's ToolNode + model→tools edge, and
-        # GenieAgentMiddleware injects a ``handoff_to_supervisor`` tool call into
-        # Genie's answer so control deterministically returns to the supervisor.
-        genie_handback: bool = is_genie_brain and bool(registered_agent.handoff)
+        genie_handback: bool = is_genie_brain and registered_agent.handoff is not False
+        genie_sink: bool = is_genie_brain and registered_agent.handoff is False
         additional_tools: list[BaseTool] = (
-            [] if (is_genie_brain and not genie_handback)
-            else [_create_handoff_back_to_supervisor_tool()]
+            [] if genie_sink else [_create_handoff_back_to_supervisor_tool()]
         )
-        if is_genie_brain and not genie_handback:
-            # Without the handoff tool, and with no worker -> supervisor edge,
-            # this worker is a graph sink. That is correct, but it silently
-            # rules out something a config author may well expect: the
-            # supervisor cannot collect this agent's answer and then route on
-            # to another agent inside the same turn.
+        if genie_sink:
+            # Author explicitly opted out (``handoff: false``): no handoff tool,
+            # no worker -> supervisor edge, so this worker is a graph sink. The
+            # supervisor cannot collect its answer and route on to another agent
+            # in the same turn — it re-routes on the next turn instead.
             logger.warning(
-                "Genie-brain worker is a graph sink: it answers and the turn "
-                "ends. The supervisor cannot chain it with another agent in the "
-                "same turn — it re-routes on the next turn instead.",
+                "Genie-brain worker has handoff: false — it is a graph sink: it "
+                "answers and the turn ends. The supervisor cannot chain it with "
+                "another agent in the same turn — it re-routes on the next turn "
+                "instead.",
                 agent=registered_agent.name,
             )
 
@@ -385,6 +382,7 @@ def create_supervisor_graph(config: AppConfig) -> CompiledStateGraph:
             additional_tools=additional_tools,
             extraction_manager=extraction_manager,
             checkpointer=checkpointer,
+            genie_handback=genie_handback,
         )
         agent_subgraphs[registered_agent.name] = agent_subgraph
         agent_recursion_limits[registered_agent.name] = registered_agent.recursion_limit

--- a/tests/dao_ai/test_genie_agent_middleware.py
+++ b/tests/dao_ai/test_genie_agent_middleware.py
@@ -222,6 +222,34 @@ class TestDeterministicHandback:
         call = _final_ai_message(result).tool_calls[0]
         assert call["name"] == "handoff_to_supervisor"
 
+    def test_warns_when_tool_bound_but_no_ai_message(self, monkeypatch: Any) -> None:
+        """Handback enabled + tool bound but the response has no AIMessage: no
+        injection, and a warning fires (not a silent skip)."""
+        from loguru import logger
+
+        mw, _ = _middleware(monkeypatch, handback=True)
+        request = _request(None, tools=[handoff_to_supervisor])
+        msgs: list[str] = []
+        sink = logger.add(lambda m: msgs.append(m), level="WARNING", format="{message}")
+        try:
+            result = mw.wrap_model_call(request, lambda _req: ModelResponse(result=[]))
+        finally:
+            logger.remove(sink)
+        assert result.result == []  # nothing injected
+        assert any("no AIMessage" in m for m in msgs), msgs
+
+    def test_long_summary_is_truncated_with_ellipsis(self, monkeypatch: Any) -> None:
+        mw, _ = _middleware(monkeypatch, handback=True)
+        request = _request(None, tools=[handoff_to_supervisor])
+        long = "x " * 600  # > 500 chars
+
+        result = mw.wrap_model_call(
+            request, lambda _req: ModelResponse(result=[AIMessage(long)])
+        )
+        summary = _final_ai_message(result).tool_calls[0]["args"]["summary"]
+        assert len(summary) <= 500
+        assert summary.endswith("…")
+
 
 class TestAsync:
     def test_awrap_persists(self, monkeypatch: Any) -> None:

--- a/tests/dao_ai/test_genie_brain_orchestration.py
+++ b/tests/dao_ai/test_genie_brain_orchestration.py
@@ -57,8 +57,13 @@ def _brain(name: str, space_id: str) -> dict[str, Any]:
 
 
 def _brain_handback(name: str, space_id: str) -> dict[str, Any]:
-    """A Genie brain opted into deterministic handback (``handoff: true``)."""
+    """A Genie brain with handback stated explicitly (``handoff: true``)."""
     return {**_brain(name, space_id), "handoff": True}
+
+
+def _brain_sink(name: str, space_id: str) -> dict[str, Any]:
+    """A Genie brain opted OUT of handback (``handoff: false``) — a graph sink."""
+    return {**_brain(name, space_id), "handoff": False}
 
 
 def _llm(name: str) -> dict[str, Any]:
@@ -80,47 +85,69 @@ def _config(agents: list[dict[str, Any]], **app_extra: Any) -> AppConfig:
 
 
 # =============================================================================
-# 1. Supervisor: no handoff tool for a brain worker
+# 1. Supervisor: a Genie brain hands back by default (opt-out)
 # =============================================================================
 
 
-@pytest.mark.unit
-class TestSupervisorGivesBrainNoHandoffTool:
-    def test_llm_worker_gets_handoff_brain_gets_none(self) -> None:
-        from dao_ai.orchestration.supervisor import create_supervisor_graph
+def _capture_supervisor_worker_wiring(
+    config: AppConfig,
+) -> tuple[dict[str, list[str]], dict[str, bool]]:
+    """Build the supervisor graph, capturing per-worker additional_tools names
+    and the ``genie_handback`` flag passed to ``create_agent_node``."""
+    from dao_ai.orchestration.supervisor import create_supervisor_graph
 
+    tools_by_agent: dict[str, list[str]] = {}
+    handback_by_agent: dict[str, bool] = {}
+
+    def _fake_create_agent_node(agent: Any, **kwargs: Any) -> Any:
+        tools_by_agent[agent.name] = [
+            t.name for t in kwargs.get("additional_tools") or []
+        ]
+        handback_by_agent[agent.name] = bool(kwargs.get("genie_handback"))
+        return MagicMock(name=f"subgraph:{agent.name}")
+
+    with (
+        patch("dao_ai.orchestration.supervisor.create_checkpointer", return_value=None),
+        patch("dao_ai.orchestration.supervisor.create_store", return_value=None),
+        patch(
+            "dao_ai.orchestration.supervisor.create_extraction_manager_and_executor",
+            return_value=(None, None),
+        ),
+        patch(
+            "dao_ai.orchestration.supervisor.create_agent_node",
+            side_effect=_fake_create_agent_node,
+        ),
+    ):
+        create_supervisor_graph(config)
+    return tools_by_agent, handback_by_agent
+
+
+@pytest.mark.unit
+class TestSupervisorGivesBrainHandbackByDefault:
+    def test_default_brain_hands_back(self) -> None:
+        """A Genie brain with no ``handoff`` set hands back by default — it gets
+        the handback tool and ``genie_handback=True`` (opt-out semantics)."""
         config = _config(
             [_llm("billing"), _brain("sellout", SPACE_A)],
             orchestration={"supervisor": {"model": {"name": "test-model"}}},
         )
-        additional_tools_by_agent: dict[str, list[str]] = {}
-
-        def _fake_create_agent_node(agent: Any, **kwargs: Any) -> Any:
-            additional_tools_by_agent[agent.name] = [
-                t.name for t in kwargs.get("additional_tools") or []
-            ]
-            return MagicMock(name=f"subgraph:{agent.name}")
-
-        with (
-            patch(
-                "dao_ai.orchestration.supervisor.create_checkpointer", return_value=None
-            ),
-            patch("dao_ai.orchestration.supervisor.create_store", return_value=None),
-            patch(
-                "dao_ai.orchestration.supervisor.create_extraction_manager_and_executor",
-                return_value=(None, None),
-            ),
-            patch(
-                "dao_ai.orchestration.supervisor.create_agent_node",
-                side_effect=_fake_create_agent_node,
-            ),
-        ):
-            create_supervisor_graph(config)
-
-        assert additional_tools_by_agent == {
+        tools, handback = _capture_supervisor_worker_wiring(config)
+        assert tools == {
             "billing": ["handoff_to_supervisor"],
-            "sellout": [],
+            "sellout": ["handoff_to_supervisor"],
         }
+        assert handback["sellout"] is True
+
+    def test_brain_with_handoff_false_is_a_sink(self) -> None:
+        """Opting OUT with ``handoff: false`` gives the brain no handback tool and
+        ``genie_handback=False`` — a terminal graph sink."""
+        config = _config(
+            [_llm("billing"), _brain_sink("sellout", SPACE_A)],
+            orchestration={"supervisor": {"model": {"name": "test-model"}}},
+        )
+        tools, handback = _capture_supervisor_worker_wiring(config)
+        assert tools["sellout"] == []
+        assert handback["sellout"] is False
 
     def test_brain_with_handoff_true_gets_the_handback_tool(self) -> None:
         """Opting in with ``handoff: true`` gives the brain worker the handback
@@ -340,17 +367,17 @@ class TestSwarmBrainHandoffs:
 
 
 # =============================================================================
-# 6. Supervisor: say out loud that a brain worker is a graph sink
+# 6. Supervisor: warn only when a brain is explicitly opted out (handoff: false)
 # =============================================================================
 
 
 @pytest.mark.unit
-class TestSupervisorWarnsBrainIsASink:
-    """A brain worker has no ``handoff_to_supervisor`` and no outgoing edge, so
-    control cannot return to the supervisor mid-turn: the brain answers and the
-    turn ends. That is intended, but it means a supervisor cannot compose a
-    brain with another agent inside one turn — and nothing in the build says so.
-    Warn once per brain worker, naming it.
+class TestSupervisorWarnsBrainSink:
+    """A Genie brain hands back by default. Only when the author opts OUT with
+    ``handoff: false`` does the brain become a graph sink with no outgoing edge —
+    control cannot return to the supervisor mid-turn. That is a deliberate choice,
+    but easy to forget, so warn once per opted-out brain worker, naming it. A
+    default or ``handoff: true`` brain hands back and must NOT be warned.
     """
 
     def _build(self, agents: list[dict[str, Any]]) -> Callable[[], Any]:
@@ -385,15 +412,15 @@ class TestSupervisorWarnsBrainIsASink:
 
         return _run
 
-    def test_brain_worker_is_named_in_a_warning(self) -> None:
+    def test_opted_out_brain_worker_is_named_in_a_warning(self) -> None:
         msgs = _capture_warnings(
-            self._build([_llm("billing"), _brain("sellout", SPACE_A)])
+            self._build([_llm("billing"), _brain_sink("sellout", SPACE_A)])
         )
         assert any("sellout" in m for m in msgs), msgs
 
     def test_the_warning_says_control_cannot_return_mid_turn(self) -> None:
         msgs = _capture_warnings(
-            self._build([_llm("billing"), _brain("sellout", SPACE_A)])
+            self._build([_llm("billing"), _brain_sink("sellout", SPACE_A)])
         )
         brain_msgs = [m for m in msgs if "sellout" in m]
         assert brain_msgs, msgs
@@ -405,9 +432,17 @@ class TestSupervisorWarnsBrainIsASink:
         msgs = _capture_warnings(self._build([_llm("billing"), _llm("returns")]))
         assert not [m for m in msgs if "billing" in m or "returns" in m], msgs
 
+    def test_a_default_brain_is_not_warned(self) -> None:
+        """A brain that hands back by default (no ``handoff`` set) is not a sink,
+        so the warning must not fire for it."""
+        msgs = _capture_warnings(
+            self._build([_llm("billing"), _brain("sellout", SPACE_A)])
+        )
+        assert not [m for m in msgs if "sellout" in m], msgs
+
     def test_a_brain_with_handoff_true_is_not_warned(self) -> None:
-        """Opting into handback removes the sink limitation, so the sink warning
-        must not fire for that worker."""
+        """Explicit ``handoff: true`` hands back, so the sink warning must not
+        fire for that worker."""
         msgs = _capture_warnings(
             self._build([_llm("billing"), _brain_handback("sellout", SPACE_A)])
         )


### PR DESCRIPTION
## Context

Follow-up to #297 (deterministic supervisor handback for Genie brains), which shipped `handoff` as **opt-in**. On reflection, that leaves the *surprising* behavior as the default: a Genie worker under a supervisor is a worker like any other, and every normal worker already hands back automatically. A Genie brain silently swallowing the turn is the anomaly — the exact case the sink `logger.warning` flags.

## Change: flip `handoff` to opt-out

| `handoff` | Behavior under a supervisor |
|---|---|
| unset (default) | **Hands back** to the supervisor |
| `true` | Hands back (explicit) |
| `false` | Terminal graph sink (answers, turn ends) |

The default is resolved in the **supervisor builder**, not globally, and passed into `create_agent_node` via a new `genie_handback` parameter. This keeps the behavior correctly scoped: swarm / single-agent / deep_agent callers leave it `False`, so they never inject a handback and never emit a spurious "no handoff tool bound" warning. The sink warning now fires **only** for `handoff: false`.

- **`supervisor.py`** — `genie_handback = registered_agent.handoff is not False`; sink (+ warning) only when `handoff is False`; passes `genie_handback` to `create_agent_node`.
- **`nodes.py`** — new `genie_handback: bool = False` param; the middleware handback flag comes from it rather than `bool(agent.handoff)`.
- **`config.py`** — `handoff` field documents the opt-out default.
- **example + tests** — updated for the new default (a default brain hands back; only a `handoff: false` brain is a sink / is warned).

## Tests

`test_genie_brain_orchestration.py` and `test_genie_agent_middleware.py` green (38 passed); config suite green (53 passed). New/updated cases: default brain hands back (tool bound + `genie_handback=True`), `handoff: false` brain is a sink (no tool, `genie_handback=False`, warned), default/`true` brains not warned.

## Compatibility

Behavior change is intentional and scoped to Genie brains under a supervisor. Because the handback feature only just merged, no established config relies on the old opt-in default; a config that wants the old terminal-sink behavior sets `handoff: false`.

This pull request and its description were written by Isaac.