### PR TITLE
docs(examples): add custom MCP example using a Databricks App resource

### DIFF
--- a/examples/02_mcp/README.md
+++ b/examples/02_mcp/README.md
@@ -288,7 +288,7 @@ tools:
     name: jira_mcp
     function:
       type: mcp
-      url: https://mcp-harbor-freight.databricksapps.com/mcp/  # ← Explicit URL
+      url: https://mcp-jira-server-1234567890123456.7.aws.databricksapps.com/mcp/  # ← Explicit URL (yours)
       client_id: *client_id
       client_secret: *client_secret
       workspace_host: *workspace_host
@@ -333,7 +333,7 @@ flowchart LR
 resources:
   apps:
     jira_mcp_app: &jira_mcp_app
-      name: mcp-harbor-freight               # ← Deployed Databricks App instance name
+      name: mcp-jira-server                  # ← Your deployed Databricks App instance name
 
 tools:
   jira_mcp: &jira_mcp

--- a/examples/02_mcp/README.md
+++ b/examples/02_mcp/README.md
@@ -75,7 +75,8 @@ flowchart TB
 |------|-------------|-------------|
 | [`managed_mcp.yaml`](./managed_mcp.yaml) | 📦 Managed | Databricks-native MCP (SQL, Vector Search, Functions, Genie) |
 | [`external_mcp.yaml`](./external_mcp.yaml) | 🔗 External | UC Connection-based MCP (GitHub example) |
-| [`custom_mcp.yaml`](./custom_mcp.yaml) | 🛠️ Custom URL | Self-hosted MCP App (JIRA example) |
+| [`custom_mcp.yaml`](./custom_mcp.yaml) | 🛠️ Custom URL | Self-hosted MCP App via explicit `url:` (JIRA example) |
+| [`custom_mcp_app.yaml`](./custom_mcp_app.yaml) | 📱 Custom App | Self-hosted MCP App via `app:` resource — URL resolved dynamically |
 | [`filtered_mcp.yaml`](./filtered_mcp.yaml) | 🔒 Filtered | Tool filtering with include/exclude patterns |
 | [`meta_mcp.yaml`](./meta_mcp.yaml) | 🧬 Meta | Workspace-wide Genie MCP (`genie: true`) + per-server `_meta` parameters |
 
@@ -295,6 +296,67 @@ tools:
 
 ---
 
