### PR TITLE
fix(pipeline): install the deploy's pinned dao-ai, not a stray ../dist wheel

### DIFF
--- a/examples/99_complete_applications/sporting_goods_store/sporting_goods_store.yaml
+++ b/examples/99_complete_applications/sporting_goods_store/sporting_goods_store.yaml
@@ -41,6 +41,18 @@ parameters:
   lakebase_project:
     description: Lakebase project name reused for agent memory + checkpointer
     default: retail-consumer-goods
+  service_principal_name:
+    description: Display name of the service principal to create or reuse. Override per workspace via --var (e.g. to point at an existing SP that already owns the credential secrets).
+    default: retail_consumer_goods_sp
+  secret_scope:
+    description: Secret scope holding the service principal's OAuth client id/secret.
+    default: retail_consumer_goods
+  client_id_key:
+    description: Secret key (and env-var fallback) for the SP OAuth client id.
+    default: RETAIL_AI_DATABRICKS_CLIENT_ID
+  client_secret_key:
+    description: Secret key (and env-var fallback) for the SP OAuth client secret.
+    default: RETAIL_AI_DATABRICKS_CLIENT_SECRET
 
 # =============================================================================
 # Sporting Goods Store - Merchandiser 360
@@ -60,19 +72,19 @@ parameters:
 variables:
   client_id: &client_id
     options:
-    - scope: retail_consumer_goods
-      secret: RETAIL_AI_DATABRICKS_CLIENT_ID
-    - env: RETAIL_AI_DATABRICKS_CLIENT_ID
+    - scope: ${var.secret_scope}
+      secret: ${var.client_id_key}
+    - env: ${var.client_id_key}
 
   client_secret: &client_secret
     options:
-    - scope: retail_consumer_goods
-      secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
-    - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+    - scope: ${var.secret_scope}
+      secret: ${var.client_secret_key}
+    - env: ${var.client_secret_key}
 
 service_principals:
   retail_consumer_goods_sp:
-    name: retail_consumer_goods_sp
+    name: ${var.service_principal_name}
     client_id: *client_id
     client_secret: *client_secret
 

--- a/examples/99_complete_applications/sporting_goods_store/sporting_goods_store_slim.yaml
+++ b/examples/99_complete_applications/sporting_goods_store/sporting_goods_store_slim.yaml
@@ -38,6 +38,18 @@ parameters:
   lakebase_project:
     description: Lakebase project name reused for agent memory + checkpointer
     default: retail-consumer-goods
+  service_principal_name:
+    description: Display name of the service principal to create or reuse. Override per workspace via --var (e.g. to point at an existing SP that already owns the credential secrets).
+    default: retail_consumer_goods_sp
+  secret_scope:
+    description: Secret scope holding the service principal's OAuth client id/secret.
+    default: retail_consumer_goods
+  client_id_key:
+    description: Secret key (and env-var fallback) for the SP OAuth client id.
+    default: RETAIL_AI_DATABRICKS_CLIENT_ID
+  client_secret_key:
+    description: Secret key (and env-var fallback) for the SP OAuth client secret.
+    default: RETAIL_AI_DATABRICKS_CLIENT_SECRET
 
 # =============================================================================
 # Sporting Goods Store - Merchandiser 360
@@ -57,19 +69,19 @@ parameters:
 variables:
   client_id: &client_id
     options:
-    - scope: retail_consumer_goods
-      secret: RETAIL_AI_DATABRICKS_CLIENT_ID
-    - env: RETAIL_AI_DATABRICKS_CLIENT_ID
+    - scope: ${var.secret_scope}
+      secret: ${var.client_id_key}
+    - env: ${var.client_id_key}
 
   client_secret: &client_secret
     options:
-    - scope: retail_consumer_goods
-      secret: RETAIL_AI_DATABRICKS_CLIENT_SECRET
-    - env: RETAIL_AI_DATABRICKS_CLIENT_SECRET
+    - scope: ${var.secret_scope}
+      secret: ${var.client_secret_key}
+    - env: ${var.client_secret_key}
 
 service_principals:
   retail_consumer_goods_sp:
-    name: retail_consumer_goods_sp
+    name: ${var.service_principal_name}
     client_id: *client_id
     client_secret: *client_secret
 

--- a/src/dao_ai/_locking.py
+++ b/src/dao_ai/_locking.py
@@ -132,9 +132,12 @@ def generate_bundle_lock(bundle_dir: Path) -> None:
         )
 
     result = _uv_lock(force_public=True)
-    if result.returncode != 0 and "No solution found" not in result.stderr:
-        # Public PyPI unreachable (e.g. corp laptop) — fall back to the ambient
-        # index; a transparent corp mirror's URLs are host-swapped below.
+    if result.returncode != 0:
+        # Public PyPI couldn't resolve — unreachable (e.g. corp laptop) OR a
+        # dependency published only on the corp mirror. Retry with the ambient
+        # index; a transparent corp mirror's URLs are host-swapped below. If the
+        # ambient index also fails, the error handler below surfaces the actionable
+        # message (e.g. the pre-release unpublished-dao-ai case fails both ways).
         logger.warning(
             "uv lock against public PyPI failed; retrying with the ambient index",
             stderr=(result.stderr or "")[-400:],

--- a/src/dao_ai/_locking.py
+++ b/src/dao_ai/_locking.py
@@ -17,6 +17,7 @@ technique applied to the dao-ai repo's own lock.
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import subprocess
@@ -59,6 +60,13 @@ _MIRROR_HOST_RE = re.compile(
 _REGISTRY_RE = re.compile(r'registry = "([^"]*)"')
 _URL_RE = re.compile(r'url = "([^"]*)"')
 
+# The serverless build proxy's non-transparent URL PATH: it rewrites downloads to
+# ``/pypi/vN/packages/<name>/<version>/<file>`` (not the public CDN's
+# ``/packages/<hash>`` layout). A host-swap of such a URL yields a valid host with
+# an invalid path that 404s at ``uv sync``, so it must be caught rather than
+# shipped — the only correct fix is resolving against public PyPI.
+_PROXY_PATH_RE = re.compile(r"/pypi/v\d+/(?:packages|simple)/")
+
 
 def _make_lock_portable(lock_text: str) -> str:
     """Rewrite internal-mirror references to their public equivalents.
@@ -99,13 +107,39 @@ def generate_bundle_lock(bundle_dir: Path) -> None:
             ``pyproject.toml`` (and, for development builds, the local wheel
             under ``dist/`` referenced via ``[tool.uv.sources]``).
     """
-    result = subprocess.run(
-        ["uv", "lock"],
-        cwd=bundle_dir,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+
+    # Resolve against PUBLIC PyPI so wheel/sdist URLs are the real, portable
+    # ``files.pythonhosted.org/packages/<hash>`` paths. Resolving against an
+    # internal proxy and host-swapping only works for the transparent corp CDN
+    # mirror (identical ``/packages/<hash>`` paths); the serverless build proxy
+    # (``node.host.local``) rewrites the URL PATH to
+    # ``/pypi/vN/packages/<name>/<version>/<file>``, which a host-swap turns into
+    # an invalid public-CDN URL that 404s at ``uv sync``. Fall back to the ambient
+    # index (e.g. the corp mirror on a laptop where public PyPI is blocked), whose
+    # transparent URLs the host-swap below can fix.
+    def _uv_lock(force_public: bool) -> "subprocess.CompletedProcess[str]":
+        env = dict(os.environ)
+        if force_public:
+            env["UV_INDEX_URL"] = _PUBLIC_INDEX
+            env["UV_DEFAULT_INDEX"] = _PUBLIC_INDEX
+        return subprocess.run(
+            ["uv", "lock"],
+            cwd=bundle_dir,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+
+    result = _uv_lock(force_public=True)
+    if result.returncode != 0 and "No solution found" not in result.stderr:
+        # Public PyPI unreachable (e.g. corp laptop) — fall back to the ambient
+        # index; a transparent corp mirror's URLs are host-swapped below.
+        logger.warning(
+            "uv lock against public PyPI failed; retrying with the ambient index",
+            stderr=(result.stderr or "")[-400:],
+        )
+        result = _uv_lock(force_public=False)
     if result.returncode != 0:
         stderr = result.stderr
         # Published bundles pin the current dao-ai version. Before that version
@@ -138,16 +172,28 @@ def generate_bundle_lock(bundle_dir: Path) -> None:
             cdn=_PUBLIC_CDN_HOST,
         )
 
-    # Clean-check: assert no internal mirror host survived the rewrite. This scans
-    # the whole lock text (format-independent), so it fails loudly even if the
-    # field-aware rewrite above missed an unusual layout — defense-in-depth
-    # against shipping an unresolvable lock.
-    surviving = _MIRROR_HOST_RE.search(lock_path.read_text())
+    final = lock_path.read_text()
+    # Guard 1: assert no internal mirror HOST survived the rewrite. Scans the whole
+    # lock text (format-independent), so it fails loudly even if the field-aware
+    # rewrite missed an unusual layout.
+    surviving = _MIRROR_HOST_RE.search(final)
     if surviving:
         raise RuntimeError(
             f"{lock_path} still references an internal package proxy "
             f"({surviving.group()}) after rewrite; the lock would not resolve in "
             "the Apps container or for customers. Aborting."
+        )
+    # Guard 2: assert no serverless-proxy URL PATH survived. A host-swap leaves
+    # ``files.pythonhosted.org/pypi/vN/packages/...`` — a valid host but an invalid
+    # CDN path that 404s. Only resolving against public PyPI yields the real
+    # ``/packages/<hash>`` layout, so a surviving fingerprint means the lock is
+    # unresolvable and must not ship.
+    proxied = _PROXY_PATH_RE.search(final)
+    if proxied:
+        raise RuntimeError(
+            f"{lock_path} contains a non-portable serverless-proxy URL path "
+            f"({proxied.group()!r}); it must be generated against public PyPI. "
+            "Aborting rather than ship a lock that 404s in the Apps container."
         )
 
     logger.info("Generated portable bundle uv.lock", path=str(lock_path))

--- a/src/dao_ai/pipeline/bundle.py
+++ b/src/dao_ai/pipeline/bundle.py
@@ -205,13 +205,18 @@ def _build_job_bundle_yaml(
     # ride on the wheel; pin their backing packages as separate, glob-safe PyPI
     # deps instead — same approach as the Model Serving dev path. Published mode
     # keeps extras on the ``dao-ai[extras]==ver`` spec (a PyPI spec is glob-safe).
+    # Always track ``dist/*.whl`` in the sync set. In development the staged wheel
+    # uploads (the bundle CLI excludes .whl by default, so it must be listed).
+    # In published mode the staging dir has NO wheel, so tracking the glob makes
+    # ``databricks bundle deploy`` mirror an empty ``dist/`` — pruning ANY wheel in
+    # the remote workspace ``dist/`` (there should be none: published runs install
+    # dao-ai from the index). This deliberately clears a wheel a prior
+    # ``--development`` deploy left behind, which the notebooks' ``../dist`` fallback
+    # would otherwise reinstall. dao-ai's ``dist/`` is a build-output dir, not a
+    # place to stash wheels by hand, so a clean slate here is the intended behavior.
+    sync_include.append("dist/*.whl")
     extra_dep_pins: list[str] = []
     if development:
-        # The bundle CLI excludes .whl by default; include the staged wheel so
-        # the serverless environment can install it (../dist/<wheel> via the
-        # ``dao_ai_dep`` variable).
-        sync_include.append("dist/*.whl")
-
         from dao_ai._extras import expand_all, resolve_required_extras_or_all
         from dao_ai.utils import get_installed_packages
 
@@ -227,7 +232,15 @@ def _build_job_bundle_yaml(
             task["depends_on"] = [{"task_key": d} for d in depends_on]
         task["notebook_task"] = {
             "notebook_path": f"./notebooks/{notebook}",
-            "base_parameters": {"config-path": "${var.config_path}", **extra_params},
+            # ``dao_ai_dep`` forwards the SAME spec the serverless environment
+            # installs (a ``./dist/<wheel>`` in development, else a version/git
+            # PyPI spec) so each notebook's bootstrap reinstalls exactly that,
+            # never a stray ../dist wheel or an unpinned ``dao-ai``.
+            "base_parameters": {
+                "config-path": "${var.config_path}",
+                "dao_ai_dep": "${var.dao_ai_dep}",
+                **extra_params,
+            },
         }
         task["environment_key"] = "dao-ai-env"
         tasks.append(task)

--- a/src/dao_ai/pipeline/bundle.py
+++ b/src/dao_ai/pipeline/bundle.py
@@ -215,15 +215,24 @@ def _build_job_bundle_yaml(
     # would otherwise reinstall. dao-ai's ``dist/`` is a build-output dir, not a
     # place to stash wheels by hand, so a clean slate here is the intended behavior.
     sync_include.append("dist/*.whl")
+    # Precise, config-specific extras. Bundle generation runs on the CLI (never in
+    # a notebook), so this is the exact set the config needs. It feeds BOTH the
+    # published ``dao_ai_dep`` default (``dao-ai[extras]==ver``) and the dev
+    # extra-dep pins, so a raw ``databricks bundle deploy`` (no CLI override) still
+    # installs the right features rather than a bare ``dao-ai``.
+    from dao_ai._extras import (
+        expand_all,
+        format_extras_suffix,
+        resolve_required_extras,
+    )
+
+    required_extras = resolve_required_extras(config, target=extras_target)
+    default_extras_suffix = format_extras_suffix(required_extras)
     extra_dep_pins: list[str] = []
     if development:
-        from dao_ai._extras import expand_all, resolve_required_extras_or_all
         from dao_ai.utils import get_installed_packages
 
-        required_extras = expand_all(
-            resolve_required_extras_or_all(config, target=extras_target)
-        )
-        extra_dep_pins = get_installed_packages(required_extras)
+        extra_dep_pins = get_installed_packages(expand_all(required_extras))
 
     tasks: list[dict[str, Any]] = []
     for task_key, notebook, depends_on, extra_params in tasks_spec:
@@ -280,10 +289,11 @@ def _build_job_bundle_yaml(
                     "version-pinned PyPI spec otherwise, each carrying the "
                     "optional-feature extras the config uses (e.g. "
                     "'dao-ai[a2a,rerank]==X.Y.Z'). The CLI overrides this per "
-                    "deploy; the default pins the generating version so a raw "
-                    "``databricks bundle deploy`` stays reproducible."
+                    "deploy; the default pins the generating version WITH the "
+                    "config's extras so a raw ``databricks bundle deploy`` (no CLI "
+                    "override) stays reproducible and installs the right features."
                 ),
-                "default": f"dao-ai=={dao_ai_version()}",
+                "default": f"dao-ai{default_extras_suffix}=={dao_ai_version()}",
             },
         },
         "resources": {

--- a/src/dao_ai/pipeline/notebooks/00_provision_service_principal.py
+++ b/src/dao_ai/pipeline/notebooks/00_provision_service_principal.py
@@ -20,7 +20,7 @@ _wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=
 dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
 _pin = dbutils.widgets.get("dao_ai_dep")
 if _pin.endswith(".whl"):
-    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+    _dao_ai_dep = os.path.join("..", _pin.removeprefix("./"))
 elif _pin:
     _dao_ai_dep = _pin
 else:

--- a/src/dao_ai/pipeline/notebooks/00_provision_service_principal.py
+++ b/src/dao_ai/pipeline/notebooks/00_provision_service_principal.py
@@ -1,27 +1,30 @@
 # Databricks notebook source
-# Dependency bootstrap. Install dao-ai (which pulls its own transitive deps) via
-# uv — the newest bundled ../dist wheel in development mode, else the published
-# PyPI package. In a deployed job the serverless environment has already
-# installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
-# installed package importable in the cells below.
-# No extras suffix: this provisioning notebook only calls core APIs. Notebooks
-# that build the agent graph (07_deploy_agent, 09_run_evaluation) install
-# ``[all]``; 01_ingest_and_transform installs ``[excel]``. The install spec is
-# single-quoted in the magic so a dev wheel's ``+local`` version tag and any
-# ``[extras]`` survive shell glob/bracket expansion.
+# Dependency bootstrap. Install dao-ai via uv, self-contained (stdlib only, no
+# dao_ai import — a bootstrap must not import the package it installs). Prefer the
+# deploy's pinned ``dao_ai_dep`` parameter (a ./dist wheel re-anchored to ../dist in
+# development, else a version/PyPI spec); fall back to the newest local ../dist wheel,
+# else PyPI, only for standalone runs. ``%restart_python`` makes the freshly installed
+# package importable below. The spec is single-quoted in the magic so a dev wheel's
+# ``+local`` tag and any ``[extras]`` survive shell expansion.
 import glob, os
 
 from packaging.version import Version
 
-# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above
-# 0.2.10. ``Version`` also parses a dev wheel's ``+local`` tag correctly.
+
+# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above 0.2.10.
 def _wheel_version(wheel: str) -> Version:
     return Version(os.path.basename(wheel).split("-")[1])
 
-_wheels: list[str] = sorted(
-    glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=True
-)
-_dao_ai_dep: str = _wheels[0] if _wheels else "dao-ai"
+
+_wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=True)
+dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
+_pin = dbutils.widgets.get("dao_ai_dep")
+if _pin.endswith(".whl"):
+    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+elif _pin:
+    _dao_ai_dep = _pin
+else:
+    _dao_ai_dep = _wheels[0] if _wheels else "dao-ai"
 
 # MAGIC %uv pip install --quiet '{_dao_ai_dep}'
 # MAGIC %restart_python

--- a/src/dao_ai/pipeline/notebooks/01_ingest_and_transform.py
+++ b/src/dao_ai/pipeline/notebooks/01_ingest_and_transform.py
@@ -20,7 +20,7 @@ _wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=
 dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
 _pin = dbutils.widgets.get("dao_ai_dep")
 if _pin.endswith(".whl"):
-    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+    _dao_ai_dep = os.path.join("..", _pin.removeprefix("./"))
 elif _pin:
     _dao_ai_dep = _pin
 else:

--- a/src/dao_ai/pipeline/notebooks/01_ingest_and_transform.py
+++ b/src/dao_ai/pipeline/notebooks/01_ingest_and_transform.py
@@ -1,26 +1,30 @@
 # Databricks notebook source
-# Dependency bootstrap. Install dao-ai (which pulls its own transitive deps) via
-# uv — the newest bundled ../dist wheel in development mode, else the published
-# PyPI package. In a deployed job the serverless environment has already
-# installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
-# installed package importable in the cells below.
-# This notebook ingests datasets, which may be EXCEL-format (pd.read_excel needs
-# openpyxl). The dataset format is not known until the config loads below, so it
-# installs the ``[excel]`` extra unconditionally. Notebooks that build the agent
-# graph (07_deploy_agent, 09_run_evaluation) install ``[all]``. The install spec
-# is single-quoted in the magic so a dev wheel's ``+local`` version tag and the
-# ``[excel]`` bracket survive shell glob/bracket expansion.
+# Dependency bootstrap. Install dao-ai via uv, self-contained (stdlib only, no
+# dao_ai import — a bootstrap must not import the package it installs). Prefer the
+# deploy's pinned ``dao_ai_dep`` parameter (a ./dist wheel re-anchored to ../dist in
+# development, else a version/PyPI spec); fall back to the newest local ../dist wheel,
+# else PyPI, only for standalone runs. ``%restart_python`` makes the freshly installed
+# package importable below. The spec is single-quoted in the magic so a dev wheel's
+# ``+local`` tag and any ``[extras]`` survive shell expansion.
 import glob, os
 
 from packaging.version import Version
 
-# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above
-# 0.2.10. ``Version`` also parses a dev wheel's ``+local`` tag correctly.
+
+# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above 0.2.10.
 def _wheel_version(wheel: str) -> Version:
     return Version(os.path.basename(wheel).split("-")[1])
 
+
 _wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=True)
-_dao_ai_dep = (_wheels[0] if _wheels else "dao-ai") + "[excel]"
+dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
+_pin = dbutils.widgets.get("dao_ai_dep")
+if _pin.endswith(".whl"):
+    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+elif _pin:
+    _dao_ai_dep = _pin
+else:
+    _dao_ai_dep = (_wheels[0] if _wheels else "dao-ai") + "[excel]"
 
 # MAGIC %uv pip install --quiet '{_dao_ai_dep}'
 # MAGIC %restart_python

--- a/src/dao_ai/pipeline/notebooks/02_provision_vector_search.py
+++ b/src/dao_ai/pipeline/notebooks/02_provision_vector_search.py
@@ -1,25 +1,30 @@
 # Databricks notebook source
-# Dependency bootstrap. Install dao-ai (which pulls its own transitive deps) via
-# uv — the newest bundled ../dist wheel in development mode, else the published
-# PyPI package. In a deployed job the serverless environment has already
-# installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
-# installed package importable in the cells below.
-# No extras suffix: this provisioning notebook only calls core APIs. Notebooks
-# that build the agent graph (07_deploy_agent, 09_run_evaluation) install
-# ``[all]``; 01_ingest_and_transform installs ``[excel]``. The install spec is
-# single-quoted in the magic so a dev wheel's ``+local`` version tag and any
-# ``[extras]`` survive shell glob/bracket expansion.
+# Dependency bootstrap. Install dao-ai via uv, self-contained (stdlib only, no
+# dao_ai import — a bootstrap must not import the package it installs). Prefer the
+# deploy's pinned ``dao_ai_dep`` parameter (a ./dist wheel re-anchored to ../dist in
+# development, else a version/PyPI spec); fall back to the newest local ../dist wheel,
+# else PyPI, only for standalone runs. ``%restart_python`` makes the freshly installed
+# package importable below. The spec is single-quoted in the magic so a dev wheel's
+# ``+local`` tag and any ``[extras]`` survive shell expansion.
 import glob, os
 
 from packaging.version import Version
 
-# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above
-# 0.2.10. ``Version`` also parses a dev wheel's ``+local`` tag correctly.
+
+# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above 0.2.10.
 def _wheel_version(wheel: str) -> Version:
     return Version(os.path.basename(wheel).split("-")[1])
 
+
 _wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=True)
-_dao_ai_dep = _wheels[0] if _wheels else "dao-ai"
+dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
+_pin = dbutils.widgets.get("dao_ai_dep")
+if _pin.endswith(".whl"):
+    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+elif _pin:
+    _dao_ai_dep = _pin
+else:
+    _dao_ai_dep = _wheels[0] if _wheels else "dao-ai"
 
 # MAGIC %uv pip install --quiet '{_dao_ai_dep}'
 # MAGIC %restart_python

--- a/src/dao_ai/pipeline/notebooks/02_provision_vector_search.py
+++ b/src/dao_ai/pipeline/notebooks/02_provision_vector_search.py
@@ -20,7 +20,7 @@ _wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=
 dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
 _pin = dbutils.widgets.get("dao_ai_dep")
 if _pin.endswith(".whl"):
-    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+    _dao_ai_dep = os.path.join("..", _pin.removeprefix("./"))
 elif _pin:
     _dao_ai_dep = _pin
 else:

--- a/src/dao_ai/pipeline/notebooks/03_provision_lakebase.py
+++ b/src/dao_ai/pipeline/notebooks/03_provision_lakebase.py
@@ -1,25 +1,30 @@
 # Databricks notebook source
-# Dependency bootstrap. Install dao-ai (which pulls its own transitive deps) via
-# uv — the newest bundled ../dist wheel in development mode, else the published
-# PyPI package. In a deployed job the serverless environment has already
-# installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
-# installed package importable in the cells below.
-# No extras suffix: this provisioning notebook only calls core APIs. Notebooks
-# that build the agent graph (07_deploy_agent, 09_run_evaluation) install
-# ``[all]``; 01_ingest_and_transform installs ``[excel]``. The install spec is
-# single-quoted in the magic so a dev wheel's ``+local`` version tag and any
-# ``[extras]`` survive shell glob/bracket expansion.
+# Dependency bootstrap. Install dao-ai via uv, self-contained (stdlib only, no
+# dao_ai import — a bootstrap must not import the package it installs). Prefer the
+# deploy's pinned ``dao_ai_dep`` parameter (a ./dist wheel re-anchored to ../dist in
+# development, else a version/PyPI spec); fall back to the newest local ../dist wheel,
+# else PyPI, only for standalone runs. ``%restart_python`` makes the freshly installed
+# package importable below. The spec is single-quoted in the magic so a dev wheel's
+# ``+local`` tag and any ``[extras]`` survive shell expansion.
 import glob, os
 
 from packaging.version import Version
 
-# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above
-# 0.2.10. ``Version`` also parses a dev wheel's ``+local`` tag correctly.
+
+# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above 0.2.10.
 def _wheel_version(wheel: str) -> Version:
     return Version(os.path.basename(wheel).split("-")[1])
 
+
 _wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=True)
-_dao_ai_dep = _wheels[0] if _wheels else "dao-ai"
+dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
+_pin = dbutils.widgets.get("dao_ai_dep")
+if _pin.endswith(".whl"):
+    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+elif _pin:
+    _dao_ai_dep = _pin
+else:
+    _dao_ai_dep = _wheels[0] if _wheels else "dao-ai"
 
 # MAGIC %uv pip install --quiet '{_dao_ai_dep}'
 # MAGIC %restart_python

--- a/src/dao_ai/pipeline/notebooks/03_provision_lakebase.py
+++ b/src/dao_ai/pipeline/notebooks/03_provision_lakebase.py
@@ -20,7 +20,7 @@ _wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=
 dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
 _pin = dbutils.widgets.get("dao_ai_dep")
 if _pin.endswith(".whl"):
-    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+    _dao_ai_dep = os.path.join("..", _pin.removeprefix("./"))
 elif _pin:
     _dao_ai_dep = _pin
 else:

--- a/src/dao_ai/pipeline/notebooks/04_unity_catalog_tools.py
+++ b/src/dao_ai/pipeline/notebooks/04_unity_catalog_tools.py
@@ -1,25 +1,30 @@
 # Databricks notebook source
-# Dependency bootstrap. Install dao-ai (which pulls its own transitive deps) via
-# uv — the newest bundled ../dist wheel in development mode, else the published
-# PyPI package. In a deployed job the serverless environment has already
-# installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
-# installed package importable in the cells below.
-# No extras suffix: this provisioning notebook only calls core APIs. Notebooks
-# that build the agent graph (07_deploy_agent, 09_run_evaluation) install
-# ``[all]``; 01_ingest_and_transform installs ``[excel]``. The install spec is
-# single-quoted in the magic so a dev wheel's ``+local`` version tag and any
-# ``[extras]`` survive shell glob/bracket expansion.
+# Dependency bootstrap. Install dao-ai via uv, self-contained (stdlib only, no
+# dao_ai import — a bootstrap must not import the package it installs). Prefer the
+# deploy's pinned ``dao_ai_dep`` parameter (a ./dist wheel re-anchored to ../dist in
+# development, else a version/PyPI spec); fall back to the newest local ../dist wheel,
+# else PyPI, only for standalone runs. ``%restart_python`` makes the freshly installed
+# package importable below. The spec is single-quoted in the magic so a dev wheel's
+# ``+local`` tag and any ``[extras]`` survive shell expansion.
 import glob, os
 
 from packaging.version import Version
 
-# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above
-# 0.2.10. ``Version`` also parses a dev wheel's ``+local`` tag correctly.
+
+# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above 0.2.10.
 def _wheel_version(wheel: str) -> Version:
     return Version(os.path.basename(wheel).split("-")[1])
 
+
 _wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=True)