+## Pattern 3b: Custom MCP via App Resource (`app:`)
+
+Same self-hosted-App scenario as Pattern 3, but instead of pasting a hardcoded,
+workspace-specific URL, declare the App once as a first-class resource under
+`resources.apps` and reference it with `app:`. The MCP endpoint URL is resolved
+dynamically at runtime from the deployed app (`apps.get(name).url` + `/mcp`).
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#c2185b'}}}%%
+flowchart LR
+    subgraph Config["📄 Configuration"]
+        AppRef["<code>app: *jira_mcp_app</code>"]
+        Auth["<code>client_id: *sp_id</code><br/><code>client_secret: *sp_secret</code>"]
+    end
+
+    subgraph Resolve["⚙️ Runtime Resolution"]
+        Lookup["apps.get(name).url<br/>+ <code>/mcp</code>"]
+    end
+
+    subgraph App["📱 Databricks App"]
+        MCP["Custom MCP Server<br/>━━━━━━━━━━━━━━━━<br/>📋 JIRA<br/>📧 Email<br/>📊 Custom APIs"]
+    end
+
+    AppRef --> Lookup --> App
+    Auth -->|"Bearer Token"| App
+
+    style Config fill:#fce4ec,stroke:#c2185b
+    style Resolve fill:#fff3e0,stroke:#e65100
+    style App fill:#e3f2fd,stroke:#1565c0
+```
+
+### Configuration Example
+
+```yaml
+resources:
+  apps:
+    jira_mcp_app: &jira_mcp_app
+      name: mcp-harbor-freight               # ← Deployed Databricks App instance name
+
+tools:
+  jira_mcp: &jira_mcp
+    name: jira_mcp
+    function:
+      type: mcp
+      app: *jira_mcp_app                     # ← App resource; URL resolves to <app_url>/mcp
+      client_id: *client_id                  # Service principal auth
+      client_secret: *client_secret
+      workspace_host: *workspace_host
+```
+
+### `url:` vs `app:` — when to use which
+
+| | `url:` (Pattern 3) | `app:` (Pattern 3b) |
+|---|---|---|
+| MCP endpoint | Hardcoded in YAML | Resolved from app name at runtime |
+| Portability | Per-workspace edits needed | Same config across workspaces |
+| Resource declaration | None (opaque URL) | First-class `resources.apps` entry (`apps.apps` scope) |
+| Best for | Third-party / non-App MCP servers | MCP servers you host as a **named** Databricks App |
+
+---
+
 ## Pattern 4: Filtered MCP (Tool Selection)
 
 Control which tools are exposed from MCP servers using include/exclude patterns.
@@ -432,8 +494,11 @@ dao-ai chat -c examples/02_mcp/managed_mcp.yaml
 # External MCP (GitHub via UC Connection)
 dao-ai chat -c examples/02_mcp/external_mcp.yaml
 
-# Custom MCP (JIRA via App URL)
+# Custom MCP (JIRA via explicit App URL)
 dao-ai chat -c examples/02_mcp/custom_mcp.yaml
+
+# Custom MCP (JIRA via App resource — URL resolved dynamically)
+dao-ai chat -c examples/02_mcp/custom_mcp_app.yaml
 
 # Filtered MCP (Tool restrictions)
 dao-ai chat -c examples/02_mcp/filtered_mcp.yaml

--- a/examples/02_mcp/custom_mcp.yaml
+++ b/examples/02_mcp/custom_mcp.yaml
@@ -53,7 +53,7 @@ tools:
     name: jira_mcp
     function:
       type: mcp                                  # MCP function type
-      url: https://mcp-harbor-freight-984752964297111.11.azure.databricksapps.com/mcp/
+      url: https://mcp-jira-server-1234567890123456.7.aws.databricksapps.com/mcp/  # ← replace with your deployed app URL
       client_id: *client_id
       client_secret: *client_secret
       workspace_host: *workspace_host

--- a/examples/02_mcp/custom_mcp_app.yaml
+++ b/examples/02_mcp/custom_mcp_app.yaml
@@ -4,15 +4,18 @@
 # Custom MCP via Databricks App resource (`app:` instead of `url:`)
 # ==============================================================================
 # This is the same "self-hosted MCP server on a Databricks App" pattern as
-# custom_mcp.yaml (the JIRA / harbor-freight example), but instead of pasting a
-# hardcoded, workspace-specific URL into the tool:
+# custom_mcp.yaml (the JIRA example), but instead of pasting a hardcoded,
+# workspace-specific URL into the tool:
 #
-#     url: https://mcp-harbor-freight-984752964297111.11.azure.databricksapps.com/mcp/
+#     url: https://mcp-jira-server-1234567890123456.7.aws.databricksapps.com/mcp/
 #
 # we declare the App once as a first-class resource under `resources.apps` and
 # reference it from the MCP function with `app:`. The MCP endpoint URL is then
 # resolved dynamically at runtime from the deployed app
 # (apps.get(name).url + "/mcp") — no hardcoded host, no per-workspace edits.
+#
+# NOTE: `mcp-jira-server` below is a placeholder. Point `mcp_app_name` at an MCP
+# server App you have actually deployed in your own workspace.
 #
 # Why prefer `app:` over `url:` for App-hosted MCP servers:
 #   - Portable: the same config works across workspaces/deployments; the URL is
@@ -44,7 +47,7 @@ parameters:
     description: >
       Deployed Databricks App instance name that hosts the custom MCP server.
       The MCP endpoint is resolved dynamically to <app_url>/mcp.
-    default: mcp-harbor-freight
+    default: mcp-jira-server
 
 variables:
   client_id: &client_id

--- a/examples/02_mcp/custom_mcp_app.yaml
+++ b/examples/02_mcp/custom_mcp_app.yaml
@@ -1,0 +1,119 @@
+# yaml-language-server: $schema=../../../schemas/model_config_schema.json
+
+# ==============================================================================
+# Custom MCP via Databricks App resource (`app:` instead of `url:`)
+# ==============================================================================
+# This is the same "self-hosted MCP server on a Databricks App" pattern as
+# custom_mcp.yaml (the JIRA / harbor-freight example), but instead of pasting a
+# hardcoded, workspace-specific URL into the tool:
+#
+#     url: https://mcp-harbor-freight-984752964297111.11.azure.databricksapps.com/mcp/
+#
+# we declare the App once as a first-class resource under `resources.apps` and
+# reference it from the MCP function with `app:`. The MCP endpoint URL is then
+# resolved dynamically at runtime from the deployed app
+# (apps.get(name).url + "/mcp") — no hardcoded host, no per-workspace edits.
+#
+# Why prefer `app:` over `url:` for App-hosted MCP servers:
+#   - Portable: the same config works across workspaces/deployments; the URL is
+#     looked up from the app name, not baked into YAML.
+#   - First-class resource: the app is declared under `resources.apps`, so it
+#     carries the `apps.apps` API scope and is emitted as a proper resource
+#     dependency (matters for OBO and resource grants).
+#   - Single source of truth: reuse the same `*jira_mcp_app` anchor anywhere the
+#     app is referenced.
+#
+# Use `url:` (see custom_mcp.yaml) only when the MCP server is NOT a Databricks
+# App you can name — e.g. a third-party/self-hosted server reachable by URL.
+# ==============================================================================
+
+# =============================================================================
+# PARAMETERS
+# =============================================================================
+parameters:
+  catalog:
+    description: Unity Catalog catalog name
+    default: nfleming
+  schema:
+    description: Schema within the catalog
+    default: retail_consumer_goods
+  llm:
+    description: Chat/reasoning serving endpoint for the agent.
+    default: databricks-claude-sonnet-5
+  mcp_app_name:
+    description: >
+      Deployed Databricks App instance name that hosts the custom MCP server.
+      The MCP endpoint is resolved dynamically to <app_url>/mcp.
+    default: mcp-harbor-freight
+
+variables:
+  client_id: &client_id
+                                                 # Service principal client ID
+    options:
+    - env: RETAIL_AI_DATABRICKS_CLIENT_ID
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_ID
+  client_secret: &client_secret
+                                                 # Service principal secret
+    options:
+    - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+  workspace_host: &workspace_host
+                                                 # Databricks workspace URL
+    options:
+    - env: RETAIL_AI_DATABRICKS_HOST
+    - scope: retail_consumer_goods
+      secret: RETAIL_AI_DATABRICKS_HOST
+
+schemas:
+  retail_consumer_goods_schema: &retail_consumer_goods_schema
+                                                                               # Unity Catalog schema configuration
+    catalog_name: ${var.catalog}                       # Unity Catalog name
+    schema_name: ${var.schema}                       # Schema within the catalog
+
+resources:
+  models:
+    default_llm: &default_llm
+                                                 # Default LLM configuration
+      name: ${var.llm}                          # Databricks serving endpoint name
+  apps:
+    jira_mcp_app: &jira_mcp_app
+                                                 # Databricks App hosting the custom MCP server.
+      name: ${var.mcp_app_name}                  # Deployed app instance name; URL resolved at runtime.
+
+tools:
+  jira_mcp: &jira_mcp
+                               # Custom MCP server hosted on a Databricks App
+    name: jira_mcp
+    function:
+      type: mcp                                  # MCP function type
+      app: *jira_mcp_app                         # ← App resource; MCP URL resolves to <app_url>/mcp
+      client_id: *client_id                      # Service principal auth (client_id + client_secret + host)
+      client_secret: *client_secret
+      workspace_host: *workspace_host
+
+agents:
+  jira_agent: &jira_agent
+                                                   # MCP agent configuration
+    name: jira_agent                              # Agent identifier
+    model: *default_llm
+                                                 # Reference to LLM configuration
+    tools:                                       # Tools available to this agent
+    - *jira_mcp
+                                                 # Custom MCP tool (App-backed)
+
+app:
+  name: custom_mcp_app_dao                            # Application name
+  log_level: DEBUG                               # Logging level for the application
+  registered_model:                              # MLflow registered model configuration
+    name: custom_mcp_app_dao
+    schema: *retail_consumer_goods_schema
+                                                                # Schema where model will be registered
+  agents:                                        # List of agents included in the system
+  - *jira_agent
+                                                  # MCP agent
+  orchestration:                                 # Agent orchestration configuration
+    swarm:                                       # Supervisor orchestration pattern
+      default_agent: *jira_agent
+                                                 # Default agent for routing


### PR DESCRIPTION
## Summary

Adds a new MCP example, `examples/02_mcp/custom_mcp_app.yaml`, that configures a **custom (self-hosted) MCP server using a Databricks App as a first-class resource** — the `app:` attribute on the MCP function — instead of the hardcoded `url:` used by the existing `custom_mcp.yaml` (JIRA / harbor-freight) example.

Instead of:

```yaml
function:
  type: mcp
  url: https://mcp-harbor-freight-...databricksapps.com/mcp/   # hardcoded, per-workspace