-_dao_ai_dep = _wheels[0] if _wheels else "dao-ai"
+dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
+_pin = dbutils.widgets.get("dao_ai_dep")
+if _pin.endswith(".whl"):
+    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+elif _pin:
+    _dao_ai_dep = _pin
+else:
+    _dao_ai_dep = _wheels[0] if _wheels else "dao-ai"
 
 # MAGIC %uv pip install --quiet '{_dao_ai_dep}'
 # MAGIC %restart_python

--- a/src/dao_ai/pipeline/notebooks/04_unity_catalog_tools.py
+++ b/src/dao_ai/pipeline/notebooks/04_unity_catalog_tools.py
@@ -20,7 +20,7 @@ _wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=
 dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
 _pin = dbutils.widgets.get("dao_ai_dep")
 if _pin.endswith(".whl"):
-    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+    _dao_ai_dep = os.path.join("..", _pin.removeprefix("./"))
 elif _pin:
     _dao_ai_dep = _pin
 else:

--- a/src/dao_ai/pipeline/notebooks/05_provision_genie.py
+++ b/src/dao_ai/pipeline/notebooks/05_provision_genie.py
@@ -1,25 +1,30 @@
 # Databricks notebook source
-# Dependency bootstrap. Install dao-ai (which pulls its own transitive deps) via
-# uv — the newest bundled ../dist wheel in development mode, else the published
-# PyPI package. In a deployed job the serverless environment has already
-# installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
-# installed package importable in the cells below.
-# No extras suffix: this provisioning notebook only calls core APIs. Notebooks
-# that build the agent graph (07_deploy_agent, 09_run_evaluation) install
-# ``[all]``; 01_ingest_and_transform installs ``[excel]``. The install spec is
-# single-quoted in the magic so a dev wheel's ``+local`` version tag and any
-# ``[extras]`` survive shell glob/bracket expansion.
+# Dependency bootstrap. Install dao-ai via uv, self-contained (stdlib only, no
+# dao_ai import — a bootstrap must not import the package it installs). Prefer the
+# deploy's pinned ``dao_ai_dep`` parameter (a ./dist wheel re-anchored to ../dist in
+# development, else a version/PyPI spec); fall back to the newest local ../dist wheel,
+# else PyPI, only for standalone runs. ``%restart_python`` makes the freshly installed
+# package importable below. The spec is single-quoted in the magic so a dev wheel's
+# ``+local`` tag and any ``[extras]`` survive shell expansion.
 import glob, os
 
 from packaging.version import Version
 
-# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above
-# 0.2.10. ``Version`` also parses a dev wheel's ``+local`` tag correctly.
+
+# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above 0.2.10.
 def _wheel_version(wheel: str) -> Version:
     return Version(os.path.basename(wheel).split("-")[1])
 
+
 _wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=True)
-_dao_ai_dep = _wheels[0] if _wheels else "dao-ai"
+dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
+_pin = dbutils.widgets.get("dao_ai_dep")
+if _pin.endswith(".whl"):
+    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+elif _pin:
+    _dao_ai_dep = _pin
+else:
+    _dao_ai_dep = _wheels[0] if _wheels else "dao-ai"
 
 # MAGIC %uv pip install --quiet '{_dao_ai_dep}'
 # MAGIC %restart_python

--- a/src/dao_ai/pipeline/notebooks/05_provision_genie.py
+++ b/src/dao_ai/pipeline/notebooks/05_provision_genie.py
@@ -20,7 +20,7 @@ _wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=
 dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
 _pin = dbutils.widgets.get("dao_ai_dep")
 if _pin.endswith(".whl"):
-    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+    _dao_ai_dep = os.path.join("..", _pin.removeprefix("./"))
 elif _pin:
     _dao_ai_dep = _pin
 else:

--- a/src/dao_ai/pipeline/notebooks/06_grant_service_principal.py
+++ b/src/dao_ai/pipeline/notebooks/06_grant_service_principal.py
@@ -20,7 +20,7 @@ _wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=
 dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
 _pin = dbutils.widgets.get("dao_ai_dep")
 if _pin.endswith(".whl"):
-    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+    _dao_ai_dep = os.path.join("..", _pin.removeprefix("./"))
 elif _pin:
     _dao_ai_dep = _pin
 else:

--- a/src/dao_ai/pipeline/notebooks/06_grant_service_principal.py
+++ b/src/dao_ai/pipeline/notebooks/06_grant_service_principal.py
@@ -1,27 +1,30 @@
 # Databricks notebook source
-# Dependency bootstrap. Install dao-ai (which pulls its own transitive deps) via
-# uv — the newest bundled ../dist wheel in development mode, else the published
-# PyPI package. In a deployed job the serverless environment has already
-# installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
-# installed package importable in the cells below.
-# No extras suffix: this notebook only calls core APIs. Notebooks that build the
-# agent graph (07_deploy_agent, 09_run_evaluation) install ``[all]``;
-# 01_ingest_and_transform installs ``[excel]``. The install spec is single-quoted
-# in the magic so a dev wheel's ``+local`` version tag and any ``[extras]``
-# survive shell glob/bracket expansion.
+# Dependency bootstrap. Install dao-ai via uv, self-contained (stdlib only, no
+# dao_ai import — a bootstrap must not import the package it installs). Prefer the
+# deploy's pinned ``dao_ai_dep`` parameter (a ./dist wheel re-anchored to ../dist in
+# development, else a version/PyPI spec); fall back to the newest local ../dist wheel,
+# else PyPI, only for standalone runs. ``%restart_python`` makes the freshly installed
+# package importable below. The spec is single-quoted in the magic so a dev wheel's
+# ``+local`` tag and any ``[extras]`` survive shell expansion.
 import glob, os
 
 from packaging.version import Version
 
-# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above
-# 0.2.10. ``Version`` also parses a dev wheel's ``+local`` tag correctly.
+
+# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above 0.2.10.
 def _wheel_version(wheel: str) -> Version:
     return Version(os.path.basename(wheel).split("-")[1])
 
-_wheels: list[str] = sorted(
-    glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=True
-)
-_dao_ai_dep: str = _wheels[0] if _wheels else "dao-ai"
+
+_wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=True)
+dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
+_pin = dbutils.widgets.get("dao_ai_dep")
+if _pin.endswith(".whl"):
+    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+elif _pin:
+    _dao_ai_dep = _pin
+else:
+    _dao_ai_dep = _wheels[0] if _wheels else "dao-ai"
 
 # MAGIC %uv pip install --quiet '{_dao_ai_dep}'
 # MAGIC %restart_python

--- a/src/dao_ai/pipeline/notebooks/07_deploy_agent.py
+++ b/src/dao_ai/pipeline/notebooks/07_deploy_agent.py
@@ -20,7 +20,7 @@ _wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=
 dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
 _pin = dbutils.widgets.get("dao_ai_dep")
 if _pin.endswith(".whl"):
-    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+    _dao_ai_dep = os.path.join("..", _pin.removeprefix("./"))
 elif _pin:
     _dao_ai_dep = _pin
 else:

--- a/src/dao_ai/pipeline/notebooks/07_deploy_agent.py
+++ b/src/dao_ai/pipeline/notebooks/07_deploy_agent.py
@@ -1,26 +1,30 @@
 # Databricks notebook source
-# Dependency bootstrap. Install dao-ai (which pulls its own transitive deps) via
-# uv — the newest bundled ../dist wheel in development mode, else the published
-# PyPI package. In a deployed job the serverless environment has already
-# installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
-# installed package importable in the cells below.
-# This notebook builds the agent graph (display_graph / create_agent below), so
-# it must install every optional feature extra — the graph is built before the
-# config is known, and any agent may use memory (langmem), a2a, deepagents,
-# rerank, or search. Hence ``[all]``. The install spec is single-quoted in the
-# magic so a dev wheel's ``+local`` version tag and the ``[all]`` bracket survive
-# shell glob/bracket expansion.
+# Dependency bootstrap. Install dao-ai via uv, self-contained (stdlib only, no
+# dao_ai import — a bootstrap must not import the package it installs). Prefer the
+# deploy's pinned ``dao_ai_dep`` parameter (a ./dist wheel re-anchored to ../dist in
+# development, else a version/PyPI spec); fall back to the newest local ../dist wheel,
+# else PyPI, only for standalone runs. ``%restart_python`` makes the freshly installed
+# package importable below. The spec is single-quoted in the magic so a dev wheel's
+# ``+local`` tag and any ``[extras]`` survive shell expansion.
 import glob, os
 
 from packaging.version import Version
 
-# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above
-# 0.2.10. ``Version`` also parses a dev wheel's ``+local`` tag correctly.
+
+# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above 0.2.10.
 def _wheel_version(wheel: str) -> Version:
     return Version(os.path.basename(wheel).split("-")[1])
 
+
 _wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=True)
-_dao_ai_dep = (_wheels[0] if _wheels else "dao-ai") + "[all]"
+dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
+_pin = dbutils.widgets.get("dao_ai_dep")
+if _pin.endswith(".whl"):
+    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+elif _pin:
+    _dao_ai_dep = _pin
+else:
+    _dao_ai_dep = (_wheels[0] if _wheels else "dao-ai") + "[all]"
 
 # MAGIC %uv pip install --quiet '{_dao_ai_dep}'
 # MAGIC %restart_python

--- a/src/dao_ai/pipeline/notebooks/08_generate_evaluation_data.py
+++ b/src/dao_ai/pipeline/notebooks/08_generate_evaluation_data.py
@@ -20,7 +20,7 @@ _wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=
 dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
 _pin = dbutils.widgets.get("dao_ai_dep")
 if _pin.endswith(".whl"):
-    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+    _dao_ai_dep = os.path.join("..", _pin.removeprefix("./"))
 elif _pin:
     _dao_ai_dep = _pin
 else:

--- a/src/dao_ai/pipeline/notebooks/08_generate_evaluation_data.py
+++ b/src/dao_ai/pipeline/notebooks/08_generate_evaluation_data.py
@@ -1,25 +1,30 @@
 # Databricks notebook source
-# Dependency bootstrap. Install dao-ai (which pulls its own transitive deps) via
-# uv — the newest bundled ../dist wheel in development mode, else the published
-# PyPI package. In a deployed job the serverless environment has already
-# installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
-# installed package importable in the cells below.
-# No extras suffix: this notebook only calls core APIs (databricks.agents eval
-# generation). Notebooks that build the agent graph (07_deploy_agent,
-# 09_run_evaluation) install ``[all]``; 01_ingest_and_transform installs
-# ``[excel]``. The install spec is single-quoted in the magic so a dev wheel's
-# ``+local`` version tag and any ``[extras]`` survive shell glob/bracket expansion.
+# Dependency bootstrap. Install dao-ai via uv, self-contained (stdlib only, no
+# dao_ai import — a bootstrap must not import the package it installs). Prefer the
+# deploy's pinned ``dao_ai_dep`` parameter (a ./dist wheel re-anchored to ../dist in
+# development, else a version/PyPI spec); fall back to the newest local ../dist wheel,
+# else PyPI, only for standalone runs. ``%restart_python`` makes the freshly installed
+# package importable below. The spec is single-quoted in the magic so a dev wheel's
+# ``+local`` tag and any ``[extras]`` survive shell expansion.
 import glob, os
 
 from packaging.version import Version
 
-# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above
-# 0.2.10. ``Version`` also parses a dev wheel's ``+local`` tag correctly.
+
+# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above 0.2.10.
 def _wheel_version(wheel: str) -> Version:
     return Version(os.path.basename(wheel).split("-")[1])
 
+
 _wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=True)
-_dao_ai_dep = _wheels[0] if _wheels else "dao-ai"
+dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
+_pin = dbutils.widgets.get("dao_ai_dep")
+if _pin.endswith(".whl"):
+    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+elif _pin:
+    _dao_ai_dep = _pin
+else:
+    _dao_ai_dep = _wheels[0] if _wheels else "dao-ai"
 
 # MAGIC %uv pip install --quiet '{_dao_ai_dep}'
 # MAGIC %restart_python

--- a/src/dao_ai/pipeline/notebooks/09_run_evaluation.py
+++ b/src/dao_ai/pipeline/notebooks/09_run_evaluation.py
@@ -20,7 +20,7 @@ _wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=
 dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
 _pin = dbutils.widgets.get("dao_ai_dep")
 if _pin.endswith(".whl"):
-    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+    _dao_ai_dep = os.path.join("..", _pin.removeprefix("./"))
 elif _pin:
     _dao_ai_dep = _pin
 else:

--- a/src/dao_ai/pipeline/notebooks/09_run_evaluation.py
+++ b/src/dao_ai/pipeline/notebooks/09_run_evaluation.py
@@ -1,26 +1,30 @@
 # Databricks notebook source
-# Dependency bootstrap. Install dao-ai (which pulls its own transitive deps) via
-# uv — the newest bundled ../dist wheel in development mode, else the published
-# PyPI package. In a deployed job the serverless environment has already
-# installed it; this reinstall is harmless. ``%restart_python`` makes the freshly
-# installed package importable in the cells below.
-# This notebook builds the agent graph (as_responses_agent below), so it must
-# install every optional feature extra — the graph is built before the config is
-# known, and any agent may use memory (langmem), a2a, deepagents, rerank, or
-# search. Hence ``[all]``. The install spec is single-quoted in the magic so a
-# dev wheel's ``+local`` version tag and the ``[all]`` bracket survive shell
-# glob/bracket expansion.
+# Dependency bootstrap. Install dao-ai via uv, self-contained (stdlib only, no
+# dao_ai import — a bootstrap must not import the package it installs). Prefer the
+# deploy's pinned ``dao_ai_dep`` parameter (a ./dist wheel re-anchored to ../dist in
+# development, else a version/PyPI spec); fall back to the newest local ../dist wheel,
+# else PyPI, only for standalone runs. ``%restart_python`` makes the freshly installed
+# package importable below. The spec is single-quoted in the magic so a dev wheel's
+# ``+local`` tag and any ``[extras]`` survive shell expansion.
 import glob, os
 
 from packaging.version import Version
 
-# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above
-# 0.2.10. ``Version`` also parses a dev wheel's ``+local`` tag correctly.
+
+# Newest by *version*, not by filename: a lexical sort puts 0.2.8 above 0.2.10.
 def _wheel_version(wheel: str) -> Version:
     return Version(os.path.basename(wheel).split("-")[1])
 
+
 _wheels = sorted(glob.glob("../dist/dao_ai-*.whl"), key=_wheel_version, reverse=True)
-_dao_ai_dep = (_wheels[0] if _wheels else "dao-ai") + "[all]"
+dbutils.widgets.text(name="dao_ai_dep", defaultValue="")
+_pin = dbutils.widgets.get("dao_ai_dep")
+if _pin.endswith(".whl"):
+    _dao_ai_dep = os.path.join("..", _pin.lstrip("./"))
+elif _pin:
+    _dao_ai_dep = _pin
+else:
+    _dao_ai_dep = (_wheels[0] if _wheels else "dao-ai") + "[all]"
 
 # MAGIC %uv pip install --quiet '{_dao_ai_dep}'
 # MAGIC %restart_python

--- a/src/dao_ai/providers/databricks.py
+++ b/src/dao_ai/providers/databricks.py
@@ -1461,12 +1461,15 @@ class DatabricksProvider(ServiceProvider):
         from dao_ai._extras import (
             expand_all,
             format_extras_suffix,
-            resolve_required_extras_or_all,
+            resolve_required_extras,
         )
 
         # Model Serving does not mount A2A routes, so the always-on a2a routes
         # must NOT bloat the serving image — only an explicit A2A tool pulls it.