```

the App is declared once under `resources.apps` and referenced by name:

```yaml
resources:
  apps:
    jira_mcp_app: &jira_mcp_app
      name: mcp-harbor-freight       # deployed app instance name

tools:
  jira_mcp: &jira_mcp
    function:
      type: mcp
      app: *jira_mcp_app             # MCP URL resolves to <app_url>/mcp at runtime
      client_id: *client_id
      client_secret: *client_secret
      workspace_host: *workspace_host
```

This leverages the existing `McpFunctionModel.app` field, which resolves the MCP endpoint dynamically via `apps.get(name).url + "/mcp"`.

### Why `app:` over `url:`
- **Portable** — same config works across workspaces; no hardcoded host.
- **First-class resource** — the app is declared under `resources.apps`, carrying the `apps.apps` scope and emitted as a proper resource dependency (matters for OBO / grants).
- **Single source of truth** — reuse the `*jira_mcp_app` anchor anywhere.

## Docs
- Added the file to the `02_mcp` README examples table and Quick Start.
- New **Pattern 3b** section with a diagram and a `url:` vs `app:` comparison table.

## Testing
- Loaded via `AppConfig.from_file(...)`: parses cleanly; `app.name == "mcp-harbor-freight"`, `url is None`, app registered under `resources.apps`.
- No pydantic model changes — no schema regeneration needed.

This pull request and its description were written by Isaac.