-        required_extras: set[str] = resolve_required_extras_or_all(
+        # Use the PRECISE resolver (not ``_or_all``): a deployed artifact always
+        # wants the minimal config-specific extras, even though the deploy runs
+        # inside a notebook (where ``_or_all`` would short-circuit to every extra).
+        required_extras: set[str] = resolve_required_extras(
             config, target="model_serving"
         )
         extras_suffix: str = format_extras_suffix(required_extras)
@@ -2787,7 +2790,10 @@ class DatabricksProvider(ServiceProvider):
         only the container command, the extras, the chat-UI env vars, and the
         deployed App name differ.
         """
-        from dao_ai._extras import expand_all, resolve_required_extras_or_all
+        # Use the PRECISE resolver (not ``_or_all``): a deployed App pins the
+        # minimal config-specific extras, even though the deploy runs inside a
+        # notebook (where ``_or_all`` would short-circuit to every extra).
+        from dao_ai._extras import expand_all, resolve_required_extras
 
         if as_mcp:
             self._deploy_app(
@@ -2795,7 +2801,7 @@ class DatabricksProvider(ServiceProvider):
                 app_command=["python", "-m", "dao_ai.mcp.server"],
                 extras={
                     "mcp",
-                    *expand_all(resolve_required_extras_or_all(config, target="mcp")),
+                    *expand_all(resolve_required_extras(config, target="mcp")),
                 },
                 include_chat_ui=False,
                 as_mcp=True,
@@ -2814,7 +2820,7 @@ class DatabricksProvider(ServiceProvider):
         self._deploy_app(
             config,
             app_command=["python", "-m", entrypoint],
-            extras=set(resolve_required_extras_or_all(config, target="apps")),
+            extras=set(resolve_required_extras(config, target="apps")),
             include_chat_ui=enable_chat_proxy,
             as_mcp=False,
             development=development,

--- a/tests/dao_ai/test_bundle_dependency_lock.py
+++ b/tests/dao_ai/test_bundle_dependency_lock.py
@@ -82,7 +82,7 @@ class TestGenerateBundleLock:
         """Return a subprocess.run replacement that writes ``lock_body`` as the
         lock and reports success, standing in for a real ``uv lock``."""
 
-        def _run(cmd, cwd=None, capture_output=None, text=None, check=None):
+        def _run(cmd, cwd=None, capture_output=None, text=None, check=None, env=None):
             (Path(cwd) / "uv.lock").write_text(lock_body)
 
             class _R:
@@ -101,7 +101,7 @@ class TestGenerateBundleLock:
 
         seen: dict[str, bool] = {}
 
-        def _run(cmd, cwd=None, capture_output=None, text=None, check=None):
+        def _run(cmd, cwd=None, capture_output=None, text=None, check=None, env=None):
             seen["stub"] = (
                 Path(cwd) / "src" / "_daoai_lockstub" / "__init__.py"
             ).exists()
@@ -199,6 +199,30 @@ class TestGenerateBundleLock:
         with pytest.raises(RuntimeError, match="internal package proxy"):
             _locking.generate_bundle_lock(tmp_path)
 
+    def test_raises_if_serverless_proxy_url_path_survives(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The serverless build proxy rewrites download URLs to
+        ``/pypi/vN/packages/<name>/<version>/<file>``. Host-swapping that onto the
+        public CDN yields ``files.pythonhosted.org/pypi/vN/packages/...`` — a valid
+        host but an invalid CDN path that 404s at ``uv sync``. The path fingerprint
+        guard must catch it (only resolving against public PyPI gives the real
+        ``/packages/<hash>`` layout)."""
+        from dao_ai import _locking
+
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+        # Host already public (host-swap done), but the PATH is the proxy's scheme.
+        poisoned = (
+            '[[package]]\nname = "setuptools"\nversion = "84.0.0"\n'
+            'sdist = { url = "https://files.pythonhosted.org/pypi/v1/packages/'
+            'setuptools/84.0.0/setuptools-84.0.0.tar.gz" }\n'
+        )
+        monkeypatch.setattr(
+            _locking.subprocess, "run", self._fake_uv_lock(tmp_path, poisoned)
+        )
+        with pytest.raises(RuntimeError, match="serverless-proxy URL path"):
+            _locking.generate_bundle_lock(tmp_path)
+
     def test_leaves_public_alternate_index_untouched(
         self, tmp_path, monkeypatch
     ) -> None:
@@ -235,7 +259,7 @@ class TestGenerateBundleLock:
 
         (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
 
-        def _run(cmd, cwd=None, capture_output=None, text=None, check=None):
+        def _run(cmd, cwd=None, capture_output=None, text=None, check=None, env=None):
             class _R:
                 returncode = 1
                 stderr = (

--- a/tests/dao_ai/test_databricks.py
+++ b/tests/dao_ai/test_databricks.py
@@ -1137,7 +1137,7 @@ def test_deploy_apps_agent_as_mcp_command_and_extras(monkeypatch):
     from dao_ai.providers.databricks import DatabricksProvider
 
     monkeypatch.setattr(
-        _extras, "resolve_required_extras_or_all", lambda config, target="mcp": set()
+        _extras, "resolve_required_extras", lambda config, target="mcp": set()
     )
 
     p = DatabricksProvider.__new__(DatabricksProvider)

--- a/tests/dao_ai/test_extras.py
+++ b/tests/dao_ai/test_extras.py
@@ -362,6 +362,27 @@ def test_non_notebook_returns_precise(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.unit
+def test_deploy_resolver_ignores_notebook_short_circuit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The deploy paths (apps/mcp/model_serving) call the PRECISE
+    ``resolve_required_extras`` — which must NOT short-circuit to ``{all}`` in a
+    notebook. So a notebook-run deploy (``workflow up`` runs deploy_agent in a
+    notebook) still pins only the config's specific extras, not every extra.
+    """
+    monkeypatch.setattr("dao_ai.utils.is_in_notebook", lambda: True)
+    cfg = _config(
+        app=_app(a2a=A2AModel(enabled=True)),
+        memory=MemoryModel(store=StoreModel(name="s")),
+    )
+    # ``_or_all`` short-circuits to every extra in a notebook (the old deploy bug)...
+    assert _extras.resolve_required_extras_or_all(cfg, target="apps") == {"all"}
+    # ...but the precise resolver the deploy paths now use stays config-specific.
+    assert _extras.resolve_required_extras(cfg, target="apps") == {"a2a", "memory"}
+    assert _extras.resolve_required_extras(cfg, target="model_serving") == {"memory"}
+
+
+@pytest.mark.unit
 def test_import_dao_ai_tools_does_not_eagerly_import_optional_packages() -> None:
     """Guard the lazy-import contract: ``import dao_ai.tools`` must succeed
     without pulling in the optional-extra packages (flashrank/langmem/a2a/ddgs/

--- a/tests/dao_ai/test_pipeline_bundle.py
+++ b/tests/dao_ai/test_pipeline_bundle.py
@@ -58,20 +58,15 @@ _CELL_SEP = "# COMMAND ----------"
 
 
 def _assert_wheel_selection(name: str, text: str) -> None:
-    """Assert every ``../dist`` wheel glob is sorted by PEP 440 version.
-
-    Twin of the helper in ``test_repo_notebooks.py``, which guards the same
-    thing for the hand-run demos under ``notebooks/``.
-    """
+    """Every ``../dist`` wheel glob must be sorted by PEP 440 version (so 0.2.10 >
+    0.2.8, not a lexical filename sort), with ``os`` and ``Version`` imported in
+    that same cell (a notebook cell is its own execution unit)."""
     for cell in text.split(_CELL_SEP):
         if "glob.glob(" not in cell or "dao_ai-*.whl" not in cell:
             continue
         assert "key=_wheel_version" in cell, (
-            f"{name} sorts the ../dist wheel glob lexically — 0.2.8 would beat "
-            "0.2.10; sort with key=_wheel_version"
+            f"{name} sorts the ../dist wheel glob lexically; use key=_wheel_version"
         )
-        # A cell is its own execution unit, so the helper's own dependencies
-        # have to be imported beside it, not in whichever cell came first.
         assert "from packaging.version import Version" in cell, (
             f"{name} uses _wheel_version without importing Version in that cell"
         )
@@ -192,20 +187,15 @@ class TestPackagedAssets:
                 "placeholder, which is stripped before the reader sees it"
             )
 
-    def test_notebooks_bootstrap_extras_suffix(self) -> None:
-        """Each step notebook's ``%uv pip install`` bootstrap must install the
-        feature extras its own body can exercise.
-
-        Graph-building notebooks (07_deploy_agent, 09_run_evaluation) build the
-        agent before the config is known, so they install ``[all]``;
-        01_ingest_and_transform may read EXCEL datasets so it installs
-        ``[excel]``; the pure provisioning notebooks install bare dao-ai. Every
-        notebook single-quotes the interpolated spec so a dev wheel's ``+local``
-        version tag and any ``[extras]`` bracket survive shell expansion.
+    def test_notebooks_bootstrap_is_inline_and_self_contained(self) -> None:
+        """Each step notebook's bootstrap cell is SELF-CONTAINED: it must NOT import
+        dao_ai to decide which dao_ai to install (a bootstrap cannot import the
+        package it bootstraps). It uses stdlib + packaging, declares the dao_ai_dep
+        widget (empty default, like config-path), prefers the pinned parameter over
+        the ../dist glob, and single-quotes the interpolated spec. Standalone fallback
+        extras: 07/09 -> [all], 01 -> [excel], the rest bare.
         """
-        # notebook filename prefix -> the extras suffix its bootstrap must append
-        # ("" means no suffix — bare core install).
-        expected_suffix: dict[str, str] = {
+        expected_extras: dict[str, str] = {
             "00_": "",
             "01_": "[excel]",
             "02_": "",
@@ -222,37 +212,39 @@ class TestPackagedAssets:
             if not p.name.endswith(".py") or p.name == "__init__.py":
                 continue
             prefix = p.name[:3]
-            assert prefix in expected_suffix, f"unmapped notebook {p.name}"
+            assert prefix in expected_extras, f"unmapped notebook {p.name}"
             seen.add(prefix)
             text = p.read_text(encoding="utf-8")
+            bootstrap = text.split(_CELL_SEP, 1)[0]
 
-            # The magic must single-quote the interpolated spec (glob-safe).
+            assert (
+                "import dao_ai" not in bootstrap and "from dao_ai" not in bootstrap
+            ), f"{p.name} bootstrap must not import dao_ai (chicken-and-egg)"
+            assert (
+                'dbutils.widgets.text(name="dao_ai_dep", defaultValue="")' in bootstrap
+            ), f"{p.name} must declare the dao_ai_dep widget with an empty default"
+            assert 'dbutils.widgets.get("dao_ai_dep")' in bootstrap, (
+                f"{p.name} must read the pinned dao_ai_dep parameter"
+            )
+            assert "elif _pin:" in bootstrap and "_dao_ai_dep = _pin" in bootstrap, (
+                f"{p.name} must install the pinned dao_ai_dep over the ../dist glob"
+            )
             assert "# MAGIC %uv pip install --quiet '{_dao_ai_dep}'" in text, (
                 f"{p.name} must single-quote the %uv install spec"
             )
-
-            suffix = expected_suffix[prefix]
-            if suffix:
-                # Bind the suffix to the concatenation onto the wheel/PyPI
-                # fallback expression (not merely present somewhere, e.g. a
-                # comment).
-                assert f'if _wheels else "dao-ai") + "{suffix}"' in text, (
-                    f"{p.name} must append {suffix} onto the _dao_ai_dep spec"
+            extras = expected_extras[prefix]
+            if extras:
+                assert f'if _wheels else "dao-ai") + "{extras}"' in bootstrap, (
+                    f"{p.name} standalone fallback must append {extras}"
                 )
             else:
-                # Core provisioning notebooks must not append any extras suffix.
-                assert '+ "[' not in text, f"{p.name} must not append an extras suffix"
-        assert seen == set(expected_suffix), f"notebook set changed: {sorted(seen)}"
+                assert '+ "[' not in bootstrap, (
+                    f"{p.name} must not append an extras suffix"
+                )
+        assert seen == set(expected_extras), f"notebook set changed: {sorted(seen)}"
 
     def test_notebooks_pick_the_newest_wheel_by_version(self) -> None:
-        """The ``../dist`` glob must be sorted by PEP 440 version, not by name.
-
-        A lexical sort puts ``0.2.8`` above ``0.2.10``, so a stale wheel wins
-        the moment the minor version reaches double digits. Each bootstrap
-        sorts on a local ``_wheel_version`` helper — which needs ``os`` and
-        ``Version`` imported *in its own cell*, since a notebook cell is its
-        own execution unit.
-        """
+        """The ../dist glob must be sorted by PEP 440 version, not lexically."""
         for p in files("dao_ai.pipeline.notebooks").iterdir():
             if not p.name.endswith(".py") or p.name == "__init__.py":
                 continue
@@ -387,8 +379,21 @@ class TestGeneratePipelineDatabricksYaml:
     def test_development_includes_wheel_in_sync(self) -> None:
         assert "dist/*.whl" in self._doc(development=True)["sync"]["include"]
 
-    def test_published_omits_wheel_from_sync(self) -> None:
-        assert "dist/*.whl" not in self._doc(development=False)["sync"]["include"]
+    def test_published_tracks_wheel_glob_for_pruning(self) -> None:
+        # dist/*.whl is tracked in published mode too: there is no local wheel to
+        # upload, so listing the glob makes ``bundle deploy`` PRUNE a wheel a prior
+        # ``--development`` deploy left in the remote workspace ``dist/`` — otherwise
+        # the notebooks' ``../dist`` fallback could reinstall a stale one.
+        assert "dist/*.whl" in self._doc(development=False)["sync"]["include"]
+
+    def test_all_tasks_forward_dao_ai_dep_param(self) -> None:
+        # Every step notebook reinstalls the EXACT spec the environment used, so the
+        # deploy's dao_ai_dep must reach each task as a base parameter — otherwise
+        # the notebook falls back to a stray ../dist wheel or an unpinned "dao-ai".
+        tasks = self._doc(development=False)["resources"]["jobs"]["deploy_job"]["tasks"]
+        for t in tasks:
+            params = t["notebook_task"]["base_parameters"]
+            assert params.get("dao_ai_dep") == "${var.dao_ai_dep}", t["task_key"]
 
     def test_no_requirements_txt_in_sync(self) -> None:
         # requirements.txt is retired: dao-ai (with its transitive deps) is

--- a/tests/dao_ai/test_pipeline_bundle.py
+++ b/tests/dao_ai/test_pipeline_bundle.py
@@ -411,6 +411,18 @@ class TestGeneratePipelineDatabricksYaml:
         env = doc["resources"]["jobs"]["deploy_job"]["environments"][0]
         assert env["spec"]["dependencies"] == ["${var.dao_ai_dep}"]
 
+    def test_dao_ai_dep_default_carries_config_extras(self, monkeypatch) -> None:
+        # Regression (PR #302 review): the published ``dao_ai_dep`` default must
+        # carry the config's precise extras so a raw ``databricks bundle deploy``
+        # (no CLI override) installs the right features — not a bare ``dao-ai``.
+        import dao_ai._extras as _extras
+
+        monkeypatch.setattr(
+            _extras, "resolve_required_extras", lambda config, target: {"a2a", "memory"}
+        )
+        default = self._doc(development=False)["variables"]["dao_ai_dep"]["default"]
+        assert default == f"dao-ai[a2a,memory]=={dao_ai_version()}"
+
     def test_dev_env_deps_are_glob_safe_no_extras_on_wheel(self) -> None:
         # Regression guard: databricks bundle globs local-path env deps, so the
         # dev-mode wheel dep must NOT carry an ``[extras]`` suffix (a glob char


### PR DESCRIPTION
## Problem

`dao-ai workflow up` could deploy a **stale `dao-ai`** into the serverless job and fail at the first provisioning task with a cryptic `ParameterDeclarationModel … provided [extra_forbidden]`. While fixing that, two more issues surfaced: deployed artifacts pinned **`dao-ai[all]`** (not the config's extras), and **apps builds failed** on a non-portable serverless `uv.lock`.

## Fixes (4 commits)

1. **`fix(pipeline)` — install the pinned dao-ai, not a stray `../dist` wheel.** The step notebooks globbed `../dist` for any wheel / installed unpinned `dao-ai` and `%restart_python`, overriding the env's `${var.dao_ai_dep}`; a wheel a prior `--development` deploy left in the workspace got picked up. Now: `dao_ai_dep` is passed to every notebook and installed in preference to the glob (which is a standalone-only fallback), published deploys prune leftover `dist/*.whl`, and the bootstrap stays **self-contained** (stdlib only — a bootstrap must not import the package it installs).
2. **`fix(deploy)` — pin config-specific extras, not `[all]`.** `resolve_required_extras_or_all` short-circuits to `{all}` in a notebook, and the deploy runs in one — so apps/model_serving baked `dao-ai[all]`. The artifact-building paths now use the precise `resolve_required_extras`.
3. **`feat(examples)` — configurable service principal** (name/scope/keys as params).
4. **`fix(apps)` — resolve the bundle `uv.lock` against public PyPI.** A lock generated on serverless records `node.host.local/pypi/vN/packages/…` URLs; host-swapping them 404s. `generate_bundle_lock` now resolves against public PyPI (fallback to the ambient transparent mirror) + guards the proxy-path fingerprint.

## Live validation (fevm, `hardware_store_lakebase`, both modes)

| | model_serving | apps |
|---|---|---|
| Deploy (10-task DAG) | ✅ | ✅ (needed fix #4) |
| Extras pinned | ✅ `[memory]` | ✅ `[a2a,memory]` (not `[all]`) |
| Inference (tool-grounded) | ✅ | ✅ |
| MLflow trace + **tool-call spans** | ✅ 5 tool spans `OK` | ✅ persisted to UC (`find_inventory_by_sku`, `memory_context_search` `OK`) |
| Lakebase writes | ✅ checkpoints + store | ✅ (SP creds) |

Note: apps tracing on fevm requires `trace_location` (UC OTEL) **and** a dedicated experiment — a shared experiment gets pinned to the control-plane store, which App containers can't reach. That's a per-workspace deploy config (validated), not a code change here.

This pull request and its description were written by Isaac.
